### PR TITLE
Fix MSYS build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,14 +15,12 @@ else
 endif
 
 ROOT       := $(shell pwd)
-BUILD_DIR  := $(ROOT)/build
+BUILD_DIR  := build
 TARGET_DIR := $(BUILD_DIR)/$(REGION_NAME)
-TOOLS_DIR  := $(ROOT)/tools
-BASE_DIR   := $(ROOT)/ph_$(REGION_NAME)
-LCF_FILE   := $(BUILD_DIR)/arm9_linker_script.lcf
-OBJS_FILE  := $(BUILD_DIR)/arm9_objects.txt
-ARM7_BIOS  := $(ROOT)/arm7_bios.bin
-ASSETS_TXT := $(ROOT)/assets.txt
+TOOLS_DIR  := tools
+BASE_DIR   := ph_$(REGION_NAME)
+ARM7_BIOS  := arm7_bios.bin
+ASSETS_TXT := assets.txt
 
 ASM_FILES := $(shell find asm -name *.s)
 CXX_FILES := $(shell find src -name *.cpp)
@@ -37,10 +35,12 @@ BASE_ROM := baserom_$(REGION_NAME).nds
 CHECKSUM := ph_$(REGION_NAME).sha1
 
 MW_VER     := 2.0/sp1p5
-MW_ASM     := $(TOOLS_DIR)/mwccarm/$(MW_VER)/mwasmarm.exe
-MW_CC      := $(TOOLS_DIR)/mwccarm/$(MW_VER)/mwccarm.exe
-MW_LD      := $(TOOLS_DIR)/mwccarm/$(MW_VER)/mwldarm.exe
-MW_LICENSE := $(TOOLS_DIR)/mwccarm/license.dat
+MW_ASM     := $(ROOT)/$(TOOLS_DIR)/mwccarm/$(MW_VER)/mwasmarm.exe
+MW_CC      := $(ROOT)/$(TOOLS_DIR)/mwccarm/$(MW_VER)/mwccarm.exe
+MW_LD      := $(ROOT)/$(TOOLS_DIR)/mwccarm/$(MW_VER)/mwldarm.exe
+MW_LICENSE := $(ROOT)/$(TOOLS_DIR)/mwccarm/license.dat
+LCF_FILE   := $(ROOT)/$(BUILD_DIR)/arm9_linker_script.lcf
+OBJS_FILE  := $(ROOT)/$(BUILD_DIR)/arm9_objects.txt
 
 ASM_FLAGS := -proc arm5te -d $(REGION) -i asm -msgstyle gcc
 CC_FLAGS  := -proc arm946e -interworking -O4,p -enum int -i include -nolink -d $(REGION) -char signed -lang=c++ -sym on

--- a/tools/include/util.h
+++ b/tools/include/util.h
@@ -128,8 +128,9 @@ void FileClose(File *file) {
 size_t FileRead(const File *file, void *buf, size_t size, size_t count) {
 #ifdef __UTIL_WINDOWS
     DWORD bytesRead;
-    if (ReadFile(file->handle, buf, size * count, &bytesRead, NULL)) return true;
-    if (bytesRead > 0) return bytesRead / size;
+    if (ReadFile(file->handle, buf, size * count, &bytesRead, NULL)) {
+        if (bytesRead > 0) return bytesRead / size;
+    }
 #elif defined(__UTIL_LINUX)
     size_t countRead = fread(buf, size, count, file->fp);
     if (countRead > 0) return countRead;

--- a/tools/include/util.h
+++ b/tools/include/util.h
@@ -151,7 +151,7 @@ size_t FileSize(const File *file) {
 #ifdef __UTIL_WINDOWS
     DWORD sizeHigh;
     DWORD sizeLow = GetFileSize(file->handle, &sizeHigh);
-    return sizeLow | (sizeHigh << 32);
+    return sizeLow | ((size_t)(sizeHigh) << 32);
 #elif defined(__UTIL_LINUX)
     size_t pos = ftell(file->fp);
     fseek(file->fp, 0, SEEK_END);
@@ -163,9 +163,9 @@ size_t FileSize(const File *file) {
 
 size_t FileOffset(const File *file) {
 #ifdef __UTIL_WINDOWS
-    DWORD offsetHigh = 0;
+    LONG offsetHigh = 0;
     DWORD offsetLow = SetFilePointer(file->handle, 0, &offsetHigh, FILE_CURRENT);
-    return offsetLow | (offsetHigh << 32);
+    return offsetLow | ((size_t)(offsetHigh) << 32);
 #elif defined(__UTIL_LINUX)
     return ftell(file->fp);
 #endif
@@ -173,9 +173,9 @@ size_t FileOffset(const File *file) {
 
 void FileGoTo(const File *file, size_t offset) {
 #ifdef __UTIL_WINDOWS
-    DWORD offsetHigh = offset >> 32;
-    DWORD offsetLow = offset & 0xffffffff;
-    SetFilePointer(file->handle, offsetHigh, &offsetHigh, FILE_BEGIN);
+    LONG offsetHigh = offset >> 32;
+    LONG offsetLow = offset & 0xffffffff;
+    SetFilePointer(file->handle, offsetLow, &offsetHigh, FILE_BEGIN);
 #elif defined(__UTIL_LINUX)
     fseek(file->fp, offset, SEEK_SET);
 #endif

--- a/tools/include/util.h
+++ b/tools/include/util.h
@@ -69,7 +69,7 @@ bool ChangeDir(const char *dir) {
 typedef struct {
     const char *name;
 #ifdef __UTIL_WINDOWS
-    HFILE handle;
+    HANDLE handle;
 #elif defined(__UTIL_LINUX)
     FILE *fp;
 #endif
@@ -77,7 +77,7 @@ typedef struct {
 
 bool FileOpenRead(const char *name, File *file) {
 #ifdef __UTIL_WINDOWS
-    HFILE handle = CreateFileA(name, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+    HANDLE handle = CreateFileA(name, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
     if (handle != INVALID_HANDLE_VALUE) {
         file->name = name;
         file->handle = handle;
@@ -96,7 +96,7 @@ bool FileOpenRead(const char *name, File *file) {
 
 bool FileOpenWrite(const char *name, File *file) {
 #ifdef __UTIL_WINDOWS
-    HFILE handle = CreateFileA(name, GENERIC_WRITE, 0, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
+    HANDLE handle = CreateFileA(name, GENERIC_WRITE, 0, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
     if (handle != INVALID_HANDLE_VALUE) {
         file->name = name;
         file->handle = handle;

--- a/tools/rom/Makefile
+++ b/tools/rom/Makefile
@@ -1,5 +1,5 @@
 CC := gcc
-CFLAGS := -g -Wall
+CFLAGS := -g -Wall -I../include
 
 ifneq ($(DEBUG),1)
 	CFLAGS += -O2 -DNDEBUG

--- a/tools/rom/build.c
+++ b/tools/rom/build.c
@@ -211,7 +211,7 @@ bool LoadArm9Metadata(Arm9Metadata *pMetadata) {
 // Reads an entire file into a newly allocated buffer and writes it to *pBuffer if successful.
 // If pFileSize != NULL, this function writes the file's size into *pFileSize.
 // The buffer can be freed with free().
-bool ReadFile(const char *filePath, uint8_t **pBuffer, uint32_t *pFileSize) {
+bool ReadFileAlloc(const char *filePath, uint8_t **pBuffer, uint32_t *pFileSize) {
     FILE *fp = fopen(filePath, "rb");
     if (fp == NULL) FATAL("Failed to open file '%s'\n", filePath);
     fseek(fp, 0, SEEK_END);
@@ -263,7 +263,7 @@ bool WriteArm9Program(FILE *fpRom, size_t *pAddress, uint32_t *pFileSize, uint32
 
     uint8_t *arm9;
     uint32_t fileSize;
-    if (!ReadFile(ARM9_PROGRAM_FILE, &arm9, &fileSize)) return false;
+    if (!ReadFileAlloc(ARM9_PROGRAM_FILE, &arm9, &fileSize)) return false;
 
     // Write module info, see spAutoloadBlockInfosStart in asm/main.s
     // This might seem unsafe since the ARM9 program is compressed, but the addresses we're writing to are in the secure area,

--- a/tools/rom/files.h
+++ b/tools/rom/files.h
@@ -18,7 +18,7 @@ typedef struct FileTree {
 bool MakeFileTree(FileTree *pTree);
 
 bool IterFiles(bool (*callback)(const char *name, bool isDir, void*), void *userData) {
-#ifdef _WIN32
+#ifdef __UTIL_WINDOWS
     WIN32_FIND_DATAA findData;
     HANDLE hFind = FindFirstFileA("*", &findData);
     if (hFind == INVALID_HANDLE_VALUE) FATAL("Failed to open directory to iterate files\n");
@@ -30,7 +30,7 @@ bool IterFiles(bool (*callback)(const char *name, bool isDir, void*), void *user
         if (!callback(name, isDir, userData)) return false;
     } while (FindNextFileA(hFind, &findData));
     FindClose(hFind);
-#elif __linux__
+#elif defined(__UTIL_LINUX)
     DIR *dir = opendir(".");
     struct dirent *entry;
     while ((entry = readdir(dir)) != NULL) {

--- a/tools/rom/files.h
+++ b/tools/rom/files.h
@@ -80,7 +80,7 @@ bool _FileTreeFileCallback(const char *name, bool isDir, void *userData) {
         memcpy(entry->name, name, nameLength);
         WRITE_SUBDIR_ID(entry, 0);
 
-        if (chdir(name) != 0) FATAL("Failed to enter directory '%s'\n", name);
+        if (!ChangeDir(name)) return false;
 
         FileTree child;
         if (!MakeFileTree(&child)) return false;
@@ -89,7 +89,7 @@ bool _FileTreeFileCallback(const char *name, bool isDir, void *userData) {
         memcpy(&pTree->children[pTree->numChildren], &child, sizeof(child));
         pTree->numChildren += 1;
 
-        if (chdir("..") != 0) FATAL("Failed to leave directory '%s'\n", name);
+        if (!ChangeDir("..")) return false;
     } else {
         FntSubEntry *entry = malloc(sizeof(FntSubEntry) + nameLength);
         if (entry == NULL) FATAL("Failed to allocate FNT sub entry for file '%s'\n", name);


### PR DESCRIPTION
This PR fixes issues when building with MSYS on Windows. Fresh MSYS installations aren't packaged with compatibility functions like `_mkdir`, `_chdir` and `getcwd`, so they have been replaced with their corresponding Win32 API functions `CreateDirectoryA`, `SetCurrentDirectory` and `GetCurrentDirectory`.

However, `SetCurrentDirectory` does not update the current working directory used by `fopen`, so all C file API functions have been abstracted in `util.h`. Thus, Linux still uses the C file API while Windows uses the Win32 API for file I/O.