### PR TITLE
Fixed ``python`` on Ubuntu

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,10 @@ else ifneq ($(REGION),)
 	$(error Unknown region '$(REGION)')
 endif
 
+PYTHON ?= python
+
 ifeq ($(OS),Windows_NT)
 	WINE :=
-	PYTHON ?= python
 else
 	WINE := wine
 	PYTHON ?= python3.11

--- a/Makefile
+++ b/Makefile
@@ -8,14 +8,14 @@ else ifneq ($(REGION),)
 	$(error Unknown region '$(REGION)')
 endif
 
-PYTHON ?= python
-
 ifeq ($(OS),Windows_NT)
 	WINE :=
 else
 	WINE := wine
 	PYTHON ?= python3.11
 endif
+
+PYTHON ?= python
 
 ROOT       := $(shell pwd)
 BUILD_DIR  := build

--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,10 @@ endif
 
 ifeq ($(OS),Windows_NT)
 	WINE :=
+	PYTHON ?= python
 else
 	WINE := wine
+	PYTHON ?= python3.11
 endif
 
 ROOT       := $(shell pwd)
@@ -110,7 +112,7 @@ clean:
 
 .PHONY: lcf
 lcf: setup $(TOOLS_DIR)/lcf.py
-	python $(TOOLS_DIR)/lcf.py
+	$(PYTHON) $(TOOLS_DIR)/lcf.py
 
 $(ASM_OBJS): $(TARGET_DIR)/%.o: %
 	mkdir -p $(dir $@)
@@ -135,4 +137,4 @@ $(OV_LZS): %.lz: %.bin
 gen_externs: $(ASM_INCS)
 
 $(ASM_INCS): %.inc: %.s
-	python $(TOOLS_DIR)/gen_externs.py $<
+	$(PYTHON) $(TOOLS_DIR)/gen_externs.py $<


### PR DESCRIPTION
On Windows you can use python from ``python`` but on Linux (and mac too?) it's ``python3``, though the default version on Ubuntu is 3.10, so you need to install it from ``apt-get install python3.11`` then run ``python3.11 file.py``, I tried using an alias but it didn't work so instead I just made an env variable that you can override when needed

Not sure how it works for you but it should make it build properly on Linux (tested on WSL2), also idk if that's a solid fix