### PR TITLE
Update inline assembler docs, remove register aliases `sb`, `sl`, `fp`

### DIFF
--- a/asm/itcm.s
+++ b/asm/itcm.s
@@ -230,28 +230,28 @@ func_01ff8230: ; 0x01ff8230
 	.global func_01ff8248
 	arm_func_start func_01ff8248
 func_01ff8248: ; 0x01ff8248
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x18
-	ldr sb, [r1]
+	ldr r9, [r1]
 	ldr r8, [r1, #4]
 	ldr r7, [r1, #8]
-	smull r1, r6, sb, sb
+	smull r1, r6, r9, r9
 	str r1, [sp]
 	rsb r1, r3, #0x1000
-	smull r4, r11, r1, sb
+	smull r4, r11, r1, r9
 	ldr r5, [sp]
 	umull r10, ip, r8, r4
 	umull lr, r5, r1, r5
 	mla r5, r1, r6, r5
 	mov r6, lr, lsr #0x18
 	mov lr, r10, lsr #0x18
-	smull sb, r10, r2, sb
-	mov sb, sb, lsr #0xc
-	orr sb, sb, r10, lsl #20
-	str sb, [sp, #0x14]
+	smull r9, r10, r2, r9
+	mov r9, r9, lsr #0xc
+	orr r9, r9, r10, lsl #20
+	str r9, [sp, #0x14]
 	ldr r10, [sp]
-	mov sb, r1, asr #0x1f
-	mla r5, sb, r10, r5
+	mov r9, r1, asr #0x1f
+	mla r5, r9, r10, r5
 	orr r6, r6, r5, lsl #8
 	add r5, r6, r3
 	mla ip, r8, r11, ip
@@ -266,7 +266,7 @@ func_01ff8248: ; 0x01ff8248
 	mla ip, r1, r10, ip
 	ldr r6, [sp, #8]
 	mov r5, r7, asr #0x1f
-	mla ip, sb, r6, ip
+	mla ip, r9, r6, ip
 	ldr r6, [sp, #4]
 	mov r6, r6, lsr #0x18
 	orr r6, r6, ip, lsl #8
@@ -278,7 +278,7 @@ func_01ff8248: ; 0x01ff8248
 	str r6, [sp, #0xc]
 	mla ip, r1, r10, ip
 	ldr r6, [sp, #0x10]
-	mla ip, sb, r6, ip
+	mla ip, r9, r6, ip
 	ldr r6, [sp, #0xc]
 	mov r6, r6, lsr #0x18
 	orr r6, r6, ip, lsl #8
@@ -288,11 +288,11 @@ func_01ff8248: ; 0x01ff8248
 	smull r8, r1, r2, r8
 	mov r8, r8, lsr #0xc
 	orr r8, r8, r1, lsl #20
-	smull sb, r1, r2, r7
-	mov sb, sb, lsr #0xc
-	orr sb, sb, r1, lsl #20
-	add r2, lr, sb
-	sub r1, lr, sb
+	smull r9, r1, r2, r7
+	mov r9, r9, lsr #0xc
+	orr r9, r9, r1, lsl #20
+	add r2, lr, r9
+	sub r1, lr, r9
 	str r2, [r0, #4]
 	str r1, [r0, #0xc]
 	umull r2, r1, r7, r4
@@ -315,23 +315,23 @@ func_01ff8248: ; 0x01ff8248
 	str r2, [r0, #0x14]
 	str r1, [r0, #0x1c]
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	arm_func_end func_01ff8248
 
 	.global func_01ff83a0
 	arm_func_start func_01ff83a0
 func_01ff83a0: ; 0x01ff83a0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x50
 	mov r10, r0
 	ldr r0, [r10, #0x14]
 	cmp r10, r1
-	addeq sb, sp, #0x2c
+	addeq r9, sp, #0x2c
 	ldr r3, [r10, #0x18]
 	ldr r2, [r10, #0xc]
 	ldr r6, [r10, #0x20]
 	str r1, [sp]
-	movne sb, r1
+	movne r9, r1
 	smull r11, r8, r2, r6
 	smull r7, r1, r0, r3
 	subs r7, r11, r7
@@ -379,7 +379,7 @@ func_01ff83a0: ; 0x01ff83a0
 	mov r1, #0
 	addeq sp, sp, #0x50
 	subeq r0, r1, #1
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	bl func_01ff9a50
 	ldr r1, [r10, #8]
 	ldr r2, [r10, #0x1c]
@@ -449,8 +449,8 @@ func_01ff83a0: ; 0x01ff83a0
 	mla r5, ip, r7, r5
 	mov r1, r11, lsr #0xc
 	orr r1, r1, r5, lsl #20
-	stmia sb, {r1, lr}
-	str r4, [sb, #8]
+	stmia r9, {r1, lr}
+	str r4, [r9, #8]
 	ldr r1, [sp, #4]
 	umull r5, r4, r0, r8
 	mla r4, r0, r1, r4
@@ -458,17 +458,17 @@ func_01ff83a0: ; 0x01ff83a0
 	mov r1, r5, lsr #0xc
 	orr r1, r1, r4, lsl #20
 	rsb r1, r1, #0
-	str r1, [sb, #0xc]
+	str r1, [r9, #0xc]
 	ldr r1, [sp, #0xc]
 	rsb r2, r2, #0
-	str r3, [sb, #0x10]
-	str r2, [sb, #0x14]
+	str r3, [r9, #0x10]
+	str r2, [r9, #0x14]
 	umull r3, r2, r0, r6
 	mla r2, r0, r1, r2
 	mla r2, ip, r6, r2
 	mov r1, r3, lsr #0xc
 	orr r1, r1, r2, lsl #20
-	str r1, [sb, #0x18]
+	str r1, [r9, #0x18]
 	ldr r3, [r10]
 	ldr r1, [r10, #0x1c]
 	ldr r2, [r10, #0x18]
@@ -483,7 +483,7 @@ func_01ff83a0: ; 0x01ff83a0
 	mov r2, r2, lsr #0xc
 	orr r2, r2, r1, lsl #20
 	rsb r1, r2, #0
-	str r1, [sb, #0x1c]
+	str r1, [r9, #0x1c]
 	ldr r4, [r10]
 	ldr r3, [r10, #0x10]
 	ldr r2, [r10, #0xc]
@@ -501,21 +501,21 @@ func_01ff83a0: ; 0x01ff83a0
 	mla r3, ip, r2, r3
 	mov r1, r4, lsr #0xc
 	orr r1, r1, r3, lsl #20
-	str r1, [sb, #0x20]
-	cmp sb, r0
+	str r1, [r9, #0x20]
+	cmp r9, r0
 	bne _01ff8684
 	ldr r1, [sp]
 	bl func_020079d8
 _01ff8684:
 	mov r0, #0
 	add sp, sp, #0x50
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	arm_func_end func_01ff83a0
 
 	.global func_01ff8690
 	arm_func_start func_01ff8690
 func_01ff8690: ; 0x01ff8690
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x40
 	mov ip, r2
 	ldr r3, [r0, #4]
@@ -551,9 +551,9 @@ func_01ff8690: ; 0x01ff8690
 	mov r2, r8, lsr #0xc
 	orr r2, r2, r7, lsl #20
 	str r2, [r10, #8]
-	ldr sb, [r0, #0x10]
+	ldr r9, [r0, #0x10]
 	ldr r2, [r0, #0xc]
-	smull r7, r6, sb, r4
+	smull r7, r6, r9, r4
 	smlal r7, r6, r2, r5
 	ldr r4, [r0, #0x14]
 	smlal r7, r6, r4, r3
@@ -562,10 +562,10 @@ func_01ff8690: ; 0x01ff8690
 	str r3, [r10, #0x14]
 	ldr r3, [r1, #0x10]
 	ldr r5, [r1, #4]
-	smull r7, r6, sb, r3
+	smull r7, r6, r9, r3
 	smlal r7, r6, r2, r5
 	ldr r5, [r1, #0x1c]
-	mov r3, sb, asr #0x1f
+	mov r3, r9, asr #0x1f
 	smlal r7, r6, r4, r5
 	str r3, [sp]
 	mov r3, r7, lsr #0xc
@@ -594,12 +594,12 @@ func_01ff8690: ; 0x01ff8690
 	ldr r3, [sp, #0xc]
 	mla r4, r2, r3, r4
 	ldr r2, [sp, #4]
-	umull r3, r11, sb, r8
+	umull r3, r11, r9, r8
 	mla r4, r2, r7, r4
 	ldr r2, [sp, #0x14]
 	adds r3, r2, r3
 	ldr r2, [sp, #0x18]
-	mla r11, sb, r2, r11
+	mla r11, r9, r2, r11
 	ldr r2, [sp]
 	mla r11, r2, r8, r11
 	adc r4, r4, r11
@@ -615,8 +615,8 @@ func_01ff8690: ; 0x01ff8690
 	ldr r4, [r0, #0x20]
 	umull r3, r0, r2, r8
 	mla r0, r2, r11, r0
-	mov sb, r2, asr #0x1f
-	mla r0, sb, r8, r0
+	mov r9, r2, asr #0x1f
+	mla r0, r9, r8, r0
 	smlal r3, r0, r5, r7
 	smlal r3, r0, r4, r6
 	mov r3, r3, lsr #0xc
@@ -642,7 +642,7 @@ func_01ff8690: ; 0x01ff8690
 	mov r1, r1, lsr #0xc
 	orr r1, r1, r0, lsl #20
 	str r1, [r10, #0x20]
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldmia lr!, {r0, r1, r2, r3}
 	stmia ip!, {r0, r1, r2, r3}
 	ldmia lr!, {r0, r1, r2, r3}
@@ -650,7 +650,7 @@ func_01ff8690: ; 0x01ff8690
 	ldr r0, [lr]
 	str r0, [ip]
 	add sp, sp, #0x40
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	arm_func_end func_01ff8690
 
 	.global func_01ff88b0
@@ -881,17 +881,17 @@ func_01ff8ad8: ; 0x01ff8ad8
 	.global func_01ff8af8
 	arm_func_start func_01ff8af8
 func_01ff8af8: ; 0x01ff8af8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x5c
 	mov r10, r0
 	ldr r0, [r10, #0x14]
 	cmp r10, r1
-	addeq sb, sp, #0x2c
+	addeq r9, sp, #0x2c
 	ldr r3, [r10, #0x18]
 	ldr r2, [r10, #0xc]
 	ldr r6, [r10, #0x20]
 	str r1, [sp]
-	movne sb, r1
+	movne r9, r1
 	smull r11, r8, r2, r6
 	smull r7, r1, r0, r3
 	subs r7, r11, r7
@@ -939,7 +939,7 @@ func_01ff8af8: ; 0x01ff8af8
 	mov r1, #0
 	addeq sp, sp, #0x5c
 	subeq r0, r1, #1
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	bl func_01ff9a50
 	ldr r1, [r10, #8]
 	ldr r2, [r10, #0x1c]
@@ -1009,8 +1009,8 @@ func_01ff8af8: ; 0x01ff8af8
 	mla r5, ip, r7, r5
 	mov r1, r11, lsr #0xc
 	orr r1, r1, r5, lsl #20
-	stmia sb, {r1, lr}
-	str r4, [sb, #8]
+	stmia r9, {r1, lr}
+	str r4, [r9, #8]
 	ldr r1, [sp, #4]
 	umull r5, r4, r0, r8
 	mla r4, r0, r1, r4
@@ -1018,17 +1018,17 @@ func_01ff8af8: ; 0x01ff8af8
 	mov r1, r5, lsr #0xc
 	orr r1, r1, r4, lsl #20
 	rsb r1, r1, #0
-	str r1, [sb, #0xc]
+	str r1, [r9, #0xc]
 	ldr r1, [sp, #0xc]
 	rsb r2, r2, #0
-	str r3, [sb, #0x10]
-	str r2, [sb, #0x14]
+	str r3, [r9, #0x10]
+	str r2, [r9, #0x14]
 	umull r3, r2, r0, r6
 	mla r2, r0, r1, r2
 	mla r2, ip, r6, r2
 	mov r1, r3, lsr #0xc
 	orr r1, r1, r2, lsl #20
-	str r1, [sb, #0x18]
+	str r1, [r9, #0x18]
 	ldr r3, [r10]
 	ldr r1, [r10, #0x1c]
 	ldr r2, [r10, #0x18]
@@ -1043,7 +1043,7 @@ func_01ff8af8: ; 0x01ff8af8
 	mov r2, r2, lsr #0xc
 	orr r2, r2, r1, lsl #20
 	rsb r1, r2, #0
-	str r1, [sb, #0x1c]
+	str r1, [r9, #0x1c]
 	ldr r4, [r10]
 	ldr r3, [r10, #0x10]
 	ldr r2, [r10, #0xc]
@@ -1060,13 +1060,13 @@ func_01ff8af8: ; 0x01ff8af8
 	mla r3, ip, r2, r3
 	mov r0, r4, lsr #0xc
 	orr r0, r0, r3, lsl #20
-	str r0, [sb, #0x20]
-	ldr r1, [sb, #0xc]
+	str r0, [r9, #0x20]
+	ldr r1, [r9, #0xc]
 	ldr r0, [r10, #0x28]
-	ldr r2, [sb]
+	ldr r2, [r9]
 	smull r5, r4, r1, r0
 	ldr r0, [r10, #0x24]
-	ldr r3, [sb, #0x18]
+	ldr r3, [r9, #0x18]
 	smlal r5, r4, r2, r0
 	ldr r1, [r10, #0x2c]
 	add r0, sp, #0x2c
@@ -1074,47 +1074,47 @@ func_01ff8af8: ; 0x01ff8af8
 	mov r1, r5, lsr #0xc
 	orr r1, r1, r4, lsl #20
 	rsb r1, r1, #0
-	str r1, [sb, #0x24]
-	ldr r2, [sb, #0x10]
+	str r1, [r9, #0x24]
+	ldr r2, [r9, #0x10]
 	ldr r1, [r10, #0x28]
-	ldr r3, [sb, #4]
+	ldr r3, [r9, #4]
 	smull r5, r4, r2, r1
 	ldr r1, [r10, #0x24]
-	ldr r2, [sb, #0x1c]
+	ldr r2, [r9, #0x1c]
 	smlal r5, r4, r3, r1
 	ldr r1, [r10, #0x2c]
-	cmp sb, r0
+	cmp r9, r0
 	smlal r5, r4, r2, r1
 	mov r1, r5, lsr #0xc
 	orr r1, r1, r4, lsl #20
 	rsb r1, r1, #0
-	str r1, [sb, #0x28]
-	ldr r2, [sb, #0x14]
+	str r1, [r9, #0x28]
+	ldr r2, [r9, #0x14]
 	ldr r1, [r10, #0x28]
-	ldr r3, [sb, #8]
+	ldr r3, [r9, #8]
 	smull r6, r5, r2, r1
 	ldr r1, [r10, #0x24]
-	ldr r4, [sb, #0x20]
+	ldr r4, [r9, #0x20]
 	smlal r6, r5, r3, r1
 	ldr r2, [r10, #0x2c]
 	smlal r6, r5, r4, r2
 	mov r1, r6, lsr #0xc
 	orr r1, r1, r5, lsl #20
 	rsb r1, r1, #0
-	str r1, [sb, #0x2c]
+	str r1, [r9, #0x2c]
 	bne _01ff8e78
 	ldr r1, [sp]
 	bl func_020079f4
 _01ff8e78:
 	mov r0, #0
 	add sp, sp, #0x5c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	arm_func_end func_01ff8af8
 
 	.global func_01ff8e84
 	arm_func_start func_01ff8e84
 func_01ff8e84: ; 0x01ff8e84
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x4c
 	mov ip, r2
 	ldr r2, [r0, #4]
@@ -1151,11 +1151,11 @@ func_01ff8e84: ; 0x01ff8e84
 	orr r5, r5, r7, lsl #20
 	str r5, [r10, #8]
 	ldr r8, [r0, #0x10]
-	ldr sb, [r0, #0xc]
+	ldr r9, [r0, #0xc]
 	smull r5, r3, r8, r3
-	smlal r5, r3, sb, r4
+	smlal r5, r3, r9, r4
 	ldr r7, [r0, #0x14]
-	mov r6, sb, asr #0x1f
+	mov r6, r9, asr #0x1f
 	smlal r5, r3, r7, r2
 	mov r2, r5, lsr #0xc
 	orr r2, r2, r3, lsl #20
@@ -1163,7 +1163,7 @@ func_01ff8e84: ; 0x01ff8e84
 	ldr r2, [r1, #0x10]
 	ldr r3, [r1, #4]
 	smull r5, r4, r8, r2
-	smlal r5, r4, sb, r3
+	smlal r5, r4, r9, r3
 	ldr r3, [r1, #0x1c]
 	mov r2, r8, asr #0x1f
 	smlal r5, r4, r7, r3
@@ -1187,14 +1187,14 @@ func_01ff8e84: ; 0x01ff8e84
 	ldr r2, [sp]
 	ldr r7, [sp, #8]
 	mla r3, r2, lr, r3
-	umull r11, r2, sb, r5
-	mla r2, sb, r7, r2
+	umull r11, r2, r9, r5
+	mla r2, r9, r7, r2
 	mla r2, r6, r5, r2
 	ldr r6, [sp, #4]
-	umull sb, r7, r8, r4
+	umull r9, r7, r8, r4
 	mla r7, r8, r6, r7
 	ldr r8, [sp, #0x14]
-	adds r6, r11, sb
+	adds r6, r11, r9
 	mla r7, r8, r4, r7
 	adc r7, r2, r7
 	ldr r2, [sp, #0xc]
@@ -1231,10 +1231,10 @@ func_01ff8e84: ; 0x01ff8e84
 	orr r2, r2, r7, lsl #20
 	str r2, [r10, #0x20]
 	ldr r2, [r0, #0x28]
-	ldr sb, [r0, #0x24]
+	ldr r9, [r0, #0x24]
 	ldr r7, [r0, #0x2c]
 	smull r5, r0, r2, r5
-	smlal r5, r0, sb, r4
+	smlal r5, r0, r9, r4
 	smlal r5, r0, r7, r3
 	mov r3, r5, lsr #0xc
 	orr r3, r3, r0, lsl #20
@@ -1247,25 +1247,25 @@ func_01ff8e84: ; 0x01ff8e84
 	ldr r3, [r1, #0x10]
 	ldr r4, [r1, #4]
 	smull r6, r3, r2, r3
-	smlal r6, r3, sb, r4
+	smlal r6, r3, r9, r4
 	ldr r5, [r1, #0x1c]
 	ldr r0, [r1, #0x28]
 	smlal r6, r3, r7, r5
 	mov r4, r6, lsr #0xc
 	orr r4, r4, r3, lsl #20
 	adds r0, r0, r4
-	mov r8, sb, asr #0x1f
+	mov r8, r9, asr #0x1f
 	str r0, [r10, #0x28]
 	ldr r4, [r1]
 	ldr r3, [r1, #0xc]
-	umull r0, r5, sb, r4
+	umull r0, r5, r9, r4
 	mov lr, r4, asr #0x1f
-	mla r5, sb, lr, r5
-	mov sb, r3, asr #0x1f
+	mla r5, r9, lr, r5
+	mov r9, r3, asr #0x1f
 	str r0, [sp, #0x10]
 	mla r5, r8, r4, r5
 	umull r8, r0, r2, r3
-	mla r0, r2, sb, r0
+	mla r0, r2, r9, r0
 	ldr r4, [sp, #0x10]
 	mla r0, r11, r3, r0
 	adds r4, r4, r8
@@ -1286,7 +1286,7 @@ func_01ff8e84: ; 0x01ff8e84
 	cmp r10, r4
 	addne sp, sp, #0x4c
 	str r0, [r10, #0x24]
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldmia r4!, {r0, r1, r2, r3}
 	stmia ip!, {r0, r1, r2, r3}
 	ldmia r4!, {r0, r1, r2, r3}
@@ -1294,7 +1294,7 @@ func_01ff8e84: ; 0x01ff8e84
 	ldmia r4, {r0, r1, r2, r3}
 	stmia ip, {r0, r1, r2, r3}
 	add sp, sp, #0x4c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	arm_func_end func_01ff8e84
 
 	.global func_01ff9158
@@ -1402,7 +1402,7 @@ func_01ff9258: ; 0x01ff9258
 	.global func_01ff927c
 	arm_func_start func_01ff927c
 func_01ff927c: ; 0x01ff927c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0xe8
 	cmp r2, r1
 	addeq r10, sp, #0xa8
@@ -1425,24 +1425,24 @@ func_01ff927c: ; 0x01ff927c
 	str r6, [r10]
 	ldr r6, [r1, #0x14]
 	ldr r7, [r1, #4]
-	smull sb, r8, r4, r6
-	smlal sb, r8, r5, r7
+	smull r9, r8, r4, r6
+	smlal r9, r8, r5, r7
 	ldr r6, [r1, #0x24]
 	ldr r7, [r1, #0x34]
-	smlal sb, r8, r3, r6
-	smlal sb, r8, r2, r7
-	mov r6, sb, lsr #0xc
+	smlal r9, r8, r3, r6
+	smlal r9, r8, r2, r7
+	mov r6, r9, lsr #0xc
 	orr r6, r6, r8, lsl #20
 	str r6, [r10, #4]
 	ldr r6, [r1, #0x1c]
 	ldr r7, [r1, #0xc]
-	smull sb, r8, r4, r6
-	smlal sb, r8, r5, r7
+	smull r9, r8, r4, r6
+	smlal r9, r8, r5, r7
 	ldr r6, [r1, #0x2c]
 	ldr r7, [r1, #0x3c]
-	smlal sb, r8, r3, r6
-	smlal sb, r8, r2, r7
-	mov r6, sb, lsr #0xc
+	smlal r9, r8, r3, r6
+	smlal r9, r8, r2, r7
+	mov r6, r9, lsr #0xc
 	orr r6, r6, r8, lsl #20
 	str r6, [r10, #0xc]
 	ldr r11, [r1, #0x18]
@@ -1450,9 +1450,9 @@ func_01ff927c: ; 0x01ff927c
 	smull r7, r6, r4, r11
 	ldr r8, [r1, #0x38]
 	smlal r7, r6, r5, ip
-	ldr sb, [r1, #0x28]
+	ldr r9, [r1, #0x28]
 	mov lr, r8, asr #0x1f
-	smlal r7, r6, r3, sb
+	smlal r7, r6, r3, r9
 	smlal r7, r6, r2, r8
 	mov r2, r7, lsr #0xc
 	orr r2, r2, r6, lsl #20
@@ -1461,7 +1461,7 @@ func_01ff927c: ; 0x01ff927c
 	str r2, [sp, #4]
 	mov r2, ip, asr #0x1f
 	str r2, [sp, #8]
-	mov r2, sb, asr #0x1f
+	mov r2, r9, asr #0x1f
 	str r2, [sp, #0x8c]
 	ldr r6, [r0, #0x14]
 	ldr r7, [r0, #0x10]
@@ -1480,31 +1480,31 @@ func_01ff927c: ; 0x01ff927c
 	mla r3, r4, lr, r3
 	ldr r2, [sp, #0x18]
 	mla r3, r2, r8, r3
-	umull r8, r2, r5, sb
+	umull r8, r2, r5, r9
 	str r8, [sp, #0x20]
 	ldr r8, [sp, #0x8c]
 	mla r2, r5, r8, r2
 	ldr r8, [sp, #0x14]
-	mla r2, r8, sb, r2
+	mla r2, r8, r9, r2
 	ldr r8, [sp, #8]
-	umull lr, sb, r7, ip
-	mla sb, r7, r8, sb
+	umull lr, r9, r7, ip
+	mla r9, r7, r8, r9
 	ldr r8, [sp, #0x10]
-	mla sb, r8, ip, sb
+	mla r9, r8, ip, r9
 	umull ip, r8, r6, r11
 	adds lr, lr, ip
 	ldr ip, [sp, #4]
 	mla r8, r6, ip, r8
 	ldr ip, [sp, #0xc]
 	mla r8, ip, r11, r8
-	adc sb, sb, r8
+	adc r9, r9, r8
 	ldr r8, [sp, #0x20]
 	adds r11, r8, lr
-	adc r8, r2, sb
+	adc r8, r2, r9
 	ldr r2, [sp, #0x1c]
-	adds sb, r2, r11
+	adds r9, r2, r11
 	adc r2, r3, r8
-	mov r3, sb, lsr #0xc
+	mov r3, r9, lsr #0xc
 	orr r3, r3, r2, lsl #20
 	str r3, [r10, #0x18]
 	ldr r2, [r1, #0x14]
@@ -1512,9 +1512,9 @@ func_01ff927c: ; 0x01ff927c
 	smull r11, r2, r6, r2
 	smlal r11, r2, r7, r3
 	ldr r8, [r1, #0x24]
-	ldr sb, [r1, #0x34]
+	ldr r9, [r1, #0x34]
 	smlal r11, r2, r5, r8
-	smlal r11, r2, r4, sb
+	smlal r11, r2, r4, r9
 	mov r3, r11, lsr #0xc
 	orr r3, r3, r2, lsl #20
 	str r3, [r10, #0x14]
@@ -1523,15 +1523,15 @@ func_01ff927c: ; 0x01ff927c
 	smull r11, r2, r6, r2
 	smlal r11, r2, r7, r3
 	ldr r8, [r1, #0x2c]
-	ldr sb, [r1, #0x3c]
+	ldr r9, [r1, #0x3c]
 	smlal r11, r2, r5, r8
-	smlal r11, r2, r4, sb
+	smlal r11, r2, r4, r9
 	mov r3, r11, lsr #0xc
 	orr r3, r3, r2, lsl #20
 	str r3, [r10, #0x1c]
-	ldr sb, [r1, #0x10]
+	ldr r9, [r1, #0x10]
 	ldr r11, [r1, #0x30]
-	smull ip, r8, r6, sb
+	smull ip, r8, r6, r9
 	ldr r3, [r1]
 	ldr r2, [r1, #0x20]
 	smlal ip, r8, r7, r3
@@ -1541,7 +1541,7 @@ func_01ff927c: ; 0x01ff927c
 	orr r4, r4, r8, lsl #20
 	str r4, [r10, #0x10]
 	mov r4, r3, asr #0x1f
-	mov r5, sb, asr #0x1f
+	mov r5, r9, asr #0x1f
 	str r4, [sp, #0x28]
 	mov r4, r2, asr #0x1f
 	str r5, [sp, #0x24]
@@ -1576,21 +1576,21 @@ func_01ff927c: ; 0x01ff927c
 	mla ip, r8, r2, ip
 	ldr r2, [sp, #0x30]
 	mla ip, r2, r3, ip
-	umull r3, r11, r7, sb
+	umull r3, r11, r7, r9
 	ldr r2, [sp, #0x44]
 	adds r3, r2, r3
 	ldr r2, [sp, #0x24]
 	mla r11, r7, r2, r11
 	ldr r2, [sp, #0x90]
-	mla r11, r2, sb, r11
+	mla r11, r2, r9, r11
 	ldr r2, [sp, #0x40]
-	adc sb, ip, r11
+	adc r9, ip, r11
 	adds r11, r2, r3
 	ldr r2, [sp, #0x3c]
-	adc r3, lr, sb
-	adds sb, r2, r11
+	adc r3, lr, r9
+	adds r9, r2, r11
 	adc r2, r4, r3
-	mov r3, sb, lsr #0xc
+	mov r3, r9, lsr #0xc
 	orr r3, r3, r2, lsl #20
 	str r3, [r10, #0x20]
 	ldr r2, [r1, #0x14]
@@ -1605,8 +1605,8 @@ func_01ff927c: ; 0x01ff927c
 	mla r11, r2, r3, r11
 	smlal ip, r11, r8, lr
 	smlal ip, r11, r6, r4
-	ldr sb, [r1, #0x34]
-	smlal ip, r11, r5, sb
+	ldr r9, [r1, #0x34]
+	smlal ip, r11, r5, r9
 	mov r2, ip, lsr #0xc
 	orr r2, r2, r11, lsl #20
 	str r2, [r10, #0x24]
@@ -1622,8 +1622,8 @@ func_01ff927c: ; 0x01ff927c
 	mla r11, r2, r3, r11
 	smlal ip, r11, r8, lr
 	smlal ip, r11, r6, r4
-	ldr sb, [r1, #0x3c]
-	smlal ip, r11, r5, sb
+	ldr r9, [r1, #0x3c]
+	smlal ip, r11, r5, r9
 	mov r2, ip, lsr #0xc
 	orr r2, r2, r11, lsl #20
 	str r2, [r10, #0x2c]
@@ -1637,8 +1637,8 @@ func_01ff927c: ; 0x01ff927c
 	ldr r2, [r1, #8]
 	mla r3, r7, r11, r3
 	smlal r4, r3, r8, r2
-	ldr sb, [r1, #0x28]
-	smlal r4, r3, r6, sb
+	ldr r9, [r1, #0x28]
+	smlal r4, r3, r6, r9
 	ldr r6, [sp, #0x50]
 	smlal r4, r3, r5, r6
 	mov r4, r4, lsr #0xc
@@ -1654,7 +1654,7 @@ func_01ff927c: ; 0x01ff927c
 	str r2, [sp, #0x58]
 	ldr r2, [r0, #0x38]
 	ldr ip, [r0, #0x3c]
-	smlal r6, r5, r2, sb
+	smlal r6, r5, r2, r9
 	ldr r0, [sp, #0x50]
 	smlal r6, r5, ip, r0
 	mov r0, r6, lsr #0xc
@@ -1667,26 +1667,26 @@ func_01ff927c: ; 0x01ff927c
 	ldr r8, [r1, #0x24]
 	ldr r7, [r1, #4]
 	mov r0, r8, asr #0x1f
-	ldr sb, [r1, #0x34]
+	ldr r9, [r1, #0x34]
 	str r0, [sp, #0x98]
 	mov r0, r7, asr #0x1f
 	ldr r6, [r1, #0x14]
 	str r0, [sp, #0x6c]
 	mov r0, r6, asr #0x1f
 	str r0, [sp, #0x70]
-	umull r0, r11, ip, sb
-	mov lr, sb, asr #0x1f
+	umull r0, r11, ip, r9
+	mov lr, r9, asr #0x1f
 	str r0, [sp, #0x64]
 	mla r11, ip, lr, r11
 	ldr r0, [sp, #0x60]
 	add r5, sp, #0xa8
-	mla r11, r0, sb, r11
-	umull r0, sb, r2, r8
+	mla r11, r0, r9, r11
+	umull r0, r9, r2, r8
 	str r0, [sp, #0x94]
 	ldr r0, [sp, #0x98]
-	mla sb, r2, r0, sb
+	mla r9, r2, r0, r9
 	ldr r0, [sp, #0x5c]
-	mla sb, r0, r8, sb
+	mla r9, r0, r8, r9
 	umull r0, r8, r3, r7
 	str r0, [sp, #0x68]
 	ldr r0, [sp, #0x6c]
@@ -1704,14 +1704,14 @@ func_01ff927c: ; 0x01ff927c
 	adc r6, r8, lr
 	adds r7, r0, r7
 	ldr r0, [sp, #0x64]
-	adc r6, sb, r6
+	adc r6, r9, r6
 	adds r7, r0, r7
 	adc r0, r11, r6
 	mov r6, r7, lsr #0xc
 	orr r6, r6, r0, lsl #20
 	str r6, [r10, #0x34]
 	ldr r8, [r1, #0x20]
-	ldr sb, [r1, #0x30]
+	ldr r9, [r1, #0x30]
 	mov r0, r8, asr #0x1f
 	ldr r7, [r1]
 	str r0, [sp, #0xa0]
@@ -1720,18 +1720,18 @@ func_01ff927c: ; 0x01ff927c
 	str r0, [sp, #0x7c]
 	mov r0, r6, asr #0x1f
 	str r0, [sp, #0x80]
-	umull r0, r11, ip, sb
-	mov lr, sb, asr #0x1f
+	umull r0, r11, ip, r9
+	mov lr, r9, asr #0x1f
 	str r0, [sp, #0x74]
 	mla r11, ip, lr, r11
 	ldr r0, [sp, #0x60]
-	mla r11, r0, sb, r11
-	umull r0, sb, r2, r8
+	mla r11, r0, r9, r11
+	umull r0, r9, r2, r8
 	str r0, [sp, #0x9c]
 	ldr r0, [sp, #0xa0]
-	mla sb, r2, r0, sb
+	mla r9, r2, r0, r9
 	ldr r0, [sp, #0x5c]
-	mla sb, r0, r8, sb
+	mla r9, r0, r8, r9
 	umull r0, r8, r3, r7
 	str r0, [sp, #0x78]
 	ldr r0, [sp, #0x7c]
@@ -1749,7 +1749,7 @@ func_01ff927c: ; 0x01ff927c
 	adc r6, r8, lr
 	adds r7, r0, r7
 	ldr r0, [sp, #0x74]
-	adc r6, sb, r6
+	adc r6, r9, r6
 	adds r7, r0, r7
 	adc r0, r11, r6
 	mov r6, r7, lsr #0xc
@@ -1767,7 +1767,7 @@ func_01ff927c: ; 0x01ff927c
 	mov lr, r6, asr #0x1f
 	mov r1, r0, asr #0x1f
 	str r1, [sp, #0xa4]
-	umull sb, r1, ip, r8
+	umull r9, r1, ip, r8
 	mla r1, ip, r11, r1
 	ldr r11, [sp, #0x60]
 	mla r1, r11, r8, r1
@@ -1789,14 +1789,14 @@ func_01ff927c: ; 0x01ff927c
 	adc r0, r2, r3
 	adds r2, ip, r4
 	adc r0, r11, r0
-	adds r2, sb, r2
+	adds r2, r9, r2
 	adc r0, r1, r0
 	mov r1, r2, lsr #0xc
 	orr r1, r1, r0, lsl #20
 	cmp r10, r5
 	addne sp, sp, #0xe8
 	str r1, [r10, #0x3c]
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r4, [sp]
 	ldmia r5!, {r0, r1, r2, r3}
 	stmia r4!, {r0, r1, r2, r3}
@@ -1810,7 +1810,7 @@ func_01ff927c: ; 0x01ff927c
 	stmia r4, {r0, r1, r2, r3}
 	str r4, [sp]
 	add sp, sp, #0xe8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	arm_func_end func_01ff927c
 
 	.global Divide
@@ -2225,7 +2225,7 @@ _01ff9d48: .word 0x040002b4
 	.global func_01ff9d4c
 	arm_func_start func_01ff9d4c
 func_01ff9d4c: ; 0x01ff9d4c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	ldr r2, [r0, #4]
 	ldr r3, [r0]
 	smull r6, r5, r2, r2
@@ -2259,15 +2259,15 @@ _01ff9dc0:
 	ldrh r2, [r3]
 	tst r2, #0x8000
 	bne _01ff9dc0
-	ldr sb, _01ff9e60 ; =0x040002a0
+	ldr r9, _01ff9e60 ; =0x040002a0
 	ldr r5, [r0]
-	ldr r8, [sb]
+	ldr r8, [r9]
 	mov r7, ip, asr #0x1f
 	umull r3, r2, r8, ip
 	umull r6, lr, r3, r5
 	mov r4, r5, asr #0x1f
 	mla r2, r8, r7, r2
-	ldr r7, [sb, #4]
+	ldr r7, [r9, #4]
 	mla lr, r3, r4, lr
 	mla r2, r7, ip, r2
 	mla lr, r2, r5, lr
@@ -2293,7 +2293,7 @@ _01ff9dc0:
 	adc r0, lr, #0x1000
 	mov r0, r0, asr #0xd
 	str r0, [r1, #8]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_01ff9d4c
 _01ff9e58: .word 0x04000280
@@ -2883,7 +2883,7 @@ _01ffa5ac:
 	ldmib sp!, {r2, r3}
 	stmib r0!, {r2, r3}
 	ldmib sp!, {r2, r3, ip, lr}
-    stmib r0!, {r2, r3, r4, r5, r6, r7, r8, sb, r10, r11, ip, sp, lr} ^
+    stmib r0!, {r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, ip, sp, lr} ^
 	stmib r0!, {lr}
 	mov r3, #0xd3
 	msr cpsr_c, r3 ; 16
@@ -2900,7 +2900,7 @@ _01ffa5ac:
 	ldr r2, [r1, #0]!
 	msr spsr_cf, r2 ; 9
 	ldr lr, [r1, #0x40]
-	ldmib r1, {r0, r1, r2, r3, r4, r5, r6, r7, r8, sb, r10, r11, ip, sp, lr} ^
+	ldmib r1, {r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, ip, sp, lr} ^
 	mov r0, r0
 	stmda sp!, {r0, r1, r2, r3, ip, lr}
 	ldmia sp!, {pc}
@@ -2976,7 +2976,7 @@ _01ffa6ec:
 	ldr ip, [r3, #0x24]
 	mov lr, ip
 	ldr r11, _01ffa730 ; =0x027fff80
-	ldmia r11, {r0, r1, r2, r3, r4, r5, r6, r7, r8, sb, r10}
+	ldmia r11, {r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10}
 	mov r11, #0
 	bx ip
 	.align 2, 0
@@ -3004,7 +3004,7 @@ _01ffa744:
 	.global func_01ffa754
 	arm_func_start func_01ffa754
 func_01ffa754: ; 0x01ffa754
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	ldr r1, _01ffa7f4 ; =0x027ffc2c
 	ldr r4, [r1]
 	cmp r4, #0x8000
@@ -3019,7 +3019,7 @@ _01ffa778:
 	ldr r6, [r0, #8]
 	ldr r7, [r0, #0xc]
 	ldr r8, [r0, #0x10]
-	ldr sb, [r0, #0x18]
+	ldr r9, [r0, #0x18]
 	ldr r10, [r0, #0x1c]
 	bl func_0200ee4c
 	mov r11, r0
@@ -3041,11 +3041,11 @@ _01ffa7d0:
 	mov r1, r6
 	mov r2, r7
 	bl func_01ffa7fc
-	mov r1, sb
+	mov r1, r9
 	mov r2, r10
 	add r0, r8, r4
 	bl func_01ffa7fc
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_01ffa754
 _01ffa7f4: .word 0x027ffc2c
@@ -3054,7 +3054,7 @@ _01ffa7f8: .word 0x027ffe20
 	.global func_01ffa7fc
 	arm_func_start func_01ffa7fc
 func_01ffa7fc: ; 0x01ffa7fc
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	ldr r4, _01ffa8c0 ; =0x027ffe60
 	ldr r3, _01ffa8c4 ; =0x000001ff
 	ldr r5, [r4]
@@ -3072,9 +3072,9 @@ _01ffa820:
 	strb r4, [r7]
 	cmp ip, r2
 	add r0, r0, ip
-	ldmgeia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmgeia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	ldr r4, _01ffa8d0 ; =0x04100010
-	mov sb, r0, lsr #0x8
+	mov r9, r0, lsr #0x8
 	mov r6, #0xb7
 	mov r5, #0
 _01ffa854:
@@ -3083,7 +3083,7 @@ _01ffa854:
 	strb lr, [r7, #8]
 	mov lr, r0, lsr #0x10
 	strb lr, [r7, #9]
-	strb sb, [r7, #0xa]
+	strb r9, [r7, #0xa]
 	strb r0, [r7, #0xb]
 	strb r5, [r7, #0xc]
 	strb r5, [r7, #0xd]
@@ -3104,10 +3104,10 @@ _01ffa8a4:
 	tst r8, #0x80000000
 	bne _01ffa880
 	cmp ip, r2
-	add sb, sb, #2
+	add r9, r9, #2
 	add r0, r0, #0x200
 	blt _01ffa854
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_01ffa7fc
 _01ffa8c0: .word 0x027ffe60
@@ -4047,11 +4047,11 @@ data_01ffb38f: ; 0x01ffb38f
 	.global func_01ffb390
 	arm_func_start func_01ffb390
 func_01ffb390: ; 0x01ffb390
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x14
 	mov r10, r0
 	ldr r0, [r10]
-	mov sb, r1
+	mov r9, r1
 	ldrb r6, [r0, #1]
 	mov r4, #4
 	strb r6, [r10, #0xae]
@@ -4060,11 +4060,11 @@ func_01ffb390: ; 0x01ffb390
 	str r0, [r10, #8]
 	tst r0, #0x400
 	beq _01ffb418
-	cmp sb, #0x40
-	cmpne sb, #0x60
+	cmp r9, #0x40
+	cmpne r9, #0x60
 	addeq r4, r4, #1
-	cmp sb, #0x20
-	cmpne sb, #0x60
+	cmp r9, #0x20
+	cmpne r9, #0x60
 	bne _01ffb404
 	tst r0, #0x100
 	add r4, r4, #1
@@ -4081,13 +4081,13 @@ _01ffb404:
 	add sp, sp, #0x14
 	add r0, r0, r4
 	str r0, [r10]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _01ffb418:
-	cmp sb, #0x40
-	cmpne sb, #0x60
+	cmp r9, #0x40
+	cmpne r9, #0x60
 	bne _01ffb45c
 	ldr r0, [r10]
-	cmp sb, #0x40
+	cmp r9, #0x40
 	ldreqb r0, [r0, #4]
 	add r4, r4, #1
 	streq r0, [sp, #0xc]
@@ -4311,8 +4311,8 @@ _01ffb72c:
 	ldr r0, [r10, #8]
 	and r0, r0, #0x40
 _01ffb75c:
-	cmp sb, #0x20
-	cmpne sb, #0x60
+	cmp r9, #0x20
+	cmpne r9, #0x60
 	bne _01ffb79c
 	cmp r0, #0
 	add r4, r4, #1
@@ -4332,7 +4332,7 @@ _01ffb79c:
 	add r0, r0, r4
 	str r0, [r10]
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_01ffb390
 _01ffb7b0: .word data_01ffb36c
@@ -4360,7 +4360,7 @@ _01ffb7e8: .word data_027e0000
 	.global func_01ffb7ec
 	arm_func_start func_01ffb7ec
 func_01ffb7ec: ; 0x01ffb7ec
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x30
 	ldrh r4, [sp, #0x58]
 	mov r10, r0
@@ -4371,7 +4371,7 @@ func_01ffb7ec: ; 0x01ffb7ec
 	mov r0, r0, lsl #0x1
 	mov r11, r1
 	ldrsh r1, [lr, r0]
-	mov sb, r2
+	mov r9, r2
 	mov r8, r3
 	cmp r1, #0
 	ldr r7, [sp, #0x60]
@@ -4440,7 +4440,7 @@ _01ffb90c:
 	movs r1, r0
 	beq _01ffb980
 	ldr r0, [r7]
-	sub r0, sb, r0
+	sub r0, r9, r0
 	bl Divide
 	mov r10, r0
 	b _01ffb980
@@ -4451,7 +4451,7 @@ _01ffb934:
 	movs r1, r0
 	beq _01ffb980
 	ldr r0, [r7, #4]
-	sub r0, sb, r0
+	sub r0, r9, r0
 	bl Divide
 	mov r10, r0
 	b _01ffb980
@@ -4462,7 +4462,7 @@ _01ffb95c:
 	movs r1, r0
 	beq _01ffb980
 	ldr r0, [r7, #8]
-	sub r0, sb, r0
+	sub r0, r9, r0
 	bl Divide
 	mov r10, r0
 _01ffb980:
@@ -4471,7 +4471,7 @@ _01ffb980:
 	cmp r8, #0x58
 	bne _01ffb9fc
 	ldr r0, [r7]
-	subs r1, sb, r0
+	subs r1, r9, r0
 	beq _01ffb9fc
 	mov r0, r10
 	bl Divide
@@ -4501,7 +4501,7 @@ _01ffb9fc:
 	cmp r8, #0x59
 	bne _01ffba74
 	ldr r0, [r7, #4]
-	subs r1, sb, r0
+	subs r1, r9, r0
 	beq _01ffba74
 	mov r0, r10
 	bl Divide
@@ -4532,7 +4532,7 @@ _01ffba74:
 	cmp r8, #0x5a
 	bne _01ffbaec
 	ldr r0, [r7, #8]
-	subs r1, sb, r0
+	subs r1, r9, r0
 	beq _01ffbaec
 	mov r0, r10
 	bl Divide
@@ -4587,7 +4587,7 @@ _01ffbafc:
 	str r6, [sp, #4]
 	str r2, [sp, #8]
 	cmp r8, #0x58
-	streq sb, [r5]
+	streq r9, [r5]
 	beq _01ffbb74
 	add r0, sp, #0x24
 	add r1, sp, #0
@@ -4597,7 +4597,7 @@ _01ffbafc:
 	str r0, [r5]
 _01ffbb74:
 	cmp r8, #0x59
-	streq sb, [r5, #4]
+	streq r9, [r5, #4]
 	beq _01ffbb98
 	add r0, sp, #0x18
 	add r1, sp, #0
@@ -4608,8 +4608,8 @@ _01ffbb74:
 _01ffbb98:
 	cmp r8, #0x5a
 	addeq sp, sp, #0x30
-	streq sb, [r5, #8]
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	streq r9, [r5, #8]
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r0, sp, #0xc
 	add r1, sp, #0
 	bl func_01ff9c2c
@@ -4617,7 +4617,7 @@ _01ffbb98:
 	add r0, r1, r0
 	str r0, [r5, #8]
 	add sp, sp, #0x30
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_01ffb7ec
 _01ffbbc8: .word data_02050f54
@@ -4889,7 +4889,7 @@ func_01ffbe78: ; 0x01ffbe78
 	.global func_01ffbf5c
 	arm_func_start func_01ffbf5c
 func_01ffbf5c: ; 0x01ffbf5c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x3c
 	ldr r8, [sp, #0x60]
 	ldr r7, [sp, #0x64]
@@ -4899,12 +4899,12 @@ func_01ffbf5c: ; 0x01ffbf5c
 	cmp r8, #0
 	str r3, [sp, #0x10]
 	mov r11, r1
-	mov sb, r2
+	mov r9, r2
 	addlt sp, sp, #0x3c
 	movlt r0, #0
-	ldmltia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmltia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r2, sp, #0x30
-	mov r0, sb
+	mov r0, r9
 	mov r1, r3
 	bl func_01ff9bf8
 	add r0, sp, #0x30
@@ -4923,11 +4923,11 @@ func_01ffbf5c: ; 0x01ffbf5c
 	ldr r3, [sp, #0x10]
 	mov r0, r10
 	mov r1, r11
-	mov r2, sb
+	mov r2, r9
 	str r5, [sp, #0xc]
 	bl func_01ffc118
 	add sp, sp, #0x3c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _01ffbff8:
 	ldrb r0, [sp, #0x70]
 	cmp r0, #0
@@ -4961,7 +4961,7 @@ _01ffbff8:
 _01ffc06c:
 	ldr r2, [sp, #0x14]
 	add r0, sp, #0x18
-	mov r1, sb
+	mov r1, r9
 	bl func_0202b2e8
 	cmp r0, #0
 	str r8, [sp]
@@ -4977,7 +4977,7 @@ _01ffc06c:
 	cmp r0, #0
 	addne sp, sp, #0x3c
 	movne r0, #1
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	cmp r4, #0
 	beq _01ffc0d8
 	ldr r0, [sp, #0x18]
@@ -4991,7 +4991,7 @@ _01ffc0d8:
 	bne _01ffc06c
 	add sp, sp, #0x3c
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _01ffc0ec:
 	str r8, [sp]
 	str r7, [sp, #4]
@@ -4999,17 +4999,17 @@ _01ffc0ec:
 	ldr r3, [sp, #0x10]
 	mov r0, r10
 	mov r1, r11
-	mov r2, sb
+	mov r2, r9
 	str r5, [sp, #0xc]
 	bl func_01ffd1e0
 	add sp, sp, #0x3c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	arm_func_end func_01ffbf5c
 
 	.global func_01ffc118
 	arm_func_start func_01ffc118
 func_01ffc118: ; 0x01ffc118
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x2b8
 	str r2, [sp, #0x18]
 	ldr r2, [sp, #0x2e8]
@@ -5029,7 +5029,7 @@ func_01ffc118: ; 0x01ffc118
 	str r0, [sp, #0x54]
 	str r0, [sp, #0x254]
 	ldr r0, [sp, #0x58]
-	mov sb, r3
+	mov r9, r3
 	str r0, [sp, #0x25c]
 	ldr r0, [sp, #0x2e8]
 	ldr r7, [sp, #0x2e4]
@@ -5176,7 +5176,7 @@ _01ffc31c:
 	cmp r0, #0
 	beq _01ffc508
 _01ffc398:
-	ldmia sb, {r0, r1, r2}
+	ldmia r9, {r0, r1, r2}
 	add ip, sp, #0x154
 	stmia ip, {r0, r1, r2}
 	mov r1, #0
@@ -5199,7 +5199,7 @@ _01ffc398:
 	cmp r0, #0
 	bne _01ffc508
 	add r3, sp, #0x138
-	ldmia sb, {r0, r1, r2}
+	ldmia r9, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
 	ldr r0, [sp, #0x18]
 	mov r1, r3
@@ -5223,7 +5223,7 @@ _01ffc398:
 	mov r0, #1
 	str r0, [sp, #0x58]
 	add r3, sp, #0x230
-	ldmia sb, {r0, r1, r2}
+	ldmia r9, {r0, r1, r2}
 	mov ip, r3
 	stmia ip, {r0, r1, r2}
 	add r0, sp, #0x260
@@ -5296,28 +5296,28 @@ _01ffc530:
 	ldmia r5, {r0, r1, r2}
 	stmia r4, {r0, r1, r2}
 	ldr r3, [sp, #0x218]
-	ldr r0, [sb]
+	ldr r0, [r9]
 	add r4, sp, #0x1f4
 	cmp r3, r0
 	strge r0, [sp, #0x218]
-	ldr r1, [sb, #4]
+	ldr r1, [r9, #4]
 	ldr r0, [sp, #0x21c]
 	add r3, sp, #0x200
 	cmp r0, r1
 	strge r1, [sp, #0x21c]
-	ldr r1, [sb, #8]
+	ldr r1, [r9, #8]
 	ldr r0, [sp, #0x220]
 	cmp r0, r1
 	strge r1, [sp, #0x220]
-	ldr r1, [sb]
+	ldr r1, [r9]
 	ldr r0, [sp, #0x20c]
 	cmp r0, r1
 	strle r1, [sp, #0x20c]
-	ldr r1, [sb, #4]
+	ldr r1, [r9, #4]
 	ldr r0, [sp, #0x210]
 	cmp r0, r1
 	strle r1, [sp, #0x210]
-	ldr r1, [sb, #8]
+	ldr r1, [r9, #8]
 	ldr r0, [sp, #0x214]
 	cmp r0, r1
 	add r0, sp, #0x218
@@ -5379,7 +5379,7 @@ _01ffc620:
 	add r0, sp, #0x68
 	add r3, sp, #0x11c
 	strh r1, [r0, #0xb0]
-	ldmia sb, {r0, r1, r2}
+	ldmia r9, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
 	mov r0, r11
 	ldr r3, [r0]
@@ -5399,7 +5399,7 @@ _01ffc6e4:
 	ldr r0, _01ffd1d4 ; =data_027e0e64
 	mov r1, r5, lsl #0x1
 	ldrh r6, [r0, r1]
-	ldmia sb, {r0, r1, r2}
+	ldmia r9, {r0, r1, r2}
 	strh r6, [sp, #0xfc]
 	add r6, sp, #0x10c
 	stmia r6, {r0, r1, r2}
@@ -5417,7 +5417,7 @@ _01ffc6e4:
 	b _01ffc8e4
 _01ffc73c:
 	add r3, sp, #0x1dc
-	ldmia sb, {r0, r1, r2}
+	ldmia r9, {r0, r1, r2}
 	mov r6, r3
 	stmia r6, {r0, r1, r2}
 	add r0, sp, #0x260
@@ -5441,7 +5441,7 @@ _01ffc73c:
 	ldr r0, _01ffd1d4 ; =data_027e0e64
 	mov r3, #0
 	ldrh r6, [r0, r1]
-	ldmia sb, {r0, r1, r2}
+	ldmia r9, {r0, r1, r2}
 	strh r6, [sp, #0xe0]
 	add r6, sp, #0xf0
 	stmia r6, {r0, r1, r2}
@@ -5485,7 +5485,7 @@ _01ffc840:
 	ldr r0, _01ffd1d4 ; =data_027e0e64
 	mov r3, #1
 	ldrh r6, [r0, r1]
-	ldmia sb, {r0, r1, r2}
+	ldmia r9, {r0, r1, r2}
 	strh r6, [sp, #0xc4]
 	add r6, sp, #0xd4
 	stmia r6, {r0, r1, r2}
@@ -5533,7 +5533,7 @@ _01ffc8f4:
 	cmp r0, #0
 	beq _01ffc998
 	add r0, sp, #0x260
-	mov r1, sb
+	mov r1, r9
 	bl func_01fffb80
 	smull r2, r1, r8, r8
 	adds r2, r2, #0x800
@@ -5552,7 +5552,7 @@ _01ffc8f4:
 	str r0, [sp, #8]
 	ldr r0, [sp, #0x14]
 	mov r1, r10
-	mov r3, sb
+	mov r3, r9
 	str r11, [sp, #0xc]
 	mov r4, #1
 	str r4, [sp, #0x10]
@@ -5560,7 +5560,7 @@ _01ffc8f4:
 	cmp r0, #0
 	addne sp, sp, #0x2b8
 	movne r0, r4
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r1, [sp, #0x260]
 	mov r0, r4
 	str r1, [r10]
@@ -5569,7 +5569,7 @@ _01ffc8f4:
 	ldr r1, [sp, #0x268]
 	add sp, sp, #0x2b8
 	str r1, [r10, #8]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _01ffc998:
 	ldr r0, [sp, #0x18]
 	add r3, sp, #0x1c4
@@ -5580,28 +5580,28 @@ _01ffc998:
 	ldmia r0, {r0, r1, r2}
 	stmia r4, {r0, r1, r2}
 	ldr r3, [sp, #0x1c4]
-	ldr r0, [sb]
+	ldr r0, [r9]
 	add r4, sp, #0x1a0
 	cmp r3, r0
 	strge r0, [sp, #0x1c4]
-	ldr r1, [sb, #4]
+	ldr r1, [r9, #4]
 	ldr r0, [sp, #0x1c8]
 	add r3, sp, #0x1ac
 	cmp r0, r1
 	strge r1, [sp, #0x1c8]
-	ldr r1, [sb, #8]
+	ldr r1, [r9, #8]
 	ldr r0, [sp, #0x1cc]
 	cmp r0, r1
 	strge r1, [sp, #0x1cc]
-	ldr r1, [sb]
+	ldr r1, [r9]
 	ldr r0, [sp, #0x1b8]
 	cmp r0, r1
 	strle r1, [sp, #0x1b8]
-	ldr r1, [sb, #4]
+	ldr r1, [r9, #4]
 	ldr r0, [sp, #0x1bc]
 	cmp r0, r1
 	strle r1, [sp, #0x1bc]
-	ldr r1, [sb, #8]
+	ldr r1, [r9, #8]
 	ldr r0, [sp, #0x1c0]
 	cmp r0, r1
 	add r0, sp, #0x1c4
@@ -5719,14 +5719,14 @@ _01ffcab4:
 	ldr r0, _01ffd1d0 ; =data_027e0f6c
 	ldr r3, [r0]
 	add r0, sp, #0x260
-	ldr sb, [r3, #0x20]
+	ldr r9, [r3, #0x20]
 	mov r3, #0x4c
 	mul r7, r6, r3
-	add r3, sb, r7
-	ldrh sb, [sb, r7]
+	add r3, r9, r7
+	ldrh r9, [r9, r7]
 	ldrh r7, [r3, #2]
 	ldmia r0, {r0, r1, r2}
-	strh sb, [r5, #4]
+	strh r9, [r5, #4]
 	strh r7, [r5, #6]
 	ldrh r7, [r3, #4]
 	strh r7, [r5, #8]
@@ -5846,7 +5846,7 @@ _01ffcd90:
 	ble _01ffcf48
 	ldr r6, _01ffd1d4 ; =data_027e0e64
 	add r5, sp, #0x26c
-	add sb, sp, #0x6c
+	add r9, sp, #0x6c
 	add r4, sp, #0x268
 _01ffcdd8:
 	mov r1, r7, lsl #0x1
@@ -5907,7 +5907,7 @@ _01ffcdd8:
 	mov r0, r5
 	add r1, sp, #0x260
 	add r2, sp, #0x254
-	mov r3, sb
+	mov r3, r9
 	bl func_01ffe904
 	cmp r0, #0
 	beq _01ffcf38
@@ -5923,7 +5923,7 @@ _01ffced4:
 	mov r0, r5
 	add r1, sp, #0x98
 	add r2, sp, #0x17c
-	mov r3, sb
+	mov r3, r9
 	bl func_01ffe904
 	cmp r0, #0
 	moveq r0, #1
@@ -6112,7 +6112,7 @@ _01ffd1b0:
 	bl func_0204f754
 	ldr r0, [sp, #0x58]
 	add sp, sp, #0x2b8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_01ffc118
 _01ffd1d0: .word data_027e0f6c
@@ -6123,7 +6123,7 @@ _01ffd1dc: .word func_ov00_0207e96c
 	.global func_01ffd1e0
 	arm_func_start func_01ffd1e0
 func_01ffd1e0: ; 0x01ffd1e0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x320
 	str r0, [sp, #0x14]
 	mov r0, r2
@@ -6138,10 +6138,10 @@ func_01ffd1e0: ; 0x01ffd1e0
 	stmia r5, {r0, r1, r2}
 	ldr r0, [sp, #0x4c]
 	add r4, sp, #0x2bc
-	mov sb, r3
+	mov r9, r3
 	str r0, [sp, #0x48]
 	str r0, [sp, #0x44]
-	ldmia sb, {r0, r1, r2}
+	ldmia r9, {r0, r1, r2}
 	stmia r4, {r0, r1, r2}
 	mov r0, r5
 	mov r1, r4
@@ -6156,10 +6156,10 @@ func_01ffd1e0: ; 0x01ffd1e0
 	str r0, [sp, #0x40]
 	beq _01ffd678
 	add r4, sp, #0x298
-	ldmia sb, {r0, r1, r2}
+	ldmia r9, {r0, r1, r2}
 	stmia r4, {r0, r1, r2}
 	add r3, sp, #0x2a4
-	ldmia sb, {r0, r1, r2}
+	ldmia r9, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
 	mov r0, r4
 	mov r1, r5
@@ -6200,7 +6200,7 @@ func_01ffd1e0: ; 0x01ffd1e0
 	ldmia r0, {r0, r1, r2}
 	stmia r4, {r0, r1, r2}
 	add r3, sp, #0x1a0
-	ldmia sb, {r0, r1, r2}
+	ldmia r9, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
 	mov r0, r4
 	mov r1, r3
@@ -6294,13 +6294,13 @@ _01ffd460:
 	andeq r0, r0, #1
 	cmpeq r0, #1
 	beq _01ffd650
-	ldr r1, [sb]
+	ldr r1, [r9]
 	mov r0, r6
 	str r1, [sp, #0x190]
-	ldr r2, [sb, #4]
+	ldr r2, [r9, #4]
 	add r1, sp, #0x190
 	str r2, [sp, #0x194]
-	ldr r3, [sb, #8]
+	ldr r3, [r9, #8]
 	add r2, sp, #0x2b0
 	str r3, [sp, #0x198]
 	str r8, [sp, #0x19c]
@@ -6324,7 +6324,7 @@ _01ffd460:
 	beq _01ffd650
 _01ffd4e4:
 	add ip, sp, #0x184
-	ldmia sb, {r0, r1, r2}
+	ldmia r9, {r0, r1, r2}
 	stmia ip, {r0, r1, r2}
 	mov r1, #0
 	add r0, sp, #0x15c
@@ -6346,7 +6346,7 @@ _01ffd4e4:
 	cmp r0, #0
 	bne _01ffd650
 	ldr r0, [sp, #0x18]
-	mov r1, sb
+	mov r1, r9
 	add r2, sp, #0x278
 	bl func_01ff9bf8
 	mov r0, r5
@@ -6367,7 +6367,7 @@ _01ffd4e4:
 	mov r0, #1
 	str r0, [sp, #0x4c]
 	add r3, sp, #0x260
-	ldmia sb, {r0, r1, r2}
+	ldmia r9, {r0, r1, r2}
 	mov ip, r3
 	stmia ip, {r0, r1, r2}
 	add r0, sp, #0x2c8
@@ -6442,7 +6442,7 @@ _01ffd678:
 	ldmia r6, {r0, r1, r2}
 	stmia r4, {r0, r1, r2}
 	add r3, sp, #0x168
-	ldmia sb, {r0, r1, r2}
+	ldmia r9, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
 	mov r0, r5
 	mov r1, r3
@@ -6464,7 +6464,7 @@ _01ffd678:
 	ldmia r0, {r0, r1, r2}
 	stmia r4, {r0, r1, r2}
 	add r3, sp, #0x150
-	ldmia sb, {r0, r1, r2}
+	ldmia r9, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
 	mov r0, r4
 	mov r1, r3
@@ -6486,13 +6486,13 @@ _01ffd730:
 	ldrne r6, [r4, #8]
 	cmpne r6, r7
 	beq _01ffda08
-	ldr r1, [sb]
+	ldr r1, [r9]
 	mov r0, r4
 	str r1, [sp, #0x140]
-	ldr r2, [sb, #4]
+	ldr r2, [r9, #4]
 	add r1, sp, #0x140
 	str r2, [sp, #0x144]
-	ldr r3, [sb, #8]
+	ldr r3, [r9, #8]
 	add r2, sp, #0x2b0
 	str r3, [sp, #0x148]
 	str r8, [sp, #0x14c]
@@ -6513,7 +6513,7 @@ _01ffd730:
 	add r0, sp, #0x5c
 	add r3, sp, #0x134
 	strh r1, [r0, #0xd4]
-	ldmia sb, {r0, r1, r2}
+	ldmia r9, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
 	mov r0, r11
 	ldr r3, [r0]
@@ -6533,7 +6533,7 @@ _01ffd7fc:
 	ldr r0, _01ffe1bc ; =data_027e0e64
 	mov r1, r5, lsl #0x1
 	ldrh ip, [r0, r1]
-	ldmia sb, {r0, r1, r2}
+	ldmia r9, {r0, r1, r2}
 	add r6, sp, #0x5c
 	strh ip, [r6, #0xb8]
 	add r6, sp, #0x124
@@ -6552,7 +6552,7 @@ _01ffd7fc:
 	b _01ffda08
 _01ffd858:
 	add r3, sp, #0x224
-	ldmia sb, {r0, r1, r2}
+	ldmia r9, {r0, r1, r2}
 	mov r6, r3
 	stmia r6, {r0, r1, r2}
 	add r0, sp, #0x2c8
@@ -6578,7 +6578,7 @@ _01ffd858:
 	ldr r0, _01ffe1bc ; =data_027e0e64
 	mov r3, #0
 	ldrh r6, [r0, r1]
-	ldmia sb, {r0, r1, r2}
+	ldmia r9, {r0, r1, r2}
 	strh r6, [sp, #0xf8]
 	add r6, sp, #0x108
 	stmia r6, {r0, r1, r2}
@@ -6622,7 +6622,7 @@ _01ffd964:
 	ldr r0, _01ffe1bc ; =data_027e0e64
 	mov r3, #1
 	ldrh r6, [r0, r1]
-	ldmia sb, {r0, r1, r2}
+	ldmia r9, {r0, r1, r2}
 	strh r6, [sp, #0xdc]
 	add r6, sp, #0xec
 	stmia r6, {r0, r1, r2}
@@ -6667,10 +6667,10 @@ _01ffda08:
 	blt _01ffd730
 _01ffda18:
 	add r5, sp, #0x200
-	ldmia sb, {r0, r1, r2}
+	ldmia r9, {r0, r1, r2}
 	stmia r5, {r0, r1, r2}
 	add r4, sp, #0x20c
-	ldmia sb, {r0, r1, r2}
+	ldmia r9, {r0, r1, r2}
 	stmia r4, {r0, r1, r2}
 	ldr r0, [sp, #0x18]
 	add r3, sp, #0xd0
@@ -6841,7 +6841,7 @@ _01ffdac4:
 	str r1, [sp, #0x318]
 	ldr r0, [r0, #0x48]
 	str r0, [sp, #0x31c]
-	ldmia sb, {r0, r1, r2}
+	ldmia r9, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
 	add r0, sp, #0x2b0
 	add r3, sp, #0x1e8
@@ -6932,7 +6932,7 @@ _01ffde0c:
 	ldmia r0, {r0, r1, r2}
 	stmia r4, {r0, r1, r2}
 	add r3, sp, #0x98
-	ldmia sb, {r0, r1, r2}
+	ldmia r9, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
 	mov r0, r4
 	mov r1, r3
@@ -6996,13 +6996,13 @@ _01ffde58:
 	ldr r0, [r1, #0x48]
 	str r0, [sp, #0x31c]
 	beq _01ffdf9c
-	ldr r1, [sb]
+	ldr r1, [r9]
 	add r0, sp, #0x2d4
 	str r1, [sp, #0x88]
-	ldr r2, [sb, #4]
+	ldr r2, [r9, #4]
 	add r1, sp, #0x88
 	str r2, [sp, #0x8c]
-	ldr r3, [sb, #8]
+	ldr r3, [r9, #8]
 	add r2, sp, #0x2b0
 	str r3, [sp, #0x90]
 	str r8, [sp, #0x94]
@@ -7090,7 +7090,7 @@ _01ffdfa8:
 	stmia r6, {r0, r1, r2}
 	ldr r0, [sp, #0x14]
 	mov r1, r7
-	mov r2, sb
+	mov r2, r9
 	str r4, [sp, #0x31c]
 	bl func_ov00_02083ef8
 	ldr r1, [sp, #0x1d4]
@@ -7100,7 +7100,7 @@ _01ffdfa8:
 	cmp r11, #0
 	mov r4, #0
 	beq _01ffe138
-	ldmia sb, {r0, r1, r2}
+	ldmia r9, {r0, r1, r2}
 	add r3, sp, #0x1c4
 	stmia r3, {r0, r1, r2}
 	add r5, sp, #0x2b0
@@ -7164,7 +7164,7 @@ _01ffe198:
 	bl func_0204f754
 	ldr r0, [sp, #0x4c]
 	add sp, sp, #0x320
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_01ffd1e0
 _01ffe1b8: .word data_027e0f6c
@@ -7176,11 +7176,11 @@ _01ffe1c8: .word 0x00001922
 	.global func_01ffe1cc
 	arm_func_start func_01ffe1cc
 func_01ffe1cc: ; 0x01ffe1cc
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x84
-	ldr sb, [sp, #0xa8]
+	ldr r9, [sp, #0xa8]
 	ldrh r4, [sp, #0xac]
-	str sb, [sp]
+	str r9, [sp]
 	ldr r8, [sp, #0xb0]
 	str r4, [sp, #4]
 	ldr r4, _01ffe464 ; =data_027e0f6c
@@ -7194,7 +7194,7 @@ func_01ffe1cc: ; 0x01ffe1cc
 	cmp r0, #0
 	addne sp, sp, #0x84
 	movne r0, #1
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldrh r5, [sp, #0xac]
 	tst r5, #4
 	beq _01ffe458
@@ -7295,13 +7295,13 @@ _01ffe314:
 	beq _01ffe43c
 	b _01ffe3b8
 _01ffe39c:
-	cmp sb, #0
-	cmpne sb, #1
+	cmp r9, #0
+	cmpne r9, #1
 	beq _01ffe3b8
 	b _01ffe43c
 _01ffe3ac:
-	cmp sb, #0
-	cmpne sb, #1
+	cmp r9, #0
+	cmpne r9, #1
 	beq _01ffe43c
 _01ffe3b8:
 	ldr r1, [sp, #0x14]
@@ -7338,7 +7338,7 @@ _01ffe3cc:
 _01ffe430:
 	add sp, sp, #0x84
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _01ffe43c:
 	add r5, r5, #1
 	cmp r5, r4
@@ -7351,7 +7351,7 @@ _01ffe448:
 _01ffe458:
 	mov r0, #0
 	add sp, sp, #0x84
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_01ffe1cc
 _01ffe464: .word data_027e0f6c
@@ -7359,7 +7359,7 @@ _01ffe464: .word data_027e0f6c
 	.global func_01ffe468
 	arm_func_start func_01ffe468
 func_01ffe468: ; 0x01ffe468
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0xc
 	mov r6, r0
 	mov r5, r2
@@ -7376,7 +7376,7 @@ func_01ffe468: ; 0x01ffe468
 	str r0, [r4]
 	add sp, sp, #0xc
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _01ffe4b0:
 	rsb r0, r0, #0
 	bl func_01ff992c
@@ -7410,25 +7410,25 @@ _01ffe518:
 	str r0, [r4]
 	add sp, sp, #0xc
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _01ffe530:
 	ldr lr, [r6, #0xac]
-	ldr sb, [r6, #0x8c]
+	ldr r9, [r6, #0x8c]
 	umull r8, r7, lr, ip
 	ldr r3, [sp]
 	mla r7, lr, r2, r7
-	smull r3, r2, sb, r3
+	smull r3, r2, r9, r3
 	adds r3, r3, #0x800
 	mov lr, lr, asr #0x1f
 	adc r2, r2, #0
 	adds r8, r8, #0x800
 	mla r7, lr, ip, r7
-	mov sb, r3, lsr #0xc
+	mov r9, r3, lsr #0xc
 	adc r3, r7, #0
 	mov r7, r8, lsr #0xc
-	orr sb, sb, r2, lsl #20
+	orr r9, r9, r2, lsl #20
 	orr r7, r7, r3, lsl #20
-	add r3, sb, r7
+	add r3, r9, r7
 	umull r8, r7, r0, r3
 	mov r2, r3, asr #0x1f
 	mla r7, r0, r2, r7
@@ -7470,7 +7470,7 @@ _01ffe530:
 	str r0, [r4]
 	mov r0, #1
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	arm_func_end func_01ffe468
 
 	.global func_01ffe61c
@@ -7500,15 +7500,15 @@ func_01ffe61c: ; 0x01ffe61c
 	.global func_01ffe668
 	arm_func_start func_01ffe668
 func_01ffe668: ; 0x01ffe668
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x2c
 	mov r10, r0
 	add r0, r10, #8
-	mov sb, r1
+	mov r9, r1
 	str r2, [sp]
 	bl func_01ff9c2c
 	ldr r2, [r10, #0x14]
-	ldr r1, [sb, #0xc]
+	ldr r1, [r9, #0xc]
 	sub r0, r0, r2
 	str r0, [sp, #4]
 	cmp r0, r1
@@ -7518,7 +7518,7 @@ func_01ffe668: ; 0x01ffe668
 _01ffe6a4:
 	add sp, sp, #0x2c
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _01ffe6b0:
 	mov r5, #0
 	mov r6, r5
@@ -7527,19 +7527,19 @@ _01ffe6b0:
 	mov r8, r5
 	add r4, r10, #0x18
 _01ffe6c8:
-	mov r1, sb
+	mov r1, r9
 	add r0, r4, r8, lsl #4
 	bl func_01ff9c2c
 	add r1, r10, r8, lsl #4
 	ldr r2, [r1, #0x24]
-	ldr r1, [sb, #0xc]
+	ldr r1, [r9, #0xc]
 	sub r2, r0, r2
 	add r0, sp, #0x20
 	cmp r2, r1
 	str r2, [r0, r8, lsl #2]
 	addge sp, sp, #0x2c
 	movge r0, #0
-	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmgeia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r0, r8, #1
 	mov r0, r0, lsl #0x10
 	cmp r2, r5
@@ -7552,7 +7552,7 @@ _01ffe6c8:
 	cmp r8, #3
 	blo _01ffe6c8
 	cmp r5, #0
-	ldr r2, [sb, #0xc]
+	ldr r2, [r9, #0xc]
 	bne _01ffe750
 	ldr r1, [sp, #4]
 	mov r0, #1
@@ -7560,7 +7560,7 @@ _01ffe6c8:
 	ldr r1, [sp]
 	add sp, sp, #0x2c
 	str r2, [r1]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _01ffe750:
 	ldr r0, [sp, #4]
 	smull r4, r3, r0, r0
@@ -7579,7 +7579,7 @@ _01ffe750:
 	cmp r5, r8
 	addgt sp, sp, #0x2c
 	movgt r0, #0
-	ldmgtia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmgtia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	cmp r7, #1
 	bne _01ffe874
 	add r0, r6, #1
@@ -7605,7 +7605,7 @@ _01ffe750:
 	mov r0, #0xc
 	mla r0, r1, r0, r2
 	add r2, sp, #8
-	mov r1, sb
+	mov r1, r9
 	bl func_01ff9bf8
 	add r0, sp, #0x14
 	add r1, sp, #8
@@ -7625,17 +7625,17 @@ _01ffe750:
 	orr r1, r1, r0, lsl #20
 	add r0, r4, r1
 	bl func_01ff9958
-	ldr r1, [sb, #0xc]
+	ldr r1, [r9, #0xc]
 	sub r1, r1, r0
 	ldr r0, [sp]
 	add sp, sp, #0x2c
 	str r1, [r0]
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _01ffe868:
 	add sp, sp, #0x2c
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _01ffe874:
 	adds r1, r6, r11
 	beq _01ffe8bc
@@ -7647,18 +7647,18 @@ _01ffe874:
 	mov r1, r1, lsl #0x1
 	ldrh r2, [r10, r1]
 	ldr r3, [r3, #8]
-	mov r1, sb
+	mov r1, r9
 	mla r0, r2, r0, r3
 	bl func_01ff9ec0
 	cmp r0, r8
 	movge r0, #0
 	blt _01ffe8c8
 	add sp, sp, #0x2c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _01ffe8bc:
 	add sp, sp, #0x2c
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _01ffe8c8:
 	smull r2, r1, r0, r0
 	adds r2, r2, #0x800
@@ -7667,13 +7667,13 @@ _01ffe8c8:
 	orr r1, r1, r0, lsl #20
 	add r0, r4, r1
 	bl func_01ff9958
-	ldr r1, [sb, #0xc]
+	ldr r1, [r9, #0xc]
 	sub r1, r1, r0
 	ldr r0, [sp]
 	str r1, [r0]
 	mov r0, #1
 	add sp, sp, #0x2c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_01ffe668
 _01ffe900: .word data_ov00_020db008
@@ -7758,7 +7758,7 @@ _01ffe9d4:
 	.global func_01ffea18
 	arm_func_start func_01ffea18
 func_01ffea18: ; 0x01ffea18
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #0x18
 	ldr r8, [sp, #0x38]
 	mov r7, r0
@@ -7771,7 +7771,7 @@ func_01ffea18: ; 0x01ffea18
 	cmp r0, #0
 	addeq sp, sp, #0x18
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	mov r1, r6
 	add r0, r7, #8
 	bl func_01ff9c2c
@@ -7779,7 +7779,7 @@ func_01ffea18: ; 0x01ffea18
 	subs r0, r0, r1
 	addmi sp, sp, #0x18
 	movmi r0, #0
-	ldmmiia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmmiia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	mov r1, r5
 	add r0, r7, #8
 	bl func_01ff9c2c
@@ -7797,7 +7797,7 @@ func_01ffea18: ; 0x01ffea18
 _01ffeaa8:
 	add sp, sp, #0x18
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _01ffeab4:
 	ldr r0, [r5]
 	ldr r2, [r6]
@@ -7837,24 +7837,24 @@ _01ffeab4:
 	cmp r0, r1
 	addgt sp, sp, #0x18
 	movgt r0, #0
-	ldmgtia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmgtia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	add r10, r7, #0x18
-	mov sb, #0
+	mov r9, #0
 	add r8, sp, #0xc
 _01ffeb5c:
 	mov r0, r10
 	mov r1, r8
 	bl func_01ff9c2c
-	add r1, r7, sb, lsl #4
+	add r1, r7, r9, lsl #4
 	ldr r2, [r1, #0x24]
 	ldr r1, [r6, #0xc]
 	sub r0, r0, r2
 	cmp r0, r1
 	addge sp, sp, #0x18
 	movge r0, #0
-	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
-	add sb, sb, #1
-	cmp sb, #3
+	ldmgeia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
+	add r9, r9, #1
+	cmp r9, #3
 	add r10, r10, #0x10
 	blt _01ffeb5c
 	add r3, sp, #0
@@ -7874,7 +7874,7 @@ _01ffeb5c:
 	str r0, [r4]
 	mov r0, #1
 	add sp, sp, #0x18
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	arm_func_end func_01ffea18
 
 	.global func_01ffebe0
@@ -7928,19 +7928,19 @@ func_01ffec34: ; 0x01ffec34
 	.global func_01ffec78
 	arm_func_start func_01ffec78
 func_01ffec78: ; 0x01ffec78
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x38
 	cmp r1, #0
 	mov r10, r0
 	addne sp, sp, #0x38
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r0, r10, #0x44
 	bl func_ov00_020951d4
 	ldr r0, [r10, #0x3c]
 	mov r11, #0
 	cmp r0, #0
 	addls sp, sp, #0x38
-	ldmlsia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmlsia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _01ffecac:
 	ldr r0, [r10, #0x40]
 	ldr r0, [r0, r11, lsl #2]
@@ -7995,14 +7995,14 @@ _01ffecac:
 	bl func_ov00_02095278
 	ldrh r0, [sp]
 	ldrh r8, [sp]
-	ldrh sb, [sp, #2]
+	ldrh r9, [sp, #2]
 	cmp r6, r0
 	bhi _01ffeddc
 	mov r0, r11, lsl #0x10
 	mov r4, r0, lsr #0x10
 _01ffed94:
 	mov r5, r7
-	cmp r7, sb
+	cmp r7, r9
 	bhi _01ffedc8
 _01ffeda0:
 	mov r1, r6
@@ -8012,7 +8012,7 @@ _01ffeda0:
 	bl func_ov00_02095224
 	add r0, r5, #1
 	mov r0, r0, lsl #0x10
-	cmp sb, r0, lsr #16
+	cmp r9, r0, lsr #16
 	mov r5, r0, lsr #0x10
 	bhs _01ffeda0
 _01ffedc8:
@@ -8027,13 +8027,13 @@ _01ffeddc:
 	cmp r11, r0
 	blo _01ffecac
 	add sp, sp, #0x38
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	arm_func_end func_01ffec78
 
 	.global func_01ffedf4
 	arm_func_start func_01ffedf4
 func_01ffedf4: ; 0x01ffedf4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x30
 	mov r10, r0
 	mov r4, r1
@@ -8044,7 +8044,7 @@ func_01ffedf4: ; 0x01ffedf4
 	mov r2, r4
 	add r1, r10, #0x24
 	str r3, [sp, #0x58]
-	ldr sb, [sp, #0x5c]
+	ldr r9, [sp, #0x5c]
 	bl func_ov00_02095278
 	add r0, sp, #0x28
 	add r1, r10, #0x24
@@ -8092,7 +8092,7 @@ _01ffeec4:
 	cmp r4, r0
 	addhs sp, sp, #0x30
 	mvnhs r0, #0
-	ldmhsia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmhsia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r1, [r7, #8]
 	mov r0, r6, lsl #0x1
 	ldrh r5, [r1, r0]
@@ -8164,17 +8164,17 @@ _01ffefac:
 	beq _01fff020
 	b _01ffeff8
 _01ffefd8:
-	cmp sb, #0
+	cmp r9, #0
 	beq _01ffeff8
-	cmp sb, #1
+	cmp r9, #1
 	bne _01fff020
 	b _01ffeff8
 _01ffefec:
-	cmp sb, #0
-	cmpne sb, #1
+	cmp r9, #0
+	cmpne r9, #1
 	beq _01fff020
 _01ffeff8:
-	cmp sb, #1
+	cmp r9, #1
 	moveq r0, r1, lsr #0x1b
 	andeq r0, r0, #1
 	cmpeq r0, #1
@@ -8212,13 +8212,13 @@ _01fff058:
 _01fff078:
 	mov r0, r4
 	add sp, sp, #0x30
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	arm_func_end func_01ffedf4
 
 	.global func_01fff084
 	arm_func_start func_01fff084
 func_01fff084: ; 0x01fff084
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x20
 	mov r10, r0
 	mov r11, r3
@@ -8228,7 +8228,7 @@ func_01fff084: ; 0x01fff084
 	add r0, sp, #0x1c
 	add r1, r10, #0x24
 	str r3, [sp, #0x48]
-	ldr sb, [sp, #0x4c]
+	ldr r9, [sp, #0x4c]
 	bl func_ov00_02095278
 	mov r4, #0
 	add r1, sp, #0x1c
@@ -8254,7 +8254,7 @@ _01fff100:
 	cmp r4, r0
 	addhs sp, sp, #0x20
 	mvnhs r0, #0
-	ldmhsia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmhsia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r1, [r7, #8]
 	mov r0, r6, lsl #0x1
 	ldrh r5, [r1, r0]
@@ -8325,13 +8325,13 @@ _01fff1e8:
 	beq _01fff240
 	b _01fff22c
 _01fff210:
-	cmp sb, #0
-	cmpne sb, #1
+	cmp r9, #0
+	cmpne r9, #1
 	beq _01fff22c
 	b _01fff240
 _01fff220:
-	cmp sb, #0
-	cmpne sb, #1
+	cmp r9, #0
+	cmpne r9, #1
 	beq _01fff240
 _01fff22c:
 	mov r0, r4, lsl #0x1
@@ -8349,13 +8349,13 @@ _01fff240:
 _01fff258:
 	mov r0, r4
 	add sp, sp, #0x20
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	arm_func_end func_01fff084
 
 	.global func_01fff264
 	arm_func_start func_01fff264
 func_01fff264: ; 0x01fff264
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x24
 	mov r10, r0
 	mov r6, r1
@@ -8363,7 +8363,7 @@ func_01fff264: ; 0x01fff264
 	add r0, sp, #0x20
 	mov r2, r6
 	add r1, r10, #0x44
-	mov sb, r3
+	mov r9, r3
 	ldr r11, [sp, #0x48]
 	ldr r8, [sp, #0x4c]
 	mov r4, #0
@@ -8410,7 +8410,7 @@ _01fff328:
 	cmp r4, r11
 	addhs sp, sp, #0x24
 	mvnhs r0, #0
-	ldmhsia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmhsia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r1, [r6, #8]
 	mov r0, r5, lsl #0x1
 	ldrh r7, [r1, r0]
@@ -8420,7 +8420,7 @@ _01fff328:
 	beq _01fff430
 	mov r0, r10
 	mov r1, r7
-	mov r2, sb
+	mov r2, r9
 	mov r3, r4
 	bl func_01fff48c
 	cmp r0, #0
@@ -8476,7 +8476,7 @@ _01fff408:
 	cmpeq r0, #1
 	beq _01fff430
 	mov r0, r4, lsl #0x1
-	strh r7, [sb, r0]
+	strh r7, [r9, r0]
 	add r0, r4, #1
 	mov r0, r0, lsl #0x10
 	mov r4, r0, lsr #0x10
@@ -8506,7 +8506,7 @@ _01fff460:
 _01fff480:
 	mov r0, r4
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	arm_func_end func_01fff264
 
 	.global func_01fff48c
@@ -8559,16 +8559,16 @@ _01fff508:
 	.global func_01fff510
 	arm_func_start func_01fff510
 func_01fff510: ; 0x01fff510
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x14c
 	add r6, sp, #0xe8
-	mov sb, r2
+	mov r9, r2
 	mov r10, r0
 	mov r4, r1
-	ldmia sb, {r0, r1, r2}
+	ldmia r9, {r0, r1, r2}
 	stmia r6, {r0, r1, r2}
 	str r3, [sp, #4]
-	ldmia sb, {r0, r1, r2}
+	ldmia r9, {r0, r1, r2}
 	add r5, sp, #0xf4
 	stmia r5, {r0, r1, r2}
 	add r3, sp, #0xb8
@@ -8593,7 +8593,7 @@ func_01fff510: ; 0x01fff510
 	add r5, sp, #0xdc
 	stmia r5, {r0, r1, r2}
 	add r3, sp, #0xd0
-	ldmia sb, {r0, r1, r2}
+	ldmia r9, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
 	mov r0, r5
 	mov r1, r3
@@ -8776,7 +8776,7 @@ _01fff820:
 	bl func_0204f754
 	add sp, sp, #0x14c
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _01fff840:
 	add r0, r4, #1
 	mov r0, r0, lsl #0x10
@@ -8910,13 +8910,13 @@ _01fffa00:
 	strne r1, [sp, #0x30]
 	cmpne r1, r8
 	beq _01fffad4
-	ldr r2, [sb]
+	ldr r2, [r9]
 	add r1, sp, #0x88
 	str r2, [sp, #0x88]
-	ldr r3, [sb, #4]
+	ldr r3, [r9, #4]
 	add r2, sp, #0xc4
 	str r3, [sp, #0x8c]
-	ldr r11, [sb, #8]
+	ldr r11, [r9, #8]
 	add r3, sp, #0x64
 	str r11, [sp, #0x90]
 	ldr r11, [sp, #4]
@@ -8956,7 +8956,7 @@ _01fffab4:
 	bl func_0204f754
 	add sp, sp, #0x14c
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _01fffad4:
 	add r4, r4, #1
 	ldr r0, [r5, #4]
@@ -8988,7 +8988,7 @@ _01fffb24:
 	bl func_0204f754
 	mov r0, #0
 	add sp, sp, #0x14c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_01fff510
 _01fffb44: .word func_ov00_0207e968

--- a/asm/itcm.s
+++ b/asm/itcm.s
@@ -230,7 +230,7 @@ func_01ff8230: ; 0x01ff8230
 	.global func_01ff8248
 	arm_func_start func_01ff8248
 func_01ff8248: ; 0x01ff8248
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x18
 	ldr sb, [r1]
 	ldr r8, [r1, #4]
@@ -238,7 +238,7 @@ func_01ff8248: ; 0x01ff8248
 	smull r1, r6, sb, sb
 	str r1, [sp]
 	rsb r1, r3, #0x1000
-	smull r4, fp, r1, sb
+	smull r4, r11, r1, sb
 	ldr r5, [sp]
 	umull sl, ip, r8, r4
 	umull lr, r5, r1, r5
@@ -254,7 +254,7 @@ func_01ff8248: ; 0x01ff8248
 	mla r5, sb, sl, r5
 	orr r6, r6, r5, lsl #8
 	add r5, r6, r3
-	mla ip, r8, fp, ip
+	mla ip, r8, r11, ip
 	mov r6, r8, asr #0x1f
 	mla ip, r6, r4, ip
 	smull r6, sl, r8, r8
@@ -296,7 +296,7 @@ func_01ff8248: ; 0x01ff8248
 	str r2, [r0, #4]
 	str r1, [r0, #0xc]
 	umull r2, r1, r7, r4
-	mla r1, r7, fp, r1
+	mla r1, r7, r11, r1
 	mla r1, r5, r4, r1
 	mov r4, r2, lsr #0x18
 	orr r4, r4, r1, lsl #8
@@ -315,13 +315,13 @@ func_01ff8248: ; 0x01ff8248
 	str r2, [r0, #0x14]
 	str r1, [r0, #0x1c]
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	arm_func_end func_01ff8248
 
 	.global func_01ff83a0
 	arm_func_start func_01ff83a0
 func_01ff83a0: ; 0x01ff83a0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x50
 	mov sl, r0
 	ldr r0, [sl, #0x14]
@@ -332,17 +332,17 @@ func_01ff83a0: ; 0x01ff83a0
 	ldr r6, [sl, #0x20]
 	str r1, [sp]
 	movne sb, r1
-	smull fp, r8, r2, r6
+	smull r11, r8, r2, r6
 	smull r7, r1, r0, r3
-	subs r7, fp, r7
+	subs r7, r11, r7
 	sbc ip, r8, r1
 	ldr r4, [sl, #0x10]
 	ldr r5, [sl, #0x1c]
 	adds r1, r7, #0x800
-	smull fp, r8, r4, r6
+	smull r11, r8, r4, r6
 	smull r7, r6, r0, r5
 	adc r0, ip, #0
-	subs r7, fp, r7
+	subs r7, r11, r7
 	sbc r6, r8, r6
 	mov r8, r1, lsr #0xc
 	orr r8, r8, r0, lsl #20
@@ -356,9 +356,9 @@ func_01ff83a0: ; 0x01ff83a0
 	sbc r5, r0, r3
 	ldr r2, [sl]
 	adds r6, r1, #0x800
-	ldr fp, [sl, #4]
+	ldr r11, [sl, #4]
 	smull r4, r3, r2, r7
-	smull r1, r0, fp, r8
+	smull r1, r0, r11, r8
 	adc r2, r5, #0
 	mov r6, r6, lsr #0xc
 	orr r6, r6, r2, lsl #20
@@ -379,13 +379,13 @@ func_01ff83a0: ; 0x01ff83a0
 	mov r1, #0
 	addeq sp, sp, #0x50
 	subeq r0, r1, #1
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	bl func_01ff9a50
 	ldr r1, [sl, #8]
 	ldr r2, [sl, #0x1c]
-	ldr fp, [sl, #0x10]
+	ldr r11, [sl, #0x10]
 	smull r0, r4, r2, r1
-	smull r3, r2, fp, r1
+	smull r3, r2, r11, r1
 	ldr r5, [sl, #0x18]
 	str r2, [sp, #0x18]
 	str r3, [sp, #0x14]
@@ -403,9 +403,9 @@ func_01ff83a0: ; 0x01ff83a0
 	smull r1, r5, r2, r1
 	str r5, [sp, #0x28]
 	mov r5, r0, lsr #0xc
-	ldr fp, [sl, #0x14]
+	ldr r11, [sl, #0x14]
 	orr r5, r5, r4, lsl #20
-	smull r4, r2, lr, fp
+	smull r4, r2, lr, r11
 	ldr r0, [sp, #0x14]
 	subs r4, r4, r0
 	ldr r0, [sp, #0x18]
@@ -418,12 +418,12 @@ func_01ff83a0: ; 0x01ff83a0
 	subs r2, ip, r2
 	ldr ip, [sp, #0x20]
 	sbc r0, r0, ip
-	smull ip, fp, r3, fp
+	smull ip, r11, r3, r11
 	ldr r3, [sp, #0x28]
 	subs r1, ip, r1
-	sbc r3, fp, r3
-	mov fp, r2, lsr #0xc
-	orr fp, fp, r0, lsl #20
+	sbc r3, r11, r3
+	mov r11, r2, lsr #0xc
+	orr r11, r11, r0, lsl #20
 	mov r0, r1, lsr #0xc
 	orr r0, r0, r3, lsl #20
 	str r0, [sp, #0x24]
@@ -435,11 +435,11 @@ func_01ff83a0: ; 0x01ff83a0
 	smull r2, r1, r0, r4
 	mov r4, r2, lsr #0xc
 	orr r4, r4, r1, lsl #20
-	smull r2, r1, r0, fp
+	smull r2, r1, r0, r11
 	mov r3, r2, lsr #0xc
 	orr r3, r3, r1, lsl #20
 	ldr r1, [sp, #0x24]
-	umull fp, r5, r0, r7
+	umull r11, r5, r0, r7
 	smull r2, r1, r0, r1
 	mov r2, r2, lsr #0xc
 	orr r2, r2, r1, lsl #20
@@ -447,7 +447,7 @@ func_01ff83a0: ; 0x01ff83a0
 	mov ip, r0, asr #0x1f
 	mla r5, r0, r1, r5
 	mla r5, ip, r7, r5
-	mov r1, fp, lsr #0xc
+	mov r1, r11, lsr #0xc
 	orr r1, r1, r5, lsl #20
 	stmia sb, {r1, lr}
 	str r4, [sb, #8]
@@ -509,13 +509,13 @@ func_01ff83a0: ; 0x01ff83a0
 _01ff8684:
 	mov r0, #0
 	add sp, sp, #0x50
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	arm_func_end func_01ff83a0
 
 	.global func_01ff8690
 	arm_func_start func_01ff8690
 func_01ff8690: ; 0x01ff8690
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x40
 	mov ip, r2
 	ldr r3, [r0, #4]
@@ -583,9 +583,9 @@ func_01ff8690: ; 0x01ff8690
 	mov r3, r7, asr #0x1f
 	str r3, [sp, #0xc]
 	umull r3, r5, r4, r6
-	mov fp, r6, asr #0x1f
+	mov r11, r6, asr #0x1f
 	str r3, [sp, #0x10]
-	mla r5, r4, fp, r5
+	mla r5, r4, r11, r5
 	ldr r3, [sp, #8]
 	add lr, sp, #0x1c
 	mla r5, r3, r6, r5
@@ -594,17 +594,17 @@ func_01ff8690: ; 0x01ff8690
 	ldr r3, [sp, #0xc]
 	mla r4, r2, r3, r4
 	ldr r2, [sp, #4]
-	umull r3, fp, sb, r8
+	umull r3, r11, sb, r8
 	mla r4, r2, r7, r4
 	ldr r2, [sp, #0x14]
 	adds r3, r2, r3
 	ldr r2, [sp, #0x18]
-	mla fp, sb, r2, fp
+	mla r11, sb, r2, r11
 	ldr r2, [sp]
-	mla fp, r2, r8, fp
-	adc r4, r4, fp
+	mla r11, r2, r8, r11
+	adc r4, r4, r11
 	ldr r2, [sp, #0x10]
-	ldr fp, [sp, #0x18]
+	ldr r11, [sp, #0x18]
 	adds r3, r2, r3
 	adc r2, r5, r4
 	mov r3, r3, lsr #0xc
@@ -614,7 +614,7 @@ func_01ff8690: ; 0x01ff8690
 	ldr r5, [r0, #0x18]
 	ldr r4, [r0, #0x20]
 	umull r3, r0, r2, r8
-	mla r0, r2, fp, r0
+	mla r0, r2, r11, r0
 	mov sb, r2, asr #0x1f
 	mla r0, sb, r8, r0
 	smlal r3, r0, r5, r7
@@ -642,7 +642,7 @@ func_01ff8690: ; 0x01ff8690
 	mov r1, r1, lsr #0xc
 	orr r1, r1, r0, lsl #20
 	str r1, [sl, #0x20]
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldmia lr!, {r0, r1, r2, r3}
 	stmia ip!, {r0, r1, r2, r3}
 	ldmia lr!, {r0, r1, r2, r3}
@@ -650,7 +650,7 @@ func_01ff8690: ; 0x01ff8690
 	ldr r0, [lr]
 	str r0, [ip]
 	add sp, sp, #0x40
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	arm_func_end func_01ff8690
 
 	.global func_01ff88b0
@@ -881,7 +881,7 @@ func_01ff8ad8: ; 0x01ff8ad8
 	.global func_01ff8af8
 	arm_func_start func_01ff8af8
 func_01ff8af8: ; 0x01ff8af8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x5c
 	mov sl, r0
 	ldr r0, [sl, #0x14]
@@ -892,17 +892,17 @@ func_01ff8af8: ; 0x01ff8af8
 	ldr r6, [sl, #0x20]
 	str r1, [sp]
 	movne sb, r1
-	smull fp, r8, r2, r6
+	smull r11, r8, r2, r6
 	smull r7, r1, r0, r3
-	subs r7, fp, r7
+	subs r7, r11, r7
 	sbc ip, r8, r1
 	ldr r4, [sl, #0x10]
 	ldr r5, [sl, #0x1c]
 	adds r1, r7, #0x800
-	smull fp, r8, r4, r6
+	smull r11, r8, r4, r6
 	smull r7, r6, r0, r5
 	adc r0, ip, #0
-	subs r7, fp, r7
+	subs r7, r11, r7
 	sbc r6, r8, r6
 	mov r8, r1, lsr #0xc
 	orr r8, r8, r0, lsl #20
@@ -916,9 +916,9 @@ func_01ff8af8: ; 0x01ff8af8
 	sbc r5, r0, r3
 	ldr r2, [sl]
 	adds r6, r1, #0x800
-	ldr fp, [sl, #4]
+	ldr r11, [sl, #4]
 	smull r4, r3, r2, r7
-	smull r1, r0, fp, r8
+	smull r1, r0, r11, r8
 	adc r2, r5, #0
 	mov r6, r6, lsr #0xc
 	orr r6, r6, r2, lsl #20
@@ -939,13 +939,13 @@ func_01ff8af8: ; 0x01ff8af8
 	mov r1, #0
 	addeq sp, sp, #0x5c
 	subeq r0, r1, #1
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	bl func_01ff9a50
 	ldr r1, [sl, #8]
 	ldr r2, [sl, #0x1c]
-	ldr fp, [sl, #0x10]
+	ldr r11, [sl, #0x10]
 	smull r0, r4, r2, r1
-	smull r3, r2, fp, r1
+	smull r3, r2, r11, r1
 	ldr r5, [sl, #0x18]
 	str r2, [sp, #0x18]
 	str r3, [sp, #0x14]
@@ -963,9 +963,9 @@ func_01ff8af8: ; 0x01ff8af8
 	smull r1, r5, r2, r1
 	str r5, [sp, #0x28]
 	mov r5, r0, lsr #0xc
-	ldr fp, [sl, #0x14]
+	ldr r11, [sl, #0x14]
 	orr r5, r5, r4, lsl #20
-	smull r4, r2, lr, fp
+	smull r4, r2, lr, r11
 	ldr r0, [sp, #0x14]
 	subs r4, r4, r0
 	ldr r0, [sp, #0x18]
@@ -978,12 +978,12 @@ func_01ff8af8: ; 0x01ff8af8
 	subs r2, ip, r2
 	ldr ip, [sp, #0x20]
 	sbc r0, r0, ip
-	smull ip, fp, r3, fp
+	smull ip, r11, r3, r11
 	ldr r3, [sp, #0x28]
 	subs r1, ip, r1
-	sbc r3, fp, r3
-	mov fp, r2, lsr #0xc
-	orr fp, fp, r0, lsl #20
+	sbc r3, r11, r3
+	mov r11, r2, lsr #0xc
+	orr r11, r11, r0, lsl #20
 	mov r0, r1, lsr #0xc
 	orr r0, r0, r3, lsl #20
 	str r0, [sp, #0x24]
@@ -995,11 +995,11 @@ func_01ff8af8: ; 0x01ff8af8
 	smull r2, r1, r0, r4
 	mov r4, r2, lsr #0xc
 	orr r4, r4, r1, lsl #20
-	smull r2, r1, r0, fp
+	smull r2, r1, r0, r11
 	mov r3, r2, lsr #0xc
 	orr r3, r3, r1, lsl #20
 	ldr r1, [sp, #0x24]
-	umull fp, r5, r0, r7
+	umull r11, r5, r0, r7
 	smull r2, r1, r0, r1
 	mov r2, r2, lsr #0xc
 	orr r2, r2, r1, lsl #20
@@ -1007,7 +1007,7 @@ func_01ff8af8: ; 0x01ff8af8
 	mov ip, r0, asr #0x1f
 	mla r5, r0, r1, r5
 	mla r5, ip, r7, r5
-	mov r1, fp, lsr #0xc
+	mov r1, r11, lsr #0xc
 	orr r1, r1, r5, lsl #20
 	stmia sb, {r1, lr}
 	str r4, [sb, #8]
@@ -1108,13 +1108,13 @@ func_01ff8af8: ; 0x01ff8af8
 _01ff8e78:
 	mov r0, #0
 	add sp, sp, #0x5c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	arm_func_end func_01ff8af8
 
 	.global func_01ff8e84
 	arm_func_start func_01ff8e84
 func_01ff8e84: ; 0x01ff8e84
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x4c
 	mov ip, r2
 	ldr r2, [r0, #4]
@@ -1181,20 +1181,20 @@ func_01ff8e84: ; 0x01ff8e84
 	mov r2, r5, asr #0x1f
 	str r2, [sp, #8]
 	umull r2, r3, r7, lr
-	mov fp, lr, asr #0x1f
-	mla r3, r7, fp, r3
+	mov r11, lr, asr #0x1f
+	mla r3, r7, r11, r3
 	str r2, [sp, #0xc]
 	ldr r2, [sp]
 	ldr r7, [sp, #8]
 	mla r3, r2, lr, r3
-	umull fp, r2, sb, r5
+	umull r11, r2, sb, r5
 	mla r2, sb, r7, r2
 	mla r2, r6, r5, r2
 	ldr r6, [sp, #4]
 	umull sb, r7, r8, r4
 	mla r7, r8, r6, r7
 	ldr r8, [sp, #0x14]
-	adds r6, fp, sb
+	adds r6, r11, sb
 	mla r7, r8, r4, r7
 	adc r7, r2, r7
 	ldr r2, [sp, #0xc]
@@ -1241,7 +1241,7 @@ func_01ff8e84: ; 0x01ff8e84
 	mov r0, r7, asr #0x1f
 	str r0, [sp, #0x18]
 	ldr r0, [r1, #0x2c]
-	mov fp, r2, asr #0x1f
+	mov r11, r2, asr #0x1f
 	adds r0, r0, r3
 	str r0, [sl, #0x2c]
 	ldr r3, [r1, #0x10]
@@ -1267,7 +1267,7 @@ func_01ff8e84: ; 0x01ff8e84
 	umull r8, r0, r2, r3
 	mla r0, r2, sb, r0
 	ldr r4, [sp, #0x10]
-	mla r0, fp, r3, r0
+	mla r0, r11, r3, r0
 	adds r4, r4, r8
 	adc r2, r5, r0
 	ldr r6, [r1, #0x18]
@@ -1286,7 +1286,7 @@ func_01ff8e84: ; 0x01ff8e84
 	cmp sl, r4
 	addne sp, sp, #0x4c
 	str r0, [sl, #0x24]
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldmia r4!, {r0, r1, r2, r3}
 	stmia ip!, {r0, r1, r2, r3}
 	ldmia r4!, {r0, r1, r2, r3}
@@ -1294,7 +1294,7 @@ func_01ff8e84: ; 0x01ff8e84
 	ldmia r4, {r0, r1, r2, r3}
 	stmia ip, {r0, r1, r2, r3}
 	add sp, sp, #0x4c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	arm_func_end func_01ff8e84
 
 	.global func_01ff9158
@@ -1402,7 +1402,7 @@ func_01ff9258: ; 0x01ff9258
 	.global func_01ff927c
 	arm_func_start func_01ff927c
 func_01ff927c: ; 0x01ff927c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0xe8
 	cmp r2, r1
 	addeq sl, sp, #0xa8
@@ -1445,9 +1445,9 @@ func_01ff927c: ; 0x01ff927c
 	mov r6, sb, lsr #0xc
 	orr r6, r6, r8, lsl #20
 	str r6, [sl, #0xc]
-	ldr fp, [r1, #0x18]
+	ldr r11, [r1, #0x18]
 	ldr ip, [r1, #8]
-	smull r7, r6, r4, fp
+	smull r7, r6, r4, r11
 	ldr r8, [r1, #0x38]
 	smlal r7, r6, r5, ip
 	ldr sb, [r1, #0x28]
@@ -1457,7 +1457,7 @@ func_01ff927c: ; 0x01ff927c
 	mov r2, r7, lsr #0xc
 	orr r2, r2, r6, lsl #20
 	str r2, [sl, #8]
-	mov r2, fp, asr #0x1f
+	mov r2, r11, asr #0x1f
 	str r2, [sp, #4]
 	mov r2, ip, asr #0x1f
 	str r2, [sp, #8]
@@ -1491,52 +1491,52 @@ func_01ff927c: ; 0x01ff927c
 	mla sb, r7, r8, sb
 	ldr r8, [sp, #0x10]
 	mla sb, r8, ip, sb
-	umull ip, r8, r6, fp
+	umull ip, r8, r6, r11
 	adds lr, lr, ip
 	ldr ip, [sp, #4]
 	mla r8, r6, ip, r8
 	ldr ip, [sp, #0xc]
-	mla r8, ip, fp, r8
+	mla r8, ip, r11, r8
 	adc sb, sb, r8
 	ldr r8, [sp, #0x20]
-	adds fp, r8, lr
+	adds r11, r8, lr
 	adc r8, r2, sb
 	ldr r2, [sp, #0x1c]
-	adds sb, r2, fp
+	adds sb, r2, r11
 	adc r2, r3, r8
 	mov r3, sb, lsr #0xc
 	orr r3, r3, r2, lsl #20
 	str r3, [sl, #0x18]
 	ldr r2, [r1, #0x14]
 	ldr r3, [r1, #4]
-	smull fp, r2, r6, r2
-	smlal fp, r2, r7, r3
+	smull r11, r2, r6, r2
+	smlal r11, r2, r7, r3
 	ldr r8, [r1, #0x24]
 	ldr sb, [r1, #0x34]
-	smlal fp, r2, r5, r8
-	smlal fp, r2, r4, sb
-	mov r3, fp, lsr #0xc
+	smlal r11, r2, r5, r8
+	smlal r11, r2, r4, sb
+	mov r3, r11, lsr #0xc
 	orr r3, r3, r2, lsl #20
 	str r3, [sl, #0x14]
 	ldr r2, [r1, #0x1c]
 	ldr r3, [r1, #0xc]
-	smull fp, r2, r6, r2
-	smlal fp, r2, r7, r3
+	smull r11, r2, r6, r2
+	smlal r11, r2, r7, r3
 	ldr r8, [r1, #0x2c]
 	ldr sb, [r1, #0x3c]
-	smlal fp, r2, r5, r8
-	smlal fp, r2, r4, sb
-	mov r3, fp, lsr #0xc
+	smlal r11, r2, r5, r8
+	smlal r11, r2, r4, sb
+	mov r3, r11, lsr #0xc
 	orr r3, r3, r2, lsl #20
 	str r3, [sl, #0x1c]
 	ldr sb, [r1, #0x10]
-	ldr fp, [r1, #0x30]
+	ldr r11, [r1, #0x30]
 	smull ip, r8, r6, sb
 	ldr r3, [r1]
 	ldr r2, [r1, #0x20]
 	smlal ip, r8, r7, r3
 	smlal ip, r8, r5, r2
-	smlal ip, r8, r4, fp
+	smlal ip, r8, r4, r11
 	mov r4, ip, lsr #0xc
 	orr r4, r4, r8, lsl #20
 	str r4, [sl, #0x10]
@@ -1551,7 +1551,7 @@ func_01ff927c: ; 0x01ff927c
 	ldr r8, [r0, #0x20]
 	ldr r6, [r0, #0x28]
 	ldr r5, [r0, #0x2c]
-	mov lr, fp, asr #0x1f
+	mov lr, r11, asr #0x1f
 	str r4, [sp, #0x90]
 	mov r4, r8, asr #0x1f
 	str r4, [sp, #0x30]
@@ -1559,36 +1559,36 @@ func_01ff927c: ; 0x01ff927c
 	str r4, [sp, #0x34]
 	mov r4, r5, asr #0x1f
 	str r4, [sp, #0x38]
-	umull ip, r4, r5, fp
+	umull ip, r4, r5, r11
 	str ip, [sp, #0x3c]
 	mla r4, r5, lr, r4
 	ldr ip, [sp, #0x38]
-	mla r4, ip, fp, r4
-	umull fp, lr, r6, r2
-	str fp, [sp, #0x40]
-	ldr fp, [sp, #0x2c]
-	mla lr, r6, fp, lr
-	ldr fp, [sp, #0x34]
-	mla lr, fp, r2, lr
+	mla r4, ip, r11, r4
+	umull r11, lr, r6, r2
+	str r11, [sp, #0x40]
+	ldr r11, [sp, #0x2c]
+	mla lr, r6, r11, lr
+	ldr r11, [sp, #0x34]
+	mla lr, r11, r2, lr
 	umull r2, ip, r8, r3
 	str r2, [sp, #0x44]
 	ldr r2, [sp, #0x28]
 	mla ip, r8, r2, ip
 	ldr r2, [sp, #0x30]
 	mla ip, r2, r3, ip
-	umull r3, fp, r7, sb
+	umull r3, r11, r7, sb
 	ldr r2, [sp, #0x44]
 	adds r3, r2, r3
 	ldr r2, [sp, #0x24]
-	mla fp, r7, r2, fp
+	mla r11, r7, r2, r11
 	ldr r2, [sp, #0x90]
-	mla fp, r2, sb, fp
+	mla r11, r2, sb, r11
 	ldr r2, [sp, #0x40]
-	adc sb, ip, fp
-	adds fp, r2, r3
+	adc sb, ip, r11
+	adds r11, r2, r3
 	ldr r2, [sp, #0x3c]
 	adc r3, lr, sb
-	adds sb, r2, fp
+	adds sb, r2, r11
 	adc r2, r4, r3
 	mov r3, sb, lsr #0xc
 	orr r3, r3, r2, lsl #20
@@ -1598,44 +1598,44 @@ func_01ff927c: ; 0x01ff927c
 	str r2, [sp, #0x48]
 	ldr r3, [sp, #0x48]
 	mov r2, r2, asr #0x1f
-	umull ip, fp, r7, r3
-	mla fp, r7, r2, fp
+	umull ip, r11, r7, r3
+	mla r11, r7, r2, r11
 	ldr r2, [sp, #0x90]
 	ldr r4, [r1, #0x24]
-	mla fp, r2, r3, fp
-	smlal ip, fp, r8, lr
-	smlal ip, fp, r6, r4
+	mla r11, r2, r3, r11
+	smlal ip, r11, r8, lr
+	smlal ip, r11, r6, r4
 	ldr sb, [r1, #0x34]
-	smlal ip, fp, r5, sb
+	smlal ip, r11, r5, sb
 	mov r2, ip, lsr #0xc
-	orr r2, r2, fp, lsl #20
+	orr r2, r2, r11, lsl #20
 	str r2, [sl, #0x24]
 	ldr r2, [r1, #0x1c]
 	ldr lr, [r1, #0xc]
 	str r2, [sp, #0x4c]
 	ldr r3, [sp, #0x4c]
 	mov r2, r2, asr #0x1f
-	umull ip, fp, r7, r3
-	mla fp, r7, r2, fp
+	umull ip, r11, r7, r3
+	mla r11, r7, r2, r11
 	ldr r2, [sp, #0x90]
 	ldr r4, [r1, #0x2c]
-	mla fp, r2, r3, fp
-	smlal ip, fp, r8, lr
-	smlal ip, fp, r6, r4
+	mla r11, r2, r3, r11
+	smlal ip, r11, r8, lr
+	smlal ip, r11, r6, r4
 	ldr sb, [r1, #0x3c]
-	smlal ip, fp, r5, sb
+	smlal ip, r11, r5, sb
 	mov r2, ip, lsr #0xc
-	orr r2, r2, fp, lsl #20
+	orr r2, r2, r11, lsl #20
 	str r2, [sl, #0x2c]
-	ldr fp, [r1, #0x18]
+	ldr r11, [r1, #0x18]
 	ldr r3, [r1, #0x38]
-	mov ip, fp, asr #0x1f
+	mov ip, r11, asr #0x1f
 	str r3, [sp, #0x50]
-	umull r4, r3, r7, fp
+	umull r4, r3, r7, r11
 	mla r3, r7, ip, r3
 	ldr r7, [sp, #0x90]
 	ldr r2, [r1, #8]
-	mla r3, r7, fp, r3
+	mla r3, r7, r11, r3
 	smlal r4, r3, r8, r2
 	ldr sb, [r1, #0x28]
 	smlal r4, r3, r6, sb
@@ -1646,7 +1646,7 @@ func_01ff927c: ; 0x01ff927c
 	str r4, [sl, #0x28]
 	ldr r4, [r0, #0x34]
 	ldr r3, [r0, #0x30]
-	smull r6, r5, r4, fp
+	smull r6, r5, r4, r11
 	smlal r6, r5, r3, r2
 	mov r2, r4, asr #0x1f
 	str r2, [sp, #0x54]
@@ -1674,13 +1674,13 @@ func_01ff927c: ; 0x01ff927c
 	str r0, [sp, #0x6c]
 	mov r0, r6, asr #0x1f
 	str r0, [sp, #0x70]
-	umull r0, fp, ip, sb
+	umull r0, r11, ip, sb
 	mov lr, sb, asr #0x1f
 	str r0, [sp, #0x64]
-	mla fp, ip, lr, fp
+	mla r11, ip, lr, r11
 	ldr r0, [sp, #0x60]
 	add r5, sp, #0xa8
-	mla fp, r0, sb, fp
+	mla r11, r0, sb, r11
 	umull r0, sb, r2, r8
 	str r0, [sp, #0x94]
 	ldr r0, [sp, #0x98]
@@ -1706,7 +1706,7 @@ func_01ff927c: ; 0x01ff927c
 	ldr r0, [sp, #0x64]
 	adc r6, sb, r6
 	adds r7, r0, r7
-	adc r0, fp, r6
+	adc r0, r11, r6
 	mov r6, r7, lsr #0xc
 	orr r6, r6, r0, lsl #20
 	str r6, [sl, #0x34]
@@ -1720,12 +1720,12 @@ func_01ff927c: ; 0x01ff927c
 	str r0, [sp, #0x7c]
 	mov r0, r6, asr #0x1f
 	str r0, [sp, #0x80]
-	umull r0, fp, ip, sb
+	umull r0, r11, ip, sb
 	mov lr, sb, asr #0x1f
 	str r0, [sp, #0x74]
-	mla fp, ip, lr, fp
+	mla r11, ip, lr, r11
 	ldr r0, [sp, #0x60]
-	mla fp, r0, sb, fp
+	mla r11, r0, sb, r11
 	umull r0, sb, r2, r8
 	str r0, [sp, #0x9c]
 	ldr r0, [sp, #0xa0]
@@ -1751,7 +1751,7 @@ func_01ff927c: ; 0x01ff927c
 	ldr r0, [sp, #0x74]
 	adc r6, sb, r6
 	adds r7, r0, r7
-	adc r0, fp, r6
+	adc r0, r11, r6
 	mov r6, r7, lsr #0xc
 	orr r6, r6, r0, lsl #20
 	str r6, [sl, #0x30]
@@ -1760,7 +1760,7 @@ func_01ff927c: ; 0x01ff927c
 	mov r0, r8, asr #0x1f
 	str r0, [sp, #0x84]
 	ldr r7, [r1, #0x2c]
-	ldr fp, [sp, #0x84]
+	ldr r11, [sp, #0x84]
 	mov r0, r7, asr #0x1f
 	str r0, [sp, #0x88]
 	ldr r0, [r1, #0x1c]
@@ -1768,15 +1768,15 @@ func_01ff927c: ; 0x01ff927c
 	mov r1, r0, asr #0x1f
 	str r1, [sp, #0xa4]
 	umull sb, r1, ip, r8
-	mla r1, ip, fp, r1
-	ldr fp, [sp, #0x60]
-	mla r1, fp, r8, r1
+	mla r1, ip, r11, r1
+	ldr r11, [sp, #0x60]
+	mla r1, r11, r8, r1
 	ldr r8, [sp, #0x88]
-	umull ip, fp, r2, r7
-	mla fp, r2, r8, fp
+	umull ip, r11, r2, r7
+	mla r11, r2, r8, r11
 	ldr r2, [sp, #0x5c]
 	ldr r8, [sp, #0xa4]
-	mla fp, r2, r7, fp
+	mla r11, r2, r7, r11
 	umull r7, r2, r3, r6
 	mla r2, r3, lr, r2
 	ldr r3, [sp, #0x58]
@@ -1788,7 +1788,7 @@ func_01ff927c: ; 0x01ff927c
 	adds r4, r7, r6
 	adc r0, r2, r3
 	adds r2, ip, r4
-	adc r0, fp, r0
+	adc r0, r11, r0
 	adds r2, sb, r2
 	adc r0, r1, r0
 	mov r1, r2, lsr #0xc
@@ -1796,7 +1796,7 @@ func_01ff927c: ; 0x01ff927c
 	cmp sl, r5
 	addne sp, sp, #0xe8
 	str r1, [sl, #0x3c]
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r4, [sp]
 	ldmia r5!, {r0, r1, r2, r3}
 	stmia r4!, {r0, r1, r2, r3}
@@ -1810,7 +1810,7 @@ func_01ff927c: ; 0x01ff927c
 	stmia r4, {r0, r1, r2, r3}
 	str r4, [sp]
 	add sp, sp, #0xe8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	arm_func_end func_01ff927c
 
 	.global Divide
@@ -2883,7 +2883,7 @@ _01ffa5ac:
 	ldmib sp!, {r2, r3}
 	stmib r0!, {r2, r3}
 	ldmib sp!, {r2, r3, ip, lr}
-    stmib r0!, {r2, r3, r4, r5, r6, r7, r8, sb, sl, fp, ip, sp, lr} ^
+    stmib r0!, {r2, r3, r4, r5, r6, r7, r8, sb, sl, r11, ip, sp, lr} ^
 	stmib r0!, {lr}
 	mov r3, #0xd3
 	msr cpsr_c, r3 ; 16
@@ -2900,7 +2900,7 @@ _01ffa5ac:
 	ldr r2, [r1, #0]!
 	msr spsr_cf, r2 ; 9
 	ldr lr, [r1, #0x40]
-	ldmib r1, {r0, r1, r2, r3, r4, r5, r6, r7, r8, sb, sl, fp, ip, sp, lr} ^
+	ldmib r1, {r0, r1, r2, r3, r4, r5, r6, r7, r8, sb, sl, r11, ip, sp, lr} ^
 	mov r0, r0
 	stmda sp!, {r0, r1, r2, r3, ip, lr}
 	ldmia sp!, {pc}
@@ -2975,9 +2975,9 @@ _01ffa6ec:
 	ldr r3, _01ffa73c ; =0x027ffe00
 	ldr ip, [r3, #0x24]
 	mov lr, ip
-	ldr fp, _01ffa730 ; =0x027fff80
-	ldmia fp, {r0, r1, r2, r3, r4, r5, r6, r7, r8, sb, sl}
-	mov fp, #0
+	ldr r11, _01ffa730 ; =0x027fff80
+	ldmia r11, {r0, r1, r2, r3, r4, r5, r6, r7, r8, sb, sl}
+	mov r11, #0
 	bx ip
 	.align 2, 0
 	arm_func_end func_01ffa674
@@ -3004,7 +3004,7 @@ _01ffa744:
 	.global func_01ffa754
 	arm_func_start func_01ffa754
 func_01ffa754: ; 0x01ffa754
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	ldr r1, _01ffa7f4 ; =0x027ffc2c
 	ldr r4, [r1]
 	cmp r4, #0x8000
@@ -3022,10 +3022,10 @@ _01ffa778:
 	ldr sb, [r0, #0x18]
 	ldr sl, [r0, #0x1c]
 	bl func_0200ee4c
-	mov fp, r0
+	mov r11, r0
 	bl func_0200e228
 	bl func_0200e21c
-	mov r0, fp
+	mov r0, r11
 	bl func_0200ee60
 	bl func_0200e2f0
 	bl func_0200e2e4
@@ -3045,7 +3045,7 @@ _01ffa7d0:
 	mov r2, sl
 	add r0, r8, r4
 	bl func_01ffa7fc
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_01ffa754
 _01ffa7f4: .word 0x027ffc2c
@@ -4047,7 +4047,7 @@ data_01ffb38f: ; 0x01ffb38f
 	.global func_01ffb390
 	arm_func_start func_01ffb390
 func_01ffb390: ; 0x01ffb390
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x14
 	mov sl, r0
 	ldr r0, [sl]
@@ -4081,7 +4081,7 @@ _01ffb404:
 	add sp, sp, #0x14
 	add r0, r0, r4
 	str r0, [sl]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _01ffb418:
 	cmp sb, #0x40
 	cmpne sb, #0x60
@@ -4192,7 +4192,7 @@ _01ffb59c:
 	tst r0, #8
 	beq _01ffb664
 	and r1, r0, #0xf0
-	mov fp, r1, asr #0x4
+	mov r11, r1, asr #0x4
 	ldrsh r1, [r6]
 	add r0, r5, #0x28
 	str r1, [sp]
@@ -4204,10 +4204,10 @@ _01ffb59c:
 	ldr r1, _01ffb7b4 ; =data_01ffb36d
 	tst r0, #0x100
 	mov r0, #0x1000
-	ldrb r2, [r2, fp, lsl #2]
-	ldrb r1, [r1, fp, lsl #2]
+	ldrb r2, [r2, r11, lsl #2]
+	ldrb r1, [r1, r11, lsl #2]
 	rsbne r0, r0, #0
-	add r3, r5, fp, lsl #2
+	add r3, r5, r11, lsl #2
 	str r0, [r3, #0x28]
 	ldr r0, [sp]
 	add r2, r5, r2, lsl #2
@@ -4223,7 +4223,7 @@ _01ffb59c:
 	str r0, [sp, #4]
 _01ffb61c:
 	ldr r0, _01ffb7b8 ; =data_01ffb36e
-	ldrb r0, [r0, fp, lsl #2]
+	ldrb r0, [r0, r11, lsl #2]
 	add r1, r5, r0, lsl #2
 	ldr r0, [sp, #4]
 	str r0, [r1, #0x28]
@@ -4236,7 +4236,7 @@ _01ffb61c:
 _01ffb648:
 	ldr r0, _01ffb7bc ; =data_01ffb36f
 	add r6, r6, #4
-	ldrb r0, [r0, fp, lsl #2]
+	ldrb r0, [r0, r11, lsl #2]
 	add r1, r5, r0, lsl #2
 	ldr r0, [sp]
 	str r0, [r1, #0x28]
@@ -4332,7 +4332,7 @@ _01ffb79c:
 	add r0, r0, r4
 	str r0, [sl]
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_01ffb390
 _01ffb7b0: .word data_01ffb36c
@@ -4360,7 +4360,7 @@ _01ffb7e8: .word data_027e0000
 	.global func_01ffb7ec
 	arm_func_start func_01ffb7ec
 func_01ffb7ec: ; 0x01ffb7ec
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x30
 	ldrh r4, [sp, #0x58]
 	mov sl, r0
@@ -4369,7 +4369,7 @@ func_01ffb7ec: ; 0x01ffb7ec
 	mov ip, r0, lsl #0x1
 	add r0, ip, #1
 	mov r0, r0, lsl #0x1
-	mov fp, r1
+	mov r11, r1
 	ldrsh r1, [lr, r0]
 	mov sb, r2
 	mov r8, r3
@@ -4390,7 +4390,7 @@ _01ffb848:
 	smull r3, r1, r2, r1
 	adds r2, r3, #0x800
 	mov r3, #0x2a
-	mul r3, fp, r3
+	mul r3, r11, r3
 	adc r1, r1, #0
 	mov r2, r2, lsr #0xc
 	orr r2, r2, r1, lsl #20
@@ -4402,28 +4402,28 @@ _01ffb848:
 	adds r2, r2, #0x800
 	mov sl, r1, lsr #0xc
 	mov r1, r2, lsr #0xc
-	ldmia r6, {r2, fp, ip}
+	ldmia r6, {r2, r11, ip}
 	adc r0, r0, #0
 	orr r1, r1, r0, lsl #20
 	str r2, [sp, #0x24]
-	str fp, [sp, #0x28]
+	str r11, [sp, #0x28]
 	str ip, [sp, #0x2c]
 	orr sl, sl, r3, lsl #20
-	ldr fp, [r6, #0x14]
+	ldr r11, [r6, #0x14]
 	ldr r3, [r6, #0x10]
 	ldr r2, [r6, #0xc]
 	mov r0, #0x1000
 	str r2, [sp, #0x18]
 	str r3, [sp, #0x1c]
-	str fp, [sp, #0x20]
-	ldr fp, [r6, #0x20]
+	str r11, [sp, #0x20]
+	ldr r11, [r6, #0x20]
 	ldr r3, [r6, #0x1c]
 	ldr r2, [r6, #0x18]
 	cmp r8, #0x58
 	str sl, [sp]
 	str r2, [sp, #0xc]
 	str r3, [sp, #0x10]
-	str fp, [sp, #0x14]
+	str r11, [sp, #0x14]
 	str r1, [sp, #4]
 	str r0, [sp, #8]
 	mov sl, #0
@@ -4479,13 +4479,13 @@ _01ffb980:
 	add r0, sp, #0xc
 	add r1, sp, #0
 	bl func_01ff9c2c
-	mov fp, r0
+	mov r11, r0
 	add r0, sp, #0x18
 	add r1, sp, #0
 	bl func_01ff9c2c
 	smull r3, r2, r0, r6
 	adds r3, r3, #0x800
-	smull r1, r0, fp, r6
+	smull r1, r0, r11, r6
 	adc r2, r2, #0
 	adds r1, r1, #0x800
 	mov r3, r3, lsr #0xc
@@ -4509,13 +4509,13 @@ _01ffb9fc:
 	add r0, sp, #0xc
 	add r1, sp, #0
 	bl func_01ff9c2c
-	mov fp, r0
+	mov r11, r0
 	add r0, sp, #0x24
 	add r1, sp, #0
 	bl func_01ff9c2c
 	smull r3, r2, r0, r6
 	adds r3, r3, #0x800
-	smull r1, r0, fp, r6
+	smull r1, r0, r11, r6
 	adc r2, r2, #0
 	adds r1, r1, #0x800
 	mov r3, r3, lsr #0xc
@@ -4540,13 +4540,13 @@ _01ffba74:
 	add r0, sp, #0x18
 	add r1, sp, #0
 	bl func_01ff9c2c
-	mov fp, r0
+	mov r11, r0
 	add r0, sp, #0x24
 	add r1, sp, #0
 	bl func_01ff9c2c
 	smull r3, r2, r0, r6
 	adds r3, r3, #0x800
-	smull r1, r0, fp, r6
+	smull r1, r0, r11, r6
 	adc r2, r2, #0
 	adds r1, r1, #0x800
 	mov r3, r3, lsr #0xc
@@ -4568,11 +4568,11 @@ _01ffbafc:
 	ldr r2, [sp]
 	ldr r0, [sp, #4]
 	smull r4, r3, r2, sl
-	adds fp, r4, #0x800
+	adds r11, r4, #0x800
 	smull r2, r4, r0, sl
 	adc r3, r3, #0
 	adds r6, r2, #0x800
-	mov r0, fp, lsr #0xc
+	mov r0, r11, lsr #0xc
 	orr r0, r0, r3, lsl #20
 	ldr r1, [sp, #8]
 	adc r4, r4, #0
@@ -4609,7 +4609,7 @@ _01ffbb98:
 	cmp r8, #0x5a
 	addeq sp, sp, #0x30
 	streq sb, [r5, #8]
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r0, sp, #0xc
 	add r1, sp, #0
 	bl func_01ff9c2c
@@ -4617,7 +4617,7 @@ _01ffbb98:
 	add r0, r1, r0
 	str r0, [r5, #8]
 	add sp, sp, #0x30
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_01ffb7ec
 _01ffbbc8: .word data_02050f54
@@ -4889,7 +4889,7 @@ func_01ffbe78: ; 0x01ffbe78
 	.global func_01ffbf5c
 	arm_func_start func_01ffbf5c
 func_01ffbf5c: ; 0x01ffbf5c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x3c
 	ldr r8, [sp, #0x60]
 	ldr r7, [sp, #0x64]
@@ -4898,11 +4898,11 @@ func_01ffbf5c: ; 0x01ffbf5c
 	mov sl, r0
 	cmp r8, #0
 	str r3, [sp, #0x10]
-	mov fp, r1
+	mov r11, r1
 	mov sb, r2
 	addlt sp, sp, #0x3c
 	movlt r0, #0
-	ldmltia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmltia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r2, sp, #0x30
 	mov r0, sb
 	mov r1, r3
@@ -4922,12 +4922,12 @@ func_01ffbf5c: ; 0x01ffbf5c
 	str r6, [sp, #8]
 	ldr r3, [sp, #0x10]
 	mov r0, sl
-	mov r1, fp
+	mov r1, r11
 	mov r2, sb
 	str r5, [sp, #0xc]
 	bl func_01ffc118
 	add sp, sp, #0x3c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _01ffbff8:
 	ldrb r0, [sp, #0x70]
 	cmp r0, #0
@@ -4968,7 +4968,7 @@ _01ffc06c:
 	str r7, [sp, #4]
 	str r6, [sp, #8]
 	mov r0, sl
-	mov r1, fp
+	mov r1, r11
 	add r2, sp, #0x18
 	add r3, sp, #0x24
 	movne r4, #0
@@ -4977,7 +4977,7 @@ _01ffc06c:
 	cmp r0, #0
 	addne sp, sp, #0x3c
 	movne r0, #1
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	cmp r4, #0
 	beq _01ffc0d8
 	ldr r0, [sp, #0x18]
@@ -4991,25 +4991,25 @@ _01ffc0d8:
 	bne _01ffc06c
 	add sp, sp, #0x3c
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _01ffc0ec:
 	str r8, [sp]
 	str r7, [sp, #4]
 	str r6, [sp, #8]
 	ldr r3, [sp, #0x10]
 	mov r0, sl
-	mov r1, fp
+	mov r1, r11
 	mov r2, sb
 	str r5, [sp, #0xc]
 	bl func_01ffd1e0
 	add sp, sp, #0x3c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	arm_func_end func_01ffbf5c
 
 	.global func_01ffc118
 	arm_func_start func_01ffc118
 func_01ffc118: ; 0x01ffc118
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x2b8
 	str r2, [sp, #0x18]
 	ldr r2, [sp, #0x2e8]
@@ -5035,7 +5035,7 @@ func_01ffc118: ; 0x01ffc118
 	ldr r7, [sp, #0x2e4]
 	tst r0, #4
 	ldr r0, [sp, #0x58]
-	ldr fp, [sp, #0x2ec]
+	ldr r11, [sp, #0x2ec]
 	sub r0, r0, #1
 	str r0, [sp, #0x50]
 	beq _01ffc530
@@ -5166,9 +5166,9 @@ _01ffc31c:
 	movne r0, #0
 	cmp r0, #0
 	bne _01ffc508
-	cmp fp, #0
+	cmp r11, #0
 	beq _01ffc398
-	mov r0, fp
+	mov r0, r11
 	mov r1, r5
 	ldr r2, [r0]
 	ldr r2, [r2, #0x10]
@@ -5371,7 +5371,7 @@ _01ffc620:
 	movne r0, #0
 	cmp r0, #0
 	bne _01ffc8e4
-	cmp fp, #0
+	cmp r11, #0
 	beq _01ffc6e4
 	ldr r0, _01ffd1d4 ; =data_027e0e64
 	mov r1, r5, lsl #0x1
@@ -5381,7 +5381,7 @@ _01ffc620:
 	strh r1, [r0, #0xb0]
 	ldmia sb, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
-	mov r0, fp
+	mov r0, r11
 	ldr r3, [r0]
 	mov r2, r6
 	ldr r3, [r3, #0x14]
@@ -5553,14 +5553,14 @@ _01ffc8f4:
 	ldr r0, [sp, #0x14]
 	mov r1, sl
 	mov r3, sb
-	str fp, [sp, #0xc]
+	str r11, [sp, #0xc]
 	mov r4, #1
 	str r4, [sp, #0x10]
 	bl func_01ffbf5c
 	cmp r0, #0
 	addne sp, sp, #0x2b8
 	movne r0, r4
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r1, [sp, #0x260]
 	mov r0, r4
 	str r1, [sl]
@@ -5569,7 +5569,7 @@ _01ffc8f4:
 	ldr r1, [sp, #0x268]
 	add sp, sp, #0x2b8
 	str r1, [sl, #8]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _01ffc998:
 	ldr r0, [sp, #0x18]
 	add r3, sp, #0x1c4
@@ -5779,7 +5779,7 @@ _01ffcab4:
 	add r1, sp, #0x188
 	mov r2, r0
 	bl func_01ff9bc4
-	cmp fp, #0
+	cmp r11, #0
 	mov r7, #0
 	beq _01ffcd18
 	add r0, sp, #0x194
@@ -5787,7 +5787,7 @@ _01ffcab4:
 	add r3, sp, #0xa8
 	ldmia r0, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
-	mov r0, fp
+	mov r0, r11
 	ldr r2, [r0]
 	add r1, sp, #0xa4
 	ldr r2, [r2, #8]
@@ -6026,7 +6026,7 @@ _01ffd060:
 	add r0, r2, r0
 	str r0, [sp, #0x174]
 _01ffd084:
-	cmp fp, #0
+	cmp r11, #0
 	mov r4, #0
 	beq _01ffd0d0
 	ldr r0, [sp, #0x50]
@@ -6035,7 +6035,7 @@ _01ffd084:
 	add r3, sp, #0x8c
 	ldmia r1, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
-	mov r0, fp
+	mov r0, r11
 	ldr r2, [r0]
 	add r1, sp, #0x88
 	ldr r2, [r2, #0xc]
@@ -6112,7 +6112,7 @@ _01ffd1b0:
 	bl func_0204f754
 	ldr r0, [sp, #0x58]
 	add sp, sp, #0x2b8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_01ffc118
 _01ffd1d0: .word data_027e0f6c
@@ -6123,7 +6123,7 @@ _01ffd1dc: .word func_ov00_0207e96c
 	.global func_01ffd1e0
 	arm_func_start func_01ffd1e0
 func_01ffd1e0: ; 0x01ffd1e0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x320
 	str r0, [sp, #0x14]
 	mov r0, r2
@@ -6148,7 +6148,7 @@ func_01ffd1e0: ; 0x01ffd1e0
 	add r2, sp, #0x2b0
 	ldr r8, [sp, #0x348]
 	ldr r7, [sp, #0x34c]
-	ldr fp, [sp, #0x354]
+	ldr r11, [sp, #0x354]
 	bl func_01ff9bf8
 	ldr r0, [sp, #0x350]
 	tst r0, #4
@@ -6313,9 +6313,9 @@ _01ffd460:
 	movne r0, #0
 	cmp r0, #0
 	bne _01ffd650
-	cmp fp, #0
+	cmp r11, #0
 	beq _01ffd4e4
-	mov r0, fp
+	mov r0, r11
 	mov r1, r5
 	ldr r2, [r0]
 	ldr r2, [r2, #0x10]
@@ -6505,7 +6505,7 @@ _01ffd730:
 	movne r0, #0
 	cmp r0, #0
 	bne _01ffda08
-	cmp fp, #0
+	cmp r11, #0
 	beq _01ffd7fc
 	ldr r0, _01ffe1bc ; =data_027e0e64
 	mov r1, r5, lsl #0x1
@@ -6515,7 +6515,7 @@ _01ffd730:
 	strh r1, [r0, #0xd4]
 	ldmia sb, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
-	mov r0, fp
+	mov r0, r11
 	ldr r3, [r0]
 	mov r2, r6
 	ldr r3, [r3, #0x14]
@@ -6855,7 +6855,7 @@ _01ffdac4:
 	mov r2, r0
 	bl func_01ff9bc4
 	mov r0, #0
-	cmp fp, #0
+	cmp r11, #0
 	str r0, [sp, #0x20]
 	beq _01ffdd50
 	add r0, sp, #0x1f4
@@ -6863,7 +6863,7 @@ _01ffdac4:
 	add r3, sp, #0xb4
 	ldmia r0, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
-	mov r0, fp
+	mov r0, r11
 	ldr r2, [r0]
 	add r1, sp, #0xb0
 	ldr r2, [r2, #8]
@@ -7097,7 +7097,7 @@ _01ffdfa8:
 	add r0, r0, r8
 	cmp r1, r0
 	strle r0, [sp, #0x1d4]
-	cmp fp, #0
+	cmp r11, #0
 	mov r4, #0
 	beq _01ffe138
 	ldmia sb, {r0, r1, r2}
@@ -7120,7 +7120,7 @@ _01ffdfa8:
 	add r0, sp, #0x1c4
 	ldmia r0, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
-	mov r0, fp
+	mov r0, r11
 	ldr r2, [r0]
 	add r1, sp, #0x78
 	ldr r2, [r2, #0xc]
@@ -7164,7 +7164,7 @@ _01ffe198:
 	bl func_0204f754
 	ldr r0, [sp, #0x4c]
 	add sp, sp, #0x320
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_01ffd1e0
 _01ffe1b8: .word data_027e0f6c
@@ -7176,7 +7176,7 @@ _01ffe1c8: .word 0x00001922
 	.global func_01ffe1cc
 	arm_func_start func_01ffe1cc
 func_01ffe1cc: ; 0x01ffe1cc
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x84
 	ldr sb, [sp, #0xa8]
 	ldrh r4, [sp, #0xac]
@@ -7194,7 +7194,7 @@ func_01ffe1cc: ; 0x01ffe1cc
 	cmp r0, #0
 	addne sp, sp, #0x84
 	movne r0, #1
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldrh r5, [sp, #0xac]
 	tst r5, #4
 	beq _01ffe458
@@ -7258,11 +7258,11 @@ _01ffe2e8:
 	sub r0, r0, #1
 	str r0, [sp, #0x28]
 	ldr r0, [sp, #0x1c]
-	sub fp, r0, #1
+	sub r11, r0, #1
 _01ffe314:
 	cmp r5, #0
 	blt _01ffe43c
-	cmp r5, fp
+	cmp r5, r11
 	bgt _01ffe43c
 	cmp r6, #0
 	blt _01ffe43c
@@ -7338,7 +7338,7 @@ _01ffe3cc:
 _01ffe430:
 	add sp, sp, #0x84
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _01ffe43c:
 	add r5, r5, #1
 	cmp r5, r4
@@ -7351,7 +7351,7 @@ _01ffe448:
 _01ffe458:
 	mov r0, #0
 	add sp, sp, #0x84
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_01ffe1cc
 _01ffe464: .word data_027e0f6c
@@ -7500,7 +7500,7 @@ func_01ffe61c: ; 0x01ffe61c
 	.global func_01ffe668
 	arm_func_start func_01ffe668
 func_01ffe668: ; 0x01ffe668
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x2c
 	mov sl, r0
 	add r0, sl, #8
@@ -7518,11 +7518,11 @@ func_01ffe668: ; 0x01ffe668
 _01ffe6a4:
 	add sp, sp, #0x2c
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _01ffe6b0:
 	mov r5, #0
 	mov r6, r5
-	mov fp, r5
+	mov r11, r5
 	mov r7, r5
 	mov r8, r5
 	add r4, sl, #0x18
@@ -7539,11 +7539,11 @@ _01ffe6c8:
 	str r2, [r0, r8, lsl #2]
 	addge sp, sp, #0x2c
 	movge r0, #0
-	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r0, r8, #1
 	mov r0, r0, lsl #0x10
 	cmp r2, r5
-	movgt fp, r6
+	movgt r11, r6
 	movgt r6, r8
 	movgt r5, r2
 	cmp r2, #0
@@ -7560,7 +7560,7 @@ _01ffe6c8:
 	ldr r1, [sp]
 	add sp, sp, #0x2c
 	str r2, [r1]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _01ffe750:
 	ldr r0, [sp, #4]
 	smull r4, r3, r0, r0
@@ -7579,7 +7579,7 @@ _01ffe750:
 	cmp r5, r8
 	addgt sp, sp, #0x2c
 	movgt r0, #0
-	ldmgtia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmgtia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	cmp r7, #1
 	bne _01ffe874
 	add r0, r6, #1
@@ -7631,13 +7631,13 @@ _01ffe750:
 	add sp, sp, #0x2c
 	str r1, [r0]
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _01ffe868:
 	add sp, sp, #0x2c
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _01ffe874:
-	adds r1, r6, fp
+	adds r1, r6, r11
 	beq _01ffe8bc
 	ldr r0, _01ffe900 ; =data_ov00_020db008
 	mov r1, r1, lsl #0x1
@@ -7654,11 +7654,11 @@ _01ffe874:
 	movge r0, #0
 	blt _01ffe8c8
 	add sp, sp, #0x2c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _01ffe8bc:
 	add sp, sp, #0x2c
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _01ffe8c8:
 	smull r2, r1, r0, r0
 	adds r2, r2, #0x800
@@ -7673,7 +7673,7 @@ _01ffe8c8:
 	str r1, [r0]
 	mov r0, #1
 	add sp, sp, #0x2c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_01ffe668
 _01ffe900: .word data_ov00_020db008
@@ -7928,22 +7928,22 @@ func_01ffec34: ; 0x01ffec34
 	.global func_01ffec78
 	arm_func_start func_01ffec78
 func_01ffec78: ; 0x01ffec78
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x38
 	cmp r1, #0
 	mov sl, r0
 	addne sp, sp, #0x38
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r0, sl, #0x44
 	bl func_ov00_020951d4
 	ldr r0, [sl, #0x3c]
-	mov fp, #0
+	mov r11, #0
 	cmp r0, #0
 	addls sp, sp, #0x38
-	ldmlsia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmlsia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _01ffecac:
 	ldr r0, [sl, #0x40]
-	ldr r0, [r0, fp, lsl #2]
+	ldr r0, [r0, r11, lsl #2]
 	cmp r0, #0
 	beq _01ffeddc
 	ldr r2, [r0]
@@ -7957,7 +7957,7 @@ _01ffecac:
 	str r1, [sp, #0x24]
 	str r0, [sp, #0x28]
 	ldr r0, [sl, #0x40]
-	ldr r0, [r0, fp, lsl #2]
+	ldr r0, [r0, r11, lsl #2]
 	ldr r1, [r0]
 	ldr r1, [r1, #0x40]
 	blx r1
@@ -7998,7 +7998,7 @@ _01ffecac:
 	ldrh sb, [sp, #2]
 	cmp r6, r0
 	bhi _01ffeddc
-	mov r0, fp, lsl #0x10
+	mov r0, r11, lsl #0x10
 	mov r4, r0, lsr #0x10
 _01ffed94:
 	mov r5, r7
@@ -8023,21 +8023,21 @@ _01ffedc8:
 	bhs _01ffed94
 _01ffeddc:
 	ldr r0, [sl, #0x3c]
-	add fp, fp, #1
-	cmp fp, r0
+	add r11, r11, #1
+	cmp r11, r0
 	blo _01ffecac
 	add sp, sp, #0x38
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	arm_func_end func_01ffec78
 
 	.global func_01ffedf4
 	arm_func_start func_01ffedf4
 func_01ffedf4: ; 0x01ffedf4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x30
 	mov sl, r0
 	mov r4, r1
-	mov fp, r3
+	mov r11, r3
 	ldr r3, [sp, #0x58]
 	mov r5, r2
 	add r0, sp, #0x2c
@@ -8092,12 +8092,12 @@ _01ffeec4:
 	cmp r4, r0
 	addhs sp, sp, #0x30
 	mvnhs r0, #0
-	ldmhsia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmhsia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r1, [r7, #8]
 	mov r0, r6, lsl #0x1
 	ldrh r5, [r1, r0]
 	mov r0, sl
-	mov r2, fp
+	mov r2, r11
 	mov r1, r5
 	mov r3, r4
 	bl func_01fff48c
@@ -8180,7 +8180,7 @@ _01ffeff8:
 	cmpeq r0, #1
 	beq _01fff020
 	mov r0, r4, lsl #0x1
-	strh r5, [fp, r0]
+	strh r5, [r11, r0]
 	add r0, r4, #1
 	mov r0, r0, lsl #0x10
 	mov r4, r0, lsr #0x10
@@ -8212,16 +8212,16 @@ _01fff058:
 _01fff078:
 	mov r0, r4
 	add sp, sp, #0x30
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	arm_func_end func_01ffedf4
 
 	.global func_01fff084
 	arm_func_start func_01fff084
 func_01fff084: ; 0x01fff084
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x20
 	mov sl, r0
-	mov fp, r3
+	mov r11, r3
 	ldr r3, [sp, #0x48]
 	mov r5, r2
 	mov r2, r1
@@ -8254,12 +8254,12 @@ _01fff100:
 	cmp r4, r0
 	addhs sp, sp, #0x20
 	mvnhs r0, #0
-	ldmhsia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmhsia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r1, [r7, #8]
 	mov r0, r6, lsl #0x1
 	ldrh r5, [r1, r0]
 	mov r0, sl
-	mov r2, fp
+	mov r2, r11
 	mov r1, r5
 	mov r3, r4
 	bl func_01fff48c
@@ -8335,7 +8335,7 @@ _01fff220:
 	beq _01fff240
 _01fff22c:
 	mov r0, r4, lsl #0x1
-	strh r5, [fp, r0]
+	strh r5, [r11, r0]
 	add r0, r4, #1
 	mov r0, r0, lsl #0x10
 	mov r4, r0, lsr #0x10
@@ -8349,13 +8349,13 @@ _01fff240:
 _01fff258:
 	mov r0, r4
 	add sp, sp, #0x20
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	arm_func_end func_01fff084
 
 	.global func_01fff264
 	arm_func_start func_01fff264
 func_01fff264: ; 0x01fff264
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x24
 	mov sl, r0
 	mov r6, r1
@@ -8364,7 +8364,7 @@ func_01fff264: ; 0x01fff264
 	mov r2, r6
 	add r1, sl, #0x44
 	mov sb, r3
-	ldr fp, [sp, #0x48]
+	ldr r11, [sp, #0x48]
 	ldr r8, [sp, #0x4c]
 	mov r4, #0
 	bl func_ov00_02095278
@@ -8407,10 +8407,10 @@ _01fff2f8:
 	cmp r0, #0
 	bls _01fff440
 _01fff328:
-	cmp r4, fp
+	cmp r4, r11
 	addhs sp, sp, #0x24
 	mvnhs r0, #0
-	ldmhsia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmhsia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r1, [r6, #8]
 	mov r0, r5, lsl #0x1
 	ldrh r7, [r1, r0]
@@ -8506,7 +8506,7 @@ _01fff460:
 _01fff480:
 	mov r0, r4
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	arm_func_end func_01fff264
 
 	.global func_01fff48c
@@ -8559,7 +8559,7 @@ _01fff508:
 	.global func_01fff510
 	arm_func_start func_01fff510
 func_01fff510: ; 0x01fff510
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x14c
 	add r6, sp, #0xe8
 	mov sb, r2
@@ -8602,7 +8602,7 @@ func_01fff510: ; 0x01fff510
 	add r0, sp, #0x160
 	ldrh r0, [r0, #0x14]
 	str r0, [sp, #8]
-	ands fp, r0, #1
+	ands r11, r0, #1
 	bne _01fff5d4
 	tst r0, #0x10
 	bne _01fff5d4
@@ -8681,7 +8681,7 @@ _01fff68c:
 	beq _01fff840
 	b _01fff740
 _01fff6e4:
-	cmp fp, #0
+	cmp r11, #0
 	beq _01fff840
 	ands r1, r1, #0x1f
 	beq _01fff708
@@ -8706,7 +8706,7 @@ _01fff728:
 	beq _01fff840
 	b _01fff740
 _01fff738:
-	cmp fp, #0
+	cmp r11, #0
 	beq _01fff840
 _01fff740:
 	ldr r1, [sp, #0x58]
@@ -8776,7 +8776,7 @@ _01fff820:
 	bl func_0204f754
 	add sp, sp, #0x14c
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _01fff840:
 	add r0, r4, #1
 	mov r0, r0, lsl #0x10
@@ -8916,14 +8916,14 @@ _01fffa00:
 	ldr r3, [sb, #4]
 	add r2, sp, #0xc4
 	str r3, [sp, #0x8c]
-	ldr fp, [sb, #8]
+	ldr r11, [sb, #8]
 	add r3, sp, #0x64
-	str fp, [sp, #0x90]
-	ldr fp, [sp, #4]
-	str fp, [sp, #0x94]
-	ldr fp, [r0]
-	ldr fp, [fp, #0x54]
-	blx fp
+	str r11, [sp, #0x90]
+	ldr r11, [sp, #4]
+	str r11, [sp, #0x94]
+	ldr r11, [r0]
+	ldr r11, [r11, #0x54]
+	blx r11
 	cmp r0, #0
 	beq _01fffad4
 	cmp r7, #0
@@ -8956,7 +8956,7 @@ _01fffab4:
 	bl func_0204f754
 	add sp, sp, #0x14c
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _01fffad4:
 	add r4, r4, #1
 	ldr r0, [r5, #4]
@@ -8988,7 +8988,7 @@ _01fffb24:
 	bl func_0204f754
 	mov r0, #0
 	add sp, sp, #0x14c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_01fff510
 _01fffb44: .word func_ov00_0207e968

--- a/asm/itcm.s
+++ b/asm/itcm.s
@@ -230,7 +230,7 @@ func_01ff8230: ; 0x01ff8230
 	.global func_01ff8248
 	arm_func_start func_01ff8248
 func_01ff8248: ; 0x01ff8248
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x18
 	ldr sb, [r1]
 	ldr r8, [r1, #4]
@@ -240,30 +240,30 @@ func_01ff8248: ; 0x01ff8248
 	rsb r1, r3, #0x1000
 	smull r4, r11, r1, sb
 	ldr r5, [sp]
-	umull sl, ip, r8, r4
+	umull r10, ip, r8, r4
 	umull lr, r5, r1, r5
 	mla r5, r1, r6, r5
 	mov r6, lr, lsr #0x18
-	mov lr, sl, lsr #0x18
-	smull sb, sl, r2, sb
+	mov lr, r10, lsr #0x18
+	smull sb, r10, r2, sb
 	mov sb, sb, lsr #0xc
-	orr sb, sb, sl, lsl #20
+	orr sb, sb, r10, lsl #20
 	str sb, [sp, #0x14]
-	ldr sl, [sp]
+	ldr r10, [sp]
 	mov sb, r1, asr #0x1f
-	mla r5, sb, sl, r5
+	mla r5, sb, r10, r5
 	orr r6, r6, r5, lsl #8
 	add r5, r6, r3
 	mla ip, r8, r11, ip
 	mov r6, r8, asr #0x1f
 	mla ip, r6, r4, ip
-	smull r6, sl, r8, r8
+	smull r6, r10, r8, r8
 	str r5, [r0]
 	orr lr, lr, ip, lsl #8
 	str r6, [sp, #8]
 	umull r6, ip, r1, r6
 	str r6, [sp, #4]
-	mla ip, r1, sl, ip
+	mla ip, r1, r10, ip
 	ldr r6, [sp, #8]
 	mov r5, r7, asr #0x1f
 	mla ip, sb, r6, ip
@@ -272,11 +272,11 @@ func_01ff8248: ; 0x01ff8248
 	orr r6, r6, ip, lsl #8
 	add r6, r6, r3
 	str r6, [r0, #0x10]
-	smull r6, sl, r7, r7
+	smull r6, r10, r7, r7
 	str r6, [sp, #0x10]
 	umull r6, ip, r1, r6
 	str r6, [sp, #0xc]
-	mla ip, r1, sl, ip
+	mla ip, r1, r10, ip
 	ldr r6, [sp, #0x10]
 	mla ip, sb, r6, ip
 	ldr r6, [sp, #0xc]
@@ -315,29 +315,29 @@ func_01ff8248: ; 0x01ff8248
 	str r2, [r0, #0x14]
 	str r1, [r0, #0x1c]
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	arm_func_end func_01ff8248
 
 	.global func_01ff83a0
 	arm_func_start func_01ff83a0
 func_01ff83a0: ; 0x01ff83a0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x50
-	mov sl, r0
-	ldr r0, [sl, #0x14]
-	cmp sl, r1
+	mov r10, r0
+	ldr r0, [r10, #0x14]
+	cmp r10, r1
 	addeq sb, sp, #0x2c
-	ldr r3, [sl, #0x18]
-	ldr r2, [sl, #0xc]
-	ldr r6, [sl, #0x20]
+	ldr r3, [r10, #0x18]
+	ldr r2, [r10, #0xc]
+	ldr r6, [r10, #0x20]
 	str r1, [sp]
 	movne sb, r1
 	smull r11, r8, r2, r6
 	smull r7, r1, r0, r3
 	subs r7, r11, r7
 	sbc ip, r8, r1
-	ldr r4, [sl, #0x10]
-	ldr r5, [sl, #0x1c]
+	ldr r4, [r10, #0x10]
+	ldr r5, [r10, #0x1c]
 	adds r1, r7, #0x800
 	smull r11, r8, r4, r6
 	smull r7, r6, r0, r5
@@ -354,16 +354,16 @@ func_01ff83a0: ; 0x01ff83a0
 	orr r7, r7, r2, lsl #20
 	subs r1, r1, r5
 	sbc r5, r0, r3
-	ldr r2, [sl]
+	ldr r2, [r10]
 	adds r6, r1, #0x800
-	ldr r11, [sl, #4]
+	ldr r11, [r10, #4]
 	smull r4, r3, r2, r7
 	smull r1, r0, r11, r8
 	adc r2, r5, #0
 	mov r6, r6, lsr #0xc
 	orr r6, r6, r2, lsl #20
 	subs r2, r4, r1
-	ldr r1, [sl, #8]
+	ldr r1, [r10, #8]
 	sbc r0, r3, r0
 	smlal r2, r0, r1, r6
 	adds r1, r2, #0x800
@@ -379,31 +379,31 @@ func_01ff83a0: ; 0x01ff83a0
 	mov r1, #0
 	addeq sp, sp, #0x50
 	subeq r0, r1, #1
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	bl func_01ff9a50
-	ldr r1, [sl, #8]
-	ldr r2, [sl, #0x1c]
-	ldr r11, [sl, #0x10]
+	ldr r1, [r10, #8]
+	ldr r2, [r10, #0x1c]
+	ldr r11, [r10, #0x10]
 	smull r0, r4, r2, r1
 	smull r3, r2, r11, r1
-	ldr r5, [sl, #0x18]
+	ldr r5, [r10, #0x18]
 	str r2, [sp, #0x18]
 	str r3, [sp, #0x14]
 	smull r3, r2, r5, r1
 	str r2, [sp, #0x20]
-	ldr r2, [sl, #0x20]
+	ldr r2, [r10, #0x20]
 	str r3, [sp, #0x1c]
 	str r2, [sp, #0x10]
 	ldr r5, [sp, #0x10]
-	ldmia sl, {r3, lr}
+	ldmia r10, {r3, lr}
 	smull ip, r5, lr, r5
 	subs r0, ip, r0
-	ldr r2, [sl, #0xc]
+	ldr r2, [r10, #0xc]
 	sbc r4, r5, r4
 	smull r1, r5, r2, r1
 	str r5, [sp, #0x28]
 	mov r5, r0, lsr #0xc
-	ldr r11, [sl, #0x14]
+	ldr r11, [r10, #0x14]
 	orr r5, r5, r4, lsl #20
 	smull r4, r2, lr, r11
 	ldr r0, [sp, #0x14]
@@ -469,11 +469,11 @@ func_01ff83a0: ; 0x01ff83a0
 	mov r1, r3, lsr #0xc
 	orr r1, r1, r2, lsl #20
 	str r1, [sb, #0x18]
-	ldr r3, [sl]
-	ldr r1, [sl, #0x1c]
-	ldr r2, [sl, #0x18]
+	ldr r3, [r10]
+	ldr r1, [r10, #0x1c]
+	ldr r2, [r10, #0x18]
 	smull r5, r4, r3, r1
-	ldr r1, [sl, #4]
+	ldr r1, [r10, #4]
 	smull r3, r1, r2, r1
 	subs r2, r5, r3
 	sbc r1, r4, r1
@@ -484,10 +484,10 @@ func_01ff83a0: ; 0x01ff83a0
 	orr r2, r2, r1, lsl #20
 	rsb r1, r2, #0
 	str r1, [sb, #0x1c]
-	ldr r4, [sl]
-	ldr r3, [sl, #0x10]
-	ldr r2, [sl, #0xc]
-	ldr r1, [sl, #4]
+	ldr r4, [r10]
+	ldr r3, [r10, #0x10]
+	ldr r2, [r10, #0xc]
+	ldr r1, [r10, #4]
 	smull r6, r5, r4, r3
 	smull r3, r1, r2, r1
 	subs r2, r6, r3
@@ -509,13 +509,13 @@ func_01ff83a0: ; 0x01ff83a0
 _01ff8684:
 	mov r0, #0
 	add sp, sp, #0x50
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	arm_func_end func_01ff83a0
 
 	.global func_01ff8690
 	arm_func_start func_01ff8690
 func_01ff8690: ; 0x01ff8690
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x40
 	mov ip, r2
 	ldr r3, [r0, #4]
@@ -524,15 +524,15 @@ func_01ff8690: ; 0x01ff8690
 	smull r7, r5, r3, r2
 	ldr r6, [r0]
 	ldr r4, [r1]
-	addeq sl, sp, #0x1c
+	addeq r10, sp, #0x1c
 	smlal r7, r5, r6, r4
 	ldr r2, [r0, #8]
 	ldr r4, [r1, #0x18]
-	movne sl, ip
+	movne r10, ip
 	smlal r7, r5, r2, r4
 	mov r4, r7, lsr #0xc
 	orr r4, r4, r5, lsl #20
-	str r4, [sl]
+	str r4, [r10]
 	ldr r4, [r1, #0x10]
 	ldr r5, [r1, #4]
 	smull r8, r7, r3, r4
@@ -541,7 +541,7 @@ func_01ff8690: ; 0x01ff8690
 	smlal r8, r7, r2, r4
 	mov r4, r8, lsr #0xc
 	orr r4, r4, r7, lsl #20
-	str r4, [sl, #4]
+	str r4, [r10, #4]
 	ldr r4, [r1, #0x14]
 	ldr r5, [r1, #8]
 	smull r8, r7, r3, r4
@@ -550,7 +550,7 @@ func_01ff8690: ; 0x01ff8690
 	smlal r8, r7, r2, r3
 	mov r2, r8, lsr #0xc
 	orr r2, r2, r7, lsl #20
-	str r2, [sl, #8]
+	str r2, [r10, #8]
 	ldr sb, [r0, #0x10]
 	ldr r2, [r0, #0xc]
 	smull r7, r6, sb, r4
@@ -559,7 +559,7 @@ func_01ff8690: ; 0x01ff8690
 	smlal r7, r6, r4, r3
 	mov r3, r7, lsr #0xc
 	orr r3, r3, r6, lsl #20
-	str r3, [sl, #0x14]
+	str r3, [r10, #0x14]
 	ldr r3, [r1, #0x10]
 	ldr r5, [r1, #4]
 	smull r7, r6, sb, r3
@@ -570,7 +570,7 @@ func_01ff8690: ; 0x01ff8690
 	str r3, [sp]
 	mov r3, r7, lsr #0xc
 	orr r3, r3, r6, lsl #20
-	str r3, [sl, #0x10]
+	str r3, [r10, #0x10]
 	mov r3, r2, asr #0x1f
 	str r3, [sp, #4]
 	mov r3, r4, asr #0x1f
@@ -609,7 +609,7 @@ func_01ff8690: ; 0x01ff8690
 	adc r2, r5, r4
 	mov r3, r3, lsr #0xc
 	orr r3, r3, r2, lsl #20
-	str r3, [sl, #0xc]
+	str r3, [r10, #0xc]
 	ldr r2, [r0, #0x1c]
 	ldr r5, [r0, #0x18]
 	ldr r4, [r0, #0x20]
@@ -621,18 +621,18 @@ func_01ff8690: ; 0x01ff8690
 	smlal r3, r0, r4, r6
 	mov r3, r3, lsr #0xc
 	orr r3, r3, r0, lsl #20
-	str r3, [sl, #0x18]
+	str r3, [r10, #0x18]
 	ldr r0, [r1, #0x10]
 	ldr r3, [r1, #4]
 	smull r7, r0, r2, r0
-	cmp sl, lr
+	cmp r10, lr
 	smlal r7, r0, r5, r3
 	ldr r6, [r1, #0x1c]
 	addne sp, sp, #0x40
 	smlal r7, r0, r4, r6
 	mov r3, r7, lsr #0xc
 	orr r3, r3, r0, lsl #20
-	str r3, [sl, #0x1c]
+	str r3, [r10, #0x1c]
 	ldr r0, [r1, #0x14]
 	ldr r6, [r1, #0x20]
 	ldr r3, [r1, #8]
@@ -641,8 +641,8 @@ func_01ff8690: ; 0x01ff8690
 	smlal r1, r0, r4, r6
 	mov r1, r1, lsr #0xc
 	orr r1, r1, r0, lsl #20
-	str r1, [sl, #0x20]
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	str r1, [r10, #0x20]
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldmia lr!, {r0, r1, r2, r3}
 	stmia ip!, {r0, r1, r2, r3}
 	ldmia lr!, {r0, r1, r2, r3}
@@ -650,7 +650,7 @@ func_01ff8690: ; 0x01ff8690
 	ldr r0, [lr]
 	str r0, [ip]
 	add sp, sp, #0x40
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	arm_func_end func_01ff8690
 
 	.global func_01ff88b0
@@ -881,23 +881,23 @@ func_01ff8ad8: ; 0x01ff8ad8
 	.global func_01ff8af8
 	arm_func_start func_01ff8af8
 func_01ff8af8: ; 0x01ff8af8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x5c
-	mov sl, r0
-	ldr r0, [sl, #0x14]
-	cmp sl, r1
+	mov r10, r0
+	ldr r0, [r10, #0x14]
+	cmp r10, r1
 	addeq sb, sp, #0x2c
-	ldr r3, [sl, #0x18]
-	ldr r2, [sl, #0xc]
-	ldr r6, [sl, #0x20]
+	ldr r3, [r10, #0x18]
+	ldr r2, [r10, #0xc]
+	ldr r6, [r10, #0x20]
 	str r1, [sp]
 	movne sb, r1
 	smull r11, r8, r2, r6
 	smull r7, r1, r0, r3
 	subs r7, r11, r7
 	sbc ip, r8, r1
-	ldr r4, [sl, #0x10]
-	ldr r5, [sl, #0x1c]
+	ldr r4, [r10, #0x10]
+	ldr r5, [r10, #0x1c]
 	adds r1, r7, #0x800
 	smull r11, r8, r4, r6
 	smull r7, r6, r0, r5
@@ -914,16 +914,16 @@ func_01ff8af8: ; 0x01ff8af8
 	orr r7, r7, r2, lsl #20
 	subs r1, r1, r5
 	sbc r5, r0, r3
-	ldr r2, [sl]
+	ldr r2, [r10]
 	adds r6, r1, #0x800
-	ldr r11, [sl, #4]
+	ldr r11, [r10, #4]
 	smull r4, r3, r2, r7
 	smull r1, r0, r11, r8
 	adc r2, r5, #0
 	mov r6, r6, lsr #0xc
 	orr r6, r6, r2, lsl #20
 	subs r2, r4, r1
-	ldr r1, [sl, #8]
+	ldr r1, [r10, #8]
 	sbc r0, r3, r0
 	smlal r2, r0, r1, r6
 	adds r1, r2, #0x800
@@ -939,31 +939,31 @@ func_01ff8af8: ; 0x01ff8af8
 	mov r1, #0
 	addeq sp, sp, #0x5c
 	subeq r0, r1, #1
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	bl func_01ff9a50
-	ldr r1, [sl, #8]
-	ldr r2, [sl, #0x1c]
-	ldr r11, [sl, #0x10]
+	ldr r1, [r10, #8]
+	ldr r2, [r10, #0x1c]
+	ldr r11, [r10, #0x10]
 	smull r0, r4, r2, r1
 	smull r3, r2, r11, r1
-	ldr r5, [sl, #0x18]
+	ldr r5, [r10, #0x18]
 	str r2, [sp, #0x18]
 	str r3, [sp, #0x14]
 	smull r3, r2, r5, r1
 	str r2, [sp, #0x20]
-	ldr r2, [sl, #0x20]
+	ldr r2, [r10, #0x20]
 	str r3, [sp, #0x1c]
 	str r2, [sp, #0x10]
 	ldr r5, [sp, #0x10]
-	ldmia sl, {r3, lr}
+	ldmia r10, {r3, lr}
 	smull ip, r5, lr, r5
 	subs r0, ip, r0
-	ldr r2, [sl, #0xc]
+	ldr r2, [r10, #0xc]
 	sbc r4, r5, r4
 	smull r1, r5, r2, r1
 	str r5, [sp, #0x28]
 	mov r5, r0, lsr #0xc
-	ldr r11, [sl, #0x14]
+	ldr r11, [r10, #0x14]
 	orr r5, r5, r4, lsl #20
 	smull r4, r2, lr, r11
 	ldr r0, [sp, #0x14]
@@ -1029,11 +1029,11 @@ func_01ff8af8: ; 0x01ff8af8
 	mov r1, r3, lsr #0xc
 	orr r1, r1, r2, lsl #20
 	str r1, [sb, #0x18]
-	ldr r3, [sl]
-	ldr r1, [sl, #0x1c]
-	ldr r2, [sl, #0x18]
+	ldr r3, [r10]
+	ldr r1, [r10, #0x1c]
+	ldr r2, [r10, #0x18]
 	smull r5, r4, r3, r1
-	ldr r1, [sl, #4]
+	ldr r1, [r10, #4]
 	smull r3, r1, r2, r1
 	subs r2, r5, r3
 	sbc r1, r4, r1
@@ -1044,10 +1044,10 @@ func_01ff8af8: ; 0x01ff8af8
 	orr r2, r2, r1, lsl #20
 	rsb r1, r2, #0
 	str r1, [sb, #0x1c]
-	ldr r4, [sl]
-	ldr r3, [sl, #0x10]
-	ldr r2, [sl, #0xc]
-	ldr r1, [sl, #4]
+	ldr r4, [r10]
+	ldr r3, [r10, #0x10]
+	ldr r2, [r10, #0xc]
+	ldr r1, [r10, #4]
 	smull r6, r5, r4, r3
 	smull r3, r1, r2, r1
 	subs r2, r6, r3
@@ -1062,13 +1062,13 @@ func_01ff8af8: ; 0x01ff8af8
 	orr r0, r0, r3, lsl #20
 	str r0, [sb, #0x20]
 	ldr r1, [sb, #0xc]
-	ldr r0, [sl, #0x28]
+	ldr r0, [r10, #0x28]
 	ldr r2, [sb]
 	smull r5, r4, r1, r0
-	ldr r0, [sl, #0x24]
+	ldr r0, [r10, #0x24]
 	ldr r3, [sb, #0x18]
 	smlal r5, r4, r2, r0
-	ldr r1, [sl, #0x2c]
+	ldr r1, [r10, #0x2c]
 	add r0, sp, #0x2c
 	smlal r5, r4, r3, r1
 	mov r1, r5, lsr #0xc
@@ -1076,13 +1076,13 @@ func_01ff8af8: ; 0x01ff8af8
 	rsb r1, r1, #0
 	str r1, [sb, #0x24]
 	ldr r2, [sb, #0x10]
-	ldr r1, [sl, #0x28]
+	ldr r1, [r10, #0x28]
 	ldr r3, [sb, #4]
 	smull r5, r4, r2, r1
-	ldr r1, [sl, #0x24]
+	ldr r1, [r10, #0x24]
 	ldr r2, [sb, #0x1c]
 	smlal r5, r4, r3, r1
-	ldr r1, [sl, #0x2c]
+	ldr r1, [r10, #0x2c]
 	cmp sb, r0
 	smlal r5, r4, r2, r1
 	mov r1, r5, lsr #0xc
@@ -1090,13 +1090,13 @@ func_01ff8af8: ; 0x01ff8af8
 	rsb r1, r1, #0
 	str r1, [sb, #0x28]
 	ldr r2, [sb, #0x14]
-	ldr r1, [sl, #0x28]
+	ldr r1, [r10, #0x28]
 	ldr r3, [sb, #8]
 	smull r6, r5, r2, r1
-	ldr r1, [sl, #0x24]
+	ldr r1, [r10, #0x24]
 	ldr r4, [sb, #0x20]
 	smlal r6, r5, r3, r1
-	ldr r2, [sl, #0x2c]
+	ldr r2, [r10, #0x2c]
 	smlal r6, r5, r4, r2
 	mov r1, r6, lsr #0xc
 	orr r1, r1, r5, lsl #20
@@ -1108,13 +1108,13 @@ func_01ff8af8: ; 0x01ff8af8
 _01ff8e78:
 	mov r0, #0
 	add sp, sp, #0x5c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	arm_func_end func_01ff8af8
 
 	.global func_01ff8e84
 	arm_func_start func_01ff8e84
 func_01ff8e84: ; 0x01ff8e84
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x4c
 	mov ip, r2
 	ldr r2, [r0, #4]
@@ -1123,15 +1123,15 @@ func_01ff8e84: ; 0x01ff8e84
 	smull r7, r4, r2, r3
 	ldr r6, [r0]
 	ldr r3, [r1]
-	addeq sl, sp, #0x1c
+	addeq r10, sp, #0x1c
 	smlal r7, r4, r6, r3
 	ldr r5, [r0, #8]
 	ldr r3, [r1, #0x18]
-	movne sl, ip
+	movne r10, ip
 	smlal r7, r4, r5, r3
 	mov r3, r7, lsr #0xc
 	orr r3, r3, r4, lsl #20
-	str r3, [sl]
+	str r3, [r10]
 	ldr r3, [r1, #0x10]
 	ldr r4, [r1, #4]
 	smull r8, r7, r2, r3
@@ -1140,7 +1140,7 @@ func_01ff8e84: ; 0x01ff8e84
 	smlal r8, r7, r5, r3
 	mov r3, r8, lsr #0xc
 	orr r3, r3, r7, lsl #20
-	str r3, [sl, #4]
+	str r3, [r10, #4]
 	ldr r3, [r1, #0x14]
 	ldr r4, [r1, #8]
 	smull r8, r7, r2, r3
@@ -1149,7 +1149,7 @@ func_01ff8e84: ; 0x01ff8e84
 	smlal r8, r7, r5, r2
 	mov r5, r8, lsr #0xc
 	orr r5, r5, r7, lsl #20
-	str r5, [sl, #8]
+	str r5, [r10, #8]
 	ldr r8, [r0, #0x10]
 	ldr sb, [r0, #0xc]
 	smull r5, r3, r8, r3
@@ -1159,7 +1159,7 @@ func_01ff8e84: ; 0x01ff8e84
 	smlal r5, r3, r7, r2
 	mov r2, r5, lsr #0xc
 	orr r2, r2, r3, lsl #20
-	str r2, [sl, #0x14]
+	str r2, [r10, #0x14]
 	ldr r2, [r1, #0x10]
 	ldr r3, [r1, #4]
 	smull r5, r4, r8, r2
@@ -1170,7 +1170,7 @@ func_01ff8e84: ; 0x01ff8e84
 	str r2, [sp, #0x14]
 	mov r2, r5, lsr #0xc
 	orr r2, r2, r4, lsl #20
-	str r2, [sl, #0x10]
+	str r2, [r10, #0x10]
 	mov r2, r7, asr #0x1f
 	ldr r5, [r1]
 	str r2, [sp]
@@ -1202,7 +1202,7 @@ func_01ff8e84: ; 0x01ff8e84
 	adc r2, r3, r7
 	mov r3, r6, lsr #0xc
 	orr r3, r3, r2, lsl #20
-	str r3, [sl, #0xc]
+	str r3, [r10, #0xc]
 	ldr r3, [r0, #0x1c]
 	ldr r6, [r0, #0x18]
 	smull r7, r4, r3, r4
@@ -1211,7 +1211,7 @@ func_01ff8e84: ; 0x01ff8e84
 	smlal r7, r4, r2, lr
 	mov r5, r7, lsr #0xc
 	orr r5, r5, r4, lsl #20
-	str r5, [sl, #0x18]
+	str r5, [r10, #0x18]
 	ldr r4, [r1, #0x10]
 	ldr r5, [r1, #4]
 	smull r8, r4, r3, r4
@@ -1220,7 +1220,7 @@ func_01ff8e84: ; 0x01ff8e84
 	smlal r8, r4, r2, r7
 	mov r5, r8, lsr #0xc
 	orr r5, r5, r4, lsl #20
-	str r5, [sl, #0x1c]
+	str r5, [r10, #0x1c]
 	ldr r5, [r1, #0x14]
 	ldr r4, [r1, #8]
 	smull r8, r7, r3, r5
@@ -1229,7 +1229,7 @@ func_01ff8e84: ; 0x01ff8e84
 	smlal r8, r7, r2, r3
 	mov r2, r8, lsr #0xc
 	orr r2, r2, r7, lsl #20
-	str r2, [sl, #0x20]
+	str r2, [r10, #0x20]
 	ldr r2, [r0, #0x28]
 	ldr sb, [r0, #0x24]
 	ldr r7, [r0, #0x2c]
@@ -1243,7 +1243,7 @@ func_01ff8e84: ; 0x01ff8e84
 	ldr r0, [r1, #0x2c]
 	mov r11, r2, asr #0x1f
 	adds r0, r0, r3
-	str r0, [sl, #0x2c]
+	str r0, [r10, #0x2c]
 	ldr r3, [r1, #0x10]
 	ldr r4, [r1, #4]
 	smull r6, r3, r2, r3
@@ -1255,7 +1255,7 @@ func_01ff8e84: ; 0x01ff8e84
 	orr r4, r4, r3, lsl #20
 	adds r0, r0, r4
 	mov r8, sb, asr #0x1f
-	str r0, [sl, #0x28]
+	str r0, [r10, #0x28]
 	ldr r4, [r1]
 	ldr r3, [r1, #0xc]
 	umull r0, r5, sb, r4
@@ -1283,10 +1283,10 @@ func_01ff8e84: ; 0x01ff8e84
 	orr r1, r1, r0, lsl #20
 	adds r0, r8, r1
 	add r4, sp, #0x1c
-	cmp sl, r4
+	cmp r10, r4
 	addne sp, sp, #0x4c
-	str r0, [sl, #0x24]
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	str r0, [r10, #0x24]
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldmia r4!, {r0, r1, r2, r3}
 	stmia ip!, {r0, r1, r2, r3}
 	ldmia r4!, {r0, r1, r2, r3}
@@ -1294,7 +1294,7 @@ func_01ff8e84: ; 0x01ff8e84
 	ldmia r4, {r0, r1, r2, r3}
 	stmia ip, {r0, r1, r2, r3}
 	add sp, sp, #0x4c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	arm_func_end func_01ff8e84
 
 	.global func_01ff9158
@@ -1402,12 +1402,12 @@ func_01ff9258: ; 0x01ff9258
 	.global func_01ff927c
 	arm_func_start func_01ff927c
 func_01ff927c: ; 0x01ff927c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0xe8
 	cmp r2, r1
-	addeq sl, sp, #0xa8
+	addeq r10, sp, #0xa8
 	str r2, [sp]
-	movne sl, r2
+	movne r10, r2
 	ldr r4, [r0, #4]
 	ldr r2, [r1, #0x10]
 	ldr r5, [r0]
@@ -1422,7 +1422,7 @@ func_01ff927c: ; 0x01ff927c
 	smlal r8, r7, r2, r6
 	mov r6, r8, lsr #0xc
 	orr r6, r6, r7, lsl #20
-	str r6, [sl]
+	str r6, [r10]
 	ldr r6, [r1, #0x14]
 	ldr r7, [r1, #4]
 	smull sb, r8, r4, r6
@@ -1433,7 +1433,7 @@ func_01ff927c: ; 0x01ff927c
 	smlal sb, r8, r2, r7
 	mov r6, sb, lsr #0xc
 	orr r6, r6, r8, lsl #20
-	str r6, [sl, #4]
+	str r6, [r10, #4]
 	ldr r6, [r1, #0x1c]
 	ldr r7, [r1, #0xc]
 	smull sb, r8, r4, r6
@@ -1444,7 +1444,7 @@ func_01ff927c: ; 0x01ff927c
 	smlal sb, r8, r2, r7
 	mov r6, sb, lsr #0xc
 	orr r6, r6, r8, lsl #20
-	str r6, [sl, #0xc]
+	str r6, [r10, #0xc]
 	ldr r11, [r1, #0x18]
 	ldr ip, [r1, #8]
 	smull r7, r6, r4, r11
@@ -1456,7 +1456,7 @@ func_01ff927c: ; 0x01ff927c
 	smlal r7, r6, r2, r8
 	mov r2, r7, lsr #0xc
 	orr r2, r2, r6, lsl #20
-	str r2, [sl, #8]
+	str r2, [r10, #8]
 	mov r2, r11, asr #0x1f
 	str r2, [sp, #4]
 	mov r2, ip, asr #0x1f
@@ -1506,7 +1506,7 @@ func_01ff927c: ; 0x01ff927c
 	adc r2, r3, r8
 	mov r3, sb, lsr #0xc
 	orr r3, r3, r2, lsl #20
-	str r3, [sl, #0x18]
+	str r3, [r10, #0x18]
 	ldr r2, [r1, #0x14]
 	ldr r3, [r1, #4]
 	smull r11, r2, r6, r2
@@ -1517,7 +1517,7 @@ func_01ff927c: ; 0x01ff927c
 	smlal r11, r2, r4, sb
 	mov r3, r11, lsr #0xc
 	orr r3, r3, r2, lsl #20
-	str r3, [sl, #0x14]
+	str r3, [r10, #0x14]
 	ldr r2, [r1, #0x1c]
 	ldr r3, [r1, #0xc]
 	smull r11, r2, r6, r2
@@ -1528,7 +1528,7 @@ func_01ff927c: ; 0x01ff927c
 	smlal r11, r2, r4, sb
 	mov r3, r11, lsr #0xc
 	orr r3, r3, r2, lsl #20
-	str r3, [sl, #0x1c]
+	str r3, [r10, #0x1c]
 	ldr sb, [r1, #0x10]
 	ldr r11, [r1, #0x30]
 	smull ip, r8, r6, sb
@@ -1539,7 +1539,7 @@ func_01ff927c: ; 0x01ff927c
 	smlal ip, r8, r4, r11
 	mov r4, ip, lsr #0xc
 	orr r4, r4, r8, lsl #20
-	str r4, [sl, #0x10]
+	str r4, [r10, #0x10]
 	mov r4, r3, asr #0x1f
 	mov r5, sb, asr #0x1f
 	str r4, [sp, #0x28]
@@ -1592,7 +1592,7 @@ func_01ff927c: ; 0x01ff927c
 	adc r2, r4, r3
 	mov r3, sb, lsr #0xc
 	orr r3, r3, r2, lsl #20
-	str r3, [sl, #0x20]
+	str r3, [r10, #0x20]
 	ldr r2, [r1, #0x14]
 	ldr lr, [r1, #4]
 	str r2, [sp, #0x48]
@@ -1609,7 +1609,7 @@ func_01ff927c: ; 0x01ff927c
 	smlal ip, r11, r5, sb
 	mov r2, ip, lsr #0xc
 	orr r2, r2, r11, lsl #20
-	str r2, [sl, #0x24]
+	str r2, [r10, #0x24]
 	ldr r2, [r1, #0x1c]
 	ldr lr, [r1, #0xc]
 	str r2, [sp, #0x4c]
@@ -1626,7 +1626,7 @@ func_01ff927c: ; 0x01ff927c
 	smlal ip, r11, r5, sb
 	mov r2, ip, lsr #0xc
 	orr r2, r2, r11, lsl #20
-	str r2, [sl, #0x2c]
+	str r2, [r10, #0x2c]
 	ldr r11, [r1, #0x18]
 	ldr r3, [r1, #0x38]
 	mov ip, r11, asr #0x1f
@@ -1643,7 +1643,7 @@ func_01ff927c: ; 0x01ff927c
 	smlal r4, r3, r5, r6
 	mov r4, r4, lsr #0xc
 	orr r4, r4, r3, lsl #20
-	str r4, [sl, #0x28]
+	str r4, [r10, #0x28]
 	ldr r4, [r0, #0x34]
 	ldr r3, [r0, #0x30]
 	smull r6, r5, r4, r11
@@ -1659,7 +1659,7 @@ func_01ff927c: ; 0x01ff927c
 	smlal r6, r5, ip, r0
 	mov r0, r6, lsr #0xc
 	orr r0, r0, r5, lsl #20
-	str r0, [sl, #0x38]
+	str r0, [r10, #0x38]
 	mov r0, r2, asr #0x1f
 	str r0, [sp, #0x5c]
 	mov r0, ip, asr #0x1f
@@ -1709,7 +1709,7 @@ func_01ff927c: ; 0x01ff927c
 	adc r0, r11, r6
 	mov r6, r7, lsr #0xc
 	orr r6, r6, r0, lsl #20
-	str r6, [sl, #0x34]
+	str r6, [r10, #0x34]
 	ldr r8, [r1, #0x20]
 	ldr sb, [r1, #0x30]
 	mov r0, r8, asr #0x1f
@@ -1754,7 +1754,7 @@ func_01ff927c: ; 0x01ff927c
 	adc r0, r11, r6
 	mov r6, r7, lsr #0xc
 	orr r6, r6, r0, lsl #20
-	str r6, [sl, #0x30]
+	str r6, [r10, #0x30]
 	ldr r8, [r1, #0x3c]
 	ldr r6, [r1, #0xc]
 	mov r0, r8, asr #0x1f
@@ -1793,10 +1793,10 @@ func_01ff927c: ; 0x01ff927c
 	adc r0, r1, r0
 	mov r1, r2, lsr #0xc
 	orr r1, r1, r0, lsl #20
-	cmp sl, r5
+	cmp r10, r5
 	addne sp, sp, #0xe8
-	str r1, [sl, #0x3c]
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	str r1, [r10, #0x3c]
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r4, [sp]
 	ldmia r5!, {r0, r1, r2, r3}
 	stmia r4!, {r0, r1, r2, r3}
@@ -1810,7 +1810,7 @@ func_01ff927c: ; 0x01ff927c
 	stmia r4, {r0, r1, r2, r3}
 	str r4, [sp]
 	add sp, sp, #0xe8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	arm_func_end func_01ff927c
 
 	.global Divide
@@ -2883,7 +2883,7 @@ _01ffa5ac:
 	ldmib sp!, {r2, r3}
 	stmib r0!, {r2, r3}
 	ldmib sp!, {r2, r3, ip, lr}
-    stmib r0!, {r2, r3, r4, r5, r6, r7, r8, sb, sl, r11, ip, sp, lr} ^
+    stmib r0!, {r2, r3, r4, r5, r6, r7, r8, sb, r10, r11, ip, sp, lr} ^
 	stmib r0!, {lr}
 	mov r3, #0xd3
 	msr cpsr_c, r3 ; 16
@@ -2900,7 +2900,7 @@ _01ffa5ac:
 	ldr r2, [r1, #0]!
 	msr spsr_cf, r2 ; 9
 	ldr lr, [r1, #0x40]
-	ldmib r1, {r0, r1, r2, r3, r4, r5, r6, r7, r8, sb, sl, r11, ip, sp, lr} ^
+	ldmib r1, {r0, r1, r2, r3, r4, r5, r6, r7, r8, sb, r10, r11, ip, sp, lr} ^
 	mov r0, r0
 	stmda sp!, {r0, r1, r2, r3, ip, lr}
 	ldmia sp!, {pc}
@@ -2976,7 +2976,7 @@ _01ffa6ec:
 	ldr ip, [r3, #0x24]
 	mov lr, ip
 	ldr r11, _01ffa730 ; =0x027fff80
-	ldmia r11, {r0, r1, r2, r3, r4, r5, r6, r7, r8, sb, sl}
+	ldmia r11, {r0, r1, r2, r3, r4, r5, r6, r7, r8, sb, r10}
 	mov r11, #0
 	bx ip
 	.align 2, 0
@@ -3004,7 +3004,7 @@ _01ffa744:
 	.global func_01ffa754
 	arm_func_start func_01ffa754
 func_01ffa754: ; 0x01ffa754
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	ldr r1, _01ffa7f4 ; =0x027ffc2c
 	ldr r4, [r1]
 	cmp r4, #0x8000
@@ -3020,7 +3020,7 @@ _01ffa778:
 	ldr r7, [r0, #0xc]
 	ldr r8, [r0, #0x10]
 	ldr sb, [r0, #0x18]
-	ldr sl, [r0, #0x1c]
+	ldr r10, [r0, #0x1c]
 	bl func_0200ee4c
 	mov r11, r0
 	bl func_0200e228
@@ -3042,10 +3042,10 @@ _01ffa7d0:
 	mov r2, r7
 	bl func_01ffa7fc
 	mov r1, sb
-	mov r2, sl
+	mov r2, r10
 	add r0, r8, r4
 	bl func_01ffa7fc
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_01ffa754
 _01ffa7f4: .word 0x027ffc2c
@@ -4047,17 +4047,17 @@ data_01ffb38f: ; 0x01ffb38f
 	.global func_01ffb390
 	arm_func_start func_01ffb390
 func_01ffb390: ; 0x01ffb390
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x14
-	mov sl, r0
-	ldr r0, [sl]
+	mov r10, r0
+	ldr r0, [r10]
 	mov sb, r1
 	ldrb r6, [r0, #1]
 	mov r4, #4
-	strb r6, [sl, #0xae]
-	ldr r0, [sl, #8]
+	strb r6, [r10, #0xae]
+	ldr r0, [r10, #8]
 	orr r0, r0, #0x10
-	str r0, [sl, #8]
+	str r0, [r10, #8]
 	tst r0, #0x400
 	beq _01ffb418
 	cmp sb, #0x40
@@ -4069,7 +4069,7 @@ func_01ffb390: ; 0x01ffb390
 	tst r0, #0x100
 	add r4, r4, #1
 	bne _01ffb404
-	ldr r0, [sl]
+	ldr r0, [r10]
 	add r1, sp, #0x10
 	ldrb r3, [r0, #4]
 	mov r0, #0x14
@@ -4077,23 +4077,23 @@ func_01ffb390: ; 0x01ffb390
 	str r3, [sp, #0x10]
 	bl func_01ffa9fc
 _01ffb404:
-	ldr r0, [sl]
+	ldr r0, [r10]
 	add sp, sp, #0x14
 	add r0, r0, r4
-	str r0, [sl]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	str r0, [r10]
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _01ffb418:
 	cmp sb, #0x40
 	cmpne sb, #0x60
 	bne _01ffb45c
-	ldr r0, [sl]
+	ldr r0, [r10]
 	cmp sb, #0x40
 	ldreqb r0, [r0, #4]
 	add r4, r4, #1
 	streq r0, [sp, #0xc]
 	ldrneb r0, [r0, #5]
 	strne r0, [sp, #0xc]
-	ldr r0, [sl, #8]
+	ldr r0, [r10, #8]
 	tst r0, #0x100
 	bne _01ffb45c
 	add r1, sp, #0xc
@@ -4101,24 +4101,24 @@ _01ffb418:
 	mov r2, #1
 	bl func_01ffa9fc
 _01ffb45c:
-	add r0, sl, #0x12c
-	str r0, [sl, #0xb4]
-	ldr r0, [sl, #0x24]
+	add r0, r10, #0x12c
+	str r0, [r10, #0xb4]
+	ldr r0, [r10, #0x24]
 	cmp r0, #0
-	ldrneb r8, [sl, #0x92]
+	ldrneb r8, [r10, #0x92]
 	moveq r8, #0
 	cmp r8, #1
 	bne _01ffb4b0
-	ldr r1, [sl, #8]
-	mov r0, sl
+	ldr r1, [r10, #8]
+	mov r0, r10
 	bic r1, r1, #0x40
-	str r1, [sl, #8]
-	ldr r1, [sl, #0x24]
+	str r1, [r10, #8]
+	ldr r1, [r10, #0x24]
 	blx r1
-	ldr r0, [sl, #0x24]
+	ldr r0, [r10, #0x24]
 	cmp r0, #0
-	ldrneb r8, [sl, #0x92]
-	ldr r0, [sl, #8]
+	ldrneb r8, [r10, #0x92]
+	ldr r0, [r10, #8]
 	moveq r8, #0
 	and r0, r0, #0x40
 	b _01ffb4b4
@@ -4127,26 +4127,26 @@ _01ffb4b0:
 _01ffb4b4:
 	cmp r0, #0
 	bne _01ffb6cc
-	ldr r0, [sl, #4]
+	ldr r0, [r10, #4]
 	ldr r1, [r0, #0x34]
 	cmp r1, #0
 	beq _01ffb4e8
 	mov r0, #0x58
 	mla r5, r6, r0, r1
-	ldr r0, [sl, #8]
+	ldr r0, [r10, #8]
 	tst r0, #0x80
 	moveq r0, #1
 	movne r0, #0
 	b _01ffb4f0
 _01ffb4e8:
-	add r5, sl, #0x12c
+	add r5, r10, #0x12c
 	mov r0, #0
 _01ffb4f0:
 	cmp r0, #0
 	bne _01ffb6c8
 	mov r0, #0
 	str r0, [r5]
-	ldr r0, [sl, #4]
+	ldr r0, [r10, #4]
 	ldr r1, [r0, #0x10]
 	cmp r1, #0
 	beq _01ffb528
@@ -4157,7 +4157,7 @@ _01ffb4f0:
 	cmp r0, #0
 	bne _01ffb6c8
 _01ffb528:
-	ldr r2, [sl, #0xd4]
+	ldr r2, [r10, #0xd4]
 	ldrh r0, [r2, #6]
 	ldrh r1, [r2, r0]
 	add r0, r2, r0
@@ -4263,26 +4263,26 @@ _01ffb664:
 	str r0, [r5, #0x48]
 _01ffb6b0:
 	ldrh r3, [r7]
-	ldr r2, [sl]
-	ldr r7, [sl, #0xe8]
+	ldr r2, [r10]
+	ldr r7, [r10, #0xe8]
 	mov r0, r5
 	mov r1, r6
 	blx r7
 _01ffb6c8:
-	str r5, [sl, #0xb4]
+	str r5, [r10, #0xb4]
 _01ffb6cc:
 	cmp r8, #2
 	bne _01ffb708
-	ldr r1, [sl, #8]
-	mov r0, sl
+	ldr r1, [r10, #8]
+	mov r0, r10
 	bic r1, r1, #0x40
-	str r1, [sl, #8]
-	ldr r1, [sl, #0x24]
+	str r1, [r10, #8]
+	ldr r1, [r10, #0x24]
 	blx r1
-	ldr r0, [sl, #0x24]
+	ldr r0, [r10, #0x24]
 	cmp r0, #0
-	ldrneb r8, [sl, #0x92]
-	ldr r0, [sl, #8]
+	ldrneb r8, [r10, #0x92]
+	ldr r0, [r10, #8]
 	moveq r8, #0
 	and r0, r0, #0x40
 	b _01ffb70c
@@ -4291,24 +4291,24 @@ _01ffb708:
 _01ffb70c:
 	cmp r0, #0
 	bne _01ffb72c
-	ldr r0, [sl, #8]
+	ldr r0, [r10, #8]
 	tst r0, #0x100
 	bne _01ffb72c
-	ldr r0, [sl, #0xb4]
-	ldr r1, [sl, #0xec]
+	ldr r0, [r10, #0xb4]
+	ldr r1, [r10, #0xec]
 	blx r1
 _01ffb72c:
 	mov r0, #0
-	str r0, [sl, #0xb4]
+	str r0, [r10, #0xb4]
 	cmp r8, #3
 	bne _01ffb75c
-	ldr r1, [sl, #8]
-	mov r0, sl
+	ldr r1, [r10, #8]
+	mov r0, r10
 	bic r1, r1, #0x40
-	str r1, [sl, #8]
-	ldr r1, [sl, #0x24]
+	str r1, [r10, #8]
+	ldr r1, [r10, #0x24]
 	blx r1
-	ldr r0, [sl, #8]
+	ldr r0, [r10, #8]
 	and r0, r0, #0x40
 _01ffb75c:
 	cmp sb, #0x20
@@ -4317,10 +4317,10 @@ _01ffb75c:
 	cmp r0, #0
 	add r4, r4, #1
 	bne _01ffb79c
-	ldr r0, [sl, #8]
+	ldr r0, [r10, #8]
 	tst r0, #0x100
 	bne _01ffb79c
-	ldr r0, [sl]
+	ldr r0, [r10]
 	add r1, sp, #8
 	ldrb r3, [r0, #4]
 	mov r0, #0x13
@@ -4328,11 +4328,11 @@ _01ffb75c:
 	str r3, [sp, #8]
 	bl func_01ffa9fc
 _01ffb79c:
-	ldr r0, [sl]
+	ldr r0, [r10]
 	add r0, r0, r4
-	str r0, [sl]
+	str r0, [r10]
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_01ffb390
 _01ffb7b0: .word data_01ffb36c
@@ -4360,10 +4360,10 @@ _01ffb7e8: .word data_027e0000
 	.global func_01ffb7ec
 	arm_func_start func_01ffb7ec
 func_01ffb7ec: ; 0x01ffb7ec
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x30
 	ldrh r4, [sp, #0x58]
-	mov sl, r0
+	mov r10, r0
 	ldr lr, _01ffbbc8 ; =data_02050f54
 	mov r0, r4, asr #0x4
 	mov ip, r0, lsl #0x1
@@ -4384,7 +4384,7 @@ func_01ffb7ec: ; 0x01ffb7ec
 	ldrsh r0, [lr, r0]
 	bl Divide
 _01ffb848:
-	mov r2, sl, lsl #0x5
+	mov r2, r10, lsl #0x5
 	ldr r1, [sp, #0x5c]
 	rsb r2, r2, #0x1000
 	smull r3, r1, r2, r1
@@ -4394,13 +4394,13 @@ _01ffb848:
 	adc r1, r1, #0
 	mov r2, r2, lsr #0xc
 	orr r2, r2, r1, lsl #20
-	smull r1, sl, r2, r0
+	smull r1, r10, r2, r0
 	sub r3, r3, #0x1000
 	smull r2, r0, r3, r0
 	adds r1, r1, #0x800
-	adc r3, sl, #0
+	adc r3, r10, #0
 	adds r2, r2, #0x800
-	mov sl, r1, lsr #0xc
+	mov r10, r1, lsr #0xc
 	mov r1, r2, lsr #0xc
 	ldmia r6, {r2, r11, ip}
 	adc r0, r0, #0
@@ -4408,7 +4408,7 @@ _01ffb848:
 	str r2, [sp, #0x24]
 	str r11, [sp, #0x28]
 	str ip, [sp, #0x2c]
-	orr sl, sl, r3, lsl #20
+	orr r10, r10, r3, lsl #20
 	ldr r11, [r6, #0x14]
 	ldr r3, [r6, #0x10]
 	ldr r2, [r6, #0xc]
@@ -4420,13 +4420,13 @@ _01ffb848:
 	ldr r3, [r6, #0x1c]
 	ldr r2, [r6, #0x18]
 	cmp r8, #0x58
-	str sl, [sp]
+	str r10, [sp]
 	str r2, [sp, #0xc]
 	str r3, [sp, #0x10]
 	str r11, [sp, #0x14]
 	str r1, [sp, #4]
 	str r0, [sp, #8]
-	mov sl, #0
+	mov r10, #0
 	beq _01ffb90c
 	cmp r8, #0x59
 	beq _01ffb934
@@ -4442,7 +4442,7 @@ _01ffb90c:
 	ldr r0, [r7]
 	sub r0, sb, r0
 	bl Divide
-	mov sl, r0
+	mov r10, r0
 	b _01ffb980
 _01ffb934:
 	add r0, sp, #0x18
@@ -4453,7 +4453,7 @@ _01ffb934:
 	ldr r0, [r7, #4]
 	sub r0, sb, r0
 	bl Divide
-	mov sl, r0
+	mov r10, r0
 	b _01ffb980
 _01ffb95c:
 	add r0, sp, #0xc
@@ -4464,7 +4464,7 @@ _01ffb95c:
 	ldr r0, [r7, #8]
 	sub r0, sb, r0
 	bl Divide
-	mov sl, r0
+	mov r10, r0
 _01ffb980:
 	cmp r4, #0
 	beq _01ffbafc
@@ -4473,7 +4473,7 @@ _01ffb980:
 	ldr r0, [r7]
 	subs r1, sb, r0
 	beq _01ffb9fc
-	mov r0, sl
+	mov r0, r10
 	bl Divide
 	mov r6, r0
 	add r0, sp, #0xc
@@ -4503,7 +4503,7 @@ _01ffb9fc:
 	ldr r0, [r7, #4]
 	subs r1, sb, r0
 	beq _01ffba74
-	mov r0, sl
+	mov r0, r10
 	bl Divide
 	mov r6, r0
 	add r0, sp, #0xc
@@ -4534,7 +4534,7 @@ _01ffba74:
 	ldr r0, [r7, #8]
 	subs r1, sb, r0
 	beq _01ffbaec
-	mov r0, sl
+	mov r0, r10
 	bl Divide
 	mov r6, r0
 	add r0, sp, #0x18
@@ -4567,16 +4567,16 @@ _01ffbaec:
 _01ffbafc:
 	ldr r2, [sp]
 	ldr r0, [sp, #4]
-	smull r4, r3, r2, sl
+	smull r4, r3, r2, r10
 	adds r11, r4, #0x800
-	smull r2, r4, r0, sl
+	smull r2, r4, r0, r10
 	adc r3, r3, #0
 	adds r6, r2, #0x800
 	mov r0, r11, lsr #0xc
 	orr r0, r0, r3, lsl #20
 	ldr r1, [sp, #8]
 	adc r4, r4, #0
-	smull r3, r2, r1, sl
+	smull r3, r2, r1, r10
 	adds r3, r3, #0x800
 	adc r1, r2, #0
 	mov r6, r6, lsr #0xc
@@ -4609,7 +4609,7 @@ _01ffbb98:
 	cmp r8, #0x5a
 	addeq sp, sp, #0x30
 	streq sb, [r5, #8]
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	add r0, sp, #0xc
 	add r1, sp, #0
 	bl func_01ff9c2c
@@ -4617,7 +4617,7 @@ _01ffbb98:
 	add r0, r1, r0
 	str r0, [r5, #8]
 	add sp, sp, #0x30
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_01ffb7ec
 _01ffbbc8: .word data_02050f54
@@ -4889,20 +4889,20 @@ func_01ffbe78: ; 0x01ffbe78
 	.global func_01ffbf5c
 	arm_func_start func_01ffbf5c
 func_01ffbf5c: ; 0x01ffbf5c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x3c
 	ldr r8, [sp, #0x60]
 	ldr r7, [sp, #0x64]
 	ldr r6, [sp, #0x68]
 	ldr r5, [sp, #0x6c]
-	mov sl, r0
+	mov r10, r0
 	cmp r8, #0
 	str r3, [sp, #0x10]
 	mov r11, r1
 	mov sb, r2
 	addlt sp, sp, #0x3c
 	movlt r0, #0
-	ldmltia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmltia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	add r2, sp, #0x30
 	mov r0, sb
 	mov r1, r3
@@ -4921,13 +4921,13 @@ func_01ffbf5c: ; 0x01ffbf5c
 	str r7, [sp, #4]
 	str r6, [sp, #8]
 	ldr r3, [sp, #0x10]
-	mov r0, sl
+	mov r0, r10
 	mov r1, r11
 	mov r2, sb
 	str r5, [sp, #0xc]
 	bl func_01ffc118
 	add sp, sp, #0x3c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _01ffbff8:
 	ldrb r0, [sp, #0x70]
 	cmp r0, #0
@@ -4967,7 +4967,7 @@ _01ffc06c:
 	str r8, [sp]
 	str r7, [sp, #4]
 	str r6, [sp, #8]
-	mov r0, sl
+	mov r0, r10
 	mov r1, r11
 	add r2, sp, #0x18
 	add r3, sp, #0x24
@@ -4977,7 +4977,7 @@ _01ffc06c:
 	cmp r0, #0
 	addne sp, sp, #0x3c
 	movne r0, #1
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	cmp r4, #0
 	beq _01ffc0d8
 	ldr r0, [sp, #0x18]
@@ -4991,25 +4991,25 @@ _01ffc0d8:
 	bne _01ffc06c
 	add sp, sp, #0x3c
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _01ffc0ec:
 	str r8, [sp]
 	str r7, [sp, #4]
 	str r6, [sp, #8]
 	ldr r3, [sp, #0x10]
-	mov r0, sl
+	mov r0, r10
 	mov r1, r11
 	mov r2, sb
 	str r5, [sp, #0xc]
 	bl func_01ffd1e0
 	add sp, sp, #0x3c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	arm_func_end func_01ffbf5c
 
 	.global func_01ffc118
 	arm_func_start func_01ffc118
 func_01ffc118: ; 0x01ffc118
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x2b8
 	str r2, [sp, #0x18]
 	ldr r2, [sp, #0x2e8]
@@ -5019,7 +5019,7 @@ func_01ffc118: ; 0x01ffc118
 	ldr r0, [sp, #0x18]
 	ldr r8, [sp, #0x2e0]
 	str r2, [sp, #0x58]
-	mov sl, r1
+	mov r10, r1
 	ldmia r0, {r0, r1, r2}
 	add r4, sp, #0x260
 	stmia r4, {r0, r1, r2}
@@ -5219,7 +5219,7 @@ _01ffc398:
 	ldr r1, [r0]
 	ldr r1, [r1, #0x1c]
 	blx r1
-	str r0, [sl, #0x54]
+	str r0, [r10, #0x54]
 	mov r0, #1
 	str r0, [sp, #0x58]
 	add r3, sp, #0x230
@@ -5244,31 +5244,31 @@ _01ffc398:
 	cmp r0, #0
 	mov r0, #1
 	beq _01ffc4dc
-	strb r0, [sl, #0x59]
-	strb r0, [sl, #0x5c]
+	strb r0, [r10, #0x59]
+	strb r0, [r10, #0x5c]
 	ldrb r1, [r5, #0x15]
 	ldrb r0, [r5, #0x14]
-	strb r0, [sl, #0x50]
-	strb r1, [sl, #0x51]
+	strb r0, [r10, #0x50]
+	strb r1, [r10, #0x51]
 	ldr r0, [sp, #0x23c]
-	str r0, [sl, #0x18]
+	str r0, [r10, #0x18]
 	ldr r0, [sp, #0x240]
-	str r0, [sl, #0x1c]
+	str r0, [r10, #0x1c]
 	ldr r0, [sp, #0x244]
-	str r0, [sl, #0x20]
+	str r0, [r10, #0x20]
 	b _01ffc508
 _01ffc4dc:
-	strb r0, [sl, #0x5a]
+	strb r0, [r10, #0x5a]
 	ldrb r1, [r5, #0x15]
 	ldrb r0, [r5, #0x14]
-	strb r0, [sl, #0x4e]
-	strb r1, [sl, #0x4f]
+	strb r0, [r10, #0x4e]
+	strb r1, [r10, #0x4f]
 	ldr r0, [sp, #0x23c]
-	str r0, [sl, #0xc]
+	str r0, [r10, #0xc]
 	ldr r0, [sp, #0x240]
-	str r0, [sl, #0x10]
+	str r0, [r10, #0x10]
 	ldr r0, [sp, #0x244]
-	str r0, [sl, #0x14]
+	str r0, [r10, #0x14]
 _01ffc508:
 	ldr r0, [sp, #0x40]
 	add r4, r4, #1
@@ -5468,18 +5468,18 @@ _01ffc73c:
 	mov r0, #1
 	str r0, [sp, #0x58]
 	str r1, [sp, #0x268]
-	strb r0, [sl, #0x59]
-	strb r0, [sl, #0x5d]
+	strb r0, [r10, #0x59]
+	strb r0, [r10, #0x5d]
 	ldr r0, _01ffd1d4 ; =data_027e0e64
 	mov r1, r5, lsl #0x1
 	ldrh r0, [r0, r1]
-	strh r0, [sl, #0x28]
+	strh r0, [r10, #0x28]
 	ldr r0, [sp, #0x1e8]
-	str r0, [sl, #0x18]
+	str r0, [r10, #0x18]
 	ldr r0, [sp, #0x1ec]
-	str r0, [sl, #0x1c]
+	str r0, [r10, #0x1c]
 	ldr r0, [sp, #0x1f0]
-	str r0, [sl, #0x20]
+	str r0, [r10, #0x20]
 	b _01ffc8e4
 _01ffc840:
 	ldr r0, _01ffd1d4 ; =data_027e0e64
@@ -5512,17 +5512,17 @@ _01ffc840:
 	mov r0, #1
 	str r0, [sp, #0x58]
 	str r1, [sp, #0x268]
-	strb r0, [sl, #0x5b]
+	strb r0, [r10, #0x5b]
 	ldr r0, _01ffd1d4 ; =data_027e0e64
 	mov r1, r5, lsl #0x1
 	ldrh r0, [r0, r1]
-	strh r0, [sl, #0x2a]
+	strh r0, [r10, #0x2a]
 	ldr r0, [sp, #0x1e8]
-	str r0, [sl, #0xc]
+	str r0, [r10, #0xc]
 	ldr r0, [sp, #0x1ec]
-	str r0, [sl, #0x10]
+	str r0, [r10, #0x10]
 	ldr r0, [sp, #0x1f0]
-	str r0, [sl, #0x14]
+	str r0, [r10, #0x14]
 _01ffc8e4:
 	ldr r0, [sp, #0x30]
 	add r5, r5, #1
@@ -5551,7 +5551,7 @@ _01ffc8f4:
 	mov r0, r0, lsr #0x10
 	str r0, [sp, #8]
 	ldr r0, [sp, #0x14]
-	mov r1, sl
+	mov r1, r10
 	mov r3, sb
 	str r11, [sp, #0xc]
 	mov r4, #1
@@ -5560,16 +5560,16 @@ _01ffc8f4:
 	cmp r0, #0
 	addne sp, sp, #0x2b8
 	movne r0, r4
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r1, [sp, #0x260]
 	mov r0, r4
-	str r1, [sl]
+	str r1, [r10]
 	ldr r1, [sp, #0x264]
-	str r1, [sl, #4]
+	str r1, [r10, #4]
 	ldr r1, [sp, #0x268]
 	add sp, sp, #0x2b8
-	str r1, [sl, #8]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	str r1, [r10, #8]
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _01ffc998:
 	ldr r0, [sp, #0x18]
 	add r3, sp, #0x1c4
@@ -5803,21 +5803,21 @@ _01ffcd18:
 	mov r0, r6, lsl #0x10
 	mov r1, r0, lsr #0x10
 	mov r0, #1
-	strb r0, [sl, #0x58]
-	strh r1, [sl, #0x26]
+	strb r0, [r10, #0x58]
+	strh r1, [r10, #0x26]
 	str r0, [sp, #0x58]
-	ldrh r0, [sl, #0x2c]
-	add r0, sl, r0, lsl #1
+	ldrh r0, [r10, #0x2c]
+	add r0, r10, r0, lsl #1
 	strh r1, [r0, #0x2e]
-	ldrh r0, [sl, #0x2c]
+	ldrh r0, [r10, #0x2c]
 	add r0, r0, #1
-	strh r0, [sl, #0x2c]
+	strh r0, [r10, #0x2c]
 	ldr r0, [sp, #0x274]
-	str r0, [sl, #0xc]
+	str r0, [r10, #0xc]
 	ldr r0, [sp, #0x278]
-	str r0, [sl, #0x10]
+	str r0, [r10, #0x10]
 	ldr r0, [sp, #0x27c]
-	str r0, [sl, #0x14]
+	str r0, [r10, #0x14]
 	ldr r0, [sp, #0x198]
 	ldr r1, [sp, #0x194]
 	str r0, [sp, #0x264]
@@ -6050,15 +6050,15 @@ _01ffd0d0:
 	bne _01ffd11c
 	mov r0, #1
 	str r0, [sp, #0x58]
-	strb r0, [sl, #0x59]
+	strb r0, [r10, #0x59]
 	ldr r0, [sp, #0x50]
-	strh r0, [sl, #0x24]
+	strh r0, [r10, #0x24]
 	ldr r0, [sp, #0x274]
-	str r0, [sl, #0x18]
+	str r0, [r10, #0x18]
 	ldr r0, [sp, #0x278]
-	str r0, [sl, #0x1c]
+	str r0, [r10, #0x1c]
 	ldr r0, [sp, #0x27c]
-	str r0, [sl, #0x20]
+	str r0, [r10, #0x20]
 	ldr r2, [sp, #0x170]
 	ldr r1, [sp, #0x174]
 	ldr r0, [sp, #0x178]
@@ -6088,22 +6088,22 @@ _01ffd11c:
 	str r0, [sp, #0x264]
 	mov r0, #1
 	str r0, [sp, #0x58]
-	strb r0, [sl, #0x59]
+	strb r0, [r10, #0x59]
 	mov r1, #0
-	str r1, [sl, #0x18]
+	str r1, [r10, #0x18]
 	mov r0, #0x1000
-	str r0, [sl, #0x1c]
-	str r1, [sl, #0x20]
+	str r0, [r10, #0x1c]
+	str r1, [r10, #0x20]
 _01ffd18c:
 	ldr r0, [sp, #0x58]
 	cmp r0, #0
 	beq _01ffd1b0
 	ldr r0, [sp, #0x260]
-	str r0, [sl]
+	str r0, [r10]
 	ldr r0, [sp, #0x264]
-	str r0, [sl, #4]
+	str r0, [r10, #4]
 	ldr r0, [sp, #0x268]
-	str r0, [sl, #8]
+	str r0, [r10, #8]
 _01ffd1b0:
 	ldr r3, _01ffd1d8 ; =func_ov00_0207e968
 	add r0, sp, #0x284
@@ -6112,7 +6112,7 @@ _01ffd1b0:
 	bl func_0204f754
 	ldr r0, [sp, #0x58]
 	add sp, sp, #0x2b8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_01ffc118
 _01ffd1d0: .word data_027e0f6c
@@ -6123,12 +6123,12 @@ _01ffd1dc: .word func_ov00_0207e96c
 	.global func_01ffd1e0
 	arm_func_start func_01ffd1e0
 func_01ffd1e0: ; 0x01ffd1e0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x320
 	str r0, [sp, #0x14]
 	mov r0, r2
 	str r2, [sp, #0x18]
-	mov sl, r1
+	mov r10, r1
 	ldmia r0, {r0, r1, r2}
 	mov r4, #0
 	str r4, [sp, #0x4c]
@@ -6363,7 +6363,7 @@ _01ffd4e4:
 	ldr r1, [r0]
 	ldr r1, [r1, #0x1c]
 	blx r1
-	str r0, [sl, #0x54]
+	str r0, [r10, #0x54]
 	mov r0, #1
 	str r0, [sp, #0x4c]
 	add r3, sp, #0x260
@@ -6390,31 +6390,31 @@ _01ffd4e4:
 	cmp r0, #0
 	mov r0, #1
 	beq _01ffd624
-	strb r0, [sl, #0x59]
-	strb r0, [sl, #0x5c]
+	strb r0, [r10, #0x59]
+	strb r0, [r10, #0x5c]
 	ldrb r1, [r5, #0x15]
 	ldrb r0, [r5, #0x14]
-	strb r0, [sl, #0x50]
-	strb r1, [sl, #0x51]
+	strb r0, [r10, #0x50]
+	strb r1, [r10, #0x51]
 	ldr r0, [sp, #0x26c]
-	str r0, [sl, #0x18]
+	str r0, [r10, #0x18]
 	ldr r0, [sp, #0x270]
-	str r0, [sl, #0x1c]
+	str r0, [r10, #0x1c]
 	ldr r0, [sp, #0x274]
-	str r0, [sl, #0x20]
+	str r0, [r10, #0x20]
 	b _01ffd650
 _01ffd624:
-	strb r0, [sl, #0x5a]
+	strb r0, [r10, #0x5a]
 	ldrb r1, [r5, #0x15]
 	ldrb r0, [r5, #0x14]
-	strb r0, [sl, #0x4e]
-	strb r1, [sl, #0x4f]
+	strb r0, [r10, #0x4e]
+	strb r1, [r10, #0x4f]
 	ldr r0, [sp, #0x26c]
-	str r0, [sl, #0xc]
+	str r0, [r10, #0xc]
 	ldr r0, [sp, #0x270]
-	str r0, [sl, #0x10]
+	str r0, [r10, #0x10]
 	ldr r0, [sp, #0x274]
-	str r0, [sl, #0x14]
+	str r0, [r10, #0x14]
 _01ffd650:
 	ldr r0, [sp, #0x38]
 	add r4, r4, #1
@@ -6605,18 +6605,18 @@ _01ffd858:
 	mov r0, #1
 	str r0, [sp, #0x4c]
 	str r1, [sp, #0x2d0]
-	strb r0, [sl, #0x59]
-	strb r0, [sl, #0x5d]
+	strb r0, [r10, #0x59]
+	strb r0, [r10, #0x5d]
 	ldr r0, _01ffe1bc ; =data_027e0e64
 	mov r1, r5, lsl #0x1
 	ldrh r0, [r0, r1]
-	strh r0, [sl, #0x28]
+	strh r0, [r10, #0x28]
 	ldr r0, [sp, #0x230]
-	str r0, [sl, #0x18]
+	str r0, [r10, #0x18]
 	ldr r0, [sp, #0x234]
-	str r0, [sl, #0x1c]
+	str r0, [r10, #0x1c]
 	ldr r0, [sp, #0x238]
-	str r0, [sl, #0x20]
+	str r0, [r10, #0x20]
 	b _01ffda08
 _01ffd964:
 	ldr r0, _01ffe1bc ; =data_027e0e64
@@ -6649,17 +6649,17 @@ _01ffd964:
 	mov r0, #1
 	str r0, [sp, #0x4c]
 	str r1, [sp, #0x2d0]
-	strb r0, [sl, #0x5b]
+	strb r0, [r10, #0x5b]
 	ldr r0, _01ffe1bc ; =data_027e0e64
 	mov r1, r5, lsl #0x1
 	ldrh r0, [r0, r1]
-	strh r0, [sl, #0x2a]
+	strh r0, [r10, #0x2a]
 	ldr r0, [sp, #0x230]
-	str r0, [sl, #0xc]
+	str r0, [r10, #0xc]
 	ldr r0, [sp, #0x234]
-	str r0, [sl, #0x10]
+	str r0, [r10, #0x10]
 	ldr r0, [sp, #0x238]
-	str r0, [sl, #0x14]
+	str r0, [r10, #0x14]
 _01ffda08:
 	ldr r0, [sp, #0x24]
 	add r5, r5, #1
@@ -6881,23 +6881,23 @@ _01ffdd50:
 	mov r0, r5, lsl #0x10
 	mov r2, r0, lsr #0x10
 	mov r0, #1
-	strb r0, [sl, #0x58]
-	strh r2, [sl, #0x26]
+	strb r0, [r10, #0x58]
+	strh r2, [r10, #0x26]
 	str r0, [sp, #0x4c]
-	ldrh r3, [sl, #0x2c]
+	ldrh r3, [r10, #0x2c]
 	add r0, sp, #0x1dc
 	mov r1, r8
-	add r3, sl, r3, lsl #1
+	add r3, r10, r3, lsl #1
 	strh r2, [r3, #0x2e]
-	ldrh r2, [sl, #0x2c]
+	ldrh r2, [r10, #0x2c]
 	add r2, r2, #1
-	strh r2, [sl, #0x2c]
+	strh r2, [r10, #0x2c]
 	ldr r2, [sp, #0x2dc]
-	str r2, [sl, #0xc]
+	str r2, [r10, #0xc]
 	ldr r2, [sp, #0x2e0]
-	str r2, [sl, #0x10]
+	str r2, [r10, #0x10]
 	ldr r2, [sp, #0x2e4]
-	str r2, [sl, #0x14]
+	str r2, [r10, #0x14]
 	ldr r3, [sp, #0x1f4]
 	ldr r2, [sp, #0x1f8]
 	str r3, [sp, #0x2c8]
@@ -7135,15 +7135,15 @@ _01ffe138:
 	bne _01ffe174
 	mov r0, #1
 	str r0, [sp, #0x4c]
-	strb r0, [sl, #0x59]
+	strb r0, [r10, #0x59]
 	ldr r0, [sp, #0x40]
-	strh r0, [sl, #0x24]
+	strh r0, [r10, #0x24]
 	ldr r0, [sp, #0x2dc]
-	str r0, [sl, #0x18]
+	str r0, [r10, #0x18]
 	ldr r0, [sp, #0x2e0]
-	str r0, [sl, #0x1c]
+	str r0, [r10, #0x1c]
 	ldr r0, [sp, #0x2e4]
-	str r0, [sl, #0x20]
+	str r0, [r10, #0x20]
 	ldr r0, [sp, #0x1d4]
 	str r0, [sp, #0x2cc]
 _01ffe174:
@@ -7151,11 +7151,11 @@ _01ffe174:
 	cmp r0, #0
 	beq _01ffe198
 	ldr r0, [sp, #0x2c8]
-	str r0, [sl]
+	str r0, [r10]
 	ldr r0, [sp, #0x2cc]
-	str r0, [sl, #4]
+	str r0, [r10, #4]
 	ldr r0, [sp, #0x2d0]
-	str r0, [sl, #8]
+	str r0, [r10, #8]
 _01ffe198:
 	ldr r3, _01ffe1c0 ; =func_ov00_0207e968
 	add r0, sp, #0x2ec
@@ -7164,7 +7164,7 @@ _01ffe198:
 	bl func_0204f754
 	ldr r0, [sp, #0x4c]
 	add sp, sp, #0x320
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_01ffd1e0
 _01ffe1b8: .word data_027e0f6c
@@ -7176,7 +7176,7 @@ _01ffe1c8: .word 0x00001922
 	.global func_01ffe1cc
 	arm_func_start func_01ffe1cc
 func_01ffe1cc: ; 0x01ffe1cc
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x84
 	ldr sb, [sp, #0xa8]
 	ldrh r4, [sp, #0xac]
@@ -7188,13 +7188,13 @@ func_01ffe1cc: ; 0x01ffe1cc
 	str r0, [sp, #0xc]
 	ldr r0, [r4]
 	mov r4, r1
-	mov sl, r2
+	mov r10, r2
 	str r3, [sp, #0x10]
 	bl func_01fff510
 	cmp r0, #0
 	addne sp, sp, #0x84
 	movne r0, #1
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldrh r5, [sp, #0xac]
 	tst r5, #4
 	beq _01ffe458
@@ -7202,17 +7202,17 @@ func_01ffe1cc: ; 0x01ffe1cc
 	add r4, sp, #0x78
 	stmia r4, {r0, r1, r2}
 	add r3, sp, #0x6c
-	ldmia sl, {r0, r1, r2}
+	ldmia r10, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
 	add r2, sp, #0x60
 	mov r0, r4
-	mov r1, sl
+	mov r1, r10
 	bl func_01ff9bf8
 	add r4, sp, #0x48
-	ldmia sl, {r0, r1, r2}
+	ldmia r10, {r0, r1, r2}
 	stmia r4, {r0, r1, r2}
 	add r3, sp, #0x54
-	ldmia sl, {r0, r1, r2}
+	ldmia r10, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
 	mov r0, r4
 	add r1, sp, #0x78
@@ -7310,13 +7310,13 @@ _01ffe3b8:
 	tst r2, #0x1f
 	beq _01ffe43c
 _01ffe3cc:
-	ldr r2, [sl]
+	ldr r2, [r10]
 	add r1, sp, #0x38
 	str r2, [sp, #0x38]
-	ldr r3, [sl, #4]
+	ldr r3, [r10, #4]
 	add r2, sp, #0x60
 	str r3, [sp, #0x3c]
-	ldr ip, [sl, #8]
+	ldr ip, [r10, #8]
 	add r3, sp, #0x34
 	str ip, [sp, #0x40]
 	ldr ip, [sp, #0x10]
@@ -7338,7 +7338,7 @@ _01ffe3cc:
 _01ffe430:
 	add sp, sp, #0x84
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _01ffe43c:
 	add r5, r5, #1
 	cmp r5, r4
@@ -7351,7 +7351,7 @@ _01ffe448:
 _01ffe458:
 	mov r0, #0
 	add sp, sp, #0x84
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_01ffe1cc
 _01ffe464: .word data_027e0f6c
@@ -7500,14 +7500,14 @@ func_01ffe61c: ; 0x01ffe61c
 	.global func_01ffe668
 	arm_func_start func_01ffe668
 func_01ffe668: ; 0x01ffe668
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x2c
-	mov sl, r0
-	add r0, sl, #8
+	mov r10, r0
+	add r0, r10, #8
 	mov sb, r1
 	str r2, [sp]
 	bl func_01ff9c2c
-	ldr r2, [sl, #0x14]
+	ldr r2, [r10, #0x14]
 	ldr r1, [sb, #0xc]
 	sub r0, r0, r2
 	str r0, [sp, #4]
@@ -7518,19 +7518,19 @@ func_01ffe668: ; 0x01ffe668
 _01ffe6a4:
 	add sp, sp, #0x2c
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _01ffe6b0:
 	mov r5, #0
 	mov r6, r5
 	mov r11, r5
 	mov r7, r5
 	mov r8, r5
-	add r4, sl, #0x18
+	add r4, r10, #0x18
 _01ffe6c8:
 	mov r1, sb
 	add r0, r4, r8, lsl #4
 	bl func_01ff9c2c
-	add r1, sl, r8, lsl #4
+	add r1, r10, r8, lsl #4
 	ldr r2, [r1, #0x24]
 	ldr r1, [sb, #0xc]
 	sub r2, r0, r2
@@ -7539,7 +7539,7 @@ _01ffe6c8:
 	str r2, [r0, r8, lsl #2]
 	addge sp, sp, #0x2c
 	movge r0, #0
-	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	add r0, r8, #1
 	mov r0, r0, lsl #0x10
 	cmp r2, r5
@@ -7560,7 +7560,7 @@ _01ffe6c8:
 	ldr r1, [sp]
 	add sp, sp, #0x2c
 	str r2, [r1]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _01ffe750:
 	ldr r0, [sp, #4]
 	smull r4, r3, r0, r0
@@ -7579,7 +7579,7 @@ _01ffe750:
 	cmp r5, r8
 	addgt sp, sp, #0x2c
 	movgt r0, #0
-	ldmgtia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmgtia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	cmp r7, #1
 	bne _01ffe874
 	add r0, r6, #1
@@ -7589,9 +7589,9 @@ _01ffe750:
 	movhi r0, #0
 	mov r1, r6, lsl #0x1
 	mov r0, r0, lsl #0x1
-	ldr r7, [sl, #0x48]
-	ldrh r3, [sl, r1]
-	ldrh r2, [sl, r0]
+	ldr r7, [r10, #0x48]
+	ldrh r3, [r10, r1]
+	ldrh r2, [r10, r0]
 	ldr r7, [r7, #8]
 	mov r1, #0xc
 	mla r0, r3, r1, r7
@@ -7599,8 +7599,8 @@ _01ffe750:
 	add r2, sp, #0x14
 	bl func_01ff9bf8
 	mov r0, r6, lsl #0x1
-	ldr r2, [sl, #0x48]
-	ldrh r1, [sl, r0]
+	ldr r2, [r10, #0x48]
+	ldrh r1, [r10, r0]
 	ldr r2, [r2, #8]
 	mov r0, #0xc
 	mla r0, r1, r0, r2
@@ -7631,21 +7631,21 @@ _01ffe750:
 	add sp, sp, #0x2c
 	str r1, [r0]
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _01ffe868:
 	add sp, sp, #0x2c
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _01ffe874:
 	adds r1, r6, r11
 	beq _01ffe8bc
 	ldr r0, _01ffe900 ; =data_ov00_020db008
 	mov r1, r1, lsl #0x1
 	ldrh r1, [r0, r1]
-	ldr r3, [sl, #0x48]
+	ldr r3, [r10, #0x48]
 	mov r0, #0xc
 	mov r1, r1, lsl #0x1
-	ldrh r2, [sl, r1]
+	ldrh r2, [r10, r1]
 	ldr r3, [r3, #8]
 	mov r1, sb
 	mla r0, r2, r0, r3
@@ -7654,11 +7654,11 @@ _01ffe874:
 	movge r0, #0
 	blt _01ffe8c8
 	add sp, sp, #0x2c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _01ffe8bc:
 	add sp, sp, #0x2c
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _01ffe8c8:
 	smull r2, r1, r0, r0
 	adds r2, r2, #0x800
@@ -7673,7 +7673,7 @@ _01ffe8c8:
 	str r1, [r0]
 	mov r0, #1
 	add sp, sp, #0x2c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_01ffe668
 _01ffe900: .word data_ov00_020db008
@@ -7758,7 +7758,7 @@ _01ffe9d4:
 	.global func_01ffea18
 	arm_func_start func_01ffea18
 func_01ffea18: ; 0x01ffea18
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #0x18
 	ldr r8, [sp, #0x38]
 	mov r7, r0
@@ -7771,7 +7771,7 @@ func_01ffea18: ; 0x01ffea18
 	cmp r0, #0
 	addeq sp, sp, #0x18
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	mov r1, r6
 	add r0, r7, #8
 	bl func_01ff9c2c
@@ -7779,7 +7779,7 @@ func_01ffea18: ; 0x01ffea18
 	subs r0, r0, r1
 	addmi sp, sp, #0x18
 	movmi r0, #0
-	ldmmiia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmmiia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	mov r1, r5
 	add r0, r7, #8
 	bl func_01ff9c2c
@@ -7797,7 +7797,7 @@ func_01ffea18: ; 0x01ffea18
 _01ffeaa8:
 	add sp, sp, #0x18
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _01ffeab4:
 	ldr r0, [r5]
 	ldr r2, [r6]
@@ -7837,12 +7837,12 @@ _01ffeab4:
 	cmp r0, r1
 	addgt sp, sp, #0x18
 	movgt r0, #0
-	ldmgtia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
-	add sl, r7, #0x18
+	ldmgtia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	add r10, r7, #0x18
 	mov sb, #0
 	add r8, sp, #0xc
 _01ffeb5c:
-	mov r0, sl
+	mov r0, r10
 	mov r1, r8
 	bl func_01ff9c2c
 	add r1, r7, sb, lsl #4
@@ -7852,10 +7852,10 @@ _01ffeb5c:
 	cmp r0, r1
 	addge sp, sp, #0x18
 	movge r0, #0
-	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	add sb, sb, #1
 	cmp sb, #3
-	add sl, sl, #0x10
+	add r10, r10, #0x10
 	blt _01ffeb5c
 	add r3, sp, #0
 	ldmia r6, {r0, r1, r2}
@@ -7874,7 +7874,7 @@ _01ffeb5c:
 	str r0, [r4]
 	mov r0, #1
 	add sp, sp, #0x18
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	arm_func_end func_01ffea18
 
 	.global func_01ffebe0
@@ -7928,21 +7928,21 @@ func_01ffec34: ; 0x01ffec34
 	.global func_01ffec78
 	arm_func_start func_01ffec78
 func_01ffec78: ; 0x01ffec78
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x38
 	cmp r1, #0
-	mov sl, r0
+	mov r10, r0
 	addne sp, sp, #0x38
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
-	add r0, sl, #0x44
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	add r0, r10, #0x44
 	bl func_ov00_020951d4
-	ldr r0, [sl, #0x3c]
+	ldr r0, [r10, #0x3c]
 	mov r11, #0
 	cmp r0, #0
 	addls sp, sp, #0x38
-	ldmlsia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmlsia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _01ffecac:
-	ldr r0, [sl, #0x40]
+	ldr r0, [r10, #0x40]
 	ldr r0, [r0, r11, lsl #2]
 	cmp r0, #0
 	beq _01ffeddc
@@ -7956,7 +7956,7 @@ _01ffecac:
 	str r2, [sp, #0x20]
 	str r1, [sp, #0x24]
 	str r0, [sp, #0x28]
-	ldr r0, [sl, #0x40]
+	ldr r0, [r10, #0x40]
 	ldr r0, [r0, r11, lsl #2]
 	ldr r1, [r0]
 	ldr r1, [r1, #0x40]
@@ -7984,11 +7984,11 @@ _01ffecac:
 	str r4, [sp, #0x10]
 	bl func_01ff9bc4
 	add r0, sp, #4
-	add r1, sl, #0x44
+	add r1, r10, #0x44
 	add r2, sp, #0x2c
 	bl func_ov00_02095278
 	add r0, sp, #0
-	add r1, sl, #0x44
+	add r1, r10, #0x44
 	add r2, sp, #0x20
 	ldrh r6, [sp, #4]
 	ldrh r7, [sp, #6]
@@ -8008,7 +8008,7 @@ _01ffeda0:
 	mov r1, r6
 	mov r2, r5
 	mov r3, r4
-	add r0, sl, #0x44
+	add r0, r10, #0x44
 	bl func_ov00_02095224
 	add r0, r5, #1
 	mov r0, r0, lsl #0x10
@@ -8022,32 +8022,32 @@ _01ffedc8:
 	mov r6, r0, lsr #0x10
 	bhs _01ffed94
 _01ffeddc:
-	ldr r0, [sl, #0x3c]
+	ldr r0, [r10, #0x3c]
 	add r11, r11, #1
 	cmp r11, r0
 	blo _01ffecac
 	add sp, sp, #0x38
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	arm_func_end func_01ffec78
 
 	.global func_01ffedf4
 	arm_func_start func_01ffedf4
 func_01ffedf4: ; 0x01ffedf4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x30
-	mov sl, r0
+	mov r10, r0
 	mov r4, r1
 	mov r11, r3
 	ldr r3, [sp, #0x58]
 	mov r5, r2
 	add r0, sp, #0x2c
 	mov r2, r4
-	add r1, sl, #0x24
+	add r1, r10, #0x24
 	str r3, [sp, #0x58]
 	ldr sb, [sp, #0x5c]
 	bl func_ov00_02095278
 	add r0, sp, #0x28
-	add r1, sl, #0x24
+	add r1, r10, #0x24
 	add r2, r4, #0xc
 	bl func_ov00_02095278
 	ldrh r0, [sp, #0x2c]
@@ -8080,7 +8080,7 @@ _01ffee94:
 	strh r0, [sp, #0x20]
 	ldr r0, [sp, #0x18]
 	strh r0, [sp, #0x22]
-	add r0, sl, #0x24
+	add r0, r10, #0x24
 	bl func_ov00_02095258
 	mov r7, r0
 	ldr r0, [r7, #4]
@@ -8092,11 +8092,11 @@ _01ffeec4:
 	cmp r4, r0
 	addhs sp, sp, #0x30
 	mvnhs r0, #0
-	ldmhsia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmhsia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r1, [r7, #8]
 	mov r0, r6, lsl #0x1
 	ldrh r5, [r1, r0]
-	mov r0, sl
+	mov r0, r10
 	mov r2, r11
 	mov r1, r5
 	mov r3, r4
@@ -8106,13 +8106,13 @@ _01ffeec4:
 	mov r0, #0x4c
 	mul r0, r5, r0
 	str r0, [sp]
-	ldr r2, [sl, #0x20]
+	ldr r2, [r10, #0x20]
 	ldr r1, [sp]
 	add r0, sp, #0x1c
 	add r1, r2, r1
 	bl func_ov00_0208e4f8
 	ldr r2, [sp, #0x1c]
-	ldr r1, [sl, #0x20]
+	ldr r1, [r10, #0x20]
 	ldr r0, [sp]
 	str r2, [sp, #0x24]
 	add r0, r1, r0
@@ -8212,27 +8212,27 @@ _01fff058:
 _01fff078:
 	mov r0, r4
 	add sp, sp, #0x30
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	arm_func_end func_01ffedf4
 
 	.global func_01fff084
 	arm_func_start func_01fff084
 func_01fff084: ; 0x01fff084
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x20
-	mov sl, r0
+	mov r10, r0
 	mov r11, r3
 	ldr r3, [sp, #0x48]
 	mov r5, r2
 	mov r2, r1
 	add r0, sp, #0x1c
-	add r1, sl, #0x24
+	add r1, r10, #0x24
 	str r3, [sp, #0x48]
 	ldr sb, [sp, #0x4c]
 	bl func_ov00_02095278
 	mov r4, #0
 	add r1, sp, #0x1c
-	add r0, sl, #0x24
+	add r0, r10, #0x24
 	str r4, [sp, #0x18]
 	bl func_ov00_02095258
 	mov r7, r0
@@ -8254,11 +8254,11 @@ _01fff100:
 	cmp r4, r0
 	addhs sp, sp, #0x20
 	mvnhs r0, #0
-	ldmhsia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmhsia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r1, [r7, #8]
 	mov r0, r6, lsl #0x1
 	ldrh r5, [r1, r0]
-	mov r0, sl
+	mov r0, r10
 	mov r2, r11
 	mov r1, r5
 	mov r3, r4
@@ -8268,13 +8268,13 @@ _01fff100:
 	mov r0, #0x4c
 	mul r0, r5, r0
 	str r0, [sp]
-	ldr r2, [sl, #0x20]
+	ldr r2, [r10, #0x20]
 	ldr r1, [sp]
 	add r0, sp, #0x14
 	add r1, r2, r1
 	bl func_ov00_0208e4f8
 	ldr r2, [sp, #0x14]
-	ldr r1, [sl, #0x20]
+	ldr r1, [r10, #0x20]
 	ldr r0, [sp]
 	str r2, [sp, #0x18]
 	add r0, r1, r0
@@ -8349,20 +8349,20 @@ _01fff240:
 _01fff258:
 	mov r0, r4
 	add sp, sp, #0x20
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	arm_func_end func_01fff084
 
 	.global func_01fff264
 	arm_func_start func_01fff264
 func_01fff264: ; 0x01fff264
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x24
-	mov sl, r0
+	mov r10, r0
 	mov r6, r1
 	mov r5, r2
 	add r0, sp, #0x20
 	mov r2, r6
-	add r1, sl, #0x44
+	add r1, r10, #0x44
 	mov sb, r3
 	ldr r11, [sp, #0x48]
 	ldr r8, [sp, #0x4c]
@@ -8370,7 +8370,7 @@ func_01fff264: ; 0x01fff264
 	bl func_ov00_02095278
 	add r0, sp, #0x1c
 	add r2, r6, #0xc
-	add r1, sl, #0x44
+	add r1, r10, #0x44
 	bl func_ov00_02095278
 	ldrh r0, [sp, #0x20]
 	mov r1, r4
@@ -8398,7 +8398,7 @@ _01fff2f8:
 	add r1, sp, #0x14
 	strh r2, [sp, #0x14]
 	ldr r2, [sp, #0x10]
-	add r0, sl, #0x44
+	add r0, r10, #0x44
 	strh r2, [sp, #0x16]
 	bl func_ov00_02095258
 	mov r6, r0
@@ -8410,22 +8410,22 @@ _01fff328:
 	cmp r4, r11
 	addhs sp, sp, #0x24
 	mvnhs r0, #0
-	ldmhsia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmhsia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r1, [r6, #8]
 	mov r0, r5, lsl #0x1
 	ldrh r7, [r1, r0]
-	ldr r0, [sl, #0x40]
+	ldr r0, [r10, #0x40]
 	ldr r0, [r0, r7, lsl #2]
 	cmp r0, #0
 	beq _01fff430
-	mov r0, sl
+	mov r0, r10
 	mov r1, r7
 	mov r2, sb
 	mov r3, r4
 	bl func_01fff48c
 	cmp r0, #0
 	bne _01fff430
-	ldr r0, [sl, #0x40]
+	ldr r0, [r10, #0x40]
 	ldr r0, [r0, r7, lsl #2]
 	ldr r0, [r0, #0xc]
 	str r0, [sp, #0x18]
@@ -8506,7 +8506,7 @@ _01fff460:
 _01fff480:
 	mov r0, r4
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	arm_func_end func_01fff264
 
 	.global func_01fff48c
@@ -8559,11 +8559,11 @@ _01fff508:
 	.global func_01fff510
 	arm_func_start func_01fff510
 func_01fff510: ; 0x01fff510
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x14c
 	add r6, sp, #0xe8
 	mov sb, r2
-	mov sl, r0
+	mov r10, r0
 	mov r4, r1
 	ldmia sb, {r0, r1, r2}
 	stmia r6, {r0, r1, r2}
@@ -8611,11 +8611,11 @@ func_01fff510: ; 0x01fff510
 _01fff5d4:
 	add r0, sp, #0x60
 	add r2, sp, #0xe8
-	add r1, sl, #0x24
+	add r1, r10, #0x24
 	bl func_ov00_02095278
 	add r0, sp, #0x5c
 	add r2, sp, #0xf4
-	add r1, sl, #0x24
+	add r1, r10, #0x24
 	bl func_ov00_02095278
 	ldrh r0, [sp, #0x60]
 	mov r2, #0
@@ -8650,7 +8650,7 @@ _01fff65c:
 	strh r0, [sp, #0x48]
 	ldr r0, [sp, #0x38]
 	strh r0, [sp, #0x4a]
-	add r0, sl, #0x24
+	add r0, r10, #0x24
 	bl func_ov00_02095258
 	mov r5, r0
 	ldr r0, [r5, #4]
@@ -8664,12 +8664,12 @@ _01fff68c:
 	mov r1, #0x4c
 	str r0, [sp, #0x3c]
 	ldr r2, [sp, #0x3c]
-	ldr r3, [sl, #0x20]
+	ldr r3, [r10, #0x20]
 	mul r6, r2, r1
 	add r0, sp, #0x44
 	add r1, r3, r6
 	bl func_ov00_0208e4f8
-	ldr r0, [sl, #0x20]
+	ldr r0, [r10, #0x20]
 	ldr r1, [sp, #0x44]
 	add r0, r0, r6
 	ldr r0, [r0, #0xc]
@@ -8743,7 +8743,7 @@ _01fff788:
 	str r0, [sp, #0xb0]
 	add r0, sp, #0x64
 	str r0, [sp]
-	ldr r0, [sl, #0x20]
+	ldr r0, [r10, #0x20]
 	add r2, sp, #0xc4
 	add r0, r0, r6
 	add r3, sp, #0x68
@@ -8776,7 +8776,7 @@ _01fff820:
 	bl func_0204f754
 	add sp, sp, #0x14c
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _01fff840:
 	add r0, r4, #1
 	mov r0, r0, lsl #0x10
@@ -8808,11 +8808,11 @@ _01fff898:
 	beq _01fffb24
 	add r0, sp, #0x54
 	add r2, sp, #0xe8
-	add r1, sl, #0x44
+	add r1, r10, #0x44
 	bl func_ov00_02095278
 	add r0, sp, #0x50
 	add r2, sp, #0xf4
-	add r1, sl, #0x44
+	add r1, r10, #0x44
 	bl func_ov00_02095278
 	ldrh r0, [sp, #0x54]
 	mov r2, #0
@@ -8844,7 +8844,7 @@ _01fff920:
 	strh r0, [sp, #0x40]
 	ldr r0, [sp, #0x34]
 	strh r0, [sp, #0x42]
-	add r0, sl, #0x44
+	add r0, r10, #0x44
 	bl func_ov00_02095258
 	mov r5, r0
 	ldr r0, [r5, #4]
@@ -8855,7 +8855,7 @@ _01fff950:
 	ldr r1, [r5, #8]
 	mov r0, r4, lsl #0x1
 	ldrh r6, [r1, r0]
-	ldr r0, [sl, #0x40]
+	ldr r0, [r10, #0x40]
 	ldr r0, [r0, r6, lsl #2]
 	cmp r0, #0
 	beq _01fffad4
@@ -8903,7 +8903,7 @@ _01fff9f4:
 	cmpne r8, #1
 	beq _01fffad4
 _01fffa00:
-	ldr r0, [sl, #0x40]
+	ldr r0, [r10, #0x40]
 	ldr r0, [r0, r6, lsl #2]
 	cmp r0, #0
 	ldrne r1, [r0, #8]
@@ -8956,7 +8956,7 @@ _01fffab4:
 	bl func_0204f754
 	add sp, sp, #0x14c
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _01fffad4:
 	add r4, r4, #1
 	ldr r0, [r5, #4]
@@ -8988,7 +8988,7 @@ _01fffb24:
 	bl func_0204f754
 	mov r0, #0
 	add sp, sp, #0x14c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_01fff510
 _01fffb44: .word func_ov00_0207e968

--- a/asm/ov00/Actor/ActorManager.s
+++ b/asm/ov00/Actor/ActorManager.s
@@ -58,17 +58,17 @@ _020c3470:
 	.global _ZN12ActorManager18func_ov00_020c3484EP8ActorRefP5Actori
 	arm_func_start _ZN12ActorManager18func_ov00_020c3484EP8ActorRefP5Actori
 _ZN12ActorManager18func_ov00_020c3484EP8ActorRefP5Actori: ; 0x020c3484
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	mov r10, r0
 	mvn r3, #0
 	str r3, [r10]
 	ldr r0, _020c3570 ; =data_027e103c
 	str r3, [r10, #4]
 	ldr r0, [r0]
-	mov sb, r2
+	mov r9, r2
 	ldrb r0, [r0, #0x24]
 	cmp r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	ldr r0, _020c3574 ; =data_027e077c
 	ldr r2, _020c3578 ; =data_02056be4
 	ldr r0, [r0]
@@ -81,7 +81,7 @@ _ZN12ActorManager18func_ov00_020c3484EP8ActorRefP5Actori: ; 0x020c3484
 	moveq r8, #0
 	add r7, r6, r0, lsl #2
 	cmp r6, r7
-	ldmhsia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmhsia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	mov r4, #0
 _020c34e8:
 	ldr r0, [r6]
@@ -89,7 +89,7 @@ _020c34e8:
 	ldrneb r1, [r0, #0x118]
 	cmpne r1, #0
 	beq _020c3560
-	mov r1, sb
+	mov r1, r9
 	bl _ZN5Actor18func_ov00_020c27a8Ei
 	cmp r0, #0
 	beq _020c3560
@@ -118,7 +118,7 @@ _020c3560:
 	add r6, r6, #4
 	cmp r6, r7
 	blo _020c34e8
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end _ZN12ActorManager18func_ov00_020c3484EP8ActorRefP5Actori
 _020c3570: .word data_027e103c
@@ -399,11 +399,11 @@ _020c38ec:
 	.global _ZN12ActorManager22FindNearestActorOfTypeEP8ActorRefPS_jP5Vec3p
 	arm_func_start _ZN12ActorManager22FindNearestActorOfTypeEP8ActorRefPS_jP5Vec3p
 _ZN12ActorManager22FindNearestActorOfTypeEP8ActorRefPS_jP5Vec3p: ; 0x020c38fc
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	mvn r4, #0
-	mov sb, r0
-	str r4, [sb]
-	str r4, [sb, #4]
+	mov r9, r0
+	str r4, [r9]
+	str r4, [r9, #4]
 	ldr r5, [r1, #0x10]
 	ldr r0, [r1, #4]
 	mov r8, r2
@@ -411,7 +411,7 @@ _ZN12ActorManager22FindNearestActorOfTypeEP8ActorRefPS_jP5Vec3p: ; 0x020c38fc
 	mov r7, r3
 	sub r4, r4, #0x80000000
 	cmp r5, r6
-	ldmhsia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmhsia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _020c3930:
 	ldr r2, [r5]
 	cmp r2, #0
@@ -429,14 +429,14 @@ _020c3930:
 	ldr r1, [r5]
 	mov r4, r0
 	ldr r0, [r1, #8]
-	str r0, [sb]
+	str r0, [r9]
 	ldr r0, [r1, #0xc]
-	str r0, [sb, #4]
+	str r0, [r9, #4]
 _020c397c:
 	add r5, r5, #4
 	cmp r5, r6
 	blo _020c3930
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	arm_func_end _ZN12ActorManager22FindNearestActorOfTypeEP8ActorRefPS_jP5Vec3p
 
 	.global _ZN12ActorManager18func_ov00_020c398cEv
@@ -462,21 +462,21 @@ _020c39a8: .word func_ov00_020c3f3c
 	.global _ZN12ActorManager18func_ov00_020c39acEjPjb
 	arm_func_start _ZN12ActorManager18func_ov00_020c39acEjPjb
 _ZN12ActorManager18func_ov00_020c39acEjPjb: ; 0x020c39ac
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x10
 	movs r8, r2
 	mov r10, r0
-	mov sb, r1
+	mov r9, r1
 	mov r7, r3
 	bne _020c39d8
 	cmp r7, #0
 	addne sp, sp, #0x10
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _020c39d8:
 	ldr r0, [r10, #0x10]
 	mov r4, #0
-	ldr r11, [r0, sb, lsl #2]
+	ldr r11, [r0, r9, lsl #2]
 	cmp r11, #0
 	ldrneb r0, [r11, #0x118]
 	cmpne r0, #0
@@ -490,7 +490,7 @@ _020c39d8:
 	cmp r0, #0
 	ble _020c3b20
 _020c3a14:
-	cmp r5, sb
+	cmp r5, r9
 	ldrne r0, [r10, #0x10]
 	ldrne r0, [r0, r5, lsl #2]
 	cmpne r0, #0
@@ -562,7 +562,7 @@ _020c3b08:
 _020c3b20:
 	mov r0, r4
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	arm_func_end _ZN12ActorManager18func_ov00_020c39acEjPjb
 
 	.global _ZN12ActorManager18func_ov00_020c3b2cEPi
@@ -610,7 +610,7 @@ _020c3ba8:
 	.global _ZN12ActorManager18func_ov00_020c3bb0EiPi
 	arm_func_start _ZN12ActorManager18func_ov00_020c3bb0EiPi
 _ZN12ActorManager18func_ov00_020c3bb0EiPi: ; 0x020c3bb0
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0xd4
 	movs r10, r2
 	str r0, [sp]
@@ -625,7 +625,7 @@ _ZN12ActorManager18func_ov00_020c3bb0EiPi: ; 0x020c3bb0
 	cmp r5, #0
 	addle sp, sp, #0xd4
 	movle r0, #0
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, [sp]
 	mov r11, #0
 	ldr r0, [r0, #4]
@@ -646,11 +646,11 @@ _020c3c10:
 	mov r8, r6
 	cmp r5, #0
 	ble _020c3c88
-	add sb, sp, #0x14
+	add r9, sp, #0x14
 	add r4, sp, #8
 _020c3c44:
 	ldr r3, [r7]
-	mov r0, sb
+	mov r0, r9
 	ldr r2, [r3, #0x48]
 	mov r1, r4
 	str r2, [sp, #8]
@@ -664,7 +664,7 @@ _020c3c44:
 	bne _020c3c88
 	add r8, r8, #1
 	cmp r8, r5
-	add sb, sb, #0x18
+	add r9, r9, #0x18
 	blt _020c3c44
 _020c3c88:
 	cmp r6, #0
@@ -692,7 +692,7 @@ _020c3cb8:
 _020c3cd8:
 	mov r0, r11
 	add sp, sp, #0xd4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end _ZN12ActorManager18func_ov00_020c3bb0EiPi
 _020c3ce4: .word data_027e0e60
@@ -700,7 +700,7 @@ _020c3ce4: .word data_027e0e60
 	.global _ZN12ActorManager18func_ov00_020c3ce8Eii
 	arm_func_start _ZN12ActorManager18func_ov00_020c3ce8Eii
 _ZN12ActorManager18func_ov00_020c3ce8Eii: ; 0x020c3ce8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0xcc
 	ldr r3, _020c3dcc ; =data_027e0e60
 	mov r11, r0
@@ -712,13 +712,13 @@ _ZN12ActorManager18func_ov00_020c3ce8Eii: ; 0x020c3ce8
 	mov r5, r0
 	cmp r5, #0
 	addle sp, sp, #0xcc
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, [r11, #4]
 	ldr r7, [r11, #0x10]
 	cmp r0, #0
 	mov r6, #0
 	addle sp, sp, #0xcc
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r4, sp, #0
 _020c3d38:
 	ldr r1, [r7]
@@ -731,10 +731,10 @@ _020c3d38:
 	mov r8, #0
 	cmp r5, #0
 	ble _020c3db0
-	add sb, sp, #0xc
+	add r9, sp, #0xc
 _020c3d64:
 	ldr r3, [r7]
-	mov r0, sb
+	mov r0, r9
 	ldr r2, [r3, #0x48]
 	mov r1, r4
 	str r2, [sp]
@@ -751,7 +751,7 @@ _020c3d64:
 _020c3da0:
 	add r8, r8, #1
 	cmp r8, r5
-	add sb, sb, #0x18
+	add r9, r9, #0x18
 	blt _020c3d64
 _020c3db0:
 	ldr r0, [r11, #4]
@@ -760,7 +760,7 @@ _020c3db0:
 	add r7, r7, #4
 	blt _020c3d38
 	add sp, sp, #0xcc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end _ZN12ActorManager18func_ov00_020c3ce8Eii
 _020c3dcc: .word data_027e0e60

--- a/asm/ov00/Actor/ActorManager.s
+++ b/asm/ov00/Actor/ActorManager.s
@@ -462,7 +462,7 @@ _020c39a8: .word func_ov00_020c3f3c
 	.global _ZN12ActorManager18func_ov00_020c39acEjPjb
 	arm_func_start _ZN12ActorManager18func_ov00_020c39acEjPjb
 _ZN12ActorManager18func_ov00_020c39acEjPjb: ; 0x020c39ac
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x10
 	movs r8, r2
 	mov sl, r0
@@ -472,13 +472,13 @@ _ZN12ActorManager18func_ov00_020c39acEjPjb: ; 0x020c39ac
 	cmp r7, #0
 	addne sp, sp, #0x10
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _020c39d8:
 	ldr r0, [sl, #0x10]
 	mov r4, #0
-	ldr fp, [r0, sb, lsl #2]
-	cmp fp, #0
-	ldrneb r0, [fp, #0x118]
+	ldr r11, [r0, sb, lsl #2]
+	cmp r11, #0
+	ldrneb r0, [r11, #0x118]
 	cmpne r0, #0
 	beq _020c3b20
 	ldr r0, [sl, #4]
@@ -524,7 +524,7 @@ _020c3a60:
 	ldr r1, [sl, #0x10]
 	ldr r3, [r0]
 	ldr r2, [r1, r5, lsl #2]
-	mov r1, fp
+	mov r1, r11
 	str r3, [r2, #0x7c]
 	ldr r3, [r0, #4]
 	str r3, [r2, #0x80]
@@ -562,7 +562,7 @@ _020c3b08:
 _020c3b20:
 	mov r0, r4
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	arm_func_end _ZN12ActorManager18func_ov00_020c39acEjPjb
 
 	.global _ZN12ActorManager18func_ov00_020c3b2cEPi
@@ -610,7 +610,7 @@ _020c3ba8:
 	.global _ZN12ActorManager18func_ov00_020c3bb0EiPi
 	arm_func_start _ZN12ActorManager18func_ov00_020c3bb0EiPi
 _ZN12ActorManager18func_ov00_020c3bb0EiPi: ; 0x020c3bb0
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0xd4
 	movs sl, r2
 	str r0, [sp]
@@ -625,11 +625,11 @@ _ZN12ActorManager18func_ov00_020c3bb0EiPi: ; 0x020c3bb0
 	cmp r5, #0
 	addle sp, sp, #0xd4
 	movle r0, #0
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, [sp]
-	mov fp, #0
+	mov r11, #0
 	ldr r0, [r0, #4]
-	str fp, [sp, #4]
+	str r11, [sp, #4]
 	cmp r0, #0
 	ldr r0, [sp]
 	ldr r7, [r0, #0x10]
@@ -679,7 +679,7 @@ _020c3c88:
 	addgt r0, r0, #1
 	strgt r0, [sl]
 _020c3cb4:
-	add fp, fp, #1
+	add r11, r11, #1
 _020c3cb8:
 	ldr r0, [sp]
 	add r7, r7, #4
@@ -690,9 +690,9 @@ _020c3cb8:
 	cmp r0, r1
 	blt _020c3c10
 _020c3cd8:
-	mov r0, fp
+	mov r0, r11
 	add sp, sp, #0xd4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end _ZN12ActorManager18func_ov00_020c3bb0EiPi
 _020c3ce4: .word data_027e0e60
@@ -700,10 +700,10 @@ _020c3ce4: .word data_027e0e60
 	.global _ZN12ActorManager18func_ov00_020c3ce8Eii
 	arm_func_start _ZN12ActorManager18func_ov00_020c3ce8Eii
 _ZN12ActorManager18func_ov00_020c3ce8Eii: ; 0x020c3ce8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0xcc
 	ldr r3, _020c3dcc ; =data_027e0e60
-	mov fp, r0
+	mov r11, r0
 	ldr r0, [r3]
 	mov sl, r2
 	add r2, sp, #0xc
@@ -712,13 +712,13 @@ _ZN12ActorManager18func_ov00_020c3ce8Eii: ; 0x020c3ce8
 	mov r5, r0
 	cmp r5, #0
 	addle sp, sp, #0xcc
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
-	ldr r0, [fp, #4]
-	ldr r7, [fp, #0x10]
+	ldmleia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldr r0, [r11, #4]
+	ldr r7, [r11, #0x10]
 	cmp r0, #0
 	mov r6, #0
 	addle sp, sp, #0xcc
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r4, sp, #0
 _020c3d38:
 	ldr r1, [r7]
@@ -754,13 +754,13 @@ _020c3da0:
 	add sb, sb, #0x18
 	blt _020c3d64
 _020c3db0:
-	ldr r0, [fp, #4]
+	ldr r0, [r11, #4]
 	add r6, r6, #1
 	cmp r6, r0
 	add r7, r7, #4
 	blt _020c3d38
 	add sp, sp, #0xcc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end _ZN12ActorManager18func_ov00_020c3ce8Eii
 _020c3dcc: .word data_027e0e60

--- a/asm/ov00/Actor/ActorManager.s
+++ b/asm/ov00/Actor/ActorManager.s
@@ -58,17 +58,17 @@ _020c3470:
 	.global _ZN12ActorManager18func_ov00_020c3484EP8ActorRefP5Actori
 	arm_func_start _ZN12ActorManager18func_ov00_020c3484EP8ActorRefP5Actori
 _ZN12ActorManager18func_ov00_020c3484EP8ActorRefP5Actori: ; 0x020c3484
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
-	mov sl, r0
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	mov r10, r0
 	mvn r3, #0
-	str r3, [sl]
+	str r3, [r10]
 	ldr r0, _020c3570 ; =data_027e103c
-	str r3, [sl, #4]
+	str r3, [r10, #4]
 	ldr r0, [r0]
 	mov sb, r2
 	ldrb r0, [r0, #0x24]
 	cmp r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	ldr r0, _020c3574 ; =data_027e077c
 	ldr r2, _020c3578 ; =data_02056be4
 	ldr r0, [r0]
@@ -81,7 +81,7 @@ _ZN12ActorManager18func_ov00_020c3484EP8ActorRefP5Actori: ; 0x020c3484
 	moveq r8, #0
 	add r7, r6, r0, lsl #2
 	cmp r6, r7
-	ldmhsia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmhsia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	mov r4, #0
 _020c34e8:
 	ldr r0, [r6]
@@ -111,14 +111,14 @@ _020c34e8:
 	ldr r1, [r6]
 	mov r5, r0
 	ldr r0, [r1, #8]
-	str r0, [sl]
+	str r0, [r10]
 	ldr r0, [r1, #0xc]
-	str r0, [sl, #4]
+	str r0, [r10, #4]
 _020c3560:
 	add r6, r6, #4
 	cmp r6, r7
 	blo _020c34e8
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end _ZN12ActorManager18func_ov00_020c3484EP8ActorRefP5Actori
 _020c3570: .word data_027e103c
@@ -462,26 +462,26 @@ _020c39a8: .word func_ov00_020c3f3c
 	.global _ZN12ActorManager18func_ov00_020c39acEjPjb
 	arm_func_start _ZN12ActorManager18func_ov00_020c39acEjPjb
 _ZN12ActorManager18func_ov00_020c39acEjPjb: ; 0x020c39ac
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x10
 	movs r8, r2
-	mov sl, r0
+	mov r10, r0
 	mov sb, r1
 	mov r7, r3
 	bne _020c39d8
 	cmp r7, #0
 	addne sp, sp, #0x10
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _020c39d8:
-	ldr r0, [sl, #0x10]
+	ldr r0, [r10, #0x10]
 	mov r4, #0
 	ldr r11, [r0, sb, lsl #2]
 	cmp r11, #0
 	ldrneb r0, [r11, #0x118]
 	cmpne r0, #0
 	beq _020c3b20
-	ldr r0, [sl, #4]
+	ldr r0, [r10, #4]
 	cmp r8, #0
 	cmpeq r7, #0
 	moveq r6, #1
@@ -491,18 +491,18 @@ _020c39d8:
 	ble _020c3b20
 _020c3a14:
 	cmp r5, sb
-	ldrne r0, [sl, #0x10]
+	ldrne r0, [r10, #0x10]
 	ldrne r0, [r0, r5, lsl #2]
 	cmpne r0, #0
 	beq _020c3b08
-	ldr r0, [sl, #0x14]
+	ldr r0, [r10, #0x14]
 	mov r1, r5
 	bl func_ov00_020c3f08
 	cmp r0, #0
 	beq _020c3b08
 	cmp r6, #0
 	bne _020c3a60
-	ldr r0, [sl, #0x10]
+	ldr r0, [r10, #0x10]
 	mov r1, r8
 	ldr r0, [r0, r5, lsl #2]
 	ldr r0, [r0, #4]
@@ -510,7 +510,7 @@ _020c3a14:
 	cmp r7, r0
 	beq _020c3b08
 _020c3a60:
-	ldr r0, [sl, #0x10]
+	ldr r0, [r10, #0x10]
 	add r3, sp, #0
 	ldr r0, [r0, r5, lsl #2]
 	add ip, r0, #0x7c
@@ -519,9 +519,9 @@ _020c3a60:
 	ldr r0, [ip, #0xc]
 	mov r1, r5
 	str r0, [sp, #0xc]
-	ldr r0, [sl, #0x14]
+	ldr r0, [r10, #0x14]
 	bl func_ov00_020c3ef0
-	ldr r1, [sl, #0x10]
+	ldr r1, [r10, #0x10]
 	ldr r3, [r0]
 	ldr r2, [r1, r5, lsl #2]
 	mov r1, r11
@@ -532,14 +532,14 @@ _020c3a60:
 	str r3, [r2, #0x84]
 	ldr r0, [r0, #0xc]
 	str r0, [r2, #0x88]
-	ldr r0, [sl, #0x10]
+	ldr r0, [r10, #0x10]
 	ldr r0, [r0, r5, lsl #2]
 	ldr r2, [r0]
 	ldr r2, [r2, #0x44]
 	blx r2
 	cmp r0, #0
-	ldrne r0, [sl, #0x10]
-	ldr r1, [sl, #0x10]
+	ldrne r0, [r10, #0x10]
+	ldr r1, [r10, #0x10]
 	ldrne r4, [r0, r5, lsl #2]
 	ldr r0, [sp]
 	ldr r1, [r1, r5, lsl #2]
@@ -555,14 +555,14 @@ _020c3a60:
 _020c3b08:
 	add r0, r5, #1
 	mov r0, r0, lsl #0x10
-	ldr r1, [sl, #4]
+	ldr r1, [r10, #4]
 	mov r5, r0, lsr #0x10
 	cmp r1, r0, lsr #16
 	bgt _020c3a14
 _020c3b20:
 	mov r0, r4
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	arm_func_end _ZN12ActorManager18func_ov00_020c39acEjPjb
 
 	.global _ZN12ActorManager18func_ov00_020c3b2cEPi
@@ -610,12 +610,12 @@ _020c3ba8:
 	.global _ZN12ActorManager18func_ov00_020c3bb0EiPi
 	arm_func_start _ZN12ActorManager18func_ov00_020c3bb0EiPi
 _ZN12ActorManager18func_ov00_020c3bb0EiPi: ; 0x020c3bb0
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0xd4
-	movs sl, r2
+	movs r10, r2
 	str r0, [sp]
 	movne r0, #0
-	strne r0, [sl]
+	strne r0, [r10]
 	ldr r0, _020c3ce4 ; =data_027e0e60
 	add r2, sp, #0x14
 	ldr r0, [r0]
@@ -625,7 +625,7 @@ _ZN12ActorManager18func_ov00_020c3bb0EiPi: ; 0x020c3bb0
 	cmp r5, #0
 	addle sp, sp, #0xd4
 	movle r0, #0
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, [sp]
 	mov r11, #0
 	ldr r0, [r0, #4]
@@ -669,15 +669,15 @@ _020c3c44:
 _020c3c88:
 	cmp r6, #0
 	beq _020c3cb8
-	cmp sl, #0
+	cmp r10, #0
 	beq _020c3cb4
 	ldr r0, [r7]
 	add r0, r0, #0x100
 	ldrsh r0, [r0, #0x20]
 	cmp r0, #0
-	ldrgt r0, [sl]
+	ldrgt r0, [r10]
 	addgt r0, r0, #1
-	strgt r0, [sl]
+	strgt r0, [r10]
 _020c3cb4:
 	add r11, r11, #1
 _020c3cb8:
@@ -692,7 +692,7 @@ _020c3cb8:
 _020c3cd8:
 	mov r0, r11
 	add sp, sp, #0xd4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end _ZN12ActorManager18func_ov00_020c3bb0EiPi
 _020c3ce4: .word data_027e0e60
@@ -700,25 +700,25 @@ _020c3ce4: .word data_027e0e60
 	.global _ZN12ActorManager18func_ov00_020c3ce8Eii
 	arm_func_start _ZN12ActorManager18func_ov00_020c3ce8Eii
 _ZN12ActorManager18func_ov00_020c3ce8Eii: ; 0x020c3ce8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0xcc
 	ldr r3, _020c3dcc ; =data_027e0e60
 	mov r11, r0
 	ldr r0, [r3]
-	mov sl, r2
+	mov r10, r2
 	add r2, sp, #0xc
 	mov r3, #8
 	bl func_ov00_020836cc
 	mov r5, r0
 	cmp r5, #0
 	addle sp, sp, #0xcc
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, [r11, #4]
 	ldr r7, [r11, #0x10]
 	cmp r0, #0
 	mov r6, #0
 	addle sp, sp, #0xcc
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	add r4, sp, #0
 _020c3d38:
 	ldr r1, [r7]
@@ -746,7 +746,7 @@ _020c3d64:
 	cmp r0, #0
 	beq _020c3da0
 	ldr r0, [r7]
-	mov r1, sl
+	mov r1, r10
 	bl _ZN5Actor10SetUnk_129Eb
 _020c3da0:
 	add r8, r8, #1
@@ -760,7 +760,7 @@ _020c3db0:
 	add r7, r7, #4
 	blt _020c3d38
 	add sp, sp, #0xcc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end _ZN12ActorManager18func_ov00_020c3ce8Eii
 _020c3dcc: .word data_027e0e60

--- a/asm/ov00/Player/LinkStateInteract.s
+++ b/asm/ov00/Player/LinkStateInteract.s
@@ -483,7 +483,7 @@ _020aa840: .word gItemManager
 	.global _ZN17LinkStateInteract18func_ov00_020aa844EP5Actor
 	arm_func_start _ZN17LinkStateInteract18func_ov00_020aa844EP5Actor
 _ZN17LinkStateInteract18func_ov00_020aa844EP5Actor: ; 0x020aa844
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x2c
 	mov r4, r1
 	mov r5, r0
@@ -506,7 +506,7 @@ _ZN17LinkStateInteract18func_ov00_020aa844EP5Actor: ; 0x020aa844
 	ldr r3, _020aabd0 ; =data_02050f54
 	mov r1, r0, lsl #0x1
 	ldrsh r1, [r3, r1]
-	ldrsh sb, [r3, r2]
+	ldrsh r9, [r3, r2]
 	ldr r6, [sp, #0x20]
 	str r1, [sp]
 	mov r1, r1, asr #0x1f
@@ -524,16 +524,16 @@ _ZN17LinkStateInteract18func_ov00_020aa844EP5Actor: ; 0x020aa844
 	str r1, [sp, #0xc]
 	ldr r7, [sp, #0x28]
 	orr r2, r2, r3, lsl #20
-	smull r4, r3, r7, sb
+	smull r4, r3, r7, r9
 	adds r4, r4, #0x800
 	adc r3, r3, #0
 	mov r4, r4, lsr #0xc
 	orr r4, r4, r3, lsl #20
 	add r1, sp, #0x10
-	mov r8, sb, asr #0x1f
+	mov r8, r9, asr #0x1f
 	add r4, r2, r4
 	bl _ZN5Actor9GetHitboxEP8Cylinder
-	smull r1, r0, r6, sb
+	smull r1, r0, r6, r9
 	adds r1, r1, #0x800
 	adc r0, r0, #0
 	mov r2, r1, lsr #0xc
@@ -583,10 +583,10 @@ _ZN17LinkStateInteract18func_ov00_020aa844EP5Actor: ; 0x020aa844
 	movgt r4, r1
 	mov r0, r5
 	bl _ZN13LinkStateBase12GetPlayerVelEv
-	umull r3, r2, r4, sb
+	umull r3, r2, r4, r9
 	mla r2, r4, r8, r2
 	mov r1, r4, asr #0x1f
-	mla r2, r1, sb, r2
+	mla r2, r1, r9, r2
 	adds r3, r3, #0x800
 	adc r1, r2, #0
 	mov r2, r3, lsr #0xc
@@ -622,10 +622,10 @@ _020aaa04:
 	movlt r4, r1
 	mov r0, r5
 	bl _ZN13LinkStateBase12GetPlayerVelEv
-	umull r3, r2, r4, sb
+	umull r3, r2, r4, r9
 	mla r2, r4, r8, r2
 	mov r1, r4, asr #0x1f
-	mla r2, r1, sb, r2
+	mla r2, r1, r9, r2
 	adds r3, r3, #0x800
 	adc r1, r2, #0
 	mov r2, r3, lsr #0xc
@@ -641,11 +641,11 @@ _020aaa98:
 	cmp r7, r4
 	movle r4, r7
 	bl _ZN13LinkStateBase12GetPlayerVelEv
-	umull r3, r2, r4, sb
+	umull r3, r2, r4, r9
 	adds r3, r3, #0x800
 	mla r2, r4, r8, r2
 	mov r1, r4, asr #0x1f
-	mla r2, r1, sb, r2
+	mla r2, r1, r9, r2
 	adc r2, r2, #0
 	mov r3, r3, lsr #0xc
 	ldr r1, _020aabd4 ; =0x00000155
@@ -672,20 +672,20 @@ _020aaa98:
 	orr r2, r2, r1, lsl #20
 	add r1, r3, r2
 	str r1, [r0, #8]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _020aab34:
 	addge sp, sp, #0x2c
-	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmgeia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	mvn r4, #0x154
 	cmp r7, r4
 	movge r4, r7
 	mov r0, r5
 	bl _ZN13LinkStateBase12GetPlayerVelEv
-	umull r3, r2, r4, sb
+	umull r3, r2, r4, r9
 	adds r3, r3, #0x800
 	mla r2, r4, r8, r2
 	mov r1, r4, asr #0x1f
-	mla r2, r1, sb, r2
+	mla r2, r1, r9, r2
 	adc r2, r2, #0
 	mov r3, r3, lsr #0xc
 	mvn r1, #0x154
@@ -712,7 +712,7 @@ _020aab34:
 	add r1, r3, r2
 	str r1, [r0, #8]
 	add sp, sp, #0x2c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end _ZN17LinkStateInteract18func_ov00_020aa844EP5Actor
 _020aabd0: .word data_02050f54
@@ -1345,7 +1345,7 @@ _020ab49c:
 	.global _ZN17LinkStateInteract8vfunc_34EP5Vec3p
 	arm_func_start _ZN17LinkStateInteract8vfunc_34EP5Vec3p
 _ZN17LinkStateInteract8vfunc_34EP5Vec3p: ; 0x020ab4a4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	mov r6, r0
 	mov r4, r1
 	bl _ZN13LinkStateBase28Get_PlayerControlData_Unk120Ev
@@ -1390,10 +1390,10 @@ _020ab4ec:
 	mov r8, r0, lsl #0x1
 	mov r2, r8, lsl #0x1
 	mov r0, r5, lsl #0x1
-	ldrsh sb, [ip, r0]
+	ldrsh r9, [ip, r0]
 	adds r5, r1, #0x800
 	add r8, r8, #1
-	umull r1, r0, sb, r6
+	umull r1, r0, r9, r6
 	mov r5, r5, lsr #0xc
 	ldrsh r2, [ip, r2]
 	mov r8, r8, lsl #0x1
@@ -1403,8 +1403,8 @@ _020ab4ec:
 	mla lr, r3, r6, lr
 	adc r3, lr, #0
 	orr r5, r5, r3, lsl #20
-	mla r0, sb, r7, r0
-	mov r3, sb, asr #0x1f
+	mla r0, r9, r7, r0
+	mov r3, r9, asr #0x1f
 	mla r0, r3, r6, r0
 	smull r7, r6, r2, r5
 	smull r3, r2, ip, r5
@@ -1437,7 +1437,7 @@ _020ab5f4:
 	str r0, [r4, #4]
 _020ab604:
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end _ZN17LinkStateInteract8vfunc_34EP5Vec3p
 _020ab60c: .word data_02050f54

--- a/asm/ov00/Player/PlayerControl.s
+++ b/asm/ov00/Player/PlayerControl.s
@@ -746,10 +746,10 @@ _020af774: .word data_027e0e60
 	.global _ZN13PlayerControl18func_ov00_020af778Ev
 	arm_func_start _ZN13PlayerControl18func_ov00_020af778Ev
 _ZN13PlayerControl18func_ov00_020af778Ev: ; 0x020af778
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x14
-	mov sb, r0
-	ldrb r0, [sb, #0x78]
+	mov r9, r0
+	ldrb r0, [r9, #0x78]
 	cmp r0, #0
 	beq _020af7b8
 	ldr r0, _020afabc ; =data_027e0f74
@@ -764,54 +764,54 @@ _ZN13PlayerControl18func_ov00_020af778Ev: ; 0x020af778
 	beq _020af7cc
 _020af7b8:
 	mov r0, #0xf
-	strh r0, [sb, #0xaa]
+	strh r0, [r9, #0xaa]
 	add sp, sp, #0x14
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _020af7cc:
-	ldrsh r0, [sb, #0xaa]
+	ldrsh r0, [r9, #0xaa]
 	cmp r0, #0
 	ble _020af7ec
 	sub r0, r0, #1
-	strh r0, [sb, #0xaa]
+	strh r0, [r9, #0xaa]
 	add sp, sp, #0x14
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _020af7ec:
 	bl _ZN13PlayerControl18func_ov00_020aeef8Ev
 	cmp r0, #0
 	bne _020af810
 	mvn r0, #0
-	str r0, [sb, #0x8c]
-	str r0, [sb, #0x90]
+	str r0, [r9, #0x8c]
+	str r0, [r9, #0x90]
 	add sp, sp, #0x14
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _020af810:
-	ldrh r0, [sb, #0x34]
+	ldrh r0, [r9, #0x34]
 	mov r4, #0
 	mov r5, r4
 	tst r0, #2
 	beq _020af8b0
-	ldrsh r0, [sb, #0x60]
+	ldrsh r0, [r9, #0x60]
 	cmp r0, #0x15
 	bge _020af8b0
-	ldrsh r0, [sb, #0x68]
-	ldr r1, [sb, #0x28]
-	ldrsh r2, [sb, #0x66]
+	ldrsh r0, [r9, #0x68]
+	ldr r1, [r9, #0x28]
+	ldrsh r2, [r9, #0x66]
 	sub r1, r1, r0
 	mul r0, r1, r1
-	ldr r1, [sb, #0x24]
+	ldr r1, [r9, #0x24]
 	sub r1, r1, r2
 	mla r0, r1, r1, r0
 	cmp r0, #0x64
 	bge _020af8b0
-	mov r0, sb
+	mov r0, r9
 	mov r1, #7
 	mov r2, #1
 	bl _ZN13PlayerControl18func_ov00_020af2d4Ejb
 	cmp r0, #0
-	ldrneb r0, [sb, #0x79]
+	ldrneb r0, [r9, #0x79]
 	movne r4, #1
 	cmpne r0, #0
 	beq _020af8b0
@@ -845,14 +845,14 @@ _020af8dc:
 	mov r4, #0
 	beq _020afa68
 	ldr r0, _020afacc ; =data_027e0fe4
-	add r1, sb, #0x8c
+	add r1, r9, #0x8c
 	ldr r0, [r0]
 	bl _ZN12ActorManager8GetActorEP8ActorRef
 	movs r6, r0
 	mov r7, r4
 	beq _020af97c
 	ldr r7, [r6, #0x12c]
-	mov r0, sb
+	mov r0, r9
 	mov r1, r7
 	mov r2, r8
 	bl _ZN13PlayerControl18func_ov00_020afe88Eib
@@ -868,18 +868,18 @@ _020af8dc:
 	cmp r0, #0
 	beq _020af97c
 _020af944:
-	ldr r1, [sb, #0x8c]
+	ldr r1, [r9, #0x8c]
 	mvn r0, #0
-	str r1, [sb, #0x84]
-	ldr r2, [sb, #0x90]
+	str r1, [r9, #0x84]
+	ldr r2, [r9, #0x90]
 	mov r1, #0
-	str r2, [sb, #0x88]
-	str r0, [sb, #0x8c]
-	str r0, [sb, #0x90]
+	str r2, [r9, #0x88]
+	str r0, [r9, #0x8c]
+	str r0, [r9, #0x90]
 	mov r0, r6
-	strb r1, [sb, #0x80]
+	strb r1, [r9, #0x80]
 	mov r1, #0xf
-	strh r1, [sb, #0xa8]
+	strh r1, [r9, #0xa8]
 	bl _ZN5Actor16XzDistanceToLinkEv
 	mov r4, r0
 _020af97c:
@@ -895,19 +895,19 @@ _020af97c:
 	bne _020af9e0
 	cmp r1, #0
 	beq _020afaa8
-	mov r0, sb
+	mov r0, r9
 	mov r2, r8
 	bl _ZN13PlayerControl18func_ov00_020afeecEib
 	cmp r0, #0
 	beq _020afaa8
 	add r1, sp, #8
-	mov r0, sb
+	mov r0, r9
 	mov r2, r4
 	mov r3, r7
 	bl _ZN13PlayerControl18func_ov00_020af6e4EP5Vec3pii
 	add sp, sp, #0x14
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _020af9e0:
 	mov r0, r5
 	ldr r2, [r0]
@@ -916,13 +916,13 @@ _020af9e0:
 	cmp r0, #0
 	beq _020afa18
 	add r1, sp, #8
-	mov r0, sb
+	mov r0, r9
 	mov r2, r4
 	mov r3, r7
 	bl _ZN13PlayerControl18func_ov00_020af6e4EP5Vec3pii
 	add sp, sp, #0x14
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _020afa18:
 	cmp r4, #0
 	bne _020afaa8
@@ -933,17 +933,17 @@ _020afa18:
 	cmp r0, #0
 	beq _020afaa8
 	add r1, sp, #8
-	mov r0, sb
+	mov r0, r9
 	mov r2, #0
 	bl func_ov00_020b7d4c
 	add r1, sp, #8
-	mov r0, sb
+	mov r0, r9
 	mov r2, r4
 	mov r3, r7
 	bl _ZN13PlayerControl18func_ov00_020af6e4EP5Vec3pii
 	add sp, sp, #0x14
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _020afa68:
 	ldr r1, _020afacc ; =data_027e0fe4
 	add r0, sp, #0
@@ -951,22 +951,22 @@ _020afa68:
 	mov r2, r4
 	bl _ZN12ActorManager18func_ov00_020c3484EP8ActorRefP5Actori
 	ldr r0, [sp]
-	str r0, [sb, #0x8c]
+	str r0, [r9, #0x8c]
 	ldr r0, [sp, #4]
-	str r0, [sb, #0x90]
-	ldrsh r0, [sb, #0x60]
+	str r0, [r9, #0x90]
+	ldrsh r0, [r9, #0x60]
 	cmp r0, #0
 	bne _020afaa8
-	ldr r0, [sb, #0x8c]
-	str r0, [sb, #0x94]
-	ldr r0, [sb, #0x90]
-	str r0, [sb, #0x98]
+	ldr r0, [r9, #0x8c]
+	str r0, [r9, #0x94]
+	ldr r0, [r9, #0x90]
+	str r0, [r9, #0x98]
 _020afaa8:
 	cmp r4, #0
 	movgt r0, #1
 	movle r0, #0
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end _ZN13PlayerControl18func_ov00_020af778Ev
 _020afabc: .word data_027e0f74
@@ -1025,14 +1025,14 @@ _020afb68: .word data_027e0e60
 	.global _ZN13PlayerControl18func_ov00_020afb6cEv
 	arm_func_start _ZN13PlayerControl18func_ov00_020afb6cEv
 _ZN13PlayerControl18func_ov00_020afb6cEv: ; 0x020afb6c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x20
-	mov sb, r0
+	mov r9, r0
 	bl _ZN13PlayerControl18func_ov00_020af778Ev
 	ldr r1, _020afe70 ; =data_027e0fe4
 	mov r4, r0
 	ldr r0, [r1]
-	add r1, sb, #0x84
+	add r1, r9, #0x84
 	bl _ZN12ActorManager8GetActorEP8ActorRef
 	ldr r1, _020afe74 ; =gItemManager
 	mov r5, r0
@@ -1043,7 +1043,7 @@ _ZN13PlayerControl18func_ov00_020afb6cEv: ; 0x020afb6c
 	mov r0, r6
 	bl _ZNK11ItemManager8GetFairyEi
 	cmp r5, #0
-	ldreqb r1, [sb, #0x81]
+	ldreqb r1, [r9, #0x81]
 	cmpeq r1, #0
 	bne _020afbcc
 	cmp r0, #0
@@ -1051,7 +1051,7 @@ _ZN13PlayerControl18func_ov00_020afb6cEv: ; 0x020afb6c
 	bl func_ov00_020bad18
 _020afbcc:
 	cmp r5, #0
-	ldr r6, [sb, #0xa4]
+	ldr r6, [r9, #0xa4]
 	beq _020afce8
 	ldr r0, _020afe78 ; =data_027e0f94
 	add r1, r5, #0x48
@@ -1080,8 +1080,8 @@ _020afc20: ; jump table
 	b _020afc50 ; case 5
 _020afc38:
 	sub r0, r8, #4
-	str r0, [sb, #0x84]
-	str r0, [sb, #0x88]
+	str r0, [r9, #0x84]
+	str r0, [r9, #0x88]
 	b _020afc9c
 _020afc48:
 	mov r7, #1
@@ -1117,7 +1117,7 @@ _020afc9c:
 	cmp r0, #0
 	bne _020afcf4
 	add r1, sp, #0x10
-	mov r0, sb
+	mov r0, r9
 	mov r2, r7
 	bl _ZN13PlayerControl18func_ov00_020aff90Eii
 	cmp r4, #0
@@ -1130,17 +1130,17 @@ _020afc9c:
 	b _020afcf4
 _020afce8:
 	mvn r0, #0
-	str r0, [sb, #0x84]
-	str r0, [sb, #0x88]
+	str r0, [r9, #0x84]
+	str r0, [r9, #0x88]
 _020afcf4:
-	ldrb r0, [sb, #0x81]
+	ldrb r0, [r9, #0x81]
 	cmp r0, #0
 	beq _020afe24
 	ldr r0, _020afe84 ; =data_027e0e60
-	add r1, sb, #0x9c
+	add r1, r9, #0x9c
 	ldr r0, [r0]
 	bl func_ov00_020840c4
-	str r0, [sb, #0xa0]
+	str r0, [r9, #0xa0]
 	cmp r0, #0
 	beq _020afd88
 	ldr r1, [r0, #0x18]
@@ -1149,7 +1149,7 @@ _020afcf4:
 	str r1, [sp, #8]
 	ldr r0, [r0, #0x20]
 	str r0, [sp, #0xc]
-	ldr r0, [sb, #0xa0]
+	ldr r0, [r9, #0xa0]
 	ldr r1, [r0]
 	ldr r1, [r1, #0x54]
 	blx r1
@@ -1163,7 +1163,7 @@ _020afd5c:
 	ldr r1, [sp, #8]
 	add r0, r1, r0
 	str r0, [sp, #8]
-	ldr r0, [sb, #0xa0]
+	ldr r0, [r9, #0xa0]
 	ldrsb r0, [r0, #0x12]
 	cmp r0, #1
 	moveq r5, #1
@@ -1177,8 +1177,8 @@ _020afd88:
 	ldr r1, [r1, #4]
 	ldr r0, [r0]
 	str r1, [sp, #8]
-	ldrb r3, [sb, #0x9c]
-	ldrb r2, [sb, #0x9d]
+	ldrb r3, [r9, #0x9c]
+	ldrb r2, [r9, #0x9d]
 	sub r5, sp, #4
 	add r1, sp, #4
 	strb r3, [r5]
@@ -1196,14 +1196,14 @@ _020afdc4:
 	cmp r0, #0
 	bne _020afe10
 	add r1, sp, #4
-	mov r0, sb
+	mov r0, r9
 	mov r2, r5
 	bl _ZN13PlayerControl18func_ov00_020aff90Eii
 	cmp r4, #0
 	beq _020afe10
 	str r6, [sp]
-	ldrb r2, [sb, #0x9c]
-	ldrb r3, [sb, #0x9d]
+	ldrb r2, [r9, #0x9c]
+	ldrb r3, [r9, #0x9d]
 	ldr r0, _020afe80 ; =data_027e0ffc
 	add r1, sp, #4
 	bl func_ov00_020ced7c
@@ -1215,26 +1215,26 @@ _020afe10:
 	b _020afe2c
 _020afe24:
 	mov r0, #0
-	str r0, [sb, #0xa0]
+	str r0, [r9, #0xa0]
 _020afe2c:
-	ldrsh r1, [sb, #0xa8]
+	ldrsh r1, [r9, #0xa8]
 	cmp r1, #0
 	ble _020afe64
-	ldr r0, [sb, #0xa4]
+	ldr r0, [r9, #0xa4]
 	sub r0, r0, r6
 	cmp r0, #0x29
 	bgt _020afe64
 	sub r0, r1, #1
-	strh r0, [sb, #0xa8]
-	ldrsh r0, [sb, #0xa8]
+	strh r0, [r9, #0xa8]
+	ldrsh r0, [r9, #0xa8]
 	cmp r0, #0
 	bgt _020afe64
-	mov r0, sb
+	mov r0, r9
 	bl _ZN13PlayerControl13StopFollowingEv
 _020afe64:
-	str r6, [sb, #0xa4]
+	str r6, [r9, #0xa4]
 	add sp, sp, #0x20
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end _ZN13PlayerControl18func_ov00_020afb6cEv
 _020afe70: .word data_027e0fe4
@@ -1909,7 +1909,7 @@ _020b0774: .word data_027e0e60
 	.global _ZN13PlayerControl18func_ov00_020b0778EP5Vec3pji
 	arm_func_start _ZN13PlayerControl18func_ov00_020b0778EP5Vec3pji
 _ZN13PlayerControl18func_ov00_020b0778EP5Vec3pji: ; 0x020b0778
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x18
 	mov r8, r3
 	mov r3, #0
@@ -1918,7 +1918,7 @@ _ZN13PlayerControl18func_ov00_020b0778EP5Vec3pji: ; 0x020b0778
 	ldr r3, _020b0aac ; =data_027e0f64
 	str r4, [sp, #0xc]
 	ldr r4, [r1, #4]
-	mov sb, r0
+	mov r9, r0
 	str r4, [sp, #0x10]
 	ldr r1, [r1, #8]
 	ldr r0, [r3]
@@ -1937,7 +1937,7 @@ _ZN13PlayerControl18func_ov00_020b0778EP5Vec3pji: ; 0x020b0778
 	cmp r0, #0
 	addne sp, sp, #0x18
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	mov r0, r4, lsl #0x10
 	mov r0, r0, lsr #0x10
 	mov r0, r0, asr #0x4
@@ -1955,11 +1955,11 @@ _ZN13PlayerControl18func_ov00_020b0778EP5Vec3pji: ; 0x020b0778
 	mov r1, r3, asr #0xb
 	add r2, r2, r0, lsr #20
 	add r3, r3, r1, lsr #20
-	ldr lr, [sb, #0x10]
+	ldr lr, [r9, #0x10]
 	ldr r4, [sp, #8]
-	ldr ip, [sb, #0x14]
+	ldr ip, [r9, #0x14]
 	ldr r5, [sp, #4]
-	mov r0, sb
+	mov r0, r9
 	mov r1, #1
 	mov r6, r2, asr #0xc
 	mov r7, r3, asr #0xc
@@ -1981,7 +1981,7 @@ _ZN13PlayerControl18func_ov00_020b0778EP5Vec3pji: ; 0x020b0778
 	str r0, [r8]
 	add sp, sp, #0x18
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _020b089c:
 	mvn r0, #0x17
 	sub r1, r0, r6
@@ -1998,7 +1998,7 @@ _020b089c:
 	str r0, [r8]
 	add sp, sp, #0x18
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _020b08dc:
 	rsb r1, r6, #0
 	cmp r6, r1
@@ -2027,9 +2027,9 @@ _020b08dc:
 _020b093c:
 	add sp, sp, #0x18
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _020b0948:
-	mov r0, sb
+	mov r0, r9
 	mov r1, #1
 	bl _ZN13PlayerControl13CheckTouchingEj
 	cmp r0, #0
@@ -2055,7 +2055,7 @@ _020b099c:
 	str r0, [r8]
 	add sp, sp, #0x18
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _020b09b0:
 	cmp r6, #0
 	ble _020b09c4
@@ -2088,20 +2088,20 @@ _020b0a08:
 	str r0, [r8]
 	add sp, sp, #0x18
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _020b0a20:
-	mov r0, sb
+	mov r0, r9
 	mov r1, #1
 	bl _ZN13PlayerControl17CheckUntouchedNowEj
 	cmp r0, #0
 	beq _020b0aa0
-	ldr r3, [sb, #0x1c]
+	ldr r3, [r9, #0x1c]
 	ldr r2, [sp, #8]
 	cmp r6, #0
 	rsblt r6, r6, #0
 	cmp r7, #0
 	rsblt r7, r7, #0
-	ldr r1, [sb, #0x20]
+	ldr r1, [r9, #0x20]
 	ldr r0, [sp, #4]
 	sub r2, r3, r2
 	sub r1, r1, r0
@@ -2123,11 +2123,11 @@ _020b0a78:
 _020b0a94:
 	add sp, sp, #0x18
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _020b0aa0:
 	mov r0, #1
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end _ZN13PlayerControl18func_ov00_020b0778EP5Vec3pji
 _020b0aac: .word data_027e0f64

--- a/asm/ov00/Player/TouchGesture.s
+++ b/asm/ov00/Player/TouchGesture.s
@@ -54,7 +54,7 @@ _020a9314:
 	.global _ZN12TouchGesture6UpdateEPv
 	arm_func_start _ZN12TouchGesture6UpdateEPv
 _ZN12TouchGesture6UpdateEPv: ; 0x020a9334
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	ldrsh r2, [r1, #0x60]
 	cmp r2, #0
 	ble _020a9350
@@ -138,10 +138,10 @@ _020a944c:
 	movgt r4, sb
 _020a9468:
 	add sb, r0, r1, lsl #1
-	ldrsh fp, [sb, #0x48]
+	ldrsh r11, [sb, #0x48]
 	ldrsh sl, [sb, #0x2c]
-	add sb, sl, fp
-	sub sl, sl, fp
+	add sb, sl, r11
+	sub sl, sl, r11
 	mov sb, sb, lsl #0x10
 	mov sl, sl, lsl #0x10
 	cmp r5, sb, asr #16
@@ -171,21 +171,21 @@ _020a94b4:
 	subge r3, r8, r7
 	strb r1, [r0, #4]
 	cmpge r3, #0x46
-	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r3, _020a952c ; =0xffff2aab
 	cmp r2, r3
 	bge _020a9508
 	mov r2, #1
 	strb r2, [r0, #4]
 	str r1, [r0, #8]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _020a9508:
 	rsb r1, r3, #0
 	cmp r2, r1
 	movgt r1, #1
 	strgtb r1, [r0, #4]
 	strgt r1, [r0, #8]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end _ZN12TouchGesture6UpdateEPv
 _020a9520: .word 0xffffd555

--- a/asm/ov00/Player/TouchGesture.s
+++ b/asm/ov00/Player/TouchGesture.s
@@ -54,7 +54,7 @@ _020a9314:
 	.global _ZN12TouchGesture6UpdateEPv
 	arm_func_start _ZN12TouchGesture6UpdateEPv
 _ZN12TouchGesture6UpdateEPv: ; 0x020a9334
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	ldrsh r2, [r1, #0x60]
 	cmp r2, #0
 	ble _020a9350
@@ -119,38 +119,38 @@ _020a93cc:
 	mov r8, r7
 	mov r1, r2
 _020a9428:
-	add sb, r0, r1, lsl #1
-	ldrsh r10, [sb, #0x10]
-	ldrsh sb, [sb, #0x2c]
+	add r9, r0, r1, lsl #1
+	ldrsh r10, [r9, #0x10]
+	ldrsh r9, [r9, #0x2c]
 	add r2, r2, r10
-	cmp sb, r3
-	movlt r3, sb
+	cmp r9, r3
+	movlt r3, r9
 	blt _020a944c
-	cmp sb, ip
-	movgt ip, sb
+	cmp r9, ip
+	movgt ip, r9
 _020a944c:
-	add sb, r0, r1, lsl #1
-	ldrsh sb, [sb, #0x48]
-	cmp sb, lr
-	movlt lr, sb
+	add r9, r0, r1, lsl #1
+	ldrsh r9, [r9, #0x48]
+	cmp r9, lr
+	movlt lr, r9
 	blt _020a9468
-	cmp sb, r4
-	movgt r4, sb
+	cmp r9, r4
+	movgt r4, r9
 _020a9468:
-	add sb, r0, r1, lsl #1
-	ldrsh r11, [sb, #0x48]
-	ldrsh r10, [sb, #0x2c]
-	add sb, r10, r11
+	add r9, r0, r1, lsl #1
+	ldrsh r11, [r9, #0x48]
+	ldrsh r10, [r9, #0x2c]
+	add r9, r10, r11
 	sub r10, r10, r11
-	mov sb, sb, lsl #0x10
+	mov r9, r9, lsl #0x10
 	mov r10, r10, lsl #0x10
-	cmp r5, sb, asr #16
-	mov sb, sb, asr #0x10
+	cmp r5, r9, asr #16
+	mov r9, r9, asr #0x10
 	mov r10, r10, asr #0x10
-	movgt r5, sb
+	movgt r5, r9
 	bgt _020a94a0
-	cmp sb, r6
-	movgt r6, sb
+	cmp r9, r6
+	movgt r6, r9
 _020a94a0:
 	cmp r10, r7
 	movlt r7, r10
@@ -171,21 +171,21 @@ _020a94b4:
 	subge r3, r8, r7
 	strb r1, [r0, #4]
 	cmpge r3, #0x46
-	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmltia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r3, _020a952c ; =0xffff2aab
 	cmp r2, r3
 	bge _020a9508
 	mov r2, #1
 	strb r2, [r0, #4]
 	str r1, [r0, #8]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _020a9508:
 	rsb r1, r3, #0
 	cmp r2, r1
 	movgt r1, #1
 	strgtb r1, [r0, #4]
 	strgt r1, [r0, #8]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end _ZN12TouchGesture6UpdateEPv
 _020a9520: .word 0xffffd555

--- a/asm/ov00/Player/TouchGesture.s
+++ b/asm/ov00/Player/TouchGesture.s
@@ -54,7 +54,7 @@ _020a9314:
 	.global _ZN12TouchGesture6UpdateEPv
 	arm_func_start _ZN12TouchGesture6UpdateEPv
 _ZN12TouchGesture6UpdateEPv: ; 0x020a9334
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	ldrsh r2, [r1, #0x60]
 	cmp r2, #0
 	ble _020a9350
@@ -120,9 +120,9 @@ _020a93cc:
 	mov r1, r2
 _020a9428:
 	add sb, r0, r1, lsl #1
-	ldrsh sl, [sb, #0x10]
+	ldrsh r10, [sb, #0x10]
 	ldrsh sb, [sb, #0x2c]
-	add r2, r2, sl
+	add r2, r2, r10
 	cmp sb, r3
 	movlt r3, sb
 	blt _020a944c
@@ -139,24 +139,24 @@ _020a944c:
 _020a9468:
 	add sb, r0, r1, lsl #1
 	ldrsh r11, [sb, #0x48]
-	ldrsh sl, [sb, #0x2c]
-	add sb, sl, r11
-	sub sl, sl, r11
+	ldrsh r10, [sb, #0x2c]
+	add sb, r10, r11
+	sub r10, r10, r11
 	mov sb, sb, lsl #0x10
-	mov sl, sl, lsl #0x10
+	mov r10, r10, lsl #0x10
 	cmp r5, sb, asr #16
 	mov sb, sb, asr #0x10
-	mov sl, sl, asr #0x10
+	mov r10, r10, asr #0x10
 	movgt r5, sb
 	bgt _020a94a0
 	cmp sb, r6
 	movgt r6, sb
 _020a94a0:
-	cmp sl, r7
-	movlt r7, sl
+	cmp r10, r7
+	movlt r7, r10
 	blt _020a94b4
-	cmp sl, r8
-	movgt r8, sl
+	cmp r10, r8
+	movgt r8, r10
 _020a94b4:
 	add r1, r1, #1
 	cmp r1, #0xe
@@ -171,21 +171,21 @@ _020a94b4:
 	subge r3, r8, r7
 	strb r1, [r0, #4]
 	cmpge r3, #0x46
-	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r3, _020a952c ; =0xffff2aab
 	cmp r2, r3
 	bge _020a9508
 	mov r2, #1
 	strb r2, [r0, #4]
 	str r1, [r0, #8]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _020a9508:
 	rsb r1, r3, #0
 	cmp r2, r1
 	movgt r1, #1
 	strgtb r1, [r0, #4]
 	strgt r1, [r0, #8]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end _ZN12TouchGesture6UpdateEPv
 _020a9520: .word 0xffffd555

--- a/asm/ov00/ov00_020773c0.s
+++ b/asm/ov00/ov00_020773c0.s
@@ -4036,14 +4036,14 @@ _02079148: .word data_027e0c38
 	.global func_ov00_0207914c
 	arm_func_start func_ov00_0207914c
 func_ov00_0207914c: ; 0x0207914c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x14
 	ldr r4, _020791d8 ; =data_027e0e60
 	mov r11, r0
 	ldr r7, [r4]
 	mov r10, r1
 	mov r0, r7
-	mov sb, r2
+	mov r9, r2
 	mov r8, r3
 	bl func_ov00_02083394
 	mov r6, r0
@@ -4059,7 +4059,7 @@ func_ov00_0207914c: ; 0x0207914c
 	sub r0, r0, r5
 	sub r1, r1, r5
 	str r1, [sp]
-	stmib sp, {r0, sb}
+	stmib sp, {r0, r9}
 	ldrb r2, [sp, #0x38]
 	str r8, [sp, #0xc]
 	sub r3, r4, r6
@@ -4070,7 +4070,7 @@ func_ov00_0207914c: ; 0x0207914c
 	sub r2, r2, r6
 	bl func_ov00_02079024
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_0207914c
 _020791d8: .word data_027e0e60
@@ -4095,14 +4095,14 @@ func_ov00_020791dc: ; 0x020791dc
 	.global func_ov00_0207920c
 	arm_func_start func_ov00_0207920c
 func_ov00_0207920c: ; 0x0207920c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x14
 	ldr r4, _0207929c ; =data_027e0e60
 	mov r11, r0
 	ldr r7, [r4]
 	mov r10, r1
 	mov r0, r7
-	mov sb, r2
+	mov r9, r2
 	mov r8, r3
 	bl func_ov00_02083394
 	mov r6, r0
@@ -4121,8 +4121,8 @@ func_ov00_0207920c: ; 0x0207920c
 	str r1, [sp]
 	str r0, [sp, #4]
 	mov r0, r11
-	str sb, [sp, #8]
-	add r1, sb, #4
+	str r9, [sp, #8]
+	add r1, r9, #4
 	str r1, [sp, #0xc]
 	str r8, [sp, #0x10]
 	ldr r2, [r10]
@@ -4130,7 +4130,7 @@ func_ov00_0207920c: ; 0x0207920c
 	sub r2, r2, r6
 	bl func_ov00_02079024
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_0207920c
 _0207929c: .word data_027e0e60
@@ -4138,11 +4138,11 @@ _0207929c: .word data_027e0e60
 	.global func_ov00_020792a0
 	arm_func_start func_ov00_020792a0
 func_ov00_020792a0: ; 0x020792a0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #4
 	ldr r0, [r0]
 	mov r10, r1
-	mov sb, r2
+	mov r9, r2
 	mov r8, r3
 	cmp r0, #0
 	ldr r7, [sp, #0x28]
@@ -4150,16 +4150,16 @@ func_ov00_020792a0: ; 0x020792a0
 	str r7, [sp]
 	bl func_ov03_020f0844
 	add sp, sp, #4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 _020792d4:
 	cmp r10, #0
 	ldreq r0, _020793b0 ; =data_027e0c38
 	ldreq r0, [r0, #0x14]
-	addeq sb, sb, r0, lsl #12
+	addeq r9, r9, r0, lsl #12
 	beq _020792f4
 	ldr r0, _020793b0 ; =data_027e0c38
 	ldr r0, [r0, #0x14]
-	add sb, sb, r0
+	add r9, r9, r0
 _020792f4:
 	ldr r0, _020793b4 ; =data_027e0e60
 	ldr r6, [r0]
@@ -4182,16 +4182,16 @@ _020792f4:
 	bl func_01ff9b4c
 	cmp r10, #0
 	beq _02079368
-	mla r1, sb, r6, r5
+	mla r1, r9, r6, r5
 	str r1, [r7]
 	mov r1, #0
 	mla r0, r8, r0, r4
 	str r1, [r7, #4]
 	add sp, sp, #4
 	str r0, [r7, #8]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 _02079368:
-	smull r1, r2, sb, r6
+	smull r1, r2, r9, r6
 	adds r3, r1, #0x800
 	smull r1, r0, r8, r0
 	adc r2, r2, #0
@@ -4208,7 +4208,7 @@ _02079368:
 	add r0, r4, r1
 	str r0, [r7, #8]
 	add sp, sp, #4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020792a0
 _020793b0: .word data_027e0c38
@@ -4275,9 +4275,9 @@ _02079458:
 	.global func_ov00_02079470
 	arm_func_start func_ov00_02079470
 func_ov00_02079470: ; 0x02079470
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x14
-	mov sb, r0
+	mov r9, r0
 	mov r8, r1
 	mov r7, r2
 	mov r6, r3
@@ -4302,13 +4302,13 @@ _020794c8:
 	ldrb r0, [sp, #0x3c]
 	cmp r0, #0
 	bne _02079564
-	mov r0, sb
+	mov r0, r9
 	bl func_ov00_02078f54
 	cmp r0, #0
 	beq _02079564
 	ldrb r0, [sp, #0x38]
 	cmp r0, #0
-	ldrne r0, [sb]
+	ldrne r0, [r9]
 	cmpne r0, #0
 	beq _0207955c
 	ldr r1, _02079674 ; =gOverlayManager
@@ -4330,7 +4330,7 @@ _020794c8:
 	mov r0, #0
 	str r0, [sp, #0x10]
 	ldr r1, [r5]
-	mov r0, sb
+	mov r0, r9
 	mov r2, r1, lsl #0xc
 	mov r1, #1
 	mov r3, #0x100000
@@ -4371,7 +4371,7 @@ _02079564:
 	mov r0, #0
 	str r0, [sp, #0x10]
 	ldr r1, [r5]
-	mov r0, sb
+	mov r0, r9
 	mov r2, r1, lsl #0xc
 	mov r1, #1
 	mov r3, #0x100000
@@ -4379,7 +4379,7 @@ _02079564:
 	b _02079614
 _020795f8:
 	mov ip, #0
-	mov r0, sb
+	mov r0, r9
 	mov r1, r8
 	mov r2, r5
 	mov r3, r4
@@ -4394,10 +4394,10 @@ _02079614:
 	str r0, [r4]
 	add sp, sp, #0x14
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _02079638:
 	ldr r1, [r5]
-	mov r0, sb
+	mov r0, r9
 	add r1, r1, r7
 	str r1, [r5]
 	ldr r2, [r4]
@@ -4408,7 +4408,7 @@ _02079638:
 	str r5, [r4]
 	bl func_ov00_020793d0
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov00_02079470
 _0207966c: .word data_027e0e28

--- a/asm/ov00/ov00_020773c0.s
+++ b/asm/ov00/ov00_020773c0.s
@@ -4036,12 +4036,12 @@ _02079148: .word data_027e0c38
 	.global func_ov00_0207914c
 	arm_func_start func_ov00_0207914c
 func_ov00_0207914c: ; 0x0207914c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x14
 	ldr r4, _020791d8 ; =data_027e0e60
 	mov r11, r0
 	ldr r7, [r4]
-	mov sl, r1
+	mov r10, r1
 	mov r0, r7
 	mov sb, r2
 	mov r8, r3
@@ -4055,7 +4055,7 @@ func_ov00_0207914c: ; 0x0207914c
 	mov r4, r0
 	mov r0, r7
 	bl func_ov00_020833b8
-	ldr r1, [sl, #8]
+	ldr r1, [r10, #8]
 	sub r0, r0, r5
 	sub r1, r1, r5
 	str r1, [sp]
@@ -4064,13 +4064,13 @@ func_ov00_0207914c: ; 0x0207914c
 	str r8, [sp, #0xc]
 	sub r3, r4, r6
 	str r2, [sp, #0x10]
-	ldr r2, [sl]
+	ldr r2, [r10]
 	mov r0, r11
 	mov r1, #1
 	sub r2, r2, r6
 	bl func_ov00_02079024
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_0207914c
 _020791d8: .word data_027e0e60
@@ -4095,12 +4095,12 @@ func_ov00_020791dc: ; 0x020791dc
 	.global func_ov00_0207920c
 	arm_func_start func_ov00_0207920c
 func_ov00_0207920c: ; 0x0207920c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x14
 	ldr r4, _0207929c ; =data_027e0e60
 	mov r11, r0
 	ldr r7, [r4]
-	mov sl, r1
+	mov r10, r1
 	mov r0, r7
 	mov sb, r2
 	mov r8, r3
@@ -4115,7 +4115,7 @@ func_ov00_0207920c: ; 0x0207920c
 	mov r0, r7
 	bl func_ov00_020833b8
 	sub r3, r4, r6
-	ldr r1, [sl, #8]
+	ldr r1, [r10, #8]
 	sub r0, r0, r5
 	sub r1, r1, r5
 	str r1, [sp]
@@ -4125,12 +4125,12 @@ func_ov00_0207920c: ; 0x0207920c
 	add r1, sb, #4
 	str r1, [sp, #0xc]
 	str r8, [sp, #0x10]
-	ldr r2, [sl]
+	ldr r2, [r10]
 	mov r1, #0
 	sub r2, r2, r6
 	bl func_ov00_02079024
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_0207920c
 _0207929c: .word data_027e0e60
@@ -4138,10 +4138,10 @@ _0207929c: .word data_027e0e60
 	.global func_ov00_020792a0
 	arm_func_start func_ov00_020792a0
 func_ov00_020792a0: ; 0x020792a0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #4
 	ldr r0, [r0]
-	mov sl, r1
+	mov r10, r1
 	mov sb, r2
 	mov r8, r3
 	cmp r0, #0
@@ -4150,9 +4150,9 @@ func_ov00_020792a0: ; 0x020792a0
 	str r7, [sp]
 	bl func_ov03_020f0844
 	add sp, sp, #4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 _020792d4:
-	cmp sl, #0
+	cmp r10, #0
 	ldreq r0, _020793b0 ; =data_027e0c38
 	ldreq r0, [r0, #0x14]
 	addeq sb, sb, r0, lsl #12
@@ -4180,7 +4180,7 @@ _020792f4:
 	sub r0, r0, r4
 	mov r1, #0xc0
 	bl func_01ff9b4c
-	cmp sl, #0
+	cmp r10, #0
 	beq _02079368
 	mla r1, sb, r6, r5
 	str r1, [r7]
@@ -4189,7 +4189,7 @@ _020792f4:
 	str r1, [r7, #4]
 	add sp, sp, #4
 	str r0, [r7, #8]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 _02079368:
 	smull r1, r2, sb, r6
 	adds r3, r1, #0x800
@@ -4208,7 +4208,7 @@ _02079368:
 	add r0, r4, r1
 	str r0, [r7, #8]
 	add sp, sp, #4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020792a0
 _020793b0: .word data_027e0c38

--- a/asm/ov00/ov00_020773c0.s
+++ b/asm/ov00/ov00_020773c0.s
@@ -4036,10 +4036,10 @@ _02079148: .word data_027e0c38
 	.global func_ov00_0207914c
 	arm_func_start func_ov00_0207914c
 func_ov00_0207914c: ; 0x0207914c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x14
 	ldr r4, _020791d8 ; =data_027e0e60
-	mov fp, r0
+	mov r11, r0
 	ldr r7, [r4]
 	mov sl, r1
 	mov r0, r7
@@ -4065,12 +4065,12 @@ func_ov00_0207914c: ; 0x0207914c
 	sub r3, r4, r6
 	str r2, [sp, #0x10]
 	ldr r2, [sl]
-	mov r0, fp
+	mov r0, r11
 	mov r1, #1
 	sub r2, r2, r6
 	bl func_ov00_02079024
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_0207914c
 _020791d8: .word data_027e0e60
@@ -4095,10 +4095,10 @@ func_ov00_020791dc: ; 0x020791dc
 	.global func_ov00_0207920c
 	arm_func_start func_ov00_0207920c
 func_ov00_0207920c: ; 0x0207920c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x14
 	ldr r4, _0207929c ; =data_027e0e60
-	mov fp, r0
+	mov r11, r0
 	ldr r7, [r4]
 	mov sl, r1
 	mov r0, r7
@@ -4120,7 +4120,7 @@ func_ov00_0207920c: ; 0x0207920c
 	sub r1, r1, r5
 	str r1, [sp]
 	str r0, [sp, #4]
-	mov r0, fp
+	mov r0, r11
 	str sb, [sp, #8]
 	add r1, sb, #4
 	str r1, [sp, #0xc]
@@ -4130,7 +4130,7 @@ func_ov00_0207920c: ; 0x0207920c
 	sub r2, r2, r6
 	bl func_ov00_02079024
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_0207920c
 _0207929c: .word data_027e0e60

--- a/asm/ov00/ov00_0207af9c.s
+++ b/asm/ov00/ov00_0207af9c.s
@@ -1347,11 +1347,11 @@ _0207bb48: .word data_ov00_020d8798
 	.global func_ov00_0207bb4c
 	arm_func_start func_ov00_0207bb4c
 func_ov00_0207bb4c: ; 0x0207bb4c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	mov r10, r0
 	ldr r0, [r10]
 	cmp r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	bl func_01ffa8d4
 	ldr r5, _0207bc30 ; =0x04000440
 	mov r7, #3
@@ -1383,13 +1383,13 @@ _0207bb84:
 	str r1, [r5, #0x14]
 	bl func_01ff892c
 	ldr r0, _0207bc3c ; =data_027e037c
-	ldr sb, _0207bc44 ; =data_ov00_020d8798
+	ldr r9, _0207bc44 ; =data_ov00_020d8798
 	ldr r1, [r0, #0xfc]
 	mov r6, #0
 	bic r1, r1, #0xe8
 	str r1, [r0, #0xfc]
 _0207bbec:
-	ldrb r0, [sb]
+	ldrb r0, [r9]
 	cmp r0, r7
 	bne _0207bc10
 	add r0, r10, r6, lsl #2
@@ -1399,7 +1399,7 @@ _0207bbec:
 	ldr r0, [r0, #0x24]
 	blx r1
 _0207bc10:
-	add sb, sb, #1
+	add r9, r9, #1
 	add r6, r6, #1
 	cmp r6, #8
 	blt _0207bbec
@@ -1407,7 +1407,7 @@ _0207bc20:
 	sub r8, r8, #0x40
 	subs r7, r7, #1
 	bpl _0207bb84
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_0207bb4c
 _0207bc30: .word 0x04000440
@@ -2192,15 +2192,15 @@ func_ov00_0207c1f8: ; 0x0207c1f8
 	.global func_ov00_0207c260
 	arm_func_start func_ov00_0207c260
 func_ov00_0207c260: ; 0x0207c260
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	ldr r6, [sp, #0x28]
 	ldr r5, [sp, #0x2c]
-	mov sb, r1
+	mov r9, r1
 	mov r8, r2
 	mov r10, r0
 	mov r7, r3
-	cmp sb, r8
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	cmp r9, r8
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	orr r11, r5, #0x8000
 _0207c288:
 	ldr r0, [r7]
@@ -2208,7 +2208,7 @@ _0207c288:
 	movge r0, #1
 	movlt r0, #0
 	add r1, r10, r0, lsl #2
-	mov r0, sb
+	mov r0, r9
 	ldr r4, [r1, #0x10]
 	bl func_ov00_020b7e6c
 	ldr r2, [r7]
@@ -2218,15 +2218,15 @@ _0207c288:
 	movlt ip, r5
 	cmp r2, #0x1000
 	subge r2, r2, #0x1000
-	mov r1, sb
+	mov r1, r9
 	mov r3, r6
 	str ip, [sp]
 	bl func_ov00_0207c6ec
-	add sb, sb, #4
-	cmp sb, r8
+	add r9, r9, #4
+	cmp r9, r8
 	add r7, r7, #4
 	bne _0207c288
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	arm_func_end func_ov00_0207c260
 
 	.global func_ov00_0207c2e8
@@ -4537,17 +4537,17 @@ func_ov00_0207ddf4: ; 0x0207ddf4
 	.global func_ov00_0207ddf8
 	arm_func_start func_ov00_0207ddf8
 func_ov00_0207ddf8: ; 0x0207ddf8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	mov r7, #0
 	mov r10, r0
-	mov sb, r1
+	mov r9, r1
 	add r8, r10, #0x180
 	mvn r5, #0
 	mov r6, r7
 	mov r4, r7
 	mov r11, #4
 _0207de1c:
-	cmp sb, #0
+	cmp r9, #0
 	beq _0207de44
 	mov r2, r6
 	add r1, r10, r7, lsl #2
@@ -4568,7 +4568,7 @@ _0207de54:
 	cmp r7, #2
 	add r8, r8, #4
 	blt _0207de1c
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	arm_func_end func_ov00_0207ddf8
 
 	.global func_ov00_0207de68
@@ -4766,7 +4766,7 @@ func_ov00_0207e08c: ; 0x0207e08c
 	.global func_ov00_0207e0f0
 	arm_func_start func_ov00_0207e0f0
 func_ov00_0207e0f0: ; 0x0207e0f0
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x14
 	mov r10, r0
 	ldr r2, [r10, #0x13c]
@@ -4774,19 +4774,19 @@ func_ov00_0207e0f0: ; 0x0207e0f0
 	cmp r2, #0
 	addeq sp, sp, #0x14
 	mvneq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, [r2, #8]
 	adds r0, r2, r0
 	str r0, [sp, #4]
 	addeq sp, sp, #0x14
 	mvneq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldrh r1, [r0]
 	adds r0, r0, r1
 	str r0, [sp, #0xc]
 	addeq sp, sp, #0x14
 	mvneq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldrb r1, [r0, #1]
 	mov r0, #0
 	str r0, [sp, #8]
@@ -4836,9 +4836,9 @@ _0207e1d0:
 	ldr r1, [r1, #0xb4]
 	blx r1
 	add r1, r0, #0x3c
-	ldrb sb, [r1, #1]
+	ldrb r9, [r1, #1]
 	mov r6, #0
-	cmp sb, #0
+	cmp r9, #0
 	ble _0207e250
 	ldrh r0, [r1, #6]
 	add r8, r1, r0
@@ -4851,10 +4851,10 @@ _0207e218:
 	cmp r0, #0
 	addeq sp, sp, #0x14
 	moveq r0, r6
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r0, r6, #1
 	mov r0, r0, lsl #0x10
-	cmp sb, r0, lsr #16
+	cmp r9, r0, lsr #16
 	mov r6, r0, lsr #0x10
 	bgt _0207e218
 _0207e250:
@@ -4874,13 +4874,13 @@ _0207e260:
 _0207e280:
 	mvn r0, #0
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	arm_func_end func_ov00_0207e0f0
 
 	.global func_ov00_0207e28c
 	arm_func_start func_ov00_0207e28c
 func_ov00_0207e28c: ; 0x0207e28c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x14
 	mov r10, r0
 	ldr r2, [r10, #0x13c]
@@ -4888,19 +4888,19 @@ func_ov00_0207e28c: ; 0x0207e28c
 	cmp r2, #0
 	addeq sp, sp, #0x14
 	mvneq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, [r2, #8]
 	adds r0, r2, r0
 	str r0, [sp, #4]
 	addeq sp, sp, #0x14
 	mvneq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldrh r1, [r0, #2]
 	adds r0, r0, r1
 	str r0, [sp, #0xc]
 	addeq sp, sp, #0x14
 	mvneq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldrb r1, [r0, #1]
 	mov r0, #0
 	str r0, [sp, #8]
@@ -4958,8 +4958,8 @@ _0207e370:
 	ldrh r0, [r0, #0x34]
 	mov r6, #0
 	add r1, r8, r0
-	ldrb sb, [r1, #1]
-	cmp sb, #0
+	ldrb r9, [r1, #1]
+	cmp r9, #0
 	ble _0207e408
 	ldrh r0, [r1, #6]
 	add r8, r1, r0
@@ -4972,10 +4972,10 @@ _0207e3d0:
 	cmp r0, #0
 	addeq sp, sp, #0x14
 	moveq r0, r6
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r0, r6, #1
 	mov r0, r0, lsl #0x10
-	cmp sb, r0, lsr #16
+	cmp r9, r0, lsr #16
 	mov r6, r0, lsr #0x10
 	bgt _0207e3d0
 _0207e408:
@@ -4995,7 +4995,7 @@ _0207e418:
 _0207e438:
 	mvn r0, #0
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	arm_func_end func_ov00_0207e28c
 
 	.global func_ov00_0207e444
@@ -5071,15 +5071,15 @@ func_ov00_0207e4b0: ; 0x0207e4b0
 	.global func_ov00_0207e4b8
 	arm_func_start func_ov00_0207e4b8
 func_ov00_0207e4b8: ; 0x0207e4b8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x7c
 	ldr r3, _0207e92c ; =data_027e0e60
-	mov sb, r1
+	mov r9, r1
 	ldr r1, [r3]
 	mov r8, r0
 	mov r4, r2
 	add r0, sp, #8
-	mov r2, sb
+	mov r2, r9
 	bl func_ov00_02083a1c
 	mov r0, r8
 	ldr r2, [r0]
@@ -5160,24 +5160,24 @@ _0207e5e4:
 	beq _0207e724
 	add r2, sp, #0x14
 	mov r0, r8
-	mov r1, sb
+	mov r1, r9
 	bl func_ov00_0207f104
 	cmp r0, #0
 	ldrne r0, [sp, #0x14]
 	addne sp, sp, #0x7c
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r2, sp, #0x14
 	mov r0, r8
-	mov r1, sb
+	mov r1, r9
 	bl func_ov00_0207f1f4
 	cmp r0, #0
 	beq _0207e724
 	ldr r0, [sp, #0x14]
-	ldr r1, [sb, #4]
+	ldr r1, [r9, #4]
 	cmp r1, r0
 	blt _0207e724
 	add sp, sp, #0x7c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0207e63c:
 	ldrb r0, [r8, #0xe]
 	cmp r0, #0
@@ -5200,27 +5200,27 @@ _0207e63c:
 	ldr r2, [r2, #0x60]
 	blx r2
 	add sp, sp, #0x7c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0207e694:
 	add r2, sp, #0x10
 	mov r0, r8
-	mov r1, sb
+	mov r1, r9
 	bl func_ov00_0207f104
 	cmp r0, #0
 	ldrne r0, [sp, #0x10]
 	addne sp, sp, #0x7c
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r2, sp, #0x10
 	mov r0, r8
-	mov r1, sb
+	mov r1, r9
 	bl func_ov00_0207f1f4
 	cmp r0, #0
 	beq _0207e6e0
 	ldr r0, [sp, #0x10]
-	ldr r1, [sb, #4]
+	ldr r1, [r9, #4]
 	cmp r1, r0
 	addge sp, sp, #0x7c
-	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmgeia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0207e6e0:
 	mov r0, r8
 	ldr r3, [r0]
@@ -5238,7 +5238,7 @@ _0207e6e0:
 	ldr r2, [r2, #0x60]
 	blx r2
 	add sp, sp, #0x7c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0207e724:
 	mov r0, #0x20
 	str r0, [sp]
@@ -5247,7 +5247,7 @@ _0207e724:
 	ldr r0, _0207e930 ; =data_027e0f6c
 	ldr r3, _0207e934 ; =data_ov00_020ec824
 	ldr r0, [r0]
-	mov r1, sb
+	mov r1, r9
 	mov r2, #2
 	bl func_01fff084
 	ldr r4, _0207e938 ; =func_ov00_0207e968
@@ -5265,17 +5265,17 @@ _0207e724:
 	str r7, [sp, #0x24]
 	str r7, [sp, #0x2c]
 	str r0, [sp, #0x28]
-	ldmia sb, {r0, r1, r2}
+	ldmia r9, {r0, r1, r2}
 	stmia r4, {r0, r1, r2}
 	cmp r5, #0
 	ble _0207e8a0
 	ldr r10, _0207e934 ; =data_ov00_020ec824
-	ldr sb, _0207e930 ; =data_027e0f6c
+	ldr r9, _0207e930 ; =data_027e0f6c
 	mov r11, #0x4c
 _0207e7a4:
 	mov r0, r7, lsl #0x1
 	ldrh r1, [r10, r0]
-	ldr r2, [sb]
+	ldr r2, [r9]
 	add r0, sp, #0x30
 	ldr r3, [r2, #0x20]
 	mul r2, r1, r11
@@ -5358,7 +5358,7 @@ _0207e8a0:
 	bl func_0204f754
 	add sp, sp, #0x7c
 	add r0, r5, r4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0207e8f4:
 	mov r0, r8
 	ldr r2, [r0]
@@ -5373,7 +5373,7 @@ _0207e8f4:
 	bl func_0204f754
 	mov r0, r4
 	add sp, sp, #0x7c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_0207e4b8
 _0207e92c: .word data_027e0e60
@@ -5413,15 +5413,15 @@ func_ov00_0207e96c: ; 0x0207e96c
 	.global func_ov00_0207e970
 	arm_func_start func_ov00_0207e970
 func_ov00_0207e970: ; 0x0207e970
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0xc4
 	ldr r4, _0207ee00 ; =data_027e0e60
-	mov sb, r1
+	mov r9, r1
 	ldr r1, [r4]
 	mov r8, r0
 	str r2, [sp, #8]
 	add r0, sp, #0xc
-	mov r2, sb
+	mov r2, r9
 	mov r7, r3
 	bl func_ov00_02083a1c
 	mov r0, r8
@@ -5523,7 +5523,7 @@ _0207ea9c:
 	str r1, [r7]
 	mov r0, #0x1000
 	stmib r7, {r0, r1}
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0207eb04:
 	mov r0, #0x20
 	str r0, [sp]
@@ -5532,7 +5532,7 @@ _0207eb04:
 	ldr r0, _0207ee04 ; =data_027e0f6c
 	ldr r3, _0207ee08 ; =data_ov00_020ec864
 	ldr r0, [r0]
-	mov r1, sb
+	mov r1, r9
 	mov r2, #2
 	bl func_01fff084
 	ldr r5, _0207ee0c ; =func_ov00_0207e968
@@ -5557,17 +5557,17 @@ _0207eb04:
 	str r6, [sp, #0x28]
 	str r0, [sp, #0x24]
 	add r3, sp, #0x14
-	ldmia sb, {r0, r1, r2}
+	ldmia r9, {r0, r1, r2}
 	cmp r4, #0
 	stmia r3, {r0, r1, r2}
 	ble _0207ed48
 	ldr r10, _0207ee08 ; =data_ov00_020ec864
-	ldr sb, _0207ee04 ; =data_027e0f6c
+	ldr r9, _0207ee04 ; =data_027e0f6c
 	mov r11, #0x4c
 _0207eba0:
 	mov r0, r6, lsl #0x1
 	ldrh r1, [r10, r0]
-	ldr r2, [sb]
+	ldr r2, [r9]
 	add r0, sp, #0x78
 	ldr r3, [r2, #0x20]
 	mul r2, r1, r11
@@ -5720,7 +5720,7 @@ _0207edd0:
 	mov r2, #0x10
 	bl func_0204f754
 	add sp, sp, #0xc4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_0207e970
 _0207ee00: .word data_027e0e60
@@ -5732,13 +5732,13 @@ _0207ee10: .word func_ov00_0207e96c
 	.global func_ov00_0207ee14
 	arm_func_start func_ov00_0207ee14
 func_ov00_0207ee14: ; 0x0207ee14
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x74
 	ldr r0, _0207efdc ; =data_027e0e60
-	mov sb, r1
+	mov r9, r1
 	ldr r1, [r0]
 	add r0, sp, #8
-	mov r2, sb
+	mov r2, r9
 	bl func_ov00_02083a1c
 	mov r0, #0x20
 	str r0, [sp]
@@ -5747,7 +5747,7 @@ func_ov00_0207ee14: ; 0x0207ee14
 	ldr r0, _0207efe0 ; =data_027e0f6c
 	ldr r3, _0207efe4 ; =data_ov00_020ec8a4
 	ldr r0, [r0]
-	mov r1, sb
+	mov r1, r9
 	mov r2, #2
 	bl func_01fff084
 	ldr r1, _0207efe8 ; =func_ov00_0207e968
@@ -5766,17 +5766,17 @@ func_ov00_0207ee14: ; 0x0207ee14
 	str r8, [sp, #0x24]
 	str r0, [sp, #0x20]
 	add r4, sp, #0x10
-	ldmia sb, {r0, r1, r2}
+	ldmia r9, {r0, r1, r2}
 	cmp r5, #0
 	stmia r4, {r0, r1, r2}
 	ble _0207efbc
 	ldr r10, _0207efe4 ; =data_ov00_020ec8a4
-	ldr sb, _0207efe0 ; =data_027e0f6c
+	ldr r9, _0207efe0 ; =data_027e0f6c
 	mov r11, #0x4c
 _0207eeb8:
 	mov r0, r8, lsl #0x1
 	ldrh r1, [r10, r0]
-	ldr r2, [sb]
+	ldr r2, [r9]
 	add r0, sp, #0x28
 	ldr r3, [r2, #0x20]
 	mul r2, r1, r11
@@ -5848,7 +5848,7 @@ _0207efbc:
 	bl func_0204f754
 	mov r0, r7
 	add sp, sp, #0x74
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_0207ee14
 _0207efdc: .word data_027e0e60
@@ -5861,7 +5861,7 @@ _0207eff0: .word 0x0000ffff
 	.global func_ov00_0207eff4
 	arm_func_start func_ov00_0207eff4
 func_ov00_0207eff4: ; 0x0207eff4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x24
 	ldr r0, _0207f0f4 ; =data_027e0e60
 	mov r8, r1
@@ -5893,10 +5893,10 @@ func_ov00_0207eff4: ; 0x0207eff4
 	mov r6, #0
 	ble _0207f0e8
 	ldr r4, _0207f0fc ; =data_ov00_020ec8e4
-	ldr sb, _0207f0f8 ; =data_027e0f6c
+	ldr r9, _0207f0f8 ; =data_027e0f6c
 _0207f078:
 	mov r0, r6, lsl #0x1
-	ldr r1, [sb]
+	ldr r1, [r9]
 	ldrh r0, [r4, r0]
 	ldr r1, [r1, #0x40]
 	ldr r7, [r1, r0, lsl #2]
@@ -5919,7 +5919,7 @@ _0207f078:
 	cmp r0, #0
 	addne sp, sp, #0x24
 	movne r0, r7
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _0207f0dc:
 	add r6, r6, #1
 	cmp r6, r5
@@ -5927,7 +5927,7 @@ _0207f0dc:
 _0207f0e8:
 	mov r0, #0
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov00_0207eff4
 _0207f0f4: .word data_027e0e60
@@ -6010,20 +6010,20 @@ _0207f1f0: .word data_027e0e60
 	.global func_ov00_0207f1f4
 	arm_func_start func_ov00_0207f1f4
 func_ov00_0207f1f4: ; 0x0207f1f4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #0x3c
 	ldr r0, _0207f318 ; =data_027e0e60
-	mov sb, r1
+	mov r9, r1
 	ldr r1, [r0]
 	mov r8, r2
 	add r0, sp, #8
-	mov r2, sb
+	mov r2, r9
 	bl func_ov00_02083a1c
 	add r4, sp, #0x24
-	ldmia sb, {r0, r1, r2}
+	ldmia r9, {r0, r1, r2}
 	stmia r4, {r0, r1, r2}
 	add r3, sp, #0x30
-	ldmia sb, {r0, r1, r2}
+	ldmia r9, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
 	mov r0, r4
 	mov r1, #0x800
@@ -6063,7 +6063,7 @@ _0207f27c:
 	beq _0207f300
 	mov r0, r7
 	ldr r2, [r0]
-	mov r1, sb
+	mov r1, r9
 	ldr r2, [r2, #0x48]
 	blx r2
 	cmp r0, #0
@@ -6077,7 +6077,7 @@ _0207f27c:
 	add sp, sp, #0x3c
 	mov r0, #1
 	str r1, [r8]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 _0207f300:
 	add r6, r6, #1
 	cmp r6, r5
@@ -6085,7 +6085,7 @@ _0207f300:
 _0207f30c:
 	mov r0, #0
 	add sp, sp, #0x3c
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov00_0207f1f4
 _0207f318: .word data_027e0e60
@@ -6777,11 +6777,11 @@ func_ov00_0207faa8: ; 0x0207faa8
 	.global func_ov00_0207faac
 	arm_func_start func_ov00_0207faac
 func_ov00_0207faac: ; 0x0207faac
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x18
-	mov sb, r0
-	ldr r6, [sb, #0x10c]
-	ldr r0, [sb, #0x110]
+	mov r9, r0
+	ldr r6, [r9, #0x10c]
+	ldr r0, [r9, #0x110]
 	mov r8, r1
 	add r0, r6, r0, lsl #2
 	mov r7, r2
@@ -6814,8 +6814,8 @@ _0207fadc:
 	ldr r0, [sp, #0x14]
 	str r0, [r7, #0x14]
 _0207fb38:
-	ldr r1, [sb, #0x10c]
-	ldr r0, [sb, #0x110]
+	ldr r1, [r9, #0x10c]
+	ldr r0, [r9, #0x110]
 	add r6, r6, #4
 	add r0, r1, r0, lsl #2
 	cmp r6, r0
@@ -6823,7 +6823,7 @@ _0207fb38:
 _0207fb50:
 	mov r0, r5
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	arm_func_end func_ov00_0207faac
 
 	.global func_ov00_0207fb5c
@@ -6836,12 +6836,12 @@ func_ov00_0207fb5c: ; 0x0207fb5c
 	.global func_ov00_0207fb64
 	arm_func_start func_ov00_0207fb64
 func_ov00_0207fb64: ; 0x0207fb64
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #0x18
 	mov r10, r0
 	ldr r6, [r10, #0x10c]
 	ldr r0, [r10, #0x110]
-	mov sb, r1
+	mov r9, r1
 	add r0, r6, r0, lsl #2
 	mov r8, r2
 	mov r7, r3
@@ -6852,7 +6852,7 @@ func_ov00_0207fb64: ; 0x0207fb64
 _0207fb98:
 	ldr r0, [r6]
 	ldrb r1, [r0, #5]
-	cmp sb, r1
+	cmp r9, r1
 	bne _0207fbf8
 	ldr r2, [r0]
 	mov r1, r4
@@ -6878,7 +6878,7 @@ _0207fbf8:
 	cmp r5, r7
 	addhs sp, sp, #0x18
 	movhs r0, r5
-	ldmhsia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmhsia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	ldr r1, [r10, #0x10c]
 	ldr r0, [r10, #0x110]
 	add r6, r6, #4
@@ -6888,7 +6888,7 @@ _0207fbf8:
 _0207fc20:
 	mov r0, r5
 	add sp, sp, #0x18
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	arm_func_end func_ov00_0207fb64
 
 	.global func_ov00_0207fc2c
@@ -6958,11 +6958,11 @@ _0207fcd8:
 	.global func_ov00_0207fce0
 	arm_func_start func_ov00_0207fce0
 func_ov00_0207fce0: ; 0x0207fce0
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	mov r10, r0
 	ldr r6, [r10, #0x10c]
 	ldr r0, [r10, #0x110]
-	mov sb, r1
+	mov r9, r1
 	add r0, r6, r0, lsl #2
 	mov r8, r2
 	mov r7, r3
@@ -6973,7 +6973,7 @@ _0207fd0c:
 	cmp r4, r7
 	bhs _0207fd50
 	ldr r5, [r6]
-	mov r1, sb
+	mov r1, r9
 	mov r0, r5
 	ldr r2, [r0]
 	ldr r2, [r2, #0x14]
@@ -6989,7 +6989,7 @@ _0207fd0c:
 	bne _0207fd0c
 _0207fd50:
 	mov r0, r4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	arm_func_end func_ov00_0207fce0
 
 	.global func_ov00_0207fd58
@@ -7320,11 +7320,11 @@ _02080120:
 	.global func_ov00_02080140
 	arm_func_start func_ov00_02080140
 func_ov00_02080140: ; 0x02080140
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #0x50
-	ldr sb, [r1]
+	ldr r9, [r1]
 	mov r4, r0
-	str sb, [sp, #0x38]
+	str r9, [sp, #0x38]
 	ldr r8, [r1, #4]
 	mov r10, #0x18
 	str r8, [sp, #0x3c]
@@ -7343,7 +7343,7 @@ func_ov00_02080140: ; 0x02080140
 	ldrb r2, [r1, #0x14]
 	strb r2, [sp, #0x4c]
 	ldrb r1, [r1, #0x15]
-	str sb, [sp, #0x20]
+	str r9, [sp, #0x20]
 	str r8, [sp, #0x24]
 	strb r1, [sp, #0x4d]
 	str r7, [sp, #0x28]
@@ -7445,7 +7445,7 @@ _02080310:
 _02080318:
 	ldrb r0, [sp, #0x4c]
 	add sp, sp, #0x50
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	arm_func_end func_ov00_02080140
 
 	.global func_ov00_02080324
@@ -8066,7 +8066,7 @@ _02080b14:
 	.global func_ov00_02080b24
 	arm_func_start func_ov00_02080b24
 func_ov00_02080b24: ; 0x02080b24
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x14
 	ldr r3, [r0]
 	mov r2, #4
@@ -8076,7 +8076,7 @@ func_ov00_02080b24: ; 0x02080b24
 	blx r3
 	cmp r0, #0
 	addne sp, sp, #0x14
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, [sp]
 	ldrh r0, [r0, #0x30]
 	cmp r0, #0x60
@@ -8093,7 +8093,7 @@ func_ov00_02080b24: ; 0x02080b24
 	ble _02080c4c
 _02080b88:
 	cmp r11, #0
-	mov sb, #0
+	mov r9, #0
 	ble _02080c3c
 	and r0, r8, #0xff
 	str r0, [sp, #8]
@@ -8101,7 +8101,7 @@ _02080b9c:
 	ldr r1, [sp, #8]
 	ldr r0, [sp]
 	strb r1, [sp, #0x10]
-	strb sb, [sp, #0x11]
+	strb r9, [sp, #0x11]
 	ldr r2, [r0]
 	add r1, sp, #0x10
 	ldr r2, [r2, #0x78]
@@ -8121,7 +8121,7 @@ _02080b9c:
 	bl func_02042f68
 	ldrb r1, [r10, #1]
 	mov r4, r0
-	sub r0, sb, r1
+	sub r0, r9, r1
 	bl func_02042f68
 	add r7, r4, r0
 	b _02080c30
@@ -8130,15 +8130,15 @@ _02080c08:
 	bl func_02042f68
 	ldrb r1, [r10, #1]
 	mov r4, r0
-	sub r0, sb, r1
+	sub r0, r9, r1
 	bl func_02042f68
 	add r0, r4, r0
 	cmp r0, r7
 	movgt r6, r5
 	movgt r7, r0
 _02080c30:
-	add sb, sb, #1
-	cmp sb, r11
+	add r9, r9, #1
+	cmp r9, r11
 	blt _02080b9c
 _02080c3c:
 	ldr r0, [sp, #4]
@@ -8148,7 +8148,7 @@ _02080c3c:
 _02080c4c:
 	cmp r6, #0
 	addeq sp, sp, #0x14
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r1, [r6, #4]
 	ldr r0, [sp]
 	bic r1, r1, #1
@@ -8193,7 +8193,7 @@ _02080cd0:
 	ldr r0, [sp]
 	strh r1, [r0, #0x30]
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	arm_func_end func_ov00_02080b24
 
 	.global func_ov00_02080d08
@@ -10635,11 +10635,11 @@ func_ov00_02082908: ; 0x02082908
 	.global func_ov00_02082914
 	arm_func_start func_ov00_02082914
 func_ov00_02082914: ; 0x02082914
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x34
 	mov r8, r1
 	sub r1, r8, #0xfa
-	mov sb, r0
+	mov r9, r0
 	cmp r1, #4
 	addls pc, pc, r1, lsl #2
 	b _02082ac0
@@ -10664,10 +10664,10 @@ _02082948:
 	strb r0, [sp, #0x2e]
 	ldr r0, [r4, #0x10]
 	str r0, [sp, #0x30]
-	ldr r0, [sb, #4]
+	ldr r0, [r9, #4]
 	bl func_ov00_0207f844
 	add sp, sp, #0x34
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _02082990:
 	ldr r0, _02082ac8 ; =data_027e0d38
 	mov r1, #0xff
@@ -10676,7 +10676,7 @@ _02082990:
 	strb r1, [sp, #0x1a]
 	str r4, [sp, #0x1c]
 	ldr r1, [r0, #0x28]
-	ldr r0, [sb]
+	ldr r0, [r9]
 	ldr r3, [r1, #0x38]
 	ldr r2, [r1, #0x3c]
 	ldr r1, [r1, #0x40]
@@ -10689,12 +10689,12 @@ _02082990:
 	cmp r0, #2
 	mov r7, #0xfd
 	bne _02082a0c
-	ldr r0, [sb, #4]
+	ldr r0, [r9, #4]
 	ldr r1, [r0]
 	ldr r1, [r1, #0x88]
 	blx r1
 	add r5, r0, #0xa000
-	ldr r0, [sb, #4]
+	ldr r0, [r9, #4]
 	ldr r1, [r0]
 	ldr r1, [r1, #0x8c]
 	blx r1
@@ -10711,7 +10711,7 @@ _02082a1c: ; jump table
 	b _02082a60 ; case 2
 	b _02082a7c ; case 3
 _02082a2c:
-	mov r0, sb
+	mov r0, r9
 	bl func_ov00_020833e8
 	sub r0, r0, r6
 	mov r4, #0x8000
@@ -10719,14 +10719,14 @@ _02082a2c:
 	rsb r4, r4, #0
 	b _02082a90
 _02082a48:
-	mov r0, sb
+	mov r0, r9
 	bl func_ov00_020833d0
 	add r0, r6, r0
 	str r0, [sp, #8]
 	mov r4, #0
 	b _02082a90
 _02082a60:
-	mov r0, sb
+	mov r0, r9
 	bl func_ov00_020833dc
 	sub r0, r0, r5
 	mov r4, #0x4000
@@ -10734,7 +10734,7 @@ _02082a60:
 	rsb r4, r4, #0
 	b _02082a90
 _02082a7c:
-	mov r0, sb
+	mov r0, r9
 	bl func_ov00_020833c4
 	add r0, r5, r0
 	str r0, [sp]
@@ -10749,12 +10749,12 @@ _02082a90:
 	strh r4, [sp, #0x18]
 	str r7, [sp, #0x1c]
 	str r0, [sp, #0x14]
-	ldr r0, [sb, #4]
+	ldr r0, [r9, #4]
 	add r1, sp, #0xc
 	bl func_ov00_0207f844
 _02082ac0:
 	add sp, sp, #0x34
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov00_02082914
 _02082ac8: .word data_027e0d38
@@ -14093,7 +14093,7 @@ _02085104: .word data_027e0f6c
 	.global func_ov00_02085108
 	arm_func_start func_ov00_02085108
 func_ov00_02085108: ; 0x02085108
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x2c
 	ldr r0, _02085274 ; =data_027e0f64
 	str r1, [sp]
@@ -14145,12 +14145,12 @@ _020851a4:
 	tst r1, #4
 	beq _02085244
 	ldr r1, [r0]
-	ldr sb, [r4, #0x1c]
+	ldr r9, [r4, #0x1c]
 	ldr r1, [r1, #0x60]
 	ldr r8, [r4, #0x18]
 	ldr r10, [r4, #0x20]
 	blx r1
-	add sb, sb, r0
+	add r9, r9, r0
 	mov r0, r4
 	ldr r1, [r0]
 	ldr r1, [r1, #0x5c]
@@ -14159,7 +14159,7 @@ _020851a4:
 	add r0, sp, #0x1c
 	mov r1, #2
 	str r8, [sp, #0x1c]
-	str sb, [sp, #0x20]
+	str r9, [sp, #0x20]
 	str r10, [sp, #0x24]
 	bl func_0202b8e4
 	cmp r0, #0
@@ -14173,7 +14173,7 @@ _020851a4:
 	ldr r1, [r4, #0x20]
 	str r1, [r0, #8]
 	ldrsb r0, [r4, #0x12]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02085244:
 	sub r6, r6, #1
 	cmp r6, r7
@@ -14188,7 +14188,7 @@ _02085250:
 _02085268:
 	mov r0, #0
 	add sp, sp, #0x2c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_02085108
 _02085274: .word data_027e0f64
@@ -14197,7 +14197,7 @@ _02085278: .word data_027e0e60
 	.global func_ov00_0208527c
 	arm_func_start func_ov00_0208527c
 func_ov00_0208527c: ; 0x0208527c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x2c
 	ldr r3, _020853f4 ; =data_027e0f64
 	mov r4, r0
@@ -14224,7 +14224,7 @@ func_ov00_0208527c: ; 0x0208527c
 	strb r0, [sp, #0xd]
 	strb r0, [sp, #0xc]
 	ldrb r0, [sp, #0x12]
-	ldrb sb, [sp, #0x13]
+	ldrb r9, [sp, #0x13]
 	str r0, [sp, #4]
 	mov r0, r4
 	bl func_ov00_0208335c
@@ -14240,8 +14240,8 @@ func_ov00_0208527c: ; 0x0208527c
 	cmp r1, #0
 	movle r1, #0
 	strle r1, [sp, #4]
-	cmp sb, r0
-	subge sb, r0, #1
+	cmp r9, r0
+	subge r9, r0, #1
 	mov r0, #0
 	str r0, [sp, #0x24]
 	str r0, [sp, #0x18]
@@ -14255,7 +14255,7 @@ func_ov00_0208527c: ; 0x0208527c
 _02085358:
 	ldr r8, [sp, #4]
 	mov r0, r8
-	cmp r0, sb
+	cmp r0, r9
 	bgt _020853d8
 	and r7, r11, #0xff
 _0208536c:
@@ -14282,10 +14282,10 @@ _0208536c:
 	ldr r1, [r5, #0x20]
 	str r1, [r0, #8]
 	ldrsb r0, [r5, #0x12]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _020853cc:
 	add r8, r8, #1
-	cmp r8, sb
+	cmp r8, r9
 	ble _0208536c
 _020853d8:
 	ldr r0, [sp, #8]
@@ -14295,7 +14295,7 @@ _020853d8:
 _020853e8:
 	mov r0, #0
 	add sp, sp, #0x2c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_0208527c
 _020853f4: .word data_027e0f64
@@ -14304,13 +14304,13 @@ _020853f8: .word data_027e0e60
 	.global func_ov00_020853fc
 	arm_func_start func_ov00_020853fc
 func_ov00_020853fc: ; 0x020853fc
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x2c
 	ldr r3, _0208558c ; =data_027e0f64
 	mov r5, r0
 	ldr r0, [r3]
 	mov r10, r1
-	mov sb, r2
+	mov r9, r2
 	bl func_ov00_0208b180
 	mov r1, r0
 	add r0, sp, #0x14
@@ -14384,7 +14384,7 @@ _020854fc:
 	mov r1, r10
 	add r0, r5, #0x18
 	bl func_01ff9ec0
-	ldr r1, [sb]
+	ldr r1, [r9]
 	mov r4, r0
 	cmp r4, r1
 	bge _0208555c
@@ -14393,7 +14393,7 @@ _020854fc:
 	bl func_ov00_0208b7d0
 	cmp r0, #0
 	movne r11, r5
-	strne r4, [sb]
+	strne r4, [r9]
 _0208555c:
 	add r7, r7, #1
 	cmp r7, r8
@@ -14408,7 +14408,7 @@ _02085568:
 _02085580:
 	mov r0, r11
 	add sp, sp, #0x2c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020853fc
 _0208558c: .word data_027e0f64
@@ -14642,12 +14642,12 @@ _020858ac: .word data_027e077c
 	.global func_ov00_020858b0
 	arm_func_start func_ov00_020858b0
 func_ov00_020858b0: ; 0x020858b0
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x1c
-	mov sb, r2
+	mov r9, r2
 	mov r10, r0
 	mov r11, r1
-	cmp sb, #1
+	cmp r9, #1
 	bne _020858e4
 	ldr r0, _02085a2c ; =data_027e0f64
 	mov r1, #7
@@ -14728,7 +14728,7 @@ _02085980:
 	cmpeq r8, r1
 	moveq r2, #0
 	movne r2, #1
-	mov r1, sb
+	mov r1, r9
 	blx ip
 	str r0, [sp, #8]
 _02085a04:
@@ -14743,7 +14743,7 @@ _02085a10:
 _02085a20:
 	ldr r0, [sp, #8]
 	add sp, sp, #0x1c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020858b0
 _02085a2c: .word data_027e0f64
@@ -14909,7 +14909,7 @@ _02085c54:
 	.global func_ov00_02085c60
 	arm_func_start func_ov00_02085c60
 func_ov00_02085c60: ; 0x02085c60
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0xfc
 	ldr r11, [sp, #0x120]
 	ldr r8, [sp, #0x124]
@@ -14917,12 +14917,12 @@ func_ov00_02085c60: ; 0x02085c60
 	ldr r6, [sp, #0x12c]
 	cmp r11, #0
 	mov r10, r0
-	mov sb, r1
+	mov r9, r1
 	mov r5, r2
 	mov r4, r3
 	addeq sp, sp, #0xfc
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r1, sp, #0x88
 	str r1, [sp]
 	ldr r0, _0208603c ; =data_027e0d3c
@@ -15041,25 +15041,25 @@ _02085e48:
 	mov r0, #0
 	str r0, [sp, #0x10]
 	mov r0, r10
-	mov r1, sb
+	mov r1, r9
 	add r2, sp, #0x70
 	add r3, sp, #0x64
 	bl func_01ffbe78
 	cmp r0, #0
 	beq _02085fb8
-	ldr r1, [sb]
+	ldr r1, [r9]
 	add r0, sp, #0x30
 	str r1, [sp, #0x3c]
-	ldr r2, [sb, #4]
+	ldr r2, [r9, #4]
 	mov r1, r0
 	str r2, [sp, #0x40]
-	ldr r2, [sb, #8]
+	ldr r2, [r9, #8]
 	str r2, [sp, #0x44]
-	ldr r2, [sb, #0xc]
+	ldr r2, [r9, #0xc]
 	str r2, [sp, #0x30]
-	ldr r2, [sb, #0x10]
+	ldr r2, [r9, #0x10]
 	str r2, [sp, #0x34]
-	ldr r2, [sb, #0x14]
+	ldr r2, [r9, #0x14]
 	str r2, [sp, #0x38]
 	bl func_01ff9d4c
 	add r0, sp, #0x30
@@ -15071,13 +15071,13 @@ _02085e48:
 	bl func_01ff9bc4
 	ldr r1, [sp, #0x3c]
 	ldr r2, _02086040 ; =0x0000ffff
-	str r1, [sb]
+	str r1, [r9]
 	ldr r1, [sp, #0x40]
 	mov r3, #0
-	str r1, [sb, #4]
+	str r1, [r9, #4]
 	ldr r4, [sp, #0x44]
 	sub r1, r3, #1
-	str r4, [sb, #8]
+	str r4, [r9, #8]
 	strh r2, [sp, #0xb8]
 	strh r2, [sp, #0xba]
 	strh r2, [sp, #0xbc]
@@ -15122,11 +15122,11 @@ _02085f84:
 	bl func_ov00_0207920c
 	ldr r1, [sp, #0x1c]
 	mov r0, #1
-	str r1, [sb, #0x60]
+	str r1, [r9, #0x60]
 	ldr r1, [sp, #0x20]
 	add sp, sp, #0xfc
-	str r1, [sb, #0x64]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	str r1, [r9, #0x64]
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02085fb8:
 	ldr r1, [sp, #0x70]
 	ldr r0, [sp, #0x74]
@@ -15144,23 +15144,23 @@ _02085fb8:
 	beq _02085e48
 	ldr r1, [sp, #0x88]
 	ldr r0, _0208603c ; =data_027e0d3c
-	str r1, [sb]
+	str r1, [r9]
 	ldr r2, [sp, #0x8c]
 	add r1, sp, #0x88
-	str r2, [sb, #4]
+	str r2, [r9, #4]
 	ldr r3, [sp, #0x90]
 	add r2, sp, #0x14
-	str r3, [sb, #8]
+	str r3, [r9, #8]
 	ldr r0, [r0]
 	mov r3, #0
 	bl func_ov00_0207920c
 	ldr r1, [sp, #0x14]
 	mov r0, #0
-	str r1, [sb, #0x60]
+	str r1, [r9, #0x60]
 	ldr r1, [sp, #0x18]
-	str r1, [sb, #0x64]
+	str r1, [r9, #0x64]
 	add sp, sp, #0xfc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_02085c60
 _0208603c: .word data_027e0d3c
@@ -15169,16 +15169,16 @@ _02086040: .word 0x0000ffff
 	.global func_ov00_02086044
 	arm_func_start func_ov00_02086044
 func_ov00_02086044: ; 0x02086044
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0xb0
 	add r5, sp, #0x98
-	mov sb, r2
+	mov r9, r2
 	mov r10, r0
 	str r1, [sp]
-	ldmia sb, {r0, r1, r2}
+	ldmia r9, {r0, r1, r2}
 	stmia r5, {r0, r1, r2}
 	mov r8, r3
-	ldmia sb, {r0, r1, r2}
+	ldmia r9, {r0, r1, r2}
 	add r4, sp, #0xa4
 	stmia r4, {r0, r1, r2}
 	ldr r0, [sp]
@@ -15208,24 +15208,24 @@ func_ov00_02086044: ; 0x02086044
 	bl func_ov00_020839f8
 	mov r11, r0
 	add r5, sp, #0x8c
-	ldmia sb, {r0, r1, r2}
+	ldmia r9, {r0, r1, r2}
 	stmia r5, {r0, r1, r2}
 	ldr r0, [sp]
 	add r4, sp, #0x44
 	ldmia r0, {r0, r1, r2}
 	stmia r4, {r0, r1, r2}
 	add r3, sp, #0x38
-	ldmia sb, {r0, r1, r2}
+	ldmia r9, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
 	mov r0, r4
 	mov r1, r3
 	add r2, sp, #0x80
 	bl func_01ff9bf8
-	ldr r1, [sb]
+	ldr r1, [r9]
 	mov r0, r10
 	bl func_ov00_020839d4
 	mov r4, r0
-	ldr r1, [sb, #8]
+	ldr r1, [r9, #8]
 	mov r0, r10
 	bl func_ov00_020839f8
 	mov r2, r0
@@ -15258,16 +15258,16 @@ _02086164:
 	strb r7, [sp, #0x13]
 	bl func_ov00_02084024
 	ldr r0, [sp]
-	mov r1, sb
+	mov r1, r9
 	add r2, sp, #0x5c
 	bl func_01ff9bf8
-	ldr r1, [sb]
+	ldr r1, [r9]
 	add r0, sp, #0x68
 	str r1, [sp, #0x28]
-	ldr r2, [sb, #4]
+	ldr r2, [r9, #4]
 	add r1, sp, #0x28
 	str r2, [sp, #0x2c]
-	ldr r3, [sb, #8]
+	ldr r3, [r9, #8]
 	add r2, sp, #0x5c
 	str r3, [sp, #0x30]
 	add r3, sp, #0x14
@@ -15276,7 +15276,7 @@ _02086164:
 	cmp r0, #0
 	addne sp, sp, #0xb0
 	movne r0, #1
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _020861ec:
 	mov r0, r10
 	add r1, sp, #0x10
@@ -15290,13 +15290,13 @@ _020861ec:
 	blx r1
 	cmp r0, #0
 	beq _02086258
-	ldr r2, [sb]
+	ldr r2, [r9]
 	mov r0, r4
 	str r2, [sp, #0x18]
-	ldr r3, [sb, #4]
+	ldr r3, [r9, #4]
 	add r1, sp, #0x18
 	str r3, [sp, #0x1c]
-	ldr r3, [sb, #8]
+	ldr r3, [r9, #8]
 	add r2, sp, #0x80
 	str r3, [sp, #0x20]
 	str r8, [sp, #0x24]
@@ -15304,7 +15304,7 @@ _020861ec:
 	cmp r0, #0
 	addne sp, sp, #0xb0
 	movne r0, #1
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02086258:
 	add r7, r7, #1
 	cmp r7, r11
@@ -15317,7 +15317,7 @@ _02086264:
 _02086274:
 	mov r0, #0
 	add sp, sp, #0xb0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_02086044
 _02086280: .word data_027e0e60
@@ -15325,10 +15325,10 @@ _02086280: .word data_027e0e60
 	.global func_ov00_02086284
 	arm_func_start func_ov00_02086284
 func_ov00_02086284: ; 0x02086284
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x15c
-	mov sb, r1
-	mov r0, sb
+	mov r9, r1
+	mov r0, r9
 	ldr r1, [r0]
 	mov r8, r2
 	ldr r1, [r1, #8]
@@ -15345,7 +15345,7 @@ func_ov00_02086284: ; 0x02086284
 	beq _02086520
 	b _02086a78
 _020862d0:
-	mov r0, sb
+	mov r0, r9
 	ldr r2, [r0]
 	add r1, sp, #0x14c
 	ldr r2, [r2, #0x24]
@@ -15399,10 +15399,10 @@ _02086340:
 	ldr r1, [sp, #0x13c]
 	add sp, sp, #0x15c
 	str r1, [r4, #8]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _020863a8:
 	mov r1, #0
-	mov r0, sb
+	mov r0, r9
 	str r1, [sp, #0x120]
 	str r1, [sp, #0x114]
 	str r1, [sp, #0x118]
@@ -15417,7 +15417,7 @@ _020863a8:
 	str r1, [sp, #0x108]
 	str r2, [sp, #0x10c]
 	str r0, [sp, #0x110]
-	ldrb r0, [sb, #5]
+	ldrb r0, [r9, #5]
 	cmp r0, #0
 	beq _02086464
 	add r0, sp, #0x168
@@ -15447,7 +15447,7 @@ _020863a8:
 	stmib r4, {r0, r1}
 	add sp, sp, #0x15c
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _02086464:
 	add r1, sp, #0x108
 	mov r0, r8
@@ -15496,9 +15496,9 @@ _020864b0:
 	ldr r1, [sp, #0x104]
 	add sp, sp, #0x15c
 	str r1, [r4, #8]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _02086520:
-	mov r0, sb
+	mov r0, r9
 	ldr r2, [r0]
 	add r1, sp, #0xd8
 	ldr r2, [r2, #0x2c]
@@ -15530,7 +15530,7 @@ _02086520:
 	str r1, [sp, #0xb8]
 	str r0, [sp, #0xbc]
 _0208659c:
-	ldrb r0, [sb, #5]
+	ldrb r0, [r9, #5]
 	cmp r0, #0
 	beq _0208662c
 	add r0, sp, #0x168
@@ -15567,7 +15567,7 @@ _02086604:
 	stmib r4, {r0, r1}
 	add sp, sp, #0x15c
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _0208662c:
 	add r0, sp, #0xd8
 	add r1, sp, #0xa8
@@ -15857,21 +15857,21 @@ _02086a34:
 _02086a6c:
 	add sp, sp, #0x15c
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _02086a78:
 	mov r0, #0
 	add sp, sp, #0x15c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	arm_func_end func_ov00_02086284
 
 	.global func_ov00_02086a84
 	arm_func_start func_ov00_02086a84
 func_ov00_02086a84: ; 0x02086a84
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x84
 	mov r8, r2
 	mov r7, r3
-	mov sb, r1
+	mov r9, r1
 	add r2, sp, #0x78
 	mov r0, r8
 	mov r1, r7
@@ -15879,7 +15879,7 @@ func_ov00_02086a84: ; 0x02086a84
 	ldr r5, [sp, #0xac]
 	ldr r4, [sp, #0xb0]
 	bl func_01ff9bf8
-	mov r0, sb
+	mov r0, r9
 	ldr r1, [r0]
 	ldr r1, [r1, #8]
 	blx r1
@@ -15891,7 +15891,7 @@ func_ov00_02086a84: ; 0x02086a84
 	beq _02086c64
 	b _02086cc4
 _02086ae0:
-	mov r0, sb
+	mov r0, r9
 	ldr r2, [r0]
 	add r1, sp, #0x68
 	ldr r2, [r2, #0x24]
@@ -15958,10 +15958,10 @@ _02086b98:
 	ldr r1, [sp, #0x58]
 	add sp, sp, #0x84
 	str r1, [r4, #8]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _02086be4:
 	mov r1, #0
-	mov r0, sb
+	mov r0, r9
 	str r1, [sp, #0x3c]
 	str r1, [sp, #0x30]
 	str r1, [sp, #0x34]
@@ -15991,9 +15991,9 @@ _02086be4:
 	bl func_01fffb4c
 	add sp, sp, #0x84
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _02086c64:
-	mov r0, sb
+	mov r0, r9
 	ldr r2, [r0]
 	add r1, sp, #0xc
 	ldr r2, [r2, #0x2c]
@@ -16016,11 +16016,11 @@ _02086c64:
 	bl func_01fffb4c
 	add sp, sp, #0x84
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _02086cc4:
 	mov r0, #0
 	add sp, sp, #0x84
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	arm_func_end func_ov00_02086a84
 
 	.global func_ov00_02086cd0
@@ -16337,13 +16337,13 @@ _020870cc: .word func_ov00_0208e420
 	.global func_ov00_020870d0
 	arm_func_start func_ov00_020870d0
 func_ov00_020870d0: ; 0x020870d0
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0xc
-	mov sb, r0
-	ldr r1, [sb, #8]
+	mov r9, r0
+	ldr r1, [r9, #8]
 	mov r0, #0x1000
 	bl Divide
-	ldrh r1, [sb, #4]
+	ldrh r1, [r9, #4]
 	ldr r2, _02087268 ; =data_02050f54
 	mov r7, r0
 	mov r0, r1, asr #0x4
@@ -16393,9 +16393,9 @@ _02087120:
 	adds ip, ip, #0x80000000
 	adc lr, r3, #0
 	rsb r3, lr, #0
-	str r10, [sb, #0x10c]
+	str r10, [r9, #0x10c]
 	str r3, [sp, #4]
-	str r3, [sb, #0x110]
+	str r3, [r9, #0x110]
 	umull ip, r3, r4, r7
 	mla r3, r4, r11, r3
 	mov r2, r1, lsl #0xc
@@ -16405,12 +16405,12 @@ _02087120:
 	adds r4, ip, #0x80000000
 	adc r3, r3, #0
 	rsb r3, r3, #0
-	str r3, [sb, #0x114]
-	str r10, [sb, #0x118]
-	str r10, [sb, #0x11c]
+	str r3, [r9, #0x114]
+	str r10, [r9, #0x118]
+	str r10, [r9, #0x11c]
 	str r3, [sp, #8]
-	str lr, [sb, #0x120]
-	str r3, [sb, #0x124]
+	str lr, [r9, #0x120]
+	str r3, [r9, #0x124]
 	str r3, [sp, #8]
 	umull r4, r3, r0, r6
 	mla r3, r0, r5, r3
@@ -16423,23 +16423,23 @@ _02087120:
 	adc r0, r2, #0
 	rsb r0, r0, #0
 	str r0, [sp, #8]
-	str r10, [sb, #0x128]
+	str r10, [r9, #0x128]
 	rsb r1, r3, #0
-	str r1, [sb, #0x13c]
-	str r10, [sb, #0x140]
-	str r0, [sb, #0x144]
-	str r10, [sb, #0x148]
-	str r3, [sb, #0x12c]
+	str r1, [r9, #0x13c]
+	str r10, [r9, #0x140]
+	str r0, [r9, #0x144]
+	str r10, [r9, #0x148]
+	str r3, [r9, #0x12c]
 	str r10, [sp]
-	str r10, [sb, #0x130]
+	str r10, [r9, #0x130]
 	str r1, [sp]
-	str r0, [sb, #0x134]
+	str r0, [r9, #0x134]
 	str r3, [sp]
 	str r10, [sp, #4]
 	str r0, [sp, #8]
-	str r10, [sb, #0x138]
+	str r10, [r9, #0x138]
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020870d0
 _02087268: .word data_02050f54
@@ -16770,7 +16770,7 @@ _02087694:
 	.global func_ov00_020876bc
 	arm_func_start func_ov00_020876bc
 func_ov00_020876bc: ; 0x020876bc
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #0x88
 	mov r7, r0
 	mov r6, r1
@@ -16780,7 +16780,7 @@ func_ov00_020876bc: ; 0x020876bc
 	cmp r0, #0
 	addne sp, sp, #0x88
 	movne r0, #0
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	ldr r0, [r7, #0x15c]
 	bl func_ov00_02087d84
 	ldr r1, [r0, #4]
@@ -16816,7 +16816,7 @@ _02087724:
 	str r3, [sp, #0x60]
 	str r0, [sp, #0x64]
 	str r8, [sp, #0x5c]
-	ldrsh sb, [r7, #4]
+	ldrsh r9, [r7, #4]
 	add r0, sp, #0x60
 	add r3, sp, #0x38
 	str r2, [sp, #0x68]
@@ -16828,7 +16828,7 @@ _02087724:
 	add r8, sp, #0x44
 	ldmia r0, {r0, r1, r2}
 	stmia r8, {r0, r1, r2}
-	strh sb, [sp, #0x50]
+	strh r9, [sp, #0x50]
 	mov r0, #0
 	str r0, [sp]
 	ldr r0, [r7, #0x14c]
@@ -16840,7 +16840,7 @@ _020877c0:
 	ldr r10, [r7, #0x260]
 	ldr r2, [r7, #0x264]
 	ldr r1, [r7, #0x268]
-	ldr sb, [r7, #0x26c]
+	ldr r9, [r7, #0x26c]
 	ldr r8, [r7, #0x270]
 	ldr lr, [r7, #0x274]
 	str r10, [sp, #0x2c]
@@ -16853,7 +16853,7 @@ _020877c0:
 	stmia r3, {r0, r1, r2}
 	add r0, sp, #0x20
 	add r10, sp, #0x10
-	str sb, [sp, #0x20]
+	str r9, [sp, #0x20]
 	str r8, [sp, #0x24]
 	str lr, [sp, #0x28]
 	ldmia r0, {r0, r1, r2}
@@ -16872,7 +16872,7 @@ _02087830:
 	mov r3, r4
 	bl func_ov00_02087338
 	add sp, sp, #0x88
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020876bc
 _0208784c: .word data_027e0e60
@@ -16880,7 +16880,7 @@ _0208784c: .word data_027e0e60
 	.global func_ov00_02087850
 	arm_func_start func_ov00_02087850
 func_ov00_02087850: ; 0x02087850
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #0x88
 	mov r7, r0
 	mov r6, r1
@@ -16890,7 +16890,7 @@ func_ov00_02087850: ; 0x02087850
 	cmp r0, #0
 	addne sp, sp, #0x88
 	movne r0, #0
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	ldr r0, [r7, #0x15c]
 	bl func_ov00_02087d84
 	ldr r1, [r0, #4]
@@ -16926,7 +16926,7 @@ _020878b8:
 	str r3, [sp, #0x60]
 	str r0, [sp, #0x64]
 	str r8, [sp, #0x5c]
-	ldrsh sb, [r7, #4]
+	ldrsh r9, [r7, #4]
 	add r0, sp, #0x60
 	add r3, sp, #0x38
 	str r2, [sp, #0x68]
@@ -16938,7 +16938,7 @@ _020878b8:
 	add r8, sp, #0x44
 	ldmia r0, {r0, r1, r2}
 	stmia r8, {r0, r1, r2}
-	strh sb, [sp, #0x50]
+	strh r9, [sp, #0x50]
 	mov r0, #0
 	str r0, [sp]
 	ldr r0, [r7, #0x14c]
@@ -16950,7 +16950,7 @@ _02087954:
 	ldr r10, [r7, #0x260]
 	ldr r2, [r7, #0x264]
 	ldr r1, [r7, #0x268]
-	ldr sb, [r7, #0x26c]
+	ldr r9, [r7, #0x26c]
 	ldr r8, [r7, #0x270]
 	ldr lr, [r7, #0x274]
 	str r10, [sp, #0x2c]
@@ -16963,7 +16963,7 @@ _02087954:
 	stmia r3, {r0, r1, r2}
 	add r0, sp, #0x20
 	add r10, sp, #0x10
-	str sb, [sp, #0x20]
+	str r9, [sp, #0x20]
 	str r8, [sp, #0x24]
 	str lr, [sp, #0x28]
 	ldmia r0, {r0, r1, r2}
@@ -16982,7 +16982,7 @@ _020879c4:
 	mov r3, r4
 	bl func_ov00_02087400
 	add sp, sp, #0x88
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov00_02087850
 _020879e0: .word data_027e0e60
@@ -17880,7 +17880,7 @@ func_ov00_02088494: ; 0x02088494
 	.global func_ov00_020884b4
 	arm_func_start func_ov00_020884b4
 func_ov00_020884b4: ; 0x020884b4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x98
 	mov r5, r0
 	ldr r0, [r5, #0x15c]
@@ -17899,7 +17899,7 @@ _020884e0: ; jump table
 	b _020884f4 ; case 4
 _020884f4:
 	add sp, sp, #0x98
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _020884fc:
 	ldr r1, [r5, #0x160]
 	mov r0, r5
@@ -17944,7 +17944,7 @@ _02088588:
 	ldr r6, [r0, #0x14]
 	ldr r7, [r0, #0x18]
 	ldr r8, [r0, #0x1c]
-	ldr sb, [r0, #0x20]
+	ldr r9, [r0, #0x20]
 	ldr r10, [r0, #0x24]
 	mov r1, #4
 	str r1, [r5, #0x15c]
@@ -18055,7 +18055,7 @@ _020885cc:
 	str r6, [sp, #0x44]
 	str r7, [sp, #0x48]
 	str r8, [sp, #0x4c]
-	str sb, [sp, #0x50]
+	str r9, [sp, #0x50]
 	str r10, [sp, #0x54]
 	b _02088858
 _02088764:
@@ -18064,7 +18064,7 @@ _02088764:
 	add r0, r8, r7
 	ldr r11, [r8, r7]
 	ldr r10, [r0, #4]
-	ldr sb, [r0, #8]
+	ldr r9, [r0, #8]
 	ldr r8, [r0, #0xc]
 	ldr r7, [r0, #0x10]
 	ldr ip, [r0, #0x14]
@@ -18072,8 +18072,8 @@ _02088764:
 	ldr r11, [r0, #0x18]
 	str r10, [sp, #0x34]
 	ldr r10, [r0, #0x1c]
-	str sb, [sp, #0x38]
-	ldr sb, [r0, #0x20]
+	str r9, [sp, #0x38]
+	ldr r9, [r0, #0x20]
 	str r8, [sp, #0x3c]
 	ldr r8, [r0, #0x24]
 	str r7, [sp, #0x40]
@@ -18084,8 +18084,8 @@ _02088764:
 	ldr r11, [r0, #0x30]
 	str r10, [sp, #0x4c]
 	ldr r10, [r0, #0x34]
-	str sb, [sp, #0x50]
-	ldr sb, [r0, #0x38]
+	str r9, [sp, #0x50]
+	ldr r9, [r0, #0x38]
 	str r8, [sp, #0x54]
 	ldr r8, [r0, #0x3c]
 	str r7, [sp, #0x58]
@@ -18101,8 +18101,8 @@ _02088764:
 	ldr r11, [r0, #0x48]
 	str r10, [sp, #0x64]
 	ldr r10, [r0, #0x4c]
-	str sb, [sp, #0x68]
-	ldr sb, [r0, #0x50]
+	str r9, [sp, #0x68]
+	ldr r9, [r0, #0x50]
 	str r8, [sp, #0x6c]
 	ldr r8, [r0, #0x54]
 	str r7, [sp, #0x70]
@@ -18111,7 +18111,7 @@ _02088764:
 	str ip, [sp, #0x74]
 	str r11, [sp, #0x78]
 	str r10, [sp, #0x7c]
-	str sb, [sp, #0x80]
+	str r9, [sp, #0x80]
 	str r8, [sp, #0x84]
 	str r7, [sp, #0x88]
 	str r0, [sp, #0x8c]
@@ -18155,7 +18155,7 @@ _02088858:
 	str r1, [r5, #0x2b0]
 	strb r0, [r5, #0x2ec]
 	add sp, sp, #0x98
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020884b4
 _020888e4: .word data_ov00_020d8aa8
@@ -18163,7 +18163,7 @@ _020888e4: .word data_ov00_020d8aa8
 	.global func_ov00_020888e8
 	arm_func_start func_ov00_020888e8
 func_ov00_020888e8: ; 0x020888e8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #0x94
 	mov r7, r0
 	ldr r0, [r7, #0x15c]
@@ -18182,7 +18182,7 @@ _02088914: ; jump table
 	b _02088928 ; case 4
 _02088928:
 	add sp, sp, #0x94
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 _02088930:
 	ldr r1, [r7, #0x160]
 	mov r0, r7
@@ -18231,7 +18231,7 @@ _020889c0:
 	add r0, r7, #0x100
 	str r1, [r7, #0x164]
 	ldrb r1, [sp, #8]
-	add sb, sp, #0x20
+	add r9, sp, #0x20
 	mov r3, #5
 	strb r1, [r7, #0x168]
 	ldr r1, [sp, #0xc]
@@ -18252,7 +18252,7 @@ _020889c0:
 	strh r2, [r0, #0x7c]
 	strh r1, [r0, #0x7e]
 	ldmia r5, {r0, r1, r2}
-	stmia sb, {r0, r1, r2}
+	stmia r9, {r0, r1, r2}
 	ldr r1, [r7, #0x154]
 	ldr r0, [sp, #0x20]
 	ldr r1, [r1, #0x14]
@@ -18313,7 +18313,7 @@ _02088a6c:
 	str r1, [r7, #0x2b0]
 	strb r0, [r7, #0x2ec]
 	add sp, sp, #0x94
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	arm_func_end func_ov00_020888e8
 
 	.global func_ov00_02088b2c
@@ -18486,7 +18486,7 @@ _02088cec:
 	.global func_ov00_02088d9c
 	arm_func_start func_ov00_02088d9c
 func_ov00_02088d9c: ; 0x02088d9c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #0x94
 	mov r7, r0
 	ldr r0, [r7, #0x15c]
@@ -18505,7 +18505,7 @@ _02088dc8: ; jump table
 	b _02088ddc ; case 4
 _02088ddc:
 	add sp, sp, #0x94
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 _02088de4:
 	ldr r1, [r7, #0x160]
 	mov r0, r7
@@ -18554,7 +18554,7 @@ _02088e74:
 	add r0, r7, #0x100
 	str r1, [r7, #0x164]
 	ldrb r1, [sp, #8]
-	mov sb, #6
+	mov r9, #6
 	add r8, sp, #0x20
 	strb r1, [r7, #0x168]
 	ldr r1, [sp, #0xc]
@@ -18574,7 +18574,7 @@ _02088e74:
 	ldrh r1, [sp, #0x1e]
 	strh r2, [r0, #0x7c]
 	strh r1, [r0, #0x7e]
-	str sb, [r7, #0x160]
+	str r9, [r7, #0x160]
 	ldr r0, [r5]
 	str r0, [r7, #0x2a8]
 	ldr r0, [r5, #4]
@@ -18607,7 +18607,7 @@ _02088e74:
 _02088f60:
 	ldmia r6!, {r0, r1, r2, r3}
 	stmia ip!, {r0, r1, r2, r3}
-	subs sb, sb, #1
+	subs r9, r9, #1
 	bne _02088f60
 	ldrsh r3, [sp, #0xb8]
 	ldmia r6, {r0, r1}
@@ -18650,7 +18650,7 @@ _02088f60:
 	str r1, [r7, #0x2a4]
 	strb r0, [r7, #0x2ec]
 	add sp, sp, #0x94
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov00_02088d9c
 _02089018: .word data_ov00_020d8aa8
@@ -19129,23 +19129,23 @@ _02089674:
 	.global func_ov00_0208967c
 	arm_func_start func_ov00_0208967c
 func_ov00_0208967c: ; 0x0208967c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x130
-	mov sb, r0
+	mov r9, r0
 	mov r8, r1
 	mov r7, r2
 	bl func_ov00_02087f08
 	cmp r0, #0
 	addeq sp, sp, #0x130
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	ldr r0, _02089a24 ; =data_027e0f74
 	ldr r0, [r0]
 	bl func_ov00_02097738
 	cmp r0, #0
 	addne sp, sp, #0x130
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	ldr r1, [r7]
-	add r0, sb, #0x200
+	add r0, r9, #0x200
 	str r1, [sp, #0x54]
 	ldr r2, [r7, #4]
 	cmp r8, #7
@@ -19167,8 +19167,8 @@ _020896ec: ; jump table
 	b _0208976c ; case 6
 	b _0208973c ; case 7
 _0208970c:
-	ldr r8, [sb, #0x298]
-	ldr r3, [sb, #0x290]
+	ldr r8, [r9, #0x298]
+	ldr r3, [r9, #0x290]
 	add r0, sp, #0x54
 	add r1, sp, #0x48
 	str r3, [sp, #0x48]
@@ -19178,7 +19178,7 @@ _0208970c:
 	cmp r0, #0
 	bne _02089770
 	add sp, sp, #0x130
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _0208973c:
 	ldrb r0, [sp, #0x150]
 	cmp r0, #0
@@ -19197,24 +19197,24 @@ _02089764:
 _0208976c:
 	mov r5, #0x35
 _02089770:
-	ldr r1, [sb, #0x160]
-	mov r0, sb
+	ldr r1, [r9, #0x160]
+	mov r0, r9
 	bl func_ov00_0208a84c
 	cmp r0, #0
 	beq _020897d8
-	ldr r1, [sb, #0x15c]
-	add r0, sb, #0x100
-	str r1, [sb, #0x180]
-	ldr r1, [sb, #0x164]
-	str r1, [sb, #0x188]
-	ldrb r1, [sb, #0x168]
-	strb r1, [sb, #0x18c]
-	ldr r1, [sb, #0x16c]
-	str r1, [sb, #0x190]
-	ldr r1, [sb, #0x170]
-	str r1, [sb, #0x194]
-	ldr r1, [sb, #0x174]
-	str r1, [sb, #0x198]
+	ldr r1, [r9, #0x15c]
+	add r0, r9, #0x100
+	str r1, [r9, #0x180]
+	ldr r1, [r9, #0x164]
+	str r1, [r9, #0x188]
+	ldrb r1, [r9, #0x168]
+	strb r1, [r9, #0x18c]
+	ldr r1, [r9, #0x16c]
+	str r1, [r9, #0x190]
+	ldr r1, [r9, #0x170]
+	str r1, [r9, #0x194]
+	ldr r1, [r9, #0x174]
+	str r1, [r9, #0x198]
 	ldrsh r1, [r0, #0x78]
 	strh r1, [r0, #0x9c]
 	ldrsh r1, [r0, #0x7a]
@@ -19224,7 +19224,7 @@ _02089770:
 	strh r2, [r0, #0xa0]
 	strh r1, [r0, #0xa2]
 _020897d8:
-	str r5, [sb, #0x15c]
+	str r5, [r9, #0x15c]
 	mov r3, #0
 	mov r0, #0xff
 	add r2, sp, #4
@@ -19240,16 +19240,16 @@ _020897fc:
 	cmp r3, #2
 	blo _020897fc
 	ldr r1, [sp, #4]
-	add r0, sb, #0x100
-	str r1, [sb, #0x164]
+	add r0, r9, #0x100
+	str r1, [r9, #0x164]
 	ldrb r1, [sp, #8]
-	strb r1, [sb, #0x168]
+	strb r1, [r9, #0x168]
 	ldr r1, [sp, #0xc]
-	str r1, [sb, #0x16c]
+	str r1, [r9, #0x16c]
 	ldr r1, [sp, #0x10]
-	str r1, [sb, #0x170]
+	str r1, [r9, #0x170]
 	ldr r1, [sp, #0x14]
-	str r1, [sb, #0x174]
+	str r1, [r9, #0x174]
 	ldrsh r1, [sp, #0x18]
 	strh r1, [r0, #0x78]
 	ldrsh r1, [sp, #0x1a]
@@ -19258,7 +19258,7 @@ _020897fc:
 	ldrh r1, [sp, #0x1e]
 	strh r2, [r0, #0x7c]
 	strh r1, [r0, #0x7e]
-	ldr r0, [sb, #0x15c]
+	ldr r0, [r9, #0x15c]
 	bl func_ov00_02087d84
 	add r8, sp, #0xc8
 	mov ip, r0
@@ -19278,7 +19278,7 @@ _02089870:
 	str r1, [sp, #0x40]
 	ldr r1, [r7, #8]
 	str r1, [sp, #0x44]
-	ldr r1, [sb, #0x154]
+	ldr r1, [r9, #0x154]
 	ldr r2, [r1, #0x34]
 	str r3, [r2, #8]
 	ldr r1, [sp, #0x40]
@@ -19286,17 +19286,17 @@ _02089870:
 	str r1, [r2, #0xc]
 	ldr r1, [sp, #0x44]
 	str r1, [r2, #0x10]
-	ldr r1, [sb, #0x154]
+	ldr r1, [r9, #0x154]
 	add r2, sp, #0x20
 	ldr r1, [r1, #0x34]
 	strh r6, [r1, #0x14]
-	ldr r1, [sb, #0x160]
+	ldr r1, [r9, #0x160]
 	cmp r1, #0xd
 	mov r1, #0xd
-	str r1, [sb, #0x160]
+	str r1, [r9, #0x160]
 	str r1, [sp, #0xcc]
-	str r0, [sb, #0x1a4]
-	str r3, [sb, #0x1a8]
+	str r0, [r9, #0x1a4]
+	str r3, [r9, #0x1a8]
 	mov r0, #0xff
 	movne r5, #1
 	str r3, [sp, #0x20]
@@ -19311,7 +19311,7 @@ _02089910:
 	cmp r3, #2
 	blo _02089910
 	ldr r0, _02089a28 ; =data_027e0e60
-	ldrb r2, [sb, #0x1b8]
+	ldrb r2, [r9, #0x1b8]
 	ldr r0, [r0]
 	add r1, sp, #0x20
 	bl func_ov00_02083928
@@ -19347,36 +19347,36 @@ _0208994c:
 _020899a8:
 	cmp r5, #0
 	movne r0, #2
-	strne r0, [sb, #0x1a4]
+	strne r0, [r9, #0x1a4]
 _020899b4:
 	mov r2, #0
 	str r2, [sp]
 	add r1, sp, #0xc8
-	mov r0, sb
-	add r2, sb, #0x164
+	mov r0, r9
+	add r2, r9, #0x164
 	mov r3, #1
 	bl func_ov00_02087b78
-	ldr r1, [sb, #0x154]
-	ldr r0, [sb, #0x160]
+	ldr r1, [r9, #0x154]
+	ldr r0, [r9, #0x160]
 	mov r2, #0
 	ldr r0, [r1, r0, lsl #2]
 	add r1, sp, #0x3c
 	str r2, [r0, #0x18]
-	ldr r3, [sb, #0x154]
-	ldr r2, [sb, #0x160]
-	mov r0, sb
+	ldr r3, [r9, #0x154]
+	ldr r2, [r9, #0x160]
+	mov r0, r9
 	ldr r3, [r3, r2, lsl #2]
 	mov r2, r6
 	str r4, [r3, #0x1c]
 	bl func_ov00_02089c50
 	ldr r0, [sp, #0x3c]
-	str r0, [sb, #0x2a8]
+	str r0, [r9, #0x2a8]
 	ldr r0, [sp, #0x40]
-	str r0, [sb, #0x2ac]
+	str r0, [r9, #0x2ac]
 	ldr r0, [sp, #0x44]
-	str r0, [sb, #0x2b0]
+	str r0, [r9, #0x2b0]
 	add sp, sp, #0x130
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov00_0208967c
 _02089a24: .word data_027e0f74
@@ -19518,7 +19518,7 @@ func_ov00_02089b88: ; 0x02089b88
 	.global func_ov00_02089b94
 	arm_func_start func_ov00_02089b94
 func_ov00_02089b94: ; 0x02089b94
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0xc
 	add r2, r0, #0x200
 	ldrh r3, [r2, #0x26]
@@ -19535,26 +19535,26 @@ func_ov00_02089b94: ; 0x02089b94
 	ldr r4, [r0, #0x244]
 	ldr lr, [r0, #0x240]
 	smull r0, r3, r4, r8
-	adds sb, r0, #0x800
+	adds r9, r0, #0x800
 	smull r7, r6, r1, r8
 	smull r8, r0, r1, r5
 	adc r3, r3, #0
 	adds r1, r8, #0x800
-	mov ip, sb, lsr #0xc
+	mov ip, r9, lsr #0xc
 	smull r8, r5, r4, r5
 	adc r0, r0, #0
 	adds r8, r8, #0x800
 	adc r5, r5, #0
 	adds r4, r7, #0x800
-	mov sb, r1, lsr #0xc
+	mov r9, r1, lsr #0xc
 	mov r7, r8, lsr #0xc
-	orr sb, sb, r0, lsl #20
+	orr r9, r9, r0, lsl #20
 	adc r1, r6, #0
 	mov r4, r4, lsr #0xc
 	orr ip, ip, r3, lsl #20
 	orr r4, r4, r1, lsl #20
 	orr r7, r7, r5, lsl #20
-	add r6, ip, sb
+	add r6, ip, r9
 	sub r3, r7, r4
 	add r1, sp, #0
 	mov r0, r2
@@ -19563,7 +19563,7 @@ func_ov00_02089b94: ; 0x02089b94
 	str r3, [sp, #8]
 	bl func_01ff9bc4
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov00_02089b94
 _02089c4c: .word data_02050f54
@@ -19571,7 +19571,7 @@ _02089c4c: .word data_02050f54
 	.global func_ov00_02089c50
 	arm_func_start func_ov00_02089c50
 func_ov00_02089c50: ; 0x02089c50
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0xc
 	mov r2, r2, lsl #0x10
 	mov r2, r2, lsr #0x10
@@ -19588,26 +19588,26 @@ func_ov00_02089c50: ; 0x02089c50
 	ldr lr, [r0, #0x240]
 	smull r7, r6, r3, r8
 	smull r0, r8, r4, r8
-	adds sb, r0, #0x800
+	adds r9, r0, #0x800
 	mov r2, r1
 	smull r1, r0, r3, r5
 	adc r3, r8, #0
 	adds r1, r1, #0x800
-	mov ip, sb, lsr #0xc
+	mov ip, r9, lsr #0xc
 	smull r8, r5, r4, r5
 	adc r0, r0, #0
 	adds r8, r8, #0x800
 	adc r5, r5, #0
 	adds r4, r7, #0x800
-	mov sb, r1, lsr #0xc
+	mov r9, r1, lsr #0xc
 	mov r7, r8, lsr #0xc
-	orr sb, sb, r0, lsl #20
+	orr r9, r9, r0, lsl #20
 	adc r1, r6, #0
 	mov r4, r4, lsr #0xc
 	orr ip, ip, r3, lsl #20
 	orr r4, r4, r1, lsl #20
 	orr r7, r7, r5, lsl #20
-	add r6, ip, sb
+	add r6, ip, r9
 	sub r3, r7, r4
 	add r1, sp, #0
 	mov r0, r2
@@ -19616,7 +19616,7 @@ func_ov00_02089c50: ; 0x02089c50
 	str r3, [sp, #8]
 	bl func_01ff9bc4
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov00_02089c50
 _02089d08: .word data_02050f54
@@ -21282,11 +21282,11 @@ func_ov00_0208b2a0: ; 0x0208b2a0
 	.global func_ov00_0208b39c
 	arm_func_start func_ov00_0208b39c
 func_ov00_0208b39c: ; 0x0208b39c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x10
 	mov r4, r0
 	ldr r0, [sp, #0x30]
-	mov sb, r1
+	mov r9, r1
 	mov r8, r2
 	mov r7, r3
 	bl func_ov00_0208b278
@@ -21319,7 +21319,7 @@ func_ov00_0208b39c: ; 0x0208b39c
 	str r2, [sp, #8]
 	mov r2, #1
 	bl func_01ffa9fc
-	mov r0, sb
+	mov r0, r9
 	bl func_ov00_0208b220
 	ldrh r2, [sp, #0x34]
 	mov r0, #0x22
@@ -21343,17 +21343,17 @@ func_ov00_0208b39c: ; 0x0208b39c
 	mov r0, r7
 	bl func_ov00_0208b220
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	arm_func_end func_ov00_0208b39c
 
 	.global func_ov00_0208b494
 	arm_func_start func_ov00_0208b494
 func_ov00_0208b494: ; 0x0208b494
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x10
 	mov r4, r0
 	ldr r0, [sp, #0x30]
-	mov sb, r1
+	mov r9, r1
 	mov r8, r2
 	mov r7, r3
 	bl func_ov00_0208b278
@@ -21388,7 +21388,7 @@ func_ov00_0208b494: ; 0x0208b494
 	str r2, [sp, #8]
 	mov r2, #1
 	bl func_01ffa9fc
-	mov r0, sb
+	mov r0, r9
 	bl func_ov00_0208b220
 	ldr r0, [sp, #0x38]
 	bl func_ov00_0208b278
@@ -21416,7 +21416,7 @@ func_ov00_0208b494: ; 0x0208b494
 	mov r0, r7
 	bl func_ov00_0208b220
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	arm_func_end func_ov00_0208b494
 
 	.global func_ov00_0208b5a4
@@ -21945,16 +21945,16 @@ func_ov00_0208ba58: ; 0x0208ba58
 	.global func_ov00_0208ba68
 	arm_func_start func_ov00_0208ba68
 func_ov00_0208ba68: ; 0x0208ba68
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #0x98
 	ldr r8, [sp, #0xbc]
 	ldr r7, [sp, #0xc0]
 	ldr r6, [sp, #0xc4]
 	ldr r5, [sp, #0xc8]
 	ldr lr, _0208bed8 ; =0x04000444
-	mov sb, #0
+	mov r9, #0
 	ldr r0, _0208bedc ; =data_027e0d44
-	str sb, [lr]
+	str r9, [lr]
 	ldr r10, [r0]
 	ldr r4, [sp, #0xcc]
 	add r10, r10, r2, lsl #3
@@ -21975,9 +21975,9 @@ func_ov00_0208ba68: ; 0x0208ba68
 	beq _0208bb08
 	cmp r0, #2
 	ldr r0, _0208bedc ; =data_027e0d44
-	moveq sb, #1
+	moveq r9, #1
 	ldr r10, [r0]
-	rsb sb, sb, #4
+	rsb r9, r9, #4
 	add r2, r10, r2, lsl #3
 	ldr r2, [r2, #0xc]
 	ldr r0, _0208bee0 ; =0x040004ac
@@ -21991,43 +21991,43 @@ _0208bb08:
 	ldrh ip, [r4]
 	ldrh r0, [r0]
 	ldr r10, _0208bee8 ; =0x040004c0
-	mov sb, #0
+	mov r9, #0
 	orr r0, ip, r0, lsl #16
 	str r0, [r10]
 	ldr r0, _0208beec ; =0x001f0081
-	str sb, [r10, #4]
+	str r9, [r10, #4]
 	str r0, [r10, #-0x1c]
 	cmp r2, #0
 	beq _0208bb78
 	ldr r0, _0208bef0 ; =data_027e0f64
-	ldr sb, [r3]
+	ldr r9, [r3]
 	ldr r2, [r0]
 	add r0, sp, #0xc
 	add r1, r2, r1, lsl #2
 	ldr r1, [r1, #4]
 	add r2, sp, #0x58
-	str sb, [sp, #0xc]
-	ldr sb, [r3, #4]
+	str r9, [sp, #0xc]
+	ldr r9, [r3, #4]
 	add r1, r1, #0x1c
-	str sb, [sp, #0x10]
+	str r9, [sp, #0x10]
 	ldr r3, [r3, #8]
 	str r3, [sp, #0x14]
 	bl func_0202b7e4
 	b _0208bbb8
 _0208bb78:
 	ldr r0, _0208bef0 ; =data_027e0f64
-	ldr sb, [r3]
+	ldr r9, [r3]
 	ldr r2, [r0]
 	add r0, sp, #0
 	add r1, r2, r1, lsl #2
 	ldr r1, [r1, #4]
 	add r2, sp, #0x58
-	str sb, [sp]
+	str r9, [sp]
 	ldr r10, [r3, #4]
-	ldr sb, [r4, #0x18]
+	ldr r9, [r4, #0x18]
 	add r1, r1, #0x1c
-	add sb, r10, sb, asr #1
-	str sb, [sp, #4]
+	add r9, r10, r9, asr #1
+	str r9, [sp, #4]
 	ldr r3, [r3, #8]
 	str r3, [sp, #8]
 	bl func_0202b7e4
@@ -22242,7 +22242,7 @@ _0208bebc:
 	mov r0, #1
 	str r0, [r1, #-0xbc]
 	add sp, sp, #0x98
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov00_0208ba68
 _0208bed8: .word 0x04000444
@@ -22712,7 +22712,7 @@ _0208c4f4: .word data_027e0fc8
 	.global func_ov00_0208c4f8
 	arm_func_start func_ov00_0208c4f8
 func_ov00_0208c4f8: ; 0x0208c4f8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x48
 	mov r6, r0
 	bl func_ov00_0208c968
@@ -22722,7 +22722,7 @@ func_ov00_0208c4f8: ; 0x0208c4f8
 	mov r5, r0
 	cmp r5, r1
 	addeq sp, sp, #0x48
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, _0208c924 ; =data_027e0d38
 	ldr r0, [r0]
 	bl func_ov00_02078b40
@@ -22735,7 +22735,7 @@ func_ov00_0208c4f8: ; 0x0208c4f8
 	cmp r5, r0
 	beq _0208c560
 	add sp, sp, #0x48
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0208c558:
 	ldr r5, _0208c930 ; =0x53485254
 	b _0208c564
@@ -22824,16 +22824,16 @@ _0208c670:
 	ldr r6, [r3, #0xc]
 	adds r11, r10, r4
 	mla r8, r6, r2, r8
-	ldr sb, [r3, #0x14]
+	ldr r9, [r3, #0x14]
 	umull r4, r2, r7, r11
-	adc r0, sb, r8
+	adc r0, r9, r8
 	mla r2, r7, r0, r2
 	str r11, [r3]
 	adds r4, r10, r4
 	str r0, [r3, #4]
 	mla r2, r6, r11, r2
 	str r4, [r3]
-	adc r7, sb, r2
+	adc r7, r9, r2
 	umull r4, r8, r0, r1
 	mov r2, #0
 	umull r4, r6, r7, r1
@@ -22863,13 +22863,13 @@ _0208c708:
 	bl func_ov00_020c4048
 	movs r1, r0
 	addmi sp, sp, #0x48
-	ldmmiia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmmiia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, _0208c954 ; =data_027e0fe4
 	ldr r0, [r0]
 	bl _ZN12ActorManager13FindActorByIdEj
 	cmp r0, #0
 	addeq sp, sp, #0x48
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r3, [r0, #4]
 	ldr r2, _0208c934 ; =0x464c544d
 	cmp r3, r2
@@ -22883,13 +22883,13 @@ _0208c708:
 	cmp r3, r1
 	beq _0208c7d0
 	add sp, sp, #0x48
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0208c784:
 	ldr r1, _0208c93c ; =0x464c4254
 	cmp r3, r1
 	beq _0208c7d0
 	add sp, sp, #0x48
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0208c798:
 	ldr r1, _0208c940 ; =0x4c53544d
 	cmp r3, r1
@@ -22899,13 +22899,13 @@ _0208c798:
 	cmp r3, r1
 	beq _0208c7d0
 	add sp, sp, #0x48
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0208c7bc:
 	ldr r1, _0208c92c ; =0x52555059
 	cmp r3, r1
 	beq _0208c838
 	add sp, sp, #0x48
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0208c7d0:
 	ldr r2, _0208c944 ; =data_027e0764
 	ldr r1, _0208c95c ; =0x0000019a
@@ -22932,7 +22932,7 @@ _0208c7d0:
 	str r1, [r0, #0x64]
 	add sp, sp, #0x48
 	str r3, [r0, #0x68]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0208c838:
 	ldr r3, _0208c944 ; =data_027e0764
 	ldr r1, _0208c960 ; =0x00002001
@@ -22941,14 +22941,14 @@ _0208c838:
 	umull r5, r10, r7, r4
 	mla r10, r7, r2, r10
 	ldr r6, [r3, #0xc]
-	ldr sb, [r3, #0x10]
+	ldr r9, [r3, #0x10]
 	mla r10, r6, r4, r10
-	adds r11, sb, r5
+	adds r11, r9, r5
 	ldr r8, [r3, #0x14]
 	umull r5, r4, r7, r11
 	adc r2, r8, r10
 	mla r4, r7, r2, r4
-	adds ip, sb, r5
+	adds ip, r9, r5
 	mla r4, r6, r11, r4
 	adc lr, r8, r4
 	str r11, [r3]
@@ -22967,8 +22967,8 @@ _0208c838:
 	mla r10, r7, lr, r10
 	mla r10, r6, ip, r10
 	stmia r3, {ip, lr}
-	adds sb, sb, r11
-	str sb, [r3]
+	adds r9, r9, r11
+	str r9, [r3]
 	adc ip, r8, r10
 	str ip, [r3, #4]
 	ldr r3, _0208c95c ; =0x0000019a
@@ -22991,7 +22991,7 @@ _0208c838:
 	str r7, [r0, #0x64]
 	str r5, [r0, #0x68]
 	add sp, sp, #0x48
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_0208c4f8
 _0208c920: .word 0x4e554c4c
@@ -23394,18 +23394,18 @@ func_ov00_0208cd1c: ; 0x0208cd1c
 	.global func_ov00_0208cd48
 	arm_func_start func_ov00_0208cd48
 func_ov00_0208cd48: ; 0x0208cd48
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x224
 	sub sp, sp, #0x400
 	movs r5, r2
 	mov r10, r0
-	mov sb, r1
+	mov r9, r1
 	bne _0208cd78
-	str sb, [sp, #4]
+	str r9, [sp, #4]
 	bl func_ov00_0208ce84
 	add sp, sp, #0x224
 	add sp, sp, #0x400
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0208cd78:
 	ldr r4, _0208ce78 ; =func_ov00_0207f100
 	ldr r3, _0208ce7c ; =func_ov00_0208d018
@@ -23431,7 +23431,7 @@ _0208cd78:
 	add sp, sp, #0x224
 	add sp, sp, #0x400
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0208cddc:
 	cmp r6, #0
 	mov r7, #0
@@ -23440,7 +23440,7 @@ _0208cddc:
 	add r8, sp, #0x24
 	add r5, r11, #0xc
 _0208cdf4:
-	str sb, [sp, #8]
+	str r9, [sp, #8]
 	ldmia r8, {r0, r1, r2}
 	stmia r11, {r0, r1, r2}
 	add r0, r8, #0xc
@@ -23459,7 +23459,7 @@ _0208cdf4:
 	add sp, sp, #0x224
 	add sp, sp, #0x400
 	mov r0, r4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0208ce44:
 	add r7, r7, #1
 	cmp r7, r6
@@ -23474,7 +23474,7 @@ _0208ce54:
 	mov r0, #0
 	add sp, sp, #0x224
 	add sp, sp, #0x400
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_0208cd48
 _0208ce78: .word func_ov00_0207f100
@@ -23485,16 +23485,16 @@ _0208ce80: .word data_027e0e60
 	arm_func_start func_ov00_0208ce84
 func_ov00_0208ce84: ; 0x0208ce84
 	stmdb sp!, {r0, r1, r2, r3}
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x14
 	mov r6, r0
 	ldr r4, [r6, #0xc]
 	ldr r0, [r6, #0x10]
 	ldr r5, [sp, #0x34]
-	add sb, r4, r0, lsl #2
+	add r9, r4, r0, lsl #2
 	str r5, [sp]
-	str sb, [sp, #0xc]
-	str sb, [sp, #4]
+	str r9, [sp, #0xc]
+	str r9, [sp, #4]
 	str r4, [sp, #0x10]
 	str r4, [sp, #8]
 	mov r7, #0
@@ -23504,7 +23504,7 @@ _0208cec4:
 	add r4, r4, #4
 	str r4, [sp, #8]
 _0208cecc:
-	cmp r4, sb
+	cmp r4, r9
 	beq _0208cef8
 	ldr r0, [r4]
 	ldr r1, [r0]
@@ -23525,7 +23525,7 @@ _0208cef8:
 	ldrne r0, [r0]
 	moveq r0, #0
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, lr}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, lr}
 	add sp, sp, #0x10
 	bx lr
 	arm_func_end func_ov00_0208ce84
@@ -23570,12 +23570,12 @@ func_ov00_0208cf28: ; 0x0208cf28
 	arm_func_start func_ov00_0208cfa4
 func_ov00_0208cfa4: ; 0x0208cfa4
 	stmdb sp!, {r0, r1, r2, r3}
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	mov r8, r0
 	mov r7, r3
 	ldr r6, [sp, #0x28]
 	ldr r5, [sp, #0x24]
-	mov sb, #0
+	mov r9, #0
 	b _0208cfc8
 _0208cfc4:
 	add r5, r5, #4
@@ -23589,7 +23589,7 @@ _0208cfc8:
 	blx r1
 	ldr r1, [r7]
 	cmp r1, r0
-	movne r0, sb
+	movne r0, r9
 	bne _0208d000
 	add r0, r7, #4
 	add r1, r4, #0x18
@@ -23599,7 +23599,7 @@ _0208d000:
 	beq _0208cfc4
 _0208d008:
 	str r5, [r8]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	add sp, sp, #0x10
 	bx lr
 	arm_func_end func_ov00_0208cfa4
@@ -23613,24 +23613,24 @@ func_ov00_0208d018: ; 0x0208d018
 	.global func_ov00_0208d01c
 	arm_func_start func_ov00_0208d01c
 func_ov00_0208d01c: ; 0x0208d01c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x244
 	sub sp, sp, #0x400
 	movs r5, r2
 	str r0, [sp, #4]
 	mov r10, r1
-	mov sb, r3
+	mov r9, r3
 	ldr r8, [sp, #0x668]
 	bne _0208d064
 	mov r4, #0
-	mov r2, sb
+	mov r2, r9
 	mov r3, r8
 	str r10, [sp, #8]
 	str r4, [sp]
 	bl func_ov00_0208d1f8
 	add sp, sp, #0x244
 	add sp, sp, #0x400
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0208d064:
 	ldr r4, _0208d1ec ; =func_ov00_0207f100
 	ldr r3, _0208d1f0 ; =func_ov00_0208d018
@@ -23656,7 +23656,7 @@ _0208d064:
 	add sp, sp, #0x244
 	add sp, sp, #0x400
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0208d0c8:
 	cmp r4, #1
 	bne _0208d138
@@ -23672,7 +23672,7 @@ _0208d0c8:
 	mov r4, #0
 	ldr r0, [sp, #4]
 	add r1, sp, #0x28
-	mov r2, sb
+	mov r2, r9
 	mov r3, r8
 	str r4, [sp]
 	bl func_ov00_0208d310
@@ -23685,7 +23685,7 @@ _0208d0c8:
 	add sp, sp, #0x244
 	add sp, sp, #0x400
 	mov r0, r4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0208d138:
 	mov r5, #0
 	mov r6, r5
@@ -23704,7 +23704,7 @@ _0208d154:
 	stmia r11, {r0, r1, r2}
 	ldr r0, [sp, #4]
 	add r1, sp, #0xc
-	mov r2, sb
+	mov r2, r9
 	mov r3, r8
 	str r5, [sp]
 	bl func_ov00_0208d310
@@ -23719,7 +23719,7 @@ _0208d154:
 	add sp, sp, #0x244
 	add sp, sp, #0x400
 	mov r0, r5
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0208d1b8:
 	add r6, r6, #1
 	cmp r6, r4
@@ -23734,7 +23734,7 @@ _0208d1c8:
 	mov r0, r5
 	add sp, sp, #0x244
 	add sp, sp, #0x400
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_0208d01c
 _0208d1ec: .word func_ov00_0207f100
@@ -23745,7 +23745,7 @@ _0208d1f4: .word data_027e0e60
 	arm_func_start func_ov00_0208d1f8
 func_ov00_0208d1f8: ; 0x0208d1f8
 	stmdb sp!, {r0, r1, r2, r3}
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x1c
 	mov r10, r0
 	ldr r1, [r10, #0xc]
@@ -23756,11 +23756,11 @@ func_ov00_0208d1f8: ; 0x0208d1f8
 	str r1, [sp, #0x18]
 	cmp r1, r0
 	ldr r11, [sp, #0x50]
-	mov sb, #0
+	mov r9, #0
 	beq _0208d2fc
 _0208d230:
 	ldr r0, [sp, #4]
-	add r1, sb, r11
+	add r1, r9, r11
 	cmp r1, r0
 	bhs _0208d2fc
 	ldr r1, [r10, #0xc]
@@ -23803,8 +23803,8 @@ _0208d2a4:
 	beq _0208d2dc
 	ldr r0, [sp]
 	add r0, r0, r11, lsl #2
-	str r1, [r0, sb, lsl #2]
-	add sb, sb, #1
+	str r1, [r0, r9, lsl #2]
+	add r9, r9, #1
 _0208d2dc:
 	ldr r2, [sp, #0x10]
 	ldr r1, [r10, #0xc]
@@ -23815,9 +23815,9 @@ _0208d2dc:
 	cmp r2, r0
 	bne _0208d230
 _0208d2fc:
-	mov r0, sb
+	mov r0, r9
 	add sp, sp, #0x1c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	add sp, sp, #0x10
 	bx lr
 	arm_func_end func_ov00_0208d1f8
@@ -23825,12 +23825,12 @@ _0208d2fc:
 	.global func_ov00_0208d310
 	arm_func_start func_ov00_0208d310
 func_ov00_0208d310: ; 0x0208d310
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x2c
 	mov r10, r0
 	ldr r4, [r10, #0xc]
 	ldr r0, [r10, #0x10]
-	mov sb, r1
+	mov r9, r1
 	add r0, r4, r0, lsl #2
 	str r3, [sp]
 	str r4, [sp, #0xc]
@@ -23839,8 +23839,8 @@ func_ov00_0208d310: ; 0x0208d310
 	mov r7, #0
 	beq _0208d3f0
 	add r0, sp, #0x14
-	add r6, sb, #4
-	add r5, sb, #0x10
+	add r6, r9, #4
+	add r5, r9, #0x10
 	add r4, r0, #0xc
 	add r11, r2, r8, lsl #2
 _0208d358:
@@ -23848,7 +23848,7 @@ _0208d358:
 	add r1, r7, r8
 	cmp r1, r0
 	bhs _0208d3f0
-	ldr r0, [sb]
+	ldr r0, [r9]
 	add ip, sp, #0x14
 	str r0, [sp, #0x10]
 	ldmia r6, {r0, r1, r2}
@@ -23885,20 +23885,20 @@ _0208d358:
 _0208d3f0:
 	mov r0, r7
 	add sp, sp, #0x2c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	arm_func_end func_ov00_0208d310
 
 	.global func_ov00_0208d3fc
 	arm_func_start func_ov00_0208d3fc
 func_ov00_0208d3fc: ; 0x0208d3fc
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x88
 	ldrb r3, [sp, #4]
 	mov r4, #0
 	str r4, [sp]
 	sub r4, sp, #4
 	strb r3, [r4]
-	mov sb, r1
+	mov r9, r1
 	mov r8, r2
 	ldr r1, [r4]
 	add r2, sp, #8
@@ -23916,28 +23916,28 @@ _0208d444:
 	ldrsh r2, [r7, #0x10]
 	ldrsh r1, [r7, #0xe]
 	mov r0, r7
-	strh r1, [sb]
-	strh r2, [sb, #2]
+	strh r1, [r9]
+	strh r2, [r9, #2]
 	bl func_ov14_02125934
-	strb r0, [sb, #4]
+	strb r0, [r9, #4]
 	mov r0, r7
 	bl func_ov14_02125948
-	strb r0, [sb, #5]
+	strb r0, [r9, #5]
 _0208d478:
 	add r6, r6, #1
 	cmp r6, r5
-	add sb, sb, #6
+	add r9, r9, #6
 	blt _0208d444
 _0208d488:
 	mov r0, r5
 	add sp, sp, #0x88
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	arm_func_end func_ov00_0208d3fc
 
 	.global func_ov00_0208d494
 	arm_func_start func_ov00_0208d494
 func_ov00_0208d494: ; 0x0208d494
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x14
 	mov r10, r0
 	ldr r1, [r10, #0xc]
@@ -23947,12 +23947,12 @@ func_ov00_0208d494: ; 0x0208d494
 	str r3, [sp]
 	str r1, [sp, #0x10]
 	cmp r1, r0
-	ldr sb, [sp, #0x38]
+	ldr r9, [sp, #0x38]
 	mov r8, #0
 	beq _0208d5d4
 _0208d4c8:
 	ldr r0, [sp]
-	add r1, r8, sb
+	add r1, r8, r9
 	cmp r1, r0
 	bhs _0208d5d4
 	ldr r1, [r10, #0xc]
@@ -24018,7 +24018,7 @@ _0208d584:
 	ldr r1, [r0]
 	add r2, r2, #4
 	cmp r1, #0
-	addne r0, r11, sb, lsl #2
+	addne r0, r11, r9, lsl #2
 	strne r1, [r0, r8, lsl #2]
 	ldr r1, [r10, #0xc]
 	ldr r0, [r10, #0x10]
@@ -24030,7 +24030,7 @@ _0208d584:
 _0208d5d4:
 	mov r0, r8
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	arm_func_end func_ov00_0208d494
 
 	.global func_ov00_0208d5e0
@@ -24802,7 +24802,7 @@ func_ov00_0208df74: ; 0x0208df74
 	.global func_ov00_0208df78
 	arm_func_start func_ov00_0208df78
 func_ov00_0208df78: ; 0x0208df78
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x14
 	mov r6, r0
 	mov r0, r1, lsl #0xc
@@ -24885,7 +24885,7 @@ _0208dfe0:
 	ldr r2, [r5, #0x28]
 	ldr r1, [r5, #0x2c]
 	ldr r0, [sp, #0xc]
-	add sb, r8, r2
+	add r9, r8, r2
 	add r0, r0, r1
 	str r0, [sp, #8]
 _0208e0c4:
@@ -24936,11 +24936,11 @@ _0208e0f8:
 	mov r7, r2, asr #0x1f
 	umull r3, r2, r0, r2
 	mla r2, r0, r7, r2
-	mov r7, sb, asr #0x1f
-	umull r8, r6, r0, sb
+	mov r7, r9, asr #0x1f
+	umull r8, r6, r0, r9
 	mla r6, r0, r7, r6
 	ldr r0, [sp, #4]
-	mla r6, r1, sb, r6
+	mla r6, r1, r9, r6
 	mla r5, r1, r0, r5
 	adc r0, r5, #0
 	str r0, [r4]
@@ -24955,13 +24955,13 @@ _0208e0f8:
 _0208e1bc:
 	ldr r0, [sp, #0x10]
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	arm_func_end func_ov00_0208df78
 
 	.global func_ov00_0208e1c8
 	arm_func_start func_ov00_0208e1c8
 func_ov00_0208e1c8: ; 0x0208e1c8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x48
 	str r1, [sp]
 	add r1, sp, #8
@@ -24991,7 +24991,7 @@ _0208e228:
 	cmp r2, #0
 	addeq sp, sp, #0x48
 	mvneq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	cmp r3, r11
 	beq _0208e288
 	ldr r1, [sp]
@@ -25022,7 +25022,7 @@ _0208e288:
 	mov r3, #0
 	mov lr, #0x80000000
 	add r4, sp, #8
-	add sb, r2, r11, lsl #4
+	add r9, r2, r11, lsl #4
 	add r2, r4, r11, lsl #4
 	mov r4, r3
 	mov r6, r3
@@ -25036,14 +25036,14 @@ _0208e2bc:
 	mla r10, r1, r8, r10
 	adc r7, r10, r4
 	str r7, [r2, r3, lsl #2]
-	ldr r8, [sb, r3, lsl #2]
+	ldr r8, [r9, r3, lsl #2]
 	mov r7, r8, asr #0x1f
 	umull ip, r10, r0, r8
 	adds ip, ip, r5
 	mla r10, r0, r7, r10
 	mla r10, r1, r8, r10
 	adc r7, r10, r6
-	str r7, [sb, r3, lsl #2]
+	str r7, [r9, r3, lsl #2]
 	add r3, r3, #1
 	cmp r3, #4
 	blt _0208e2bc
@@ -25068,16 +25068,16 @@ _0208e328:
 	add r10, r4, ip, lsl #4
 _0208e350:
 	ldr r5, [r0, lr, lsl #2]
-	ldr sb, [r1, lr, lsl #2]
+	ldr r9, [r1, lr, lsl #2]
 	mov r4, r5, asr #0x1f
 	umull r8, r7, r3, r5
 	mla r7, r3, r4, r7
 	mla r7, r2, r5, r7
 	mov r4, r8, lsr #0xc
 	orr r4, r4, r7, lsl #20
-	subs r4, sb, r4
+	subs r4, r9, r4
 	str r4, [r1, lr, lsl #2]
-	ldr sb, [r10, lr, lsl #2]
+	ldr r9, [r10, lr, lsl #2]
 	ldr r5, [r6, lr, lsl #2]
 	mov r4, r5, asr #0x1f
 	umull r8, r7, r3, r5
@@ -25085,7 +25085,7 @@ _0208e350:
 	mla r7, r2, r5, r7
 	mov r4, r8, lsr #0xc
 	orr r4, r4, r7, lsl #20
-	subs r4, sb, r4
+	subs r4, r9, r4
 	str r4, [r10, lr, lsl #2]
 	add lr, lr, #1
 	cmp lr, #4
@@ -25099,7 +25099,7 @@ _0208e3ac:
 	blt _0208e1e8
 	mov r0, #0
 	add sp, sp, #0x48
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	arm_func_end func_ov00_0208e1c8
 
 	.global func_ov00_0208e3d0
@@ -25905,14 +25905,14 @@ func_ov00_0208ee4c: ; 0x0208ee4c
 	.global func_ov00_0208ee90
 	arm_func_start func_ov00_0208ee90
 func_ov00_0208ee90: ; 0x0208ee90
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x18
 	mov r5, r2
-	mov sb, r0
+	mov r9, r0
 	mov r8, r1
 	add r2, sp, #0xc
 	mov r0, r5
-	mov r1, sb
+	mov r1, r9
 	mov r4, r3
 	ldr r7, [sp, #0x38]
 	ldr r6, [sp, #0x3c]
@@ -25922,7 +25922,7 @@ func_ov00_0208ee90: ; 0x0208ee90
 	mov r1, r8
 	bl func_01ff9bf8
 	add r0, sp, #0xc
-	ldr r3, [sb, #0xc]
+	ldr r3, [r9, #0xc]
 	ldr r2, [r5, #0xc]
 	mov r1, r0
 	add r4, r3, r2
@@ -25939,7 +25939,7 @@ func_ov00_0208ee90: ; 0x0208ee90
 	str r0, [r6]
 	add sp, sp, #0x18
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _0208ef1c:
 	add r0, sp, #0
 	mov r1, r0
@@ -25948,7 +25948,7 @@ _0208ef1c:
 	cmp r4, #0
 	addle sp, sp, #0x18
 	movle r0, #0
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	add r0, sp, #0xc
 	add r1, sp, #0
 	bl func_01ff9c2c
@@ -25971,7 +25971,7 @@ _0208ef1c:
 	mov r1, #0
 	addmi sp, sp, #0x18
 	movmi r0, r1
-	ldmmiia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmmiia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	bl func_01ff9958
 	mov r8, r0
 	mov r0, r4, lsl #0x1
@@ -26003,7 +26003,7 @@ _0208eff4:
 _0208f004:
 	add sp, sp, #0x18
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _0208f010:
 	cmp r2, r0
 	strlt r2, [r7]
@@ -26012,7 +26012,7 @@ _0208f010:
 	strge r2, [r6]
 	mov r0, #1
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	arm_func_end func_ov00_0208ee90
 
 	.global func_ov00_0208f030
@@ -26326,12 +26326,12 @@ _0208f420:
 	.global func_ov00_0208f478
 	arm_func_start func_ov00_0208f478
 func_ov00_0208f478: ; 0x0208f478
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #0x24
-	mov sb, r0
+	mov r9, r0
 	mov r8, r1
 	mov r7, r2
-	ldr r6, [sb, #0xc]
+	ldr r6, [r9, #0xc]
 	ldr r5, [r8, #0xc]
 	add r4, sp, #0x18
 	ldmia r7, {r0, r1, r2}
@@ -26339,7 +26339,7 @@ func_ov00_0208f478: ; 0x0208f478
 	add r4, r6, r5
 	add r2, sp, #0xc
 	mov r0, r8
-	mov r1, sb
+	mov r1, r9
 	mov r6, r3
 	bl func_01ff9bf8
 	ldr r0, [sp, #0xc]
@@ -26363,21 +26363,21 @@ func_ov00_0208f478: ; 0x0208f478
 	cmp r0, r10
 	mov r0, #0
 	bgt _0208f544
-	ldr r3, [sb, #4]
+	ldr r3, [r9, #4]
 	ldr r2, [r8, #4]
 	cmp r2, r3
 	blt _0208f538
-	ldr r1, [sb, #0x10]
+	ldr r1, [r9, #0x10]
 	add r1, r3, r1
 	cmp r2, r1
 	strle r0, [r6]
 	addle sp, sp, #0x24
 	movle r0, #1
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 _0208f538:
 	add sp, sp, #0x24
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 _0208f544:
 	add r0, sp, #0x18
 	mov r1, r0
@@ -26405,7 +26405,7 @@ _0208f544:
 	mov r1, #0
 	addmi sp, sp, #0x24
 	movmi r0, r1
-	ldmmiia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmmiia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	bl func_01ff9958
 	mov r10, r0
 	mov r0, r4, lsl #0x1
@@ -26437,7 +26437,7 @@ _0208f60c:
 _0208f61c:
 	add sp, sp, #0x24
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 _0208f628:
 	add r3, sp, #0
 	ldmia r8, {r0, r1, r2}
@@ -26453,23 +26453,23 @@ _0208f628:
 	mov r2, r1, lsr #0xc
 	adc r0, r0, #0
 	orr r2, r2, r0, lsl #20
-	ldr r1, [sb, #4]
+	ldr r1, [r9, #4]
 	add r2, r3, r2
 	cmp r2, r1
 	blt _0208f680
-	ldr r0, [sb, #0x10]
+	ldr r0, [r9, #0x10]
 	add r0, r1, r0
 	cmp r2, r0
 	ble _0208f68c
 _0208f680:
 	add sp, sp, #0x24
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 _0208f68c:
 	str r4, [r6]
 	mov r0, #1
 	add sp, sp, #0x24
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	arm_func_end func_ov00_0208f478
 
 	.global func_ov00_0208f69c
@@ -26569,7 +26569,7 @@ func_ov00_0208f768: ; 0x0208f768
 	.global func_ov00_0208f794
 	arm_func_start func_ov00_0208f794
 func_ov00_0208f794: ; 0x0208f794
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x28
 	mov r10, r0
 	add r1, sp, #4
@@ -26583,13 +26583,13 @@ func_ov00_0208f794: ; 0x0208f794
 	ldr r6, _0208f9dc ; =data_ov00_020db010
 	ldr r11, _0208f9e0 ; =data_ov00_020db030
 	ldr r4, _0208f9e4 ; =data_027e0e60
-	mov sb, #0
+	mov r9, #0
 	add r5, sp, #4
 _0208f7d4:
 	ldrb r2, [r10, #0x14]
-	ldr r3, [r6, sb, lsl #2]
+	ldr r3, [r6, r9, lsl #2]
 	ldrb r0, [r10, #0x15]
-	ldr r1, [r11, sb, lsl #2]
+	ldr r1, [r11, r9, lsl #2]
 	adds r7, r3, r2
 	add r8, r1, r0
 	bmi _0208f868
@@ -26609,7 +26609,7 @@ _0208f7d4:
 	strb r8, [sp, #1]
 	bl func_ov00_020840c4
 	add r1, sp, #8
-	str r0, [r1, sb, lsl #2]
+	str r0, [r1, r9, lsl #2]
 	cmp r0, #0
 	beq _0208f868
 	ldr r1, [r0]
@@ -26617,17 +26617,17 @@ _0208f7d4:
 	blx r1
 	cmp r0, #4
 	bne _0208f868
-	mov r3, sb, lsr #0x5
+	mov r3, r9, lsr #0x5
 	ldr r2, [r5, r3, lsl #2]
-	and r1, sb, #0x1f
+	and r1, r9, #0x1f
 	mov r0, #1
 	orr r0, r2, r0, lsl r1
 	str r0, [r5, r3, lsl #2]
 _0208f868:
-	add r0, sb, #1
+	add r0, r9, #1
 	mov r0, r0, lsl #0x10
-	mov sb, r0, lsr #0x10
-	cmp sb, #8
+	mov r9, r0, lsr #0x10
+	cmp r9, #8
 	blo _0208f7d4
 	ldr r0, [sp, #4]
 	mov r1, r0
@@ -26725,7 +26725,7 @@ _0208f9ac:
 	ldr r2, [r2, #0xc]
 	blx r2
 	add sp, sp, #0x28
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_0208f794
 _0208f9dc: .word data_ov00_020db010
@@ -27152,13 +27152,13 @@ _0208fef4: .word data_027e0e60
 	.global func_ov00_0208fef8
 	arm_func_start func_ov00_0208fef8
 func_ov00_0208fef8: ; 0x0208fef8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x80
 	str r0, [sp, #4]
 	ldr r0, [r0, #0x130]
 	cmp r0, #1
 	addeq sp, sp, #0x80
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, [sp, #4]
 	ldrh r0, [r0, #0x26]
 	cmp r0, #1
@@ -27166,13 +27166,13 @@ func_ov00_0208fef8: ; 0x0208fef8
 	cmp r0, #2
 	beq _0208ff48
 	add sp, sp, #0x80
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0208ff34:
 	ldr r0, _0209030c ; =data_ov00_020eec9c
 	mov r1, #0xb
 	bl func_ov00_020d77e4
 	add sp, sp, #0x80
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0208ff48:
 	ldr r0, _0209030c ; =data_ov00_020eec9c
 	mov r1, #0xb
@@ -27240,16 +27240,16 @@ _02090004:
 	ldr r0, _0209031c ; =data_027e0764
 	ldr r3, [sp, #0x14]
 	ldr ip, [r0, #4]
-	umull sb, r3, r10, r3
+	umull r9, r3, r10, r3
 	mla r3, r10, ip, r3
 	ldr r10, [sp, #0x14]
-	adds sb, r8, sb
+	adds r9, r8, r9
 	mla r3, lr, r10, r3
 	adc r3, r7, r3
 	str r3, [sp, #0xc]
 	ldr r3, _0209031c ; =data_027e0764
 	ldr r10, [sp, #0xc]
-	str sb, [r3]
+	str r9, [r3]
 	str r10, [r3, #4]
 	mov r3, r10
 	mov r10, #0xb
@@ -27265,12 +27265,12 @@ _02090004:
 	str r3, [sp, #0x64]
 	ldr r3, [sp, #0x10]
 	add r0, sp, #0x5c
-	umull r11, r10, r3, sb
+	umull r11, r10, r3, r9
 	mov ip, r3
 	ldr r3, [sp, #0xc]
 	adds r8, r8, r11
 	mla r10, ip, r3, r10
-	mla r10, lr, sb, r10
+	mla r10, lr, r9, r10
 	adc r3, r7, r10
 	ldr r7, _0209031c ; =data_027e0764
 	mov r2, r0
@@ -27430,7 +27430,7 @@ _020902f8:
 	cmp r6, #5
 	blo _0208ffb4
 	add sp, sp, #0x80
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_0208fef8
 _0209030c: .word data_ov00_020eec9c
@@ -32171,7 +32171,7 @@ func_ov00_02093dd0: ; 0x02093dd0
 	.global func_ov00_02093e00
 	arm_func_start func_ov00_02093e00
 func_ov00_02093e00: ; 0x02093e00
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x70
 	mov r10, r0
 	ldr r1, [r10, #4]
@@ -32297,9 +32297,9 @@ _02093f80:
 	mov r5, #1
 	add r11, sp, #4
 _02093fec:
-	ldrb sb, [r10, #0x15]
-	add r0, sb, #2
-	cmp sb, r0
+	ldrb r9, [r10, #0x15]
+	add r0, r9, #2
+	cmp r9, r0
 	bge _02094058
 	and r7, r8, #0xff
 _02094000:
@@ -32307,23 +32307,23 @@ _02094000:
 	mov r1, r6
 	mov r2, r5
 	strb r7, [sp, #6]
-	strb sb, [sp, #7]
+	strb r9, [sp, #7]
 	bl func_ov00_02082680
 	ldr r0, [r4]
 	mov r1, r11
 	mov r2, #1
 	strb r7, [sp, #4]
-	strb sb, [sp, #5]
+	strb r9, [sp, #5]
 	bl func_ov00_020826a0
 	ldr r0, [r4]
 	mov r1, r8
-	mov r2, sb
+	mov r2, r9
 	mov r3, #9
 	bl func_ov00_02084d24
 	ldrb r0, [r10, #0x15]
-	add sb, sb, #1
+	add r9, r9, #1
 	add r0, r0, #2
-	cmp sb, r0
+	cmp r9, r0
 	blt _02094000
 _02094058:
 	ldrb r0, [r10, #0x14]
@@ -32348,7 +32348,7 @@ _0209408c:
 	mov r2, r1
 	blx r3
 	add sp, sp, #0x70
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _020940ac:
 	mov r0, r10
 	ldr r3, [r0]
@@ -32357,7 +32357,7 @@ _020940ac:
 	mov r2, #1
 	blx r3
 	add sp, sp, #0x70
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_02093e00
 _020940cc: .word data_027e0e60
@@ -33663,7 +33663,7 @@ func_ov00_02094e58: ; 0x02094e58
 	.global func_ov00_02094e6c
 	arm_func_start func_ov00_02094e6c
 func_ov00_02094e6c: ; 0x02094e6c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #8
 	mov r10, r0
 	mov r0, #1
@@ -33674,7 +33674,7 @@ func_ov00_02094e6c: ; 0x02094e6c
 	ldr r0, _02094f84 ; =data_027e0e60
 	strh r5, [r10, #4]
 	ldr r0, [r0]
-	mov sb, r3
+	mov r9, r3
 	bl func_ov00_0208335c
 	ldrh r1, [r10, #2]
 	bl func_02002c14
@@ -33715,9 +33715,9 @@ _02094f24:
 	cmp r8, #0
 	mov r5, #0
 	addle sp, sp, #8
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	mov r7, r5
-	mov r11, sb, lsl #0x1
+	mov r11, r9, lsl #0x1
 _02094f40:
 	ldr r0, _02094f88 ; =data_027e0ce0
 	ldr r4, [r10, #8]
@@ -33730,12 +33730,12 @@ _02094f40:
 	mov r0, #0
 	str r0, [r6, #4]
 	add r5, r5, #1
-	str sb, [r4, r7]
+	str r9, [r4, r7]
 	cmp r5, r8
 	add r7, r7, #0xc
 	blt _02094f40
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_02094e6c
 _02094f84: .word data_027e0e60
@@ -34588,10 +34588,10 @@ func_ov00_02095980: ; 0x02095980
 	.global func_ov00_02095998
 	arm_func_start func_ov00_02095998
 func_ov00_02095998: ; 0x02095998
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0xac
 	str r0, [sp, #4]
-	mov sb, r1
+	mov r9, r1
 	add r1, sp, #0xa0
 	add r0, r0, #0x14
 	bl func_ov00_0208e6b0
@@ -34656,7 +34656,7 @@ _02095a2c:
 	mov r2, r0
 	str r5, [sp, #0x60]
 	bl func_01ff9bc4
-	cmp sb, #0
+	cmp r9, #0
 	beq _02095c74
 	cmp r6, #0x3000
 	cmpge r7, #0x3000
@@ -34694,7 +34694,7 @@ _02095ac0:
 	mov r2, r0
 	str r5, [sp, #0x48]
 	bl func_01ff9bc4
-	cmp sb, #0
+	cmp r9, #0
 	beq _02095c74
 	cmp r6, #0x3000
 	cmpge r7, #0x3000
@@ -34732,7 +34732,7 @@ _02095b54:
 	mov r2, r0
 	str r4, [sp, #0x28]
 	bl func_01ff9bc4
-	cmp sb, #0
+	cmp r9, #0
 	beq _02095c74
 	cmp r6, #0x3000
 	cmpge r7, #0x3000
@@ -34770,7 +34770,7 @@ _02095be8:
 	mov r2, r0
 	str r4, [sp, #0x10]
 	bl func_01ff9bc4
-	cmp sb, #0
+	cmp r9, #0
 	beq _02095c74
 	cmp r6, #0x3000
 	cmpge r7, #0x3000
@@ -34807,13 +34807,13 @@ _02095c74:
 	add r10, r10, #0x2c
 	cmp r8, #4
 	blo _02095a08
-	cmp sb, #0
+	cmp r9, #0
 	ldrne r0, [sp, #4]
 	movne r1, #0
 	strneb r1, [r0, #0x2c]
 	mov r0, #1
 	add sp, sp, #0xac
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_02095998
 _02095d04: .word data_027e0f6c
@@ -35076,16 +35076,16 @@ _02095fdc: .word data_027e0f70
 	.global func_ov00_02095fe0
 	arm_func_start func_ov00_02095fe0
 func_ov00_02095fe0: ; 0x02095fe0
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x34
 	ldr r2, _0209614c ; =data_027e0d3c
 	mov r10, r0
 	ldr r0, [r2]
-	mov sb, r1
+	mov r9, r1
 	bl func_ov00_02078f54
 	cmp r0, #0
 	addeq sp, sp, #0x34
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, _0209614c ; =data_027e0d3c
 	ldr r1, _02096150 ; =data_027e0e60
 	ldr r2, [r0]
@@ -35096,14 +35096,14 @@ func_ov00_02095fe0: ; 0x02095fe0
 	bl func_ov00_020835e4
 	cmp r0, #0
 	addeq sp, sp, #0x34
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r8, [r10]
 	ldr r1, [r10, #4]
 	mov r0, #0x30
 	mla r0, r1, r0, r8
 	cmp r8, r0
 	addeq sp, sp, #0x34
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r4, _02096150 ; =data_027e0e60
 	add r6, sp, #0x1c
 	add r5, sp, #0x28
@@ -35159,7 +35159,7 @@ _020960b0:
 	mov r2, r7
 	mov r0, r10
 	mov r1, r5
-	mov r3, sb
+	mov r3, r9
 	bl func_ov00_02096160
 _02096128:
 	ldr r2, [r10]
@@ -35170,7 +35170,7 @@ _02096128:
 	cmp r8, r0
 	bne _02096060
 	add sp, sp, #0x34
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_02095fe0
 _0209614c: .word data_027e0d3c
@@ -35241,7 +35241,7 @@ func_ov00_020961f8: ; 0x020961f8
 	.global func_ov00_0209621c
 	arm_func_start func_ov00_0209621c
 func_ov00_0209621c: ; 0x0209621c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x30
 	ldr r6, _02096320 ; =data_ov00_020eab04
 	mov r7, r0
@@ -35249,8 +35249,8 @@ func_ov00_0209621c: ; 0x0209621c
 	mov r5, #0
 	cmp r4, #0
 	addle sp, sp, #0x30
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
-	add sb, sp, #0x10
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
+	add r9, sp, #0x10
 	mov r8, r5
 	add r11, sp, #0
 _0209624c:
@@ -35270,7 +35270,7 @@ _0209624c:
 	str r2, [sp, #8]
 	str r1, [sp, #0xc]
 	ldmia r0, {r0, r1, r2}
-	stmia sb, {r0, r1, r2}
+	stmia r9, {r0, r1, r2}
 	ldrh r10, [r6, #0x4c]
 	ldrh r3, [r6, #0x4e]
 	ldrh r2, [r6, #0x50]
@@ -35306,7 +35306,7 @@ _0209624c:
 	add r6, r6, #0x30
 	blt _0209624c
 	add sp, sp, #0x30
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_0209621c
 _02096320: .word data_ov00_020eab04
@@ -35314,7 +35314,7 @@ _02096320: .word data_ov00_020eab04
 	.global func_ov00_02096324
 	arm_func_start func_ov00_02096324
 func_ov00_02096324: ; 0x02096324
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	mov r7, r0
 	ldr r5, [r7]
 	ldr r2, [r7, #4]
@@ -35325,7 +35325,7 @@ func_ov00_02096324: ; 0x02096324
 	mov r4, #0
 	beq _0209640c
 	ldr r8, _02096414 ; =data_027e0f7c
-	mov sb, r4
+	mov r9, r4
 	mov r11, #0x30
 _02096358:
 	ldrb r0, [r5, #5]
@@ -35365,7 +35365,7 @@ _02096358:
 	stmia lr!, {r0, r1, r2, r3}
 	ldr r0, [r10]
 	str r0, [lr]
-	strb sb, [ip, #0x36]
+	strb r9, [ip, #0x36]
 _020963f0:
 	ldr r2, [r7]
 	ldr r1, [r7, #4]
@@ -35376,7 +35376,7 @@ _020963f0:
 	bne _02096358
 _0209640c:
 	strb r4, [r6, #6]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_02096324
 _02096414: .word data_027e0f7c
@@ -35974,7 +35974,7 @@ _02096bf0:
 	.global func_ov00_02096c3c
 	arm_func_start func_ov00_02096c3c
 func_ov00_02096c3c: ; 0x02096c3c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	mov r6, r1
 	mov r5, r2
 	mov r7, r0
@@ -36000,7 +36000,7 @@ _02096c8c:
 	str r1, [lr]
 	ldrb r1, [ip, #4]
 	add r3, lr, #0x10
-	add sb, ip, #0x1c
+	add r9, ip, #0x1c
 	strb r1, [lr, #4]
 	ldrb r1, [ip, #5]
 	add r8, lr, #0x1c
@@ -36018,7 +36018,7 @@ _02096c8c:
 	stmia r3, {r0, r1, r2}
 	ldmia sb!, {r0, r1, r2, r3}
 	stmia r8!, {r0, r1, r2, r3}
-	ldr r0, [sb]
+	ldr r0, [r9]
 	cmp ip, r4
 	str r0, [r8]
 	add lr, lr, #0x30
@@ -36038,7 +36038,7 @@ _02096cfc:
 	bl func_ov00_02096a88
 _02096d2c:
 	mov r0, r6
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov00_02096c3c
 _02096d34: .word 0x2aaaaaab
@@ -36114,7 +36114,7 @@ func_ov00_02096dd8: ; 0x02096dd8
 	.global func_ov00_02096de0
 	arm_func_start func_ov00_02096de0
 func_ov00_02096de0: ; 0x02096de0
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x1c
 	mov r4, r0
 	mov r7, r1
@@ -36156,7 +36156,7 @@ _02096e74:
 	add r3, lr, #0x10
 	str r0, [lr]
 	ldrb r0, [r6, #4]
-	add sb, r6, #0x1c
+	add r9, r6, #0x1c
 	add r8, lr, #0x1c
 	strb r0, [lr, #4]
 	ldrb r0, [r6, #5]
@@ -36174,7 +36174,7 @@ _02096e74:
 	stmia r3, {r0, r1, r2}
 	ldmia sb!, {r0, r1, r2, r3}
 	stmia r8!, {r0, r1, r2, r3}
-	ldr r0, [sb]
+	ldr r0, [r9]
 	add lr, lr, #0x30
 	str r0, [r8]
 	bne _02096e74
@@ -36269,7 +36269,7 @@ _02096ff0:
 	str r2, [sp, #0xc]
 	bl func_ov00_02097154
 	add sp, sp, #0x1c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	arm_func_end func_ov00_02096de0
 
 	.global func_ov00_0209703c
@@ -38853,7 +38853,7 @@ _02098e38:
 	arm_func_start func_ov00_02098f04
 func_ov00_02098f04: ; 0x02098f04
 	stmdb sp!, {r0, r1, r2, r3}
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #8
 	ldr r8, [sp, #0x30]
 	ldr r4, [sp, #0x2c]
@@ -38872,16 +38872,16 @@ func_ov00_02098f04: ; 0x02098f04
 	mov r8, #0xb4
 _02098f4c:
 	add r0, r5, r5, lsr #31
-	mov sb, r0, asr #0x1
-	mla r10, sb, r8, r4
+	mov r9, r0, asr #0x1
+	mla r10, r9, r8, r4
 	mov r0, r6
 	mov r1, r10
 	bl func_ov00_02098b78
 	cmp r0, #0
-	movne r5, sb
+	movne r5, r9
 	bne _02098f80
 	add r4, r10, #0xb4
-	add r0, sb, #1
+	add r0, r9, #1
 	str r4, [sp, #0x2c]
 	sub r5, r5, r0
 _02098f80:
@@ -38891,7 +38891,7 @@ _02098f88:
 	ldr r0, [sp, #0x2c]
 	str r0, [r7]
 	add sp, sp, #8
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	add sp, sp, #0x10
 	bx lr
 	.align 2, 0
@@ -39488,7 +39488,7 @@ _02099734:
 	.global func_ov00_02099780
 	arm_func_start func_ov00_02099780
 func_ov00_02099780: ; 0x02099780
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x18
 	mov r6, r0
 	ldr r7, [r6, #4]
@@ -39517,7 +39517,7 @@ _020997b8:
 	add r3, lr, #0x24
 	str r1, [lr, #4]
 	ldr r1, [r4, #8]
-	add sb, r4, #0x30
+	add r9, r4, #0x30
 	str r1, [lr, #8]
 	ldrb r1, [r4, #0xc]
 	add r8, lr, #0x30
@@ -39566,7 +39566,7 @@ _020998a0:
 	stmia r8!, {r0, r1, r2, r3}
 	subs r7, r7, #1
 	bne _020998a0
-	ldmia sb, {r0, r1}
+	ldmia r9, {r0, r1}
 	stmia r8, {r0, r1}
 	ldr r1, [r4, #0x98]
 	add r0, r4, #0xa4
@@ -39598,7 +39598,7 @@ _02099900:
 	add r3, lr, #0x24
 	str r1, [lr, #4]
 	ldr r1, [ip, #8]
-	add sb, ip, #0x30
+	add r9, ip, #0x30
 	str r1, [lr, #8]
 	ldrb r1, [ip, #0xc]
 	add r8, lr, #0x30
@@ -39647,7 +39647,7 @@ _020999d8:
 	stmia r8!, {r0, r1, r2, r3}
 	subs r7, r7, #1
 	bne _020999d8
-	ldmia sb, {r0, r1}
+	ldmia r9, {r0, r1}
 	stmia r8, {r0, r1}
 	ldr r1, [ip, #0x98]
 	add r0, ip, #0xa4
@@ -39935,7 +39935,7 @@ _02099e10:
 _02099e38:
 	mov r0, r5
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	arm_func_end func_ov00_02099780
 
 	.global func_ov00_02099e44
@@ -39997,9 +39997,9 @@ _02099eb4:
 	.global func_ov00_02099ecc
 	arm_func_start func_ov00_02099ecc
 func_ov00_02099ecc: ; 0x02099ecc
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	mov r7, r0
-	ldr sb, [r7]
+	ldr r9, [r7]
 	ldr r8, [r7, #4]
 	mov r0, #0
 	mov r6, r1
@@ -40008,8 +40008,8 @@ func_ov00_02099ecc: ; 0x02099ecc
 	ldr r4, [r6]
 	ldr r1, [r6, #0x10]
 	mov r5, r2
-	mla ip, r8, r3, sb
-	sub r0, r5, sb
+	mla ip, r8, r3, r9
+	sub r0, r5, r9
 	ldr r2, _0209a220 ; =0xb60b60b7
 	mla r4, r1, r3, r4
 	ldr r8, [r6, #4]
@@ -40034,7 +40034,7 @@ _02099f2c:
 	add r10, lr, #0x30
 	str r1, [r4, #8]
 	ldrb r1, [lr, #0xc]
-	add sb, r4, #0x30
+	add r9, r4, #0x30
 	mov r8, #6
 	strb r1, [r4, #0xc]
 	ldrb r1, [lr, #0xd]
@@ -40081,7 +40081,7 @@ _0209a000:
 	subs r8, r8, #1
 	bne _0209a000
 	ldmia r10, {r0, r1}
-	stmia sb, {r0, r1}
+	stmia r9, {r0, r1}
 	ldr r1, [lr, #0x98]
 	add r0, lr, #0xa4
 	str r1, [r4, #0x98]
@@ -40129,7 +40129,7 @@ _0209a090:
 	str r1, [r8, #8]
 	ldrb r1, [r5, #0xc]
 	add r10, r8, #0x30
-	mov sb, #6
+	mov r9, #6
 	strb r1, [r8, #0xc]
 	ldrb r1, [r5, #0xd]
 	strb r1, [r8, #0xd]
@@ -40172,7 +40172,7 @@ _0209a090:
 _0209a168:
 	ldmia ip!, {r0, r1, r2, r3}
 	stmia r10!, {r0, r1, r2, r3}
-	subs sb, sb, #1
+	subs r9, r9, #1
 	bne _0209a168
 	ldmia ip, {r0, r1}
 	stmia r10, {r0, r1}
@@ -40217,7 +40217,7 @@ _0209a1d8:
 	str r2, [r6, #4]
 	ldr r1, [r7]
 	mla r0, r11, r0, r1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_02099ecc
 _0209a220: .word 0xb60b60b7
@@ -41325,11 +41325,11 @@ func_ov00_0209af04: ; 0x0209af04
 	.global func_ov00_0209af20
 	arm_func_start func_ov00_0209af20
 func_ov00_0209af20: ; 0x0209af20
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #4
-	mov sb, r0
-	ldr r8, [sb]
-	ldr r1, [sb, #4]
+	mov r9, r0
+	ldr r8, [r9]
+	ldr r1, [r9, #4]
 	add r0, r8, r1, lsl #2
 	cmp r8, r0
 	beq _0209afa4
@@ -41356,7 +41356,7 @@ _0209af50:
 _0209af8c:
 	str r4, [r8]
 _0209af90:
-	ldmia sb, {r0, r1}
+	ldmia r9, {r0, r1}
 	add r8, r8, #4
 	add r0, r0, r1, lsl #2
 	cmp r8, r0
@@ -41364,11 +41364,11 @@ _0209af90:
 _0209afa4:
 	mov r0, #0
 	strb r0, [sp]
-	ldr r0, [sb, #4]
+	ldr r0, [r9, #4]
 	sub r0, r0, r1
-	str r0, [sb, #4]
+	str r0, [r9, #4]
 	add sp, sp, #4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov00_0209af20
 _0209afc0: .word func_0203010c
@@ -41376,13 +41376,13 @@ _0209afc0: .word func_0203010c
 	.global func_ov00_0209afc4
 	arm_func_start func_ov00_0209afc4
 func_ov00_0209afc4: ; 0x0209afc4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	movs r8, r2
-	mov sb, r0
+	mov r9, r0
 	mov r10, r1
 	mov r11, r3
 	mov r7, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0209afe0:
 	ldr r0, [r10, r7, lsl #2]
 	and r4, r0, #0xff
@@ -41692,7 +41692,7 @@ _0209b388:
 	ldr r0, [r0, r5, lsl #4]
 	cmp r11, r0
 	bne _0209b588
-	mov r0, sb
+	mov r0, r9
 	mov r1, r5
 	bl func_ov00_0209ba38
 	cmp r4, #0x63
@@ -41739,12 +41739,12 @@ _0209b42c:
 	beq _0209b550
 	b _0209b588
 _0209b438:
-	mov r0, sb
+	mov r0, r9
 	mov r1, #0xe6
 	bl func_ov00_0209ba38
 	b _0209b588
 _0209b448:
-	mov r0, sb
+	mov r0, r9
 	mov r1, #0x76
 	bl func_ov00_0209ba38
 	b _0209b588
@@ -41757,67 +41757,67 @@ _0209b458:
 	beq _0209b490
 	b _0209b4bc
 _0209b474:
-	mov r0, sb
+	mov r0, r9
 	mov r1, #0x33
 	bl func_ov00_0209ba38
-	mov r0, sb
+	mov r0, r9
 	mov r1, #0x35
 	bl func_ov00_0209ba38
 	b _0209b588
 _0209b490:
-	mov r0, sb
+	mov r0, r9
 	mov r1, #0x33
 	bl func_ov00_0209ba38
-	mov r0, sb
+	mov r0, r9
 	mov r1, #0x36
 	bl func_ov00_0209ba38
 	b _0209b588
 _0209b4ac:
-	mov r0, sb
+	mov r0, r9
 	mov r1, #0x34
 	bl func_ov00_0209ba38
 	b _0209b588
 _0209b4bc:
-	mov r0, sb
+	mov r0, r9
 	mov r1, #0x32
 	bl func_ov00_0209ba38
-	mov r0, sb
+	mov r0, r9
 	mov r1, #0x34
 	bl func_ov00_0209ba38
 	b _0209b588
 _0209b4d8:
-	mov r0, sb
+	mov r0, r9
 	mov r1, #0x71
 	bl func_ov00_0209ba38
-	mov r0, sb
+	mov r0, r9
 	mov r1, #0x34
 	bl func_ov00_0209ba38
-	mov r0, sb
+	mov r0, r9
 	mov r1, #0x36
 	bl func_ov00_0209ba38
 	b _0209b588
 _0209b500:
-	mov r0, sb
+	mov r0, r9
 	mov r1, #0x30
 	bl func_ov00_0209ba38
 	b _0209b588
 _0209b510:
-	mov r0, sb
+	mov r0, r9
 	mov r1, #0x1c
 	bl func_ov00_0209ba38
 	b _0209b588
 _0209b520:
-	mov r0, sb
+	mov r0, r9
 	mov r1, #0x23
 	bl func_ov00_0209ba38
 	b _0209b588
 _0209b530:
-	mov r0, sb
+	mov r0, r9
 	mov r1, #0x66
 	bl func_ov00_0209ba38
 	b _0209b588
 _0209b540:
-	mov r0, sb
+	mov r0, r9
 	mov r1, #0x68
 	bl func_ov00_0209ba38
 	b _0209b588
@@ -41826,11 +41826,11 @@ _0209b550:
 	ldr r0, [r0]
 	ldr r0, [r0, #0x14]
 	cmp r0, #1
-	mov r0, sb
+	mov r0, r9
 	bne _0209b580
 	mov r1, #0x87
 	bl func_ov00_0209ba38
-	mov r0, sb
+	mov r0, r9
 	mov r1, #0x86
 	bl func_ov00_0209ba38
 	b _0209b588
@@ -41841,7 +41841,7 @@ _0209b588:
 	add r7, r7, #1
 	cmp r7, r8
 	blo _0209afe0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_0209afc4
 _0209b598: .word data_027e0f74
@@ -41851,12 +41851,12 @@ _0209b5a0: .word data_ov00_020db058
 	.global func_ov00_0209b5a4
 	arm_func_start func_ov00_0209b5a4
 func_ov00_0209b5a4: ; 0x0209b5a4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x28
 	mov r10, r0
 	ldr r2, [r10]
 	ldr r0, [r10, #4]
-	mov sb, r1
+	mov r9, r1
 	add r1, r2, r0, lsl #2
 	mov r8, r2
 	cmp r2, r1
@@ -41871,7 +41871,7 @@ _0209b5dc:
 	beq _0209b630
 	ldr r0, [r7]
 	ldr r0, [r6, r0, lsl #4]
-	cmp sb, r0
+	cmp r9, r0
 	bne _0209b630
 	cmp r7, #0
 	beq _0209b62c
@@ -41940,7 +41940,7 @@ _0209b6ac:
 	str r1, [sp, #0x14]
 	bl func_ov00_02080f94
 	add sp, sp, #0x28
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_0209b5a4
 _0209b6ec: .word data_ov00_020db058
@@ -46292,7 +46292,7 @@ func_ov00_0209ed2c: ; 0x0209ed2c
 	.global func_ov00_0209ed30
 	arm_func_start func_ov00_0209ed30
 func_ov00_0209ed30: ; 0x0209ed30
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	ldr r4, [sp, #0x20]
 	mov r6, r1
 	mov r7, r0
@@ -46307,17 +46307,17 @@ func_ov00_0209ed30: ; 0x0209ed30
 	mov r2, #0
 	mov r0, #0x800
 	adc r3, r3, #0
-	mov sb, r6, lsr #0xc
-	orr sb, sb, r3, lsl #20
+	mov r9, r6, lsr #0xc
+	orr r9, r9, r3, lsl #20
 	sub r0, r0, #0x2800
-	umull r6, r3, sb, r0
-	sub r7, sb, #0x1000
+	umull r6, r3, r9, r0
+	sub r7, r9, #0x1000
 	sub r2, r2, #1
 	adds r6, r6, #0x800
-	mla r3, sb, r2, r3
-	mov r2, sb, asr #0x1f
+	mla r3, r9, r2, r3
+	mov r2, r9, asr #0x1f
 	mla r3, r2, r0, r3
-	smull r2, r0, sb, sb
+	smull r2, r0, r9, r9
 	adc r3, r3, #0
 	mov r6, r6, lsr #0xc
 	orr r6, r6, r3, lsl #20
@@ -46342,7 +46342,7 @@ func_ov00_0209ed30: ; 0x0209ed30
 	adc r5, r5, #0
 	mov r6, r6, lsr #0xc
 	orr r6, r6, r5, lsl #20
-	smull r8, r5, r6, sb
+	smull r8, r5, r6, r9
 	adds r6, r8, #0x800
 	adc r5, r5, #0
 	mov r6, r6, lsr #0xc
@@ -46377,13 +46377,13 @@ func_ov00_0209ed30: ; 0x0209ed30
 	add r0, r2, r1
 	add r0, r3, r0
 	add r0, r5, r0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	arm_func_end func_ov00_0209ed30
 
 	.global func_ov00_0209ee88
 	arm_func_start func_ov00_0209ee88
 func_ov00_0209ee88: ; 0x0209ee88
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x4c
 	ldr r7, [r2, #8]
 	ldr r8, [r2, #0xc]
@@ -46393,7 +46393,7 @@ func_ov00_0209ee88: ; 0x0209ee88
 	sub r4, r8, r7
 	str r1, [sp]
 	ldr r6, [r2, #4]
-	ldr sb, [r2, #0x10]
+	ldr r9, [r2, #0x10]
 	ldr r2, [r2, #0x14]
 	mov r1, r4
 	str r0, [sp, #0x1c]
@@ -46421,9 +46421,9 @@ func_ov00_0209ee88: ; 0x0209ee88
 	orr r5, r5, r0, lsl #20
 	mov r0, r5, asr #0x1f
 	str r0, [sp, #0x2c]
-	sub r0, sb, r7
+	sub r0, r9, r7
 	str r0, [sp, #0x18]
-	sub r0, sb, r10
+	sub r0, r9, r10
 	ldr r1, [sp, #0x18]
 	str r0, [sp, #0x10]
 	bl Divide
@@ -46451,7 +46451,7 @@ func_ov00_0209ee88: ; 0x0209ee88
 	ldr r0, [sp, #0x1c]
 	str r1, [sp, #0xc]
 	bl Divide
-	sub r1, sb, r6
+	sub r1, r9, r6
 	str r1, [sp, #8]
 	ldr r1, [sp, #0x28]
 	str r0, [sp, #0x3c]
@@ -46474,13 +46474,13 @@ func_ov00_0209ee88: ; 0x0209ee88
 	mov lr, r2, asr #0x1f
 	ldr r2, [sp, #0x34]
 	sub r0, r10, r0
-	umull ip, sb, r2, r5
+	umull ip, r9, r2, r5
 	mov r3, r2
 	ldr r2, [sp, #0x2c]
-	mla sb, r3, r2, sb
+	mla r9, r3, r2, r9
 	adds r2, ip, #0x800
-	mla sb, r8, r5, sb
-	adc r3, sb, #0
+	mla r9, r8, r5, r9
+	adc r3, r9, #0
 	mov r2, r2, lsr #0xc
 	orr r2, r2, r3, lsl #20
 	ldr r3, [sp, #0x30]
@@ -46502,14 +46502,14 @@ func_ov00_0209ee88: ; 0x0209ee88
 	bl Divide
 	ldr r2, [sp, #0x38]
 	str r0, [sp, #0x44]
-	umull r10, sb, r2, r4
-	mla sb, r2, r11, sb
+	umull r10, r9, r2, r4
+	mla r9, r2, r11, r9
 	mov r3, r2, asr #0x1f
-	mla sb, r3, r4, sb
+	mla r9, r3, r4, r9
 	adds r3, r10, #0x800
 	ldr r1, [sp, #8]
 	ldr r0, [sp, #4]
-	adc r2, sb, #0
+	adc r2, r9, #0
 	mov r4, r3, lsr #0xc
 	orr r4, r4, r2, lsl #20
 	bl Divide
@@ -46518,7 +46518,7 @@ func_ov00_0209ee88: ; 0x0209ee88
 	mov r1, r7
 	bl Divide
 	ldr r1, [sp, #0x40]
-	smull sb, r7, r10, r8
+	smull r9, r7, r10, r8
 	smull r3, lr, r1, r8
 	ldr r8, [sp, #0x44]
 	smull r2, r1, r8, r4
@@ -46534,7 +46534,7 @@ func_ov00_0209ee88: ; 0x0209ee88
 	adds r10, r10, #0x800
 	adc r0, r8, #0
 	mov ip, r10, lsr #0xc
-	adds r8, sb, #0x800
+	adds r8, r9, #0x800
 	orr ip, ip, r0, lsl #20
 	adc r0, r7, #0
 	mov r7, r8, lsr #0xc
@@ -46556,13 +46556,13 @@ func_ov00_0209ee88: ; 0x0209ee88
 	ldr r7, [r0]
 	ldr r2, [r0, #4]
 	ldr r0, [sp, #0x3c]
-	umull r10, sb, r0, r6
+	umull r10, r9, r0, r6
 	mov r1, r0
 	ldr r0, [sp, #0x48]
-	mla sb, r1, r0, sb
+	mla r9, r1, r0, r9
 	adds r1, r10, #0x800
-	mla sb, r8, r6, sb
-	adc r0, sb, #0
+	mla r9, r8, r6, r9
+	adc r0, r9, #0
 	mov r1, r1, lsr #0xc
 	orr r1, r1, r0, lsl #20
 	smull r7, r0, r1, r7
@@ -46592,7 +46592,7 @@ func_ov00_0209ee88: ; 0x0209ee88
 	add r0, r11, r0
 	add r0, ip, r0
 	add sp, sp, #0x4c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	arm_func_end func_ov00_0209ee88
 
 	.global func_ov00_0209f1d0
@@ -47211,7 +47211,7 @@ func_ov00_0209f918: ; 0x0209f918
 	.global func_ov00_0209f950
 	arm_func_start func_ov00_0209f950
 func_ov00_0209f950: ; 0x0209f950
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x28
 	ldr r2, [r0, #0x38]
 	ldr r5, [r2, #-4]
@@ -47298,12 +47298,12 @@ _0209fa84:
 	mov r7, #0
 	mov r8, r3, asr #0x1f
 	mov r8, r8, lsl #0xd
-	adds sb, r6, r3, lsl #13
+	adds r9, r6, r3, lsl #13
 	orr r8, r8, r3, lsr #19
 	adc r8, r8, #0
-	mov sb, sb, lsr #0xc
-	orr sb, sb, r8, lsl #20
-	sub r8, sb, lr
+	mov r9, r9, lsr #0xc
+	orr r9, r9, r8, lsl #20
+	sub r8, r9, lr
 	str r3, [sp, #4]
 	str r8, [sp]
 	cmp r0, #2
@@ -47314,20 +47314,20 @@ _0209fa84:
 _0209fad4:
 	mov r0, r4, asr #0x1f
 	mov r2, ip, asr #0x1f
-	mov sb, r2, lsl #0xd
+	mov r9, r2, lsl #0xd
 	mov r0, r0, lsl #0xd
 	adds r2, r6, r4, lsl #13
 	orr r0, r0, r4, lsr #19
-	mov r8, sb
+	mov r8, r9
 	adc r0, r0, r7
 	mov r2, r2, lsr #0xc
 	orr r2, r2, r0, lsl #20
 	sub r0, r2, r5
 	mov r4, ip, lsl #0xd
-	orr sb, sb, ip, lsr #19
+	orr r9, r9, ip, lsr #19
 	adds r5, r4, r6
 	str r0, [sp, #0x24]
-	adc r0, sb, r7
+	adc r0, r9, r7
 	adds r2, r4, r6
 	mov r4, r5, lsr #0xc
 	orr r4, r4, r0, lsl #20
@@ -47434,7 +47434,7 @@ _0209fc8c:
 	add r2, sp, #0
 	bl func_ov00_0209ee88
 	add sp, sp, #0x28
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	arm_func_end func_ov00_0209f950
 
 	.global func_ov00_0209fca4
@@ -48221,9 +48221,9 @@ func_ov00_020a0554: ; 0x020a0554
 	.global func_ov00_020a05b0
 	arm_func_start func_ov00_020a05b0
 func_ov00_020a05b0: ; 0x020a05b0
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #0x20
-	mov sb, r0
+	mov r9, r0
 	mov r0, r1
 	str r1, [sp]
 	ldr r1, [r0]
@@ -48232,14 +48232,14 @@ func_ov00_020a05b0: ; 0x020a05b0
 	mov r7, r3
 	blx r1
 	ldmib r8, {r0, r1}
-	ldr r2, [sb, #4]
+	ldr r2, [r9, #4]
 	sub r0, r1, r0
 	cmp r0, r2, lsl #1
 	addlo sp, sp, #0x20
 	movlo r0, #0
-	ldmloia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmloia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	add r1, sp, #0x1c
-	mov r0, sb
+	mov r0, r9
 	bl func_ov00_020a0554
 	ldr r1, [sp, #0x1c]
 	mov r5, r0
@@ -48275,7 +48275,7 @@ func_ov00_020a05b0: ; 0x020a05b0
 	strb r4, [r0, #0x10]
 	str r4, [r0, #0x1c]
 	str r4, [r0, #0x20]
-	ldr r1, [sb, #0x14]
+	ldr r1, [r9, #0x14]
 	cmp r5, #0
 	str r1, [r0, #0x24]
 	bne _020a06b0
@@ -48284,15 +48284,15 @@ func_ov00_020a05b0: ; 0x020a05b0
 	bl func_ov00_0209f8ac
 	add sp, sp, #0x20
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _020a06b0:
 	ldr r3, [r8]
 	ldr r0, [r8, #4]
 	mov r1, #0x28
 	str r4, [sp, #0x18]
 	add r0, r3, r0, lsl #2
-	ldr r5, [sb]
-	ldr r2, [sb, #4]
+	ldr r5, [r9]
+	ldr r2, [r9, #4]
 	str r0, [sp, #0xc]
 	mla r0, r2, r1, r5
 	cmp r5, r0
@@ -48375,8 +48375,8 @@ _020a07d4:
 _020a07f8:
 	add r4, r4, #1
 _020a07fc:
-	ldr r2, [sb]
-	ldr r1, [sb, #4]
+	ldr r2, [r9]
+	ldr r1, [r9, #4]
 	mov r0, #0x28
 	mla r0, r1, r0, r2
 	add r5, r5, #0x28
@@ -48394,13 +48394,13 @@ _020a081c:
 	blx r1
 	mov r0, #1
 	add sp, sp, #0x20
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	arm_func_end func_ov00_020a05b0
 
 	.global func_ov00_020a0848
 	arm_func_start func_ov00_020a0848
 func_ov00_020a0848: ; 0x020a0848
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #8
 	mov r5, r0
 	ldr r3, [r5, #4]
@@ -48422,25 +48422,25 @@ _020a0890:
 	ldr r0, _020a08e4 ; =data_ov00_020dc044
 	mvn r7, #0
 	ldr r0, [r0]
-	ldr sb, _020a08e8 ; =data_ov00_020dc044
+	ldr r9, _020a08e8 ; =data_ov00_020dc044
 	cmp r0, r7
 	addeq sp, sp, #8
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	add r8, r5, #0x1c
 	mov r6, #0x50
 _020a08b4:
 	mla r1, r0, r6, r8
 	str r4, [sp]
-	ldr r3, [sb]
+	ldr r3, [r9]
 	mov r0, r5
 	add r1, r1, #0x10
 	add r2, r5, #0x24c
 	bl func_ov00_020a05b0
-	ldr r0, [sb, #0x10]!
+	ldr r0, [r9, #0x10]!
 	cmp r0, r7
 	bne _020a08b4
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020a0848
 _020a08e4: .word data_ov00_020dc044
@@ -49582,7 +49582,7 @@ func_ov00_020a15dc: ; 0x020a15dc
 	.global func_ov00_020a15f0
 	arm_func_start func_ov00_020a15f0
 func_ov00_020a15f0: ; 0x020a15f0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #8
 	str r0, [sp]
 	ldr r1, [sp]
@@ -49596,15 +49596,15 @@ func_ov00_020a15f0: ; 0x020a15f0
 	str r8, [sp, #4]
 _020a1620:
 	ldr r0, [sp]
-	mov sb, #0
+	mov r9, #0
 	add r1, r0, #8
 	ldr r0, [sp, #4]
 	ldr r6, _020a1704 ; =data_ov00_020e4ed8
 	ldr r11, _020a1708 ; =data_ov00_020e4eb8
 	ldr r4, _020a170c ; =data_027e0ce0
-	mov r10, sb
+	mov r10, r9
 	add r7, r1, r0
-	mov r5, sb
+	mov r5, r9
 _020a1648:
 	cmp r8, #0
 	beq _020a165c
@@ -49646,8 +49646,8 @@ _020a16cc:
 	str r0, [r7, r10]
 _020a16d0:
 	add r10, r10, #4
-	add sb, sb, #1
-	cmp sb, #2
+	add r9, r9, #1
+	cmp r9, #2
 	blo _020a1648
 	ldr r0, [sp, #4]
 	add r8, r8, #1
@@ -49657,7 +49657,7 @@ _020a16d0:
 	blo _020a1620
 	ldr r0, [sp]
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020a15f0
 _020a1704: .word data_ov00_020e4ed8
@@ -49668,10 +49668,10 @@ _020a1710: .word data_ov00_020e4e98
 	.global func_ov00_020a1714
 	arm_func_start func_ov00_020a1714
 func_ov00_020a1714: ; 0x020a1714
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	mov r5, #0
-	mov sb, r0
-	add r7, sb, #8
+	mov r9, r0
+	add r7, r9, #8
 	mov r10, r5
 	mov r4, r5
 _020a172c:
@@ -49693,17 +49693,17 @@ _020a174c:
 	cmp r5, #2
 	add r7, r7, #8
 	blo _020a172c
-	mov r0, sb
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	mov r0, r9
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	arm_func_end func_ov00_020a1714
 
 	.global func_ov00_020a1774
 	arm_func_start func_ov00_020a1774
 func_ov00_020a1774: ; 0x020a1774
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
-	mov sb, r0
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
+	mov r9, r0
 	mov r5, #0
-	add r7, sb, #8
+	add r7, r9, #8
 	mov r4, r5
 _020a1788:
 	mov r6, r4
@@ -49720,11 +49720,11 @@ _020a1790:
 	cmp r5, #2
 	add r7, r7, #8
 	blo _020a1788
-	add r1, sb, #4
+	add r1, r9, #4
 	mov r0, #0
 	mov r2, #4
 	bl func_020078f4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	arm_func_end func_ov00_020a1774
 
 	.global func_ov00_020a17d0
@@ -49941,37 +49941,37 @@ _020a1a38: .word func_ov00_020a1c70
 	.global func_ov00_020a1a3c
 	arm_func_start func_ov00_020a1a3c
 func_ov00_020a1a3c: ; 0x020a1a3c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
-	mov sb, r0
-	ldr r0, [sb]
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
+	mov r9, r0
+	ldr r0, [r9]
 	mov r8, #0
 	cmp r0, #0
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	ldr r7, _020a1ab0 ; =0x00007fff
 	ldr r6, _020a1ab4 ; =data_ov00_020dc1f8
 	ldr r5, _020a1ab8 ; =data_ov00_020dc1f4
 	mov r4, r8
 _020a1a64:
-	add r0, sb, r8, lsl #2
+	add r0, r9, r8, lsl #2
 	ldr r0, [r0, #4]
 	cmp r0, #0
 	beq _020a1a9c
 	mov r1, r7
 	bl func_ov00_020a1c68
 	mov r0, r8, lsl #0x1
-	add r3, sb, r8, lsl #2
+	add r3, r9, r8, lsl #2
 	ldrsh r1, [r6, r0]
 	ldrsh r2, [r5, r0]
 	ldr r0, [r3, #4]
 	bl func_ov00_020a1c8c
-	add r0, sb, r8
+	add r0, r9, r8
 	strb r4, [r0, #0xc]
 _020a1a9c:
-	ldr r0, [sb]
+	ldr r0, [r9]
 	add r8, r8, #1
 	cmp r8, r0
 	blt _020a1a64
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020a1a3c
 _020a1ab0: .word 0x00007fff
@@ -50687,15 +50687,15 @@ _020a23a0: .word data_027e0fac
 	.global func_ov00_020a23a4
 	arm_func_start func_ov00_020a23a4
 func_ov00_020a23a4: ; 0x020a23a4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #0x11c
-	mov sb, r0
-	ldr r2, [sb, #4]
+	mov r9, r0
+	ldr r2, [r9, #4]
 	mov r8, r1
 	ldr r1, [r2, #0x15c]
 	cmp r1, #0x5c
 	addeq sp, sp, #0x11c
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	bl func_ov00_02090a7c
 	add r5, sp, #0xb4
 	mov r6, r0
@@ -50705,7 +50705,7 @@ _020a23d8:
 	stmia r5!, {r0, r1, r2, r3}
 	subs r4, r4, #1
 	bne _020a23d8
-	add r2, sb, #0x30
+	add r2, r9, #0x30
 	ldmia r6, {r0, r1}
 	stmia r5, {r0, r1}
 	ldmia r2, {r0, r1, r2}
@@ -50716,9 +50716,9 @@ _020a23d8:
 	stmia r3, {r0, r1, r2}
 	mov r0, r3
 	mov r2, r3
-	add r1, sb, #0x20
+	add r1, r9, #0x20
 	bl func_01ff9bf8
-	add r0, sb, #0x20
+	add r0, r9, #0x20
 	add r3, sp, #0x10
 	ldmia r0, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
@@ -50732,18 +50732,18 @@ _020a23d8:
 	ldr r1, [sp, #0x18]
 	str r0, [sp, #0x44]
 	str r1, [sp, #0x48]
-	mov r0, sb
+	mov r0, r9
 	add r1, sp, #0x40
 	bl func_ov00_02090e10
-	mov r0, sb
+	mov r0, r9
 	add r1, sp, #0x40
 	bl func_ov00_020a27d4
 	mov r4, r0
-	mov r0, sb
+	mov r0, r9
 	add r1, sp, #0x40
 	bl func_ov00_020a275c
 	mov r5, r0
-	mov r0, sb
+	mov r0, r9
 	add r1, sp, #0x40
 	bl func_ov00_020a26e4
 	mov r6, r0
@@ -50848,7 +50848,7 @@ _020a25e0:
 	mov r7, r1, asr #0x10
 	bl func_ov00_020a5e9c
 	cmp r0, #0x31
-	ldreq r0, [sb, #4]
+	ldreq r0, [r9, #4]
 	addeq r0, r0, #0x200
 	ldreqsh r7, [r0, #0x26]
 _020a2614:
@@ -50888,22 +50888,22 @@ _020a2680:
 	mov r3, r4
 	bl func_0202b66c
 	add r1, sp, #0x40
-	mov r0, sb
+	mov r0, r9
 	bl func_ov00_02090c28
 	add r1, sp, #0x34
-	mov r0, sb
+	mov r0, r9
 	bl func_ov00_02090c58
 	cmp r8, #0
 	addne sp, sp, #0x11c
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	ldr r1, [sp, #0xe0]
-	mov r0, sb
+	mov r0, r9
 	bl func_ov00_02090e9c
 	ldr r1, [sp, #0xe4]
-	mov r0, sb
+	mov r0, r9
 	bl func_ov00_02090efc
 	add sp, sp, #0x11c
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020a23a4
 _020a26dc: .word data_027e0d38
@@ -51020,7 +51020,7 @@ _020a2848: .word data_027e0e60
 	.global func_ov00_020a284c
 	arm_func_start func_ov00_020a284c
 func_ov00_020a284c: ; 0x020a284c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x40
 	mov r6, r0
 	add r0, sp, #0x18
@@ -51123,12 +51123,12 @@ _020a297c:
 	mov r3, r4, lsr #0x1f
 	mov r0, r6
 	umull ip, lr, r8, r7
-	adds sb, ip, #0x80000
+	adds r9, ip, #0x80000
 	mla lr, r8, r1, lr
 	mov ip, r8, asr #0x1f
 	mla lr, ip, r7, lr
 	adc r7, lr, #0
-	mov r8, sb, lsr #0x14
+	mov r8, r9, lsr #0x14
 	orr r8, r8, r7, lsl #12
 	str r8, [sp, #0x30]
 	str r1, [sp, #0x3c]
@@ -51186,7 +51186,7 @@ _020a2abc:
 	add r0, sp, #0x18
 	bl func_ov00_020a0368
 	add sp, sp, #0x40
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020a284c
 _020a2ad8: .word 0x66666667
@@ -54123,7 +54123,7 @@ _020a4fc4: .word func_ov00_020a4fc8
 	.global func_ov00_020a4fc8
 	arm_func_start func_ov00_020a4fc8
 func_ov00_020a4fc8: ; 0x020a4fc8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x40
 	mov r10, r0
 	ldr r1, [r10]
@@ -54147,8 +54147,8 @@ _020a5008:
 	ldr r1, _020a515c ; =data_ov00_020dc294
 	add r0, r1, r0
 	add r0, r0, r6, lsl #2
-	ldr sb, [r0, #4]
-	ldr r8, [r5, sb, lsl #5]
+	ldr r9, [r0, #4]
+	ldr r8, [r5, r9, lsl #5]
 	add r0, r10, r8, lsl #2
 	ldr r0, [r0, #4]
 	cmp r0, #0
@@ -54177,22 +54177,22 @@ _020a5008:
 	b _020a50a8
 _020a5094:
 	bl func_ov00_020a5d10
-	add r1, r5, sb, lsl #5
+	add r1, r5, r9, lsl #5
 	ldr r1, [r1, #0x18]
 	and r1, r1, #0xff
 	bl func_020197fc
 _020a50a8:
-	add r0, r5, sb, lsl #5
+	add r0, r5, r9, lsl #5
 	ldr r1, [r0, #0x14]
 	mov r0, r10
 	str r1, [sp, #0x28]
 	str r1, [sp, #0x2c]
 	str r1, [sp, #0x30]
 	ldrb r1, [r10, #0x34]
-	mov r2, sb
+	mov r2, r9
 	add r3, sp, #0x34
 	bl func_ov00_020a5170
-	add r0, r5, sb, lsl #5
+	add r0, r5, r9, lsl #5
 	ldrh r0, [r0, #0x1c]
 	cmp r0, #0
 	bne _020a5104
@@ -54230,7 +54230,7 @@ _020a5130:
 _020a5150:
 	bl func_01ffa8d4
 	add sp, sp, #0x40
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020a4fc8
 _020a515c: .word data_ov00_020dc294
@@ -54507,14 +54507,14 @@ _020a5504: .word data_ov00_020dc294
 	.global func_ov00_020a5508
 	arm_func_start func_ov00_020a5508
 func_ov00_020a5508: ; 0x020a5508
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0xb0
 	mov r4, r1
 	mov r10, r0
 	bl func_ov00_020a58ac
 	cmp r4, #4
 	addeq sp, sp, #0xb0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r2, [r10]
 	ldr r1, _020a57f4 ; =data_ov00_020dc294
 	mov r0, #0xc
@@ -54523,15 +54523,15 @@ func_ov00_020a5508: ; 0x020a5508
 	ldmia r0, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
 	ldr r0, [sp, #0xa4]
-	mov sb, #0
+	mov r9, #0
 	cmp r0, #0
 	addls sp, sp, #0xb0
-	ldmlsia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmlsia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r4, _020a57f8 ; =data_027e0ce0
 	mvn r5, #0
 _020a5560:
 	add r0, sp, #0xa4
-	add r0, r0, sb, lsl #2
+	add r0, r0, r9, lsl #2
 	ldr r1, [r0, #4]
 	cmp r1, r5
 	beq _020a57dc
@@ -54598,7 +54598,7 @@ _020a562c:
 	bl func_ov00_020a4c38
 	mov r6, r0
 _020a5664:
-	add r0, r10, sb, lsl #2
+	add r0, r10, r9, lsl #2
 	str r6, [r0, #0x10]
 	ldr r0, _020a5810 ; =data_ov00_020dc2c4
 	add r1, sp, #0x44
@@ -54630,12 +54630,12 @@ _020a5664:
 	bl func_ov00_020a581c
 	mov r6, r0
 _020a56e0:
-	add r0, r10, sb, lsl #2
+	add r0, r10, r9, lsl #2
 	str r6, [r0, #0x18]
 	mov r0, r6
 	mov r1, #0
 	bl func_ov00_020c0e5c
-	add r1, r10, sb, lsl #2
+	add r1, r10, r9, lsl #2
 	ldr r0, [r1, #0x10]
 	ldr r1, [r1, #0x18]
 	ldr r2, [r0]
@@ -54669,7 +54669,7 @@ _020a56e0:
 	bl func_ov00_020a5864
 	mov r7, r0
 _020a5778:
-	add r0, r10, sb, lsl #2
+	add r0, r10, r9, lsl #2
 	str r7, [r0, #0x20]
 	mov r0, r7
 	mov r1, #0
@@ -54678,7 +54678,7 @@ _020a5778:
 	cmp r0, #1
 	bne _020a57c0
 	ldr r0, [sp, #0x90]
-	add r1, r10, sb, lsl #2
+	add r1, r10, r9, lsl #2
 	rsb r2, r0, #0
 	ldr r0, [r1, #0x10]
 	str r2, [r0, #0x5c]
@@ -54689,19 +54689,19 @@ _020a5778:
 	b _020a57dc
 _020a57c0:
 	ldr r2, [sp, #0x90]
-	add r1, r10, sb, lsl #2
+	add r1, r10, r9, lsl #2
 	ldr r0, [r1, #0x10]
 	str r2, [r0, #0x5c]
 	ldr r0, [r1, #0x10]
 	ldr r1, [sp, #0x94]
 	str r1, [r0, #0x60]
 _020a57dc:
-	add sb, sb, #1
+	add r9, r9, #1
 	ldr r0, [sp, #0xa4]
-	cmp sb, r0
+	cmp r9, r0
 	blo _020a5560
 	add sp, sp, #0xb0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020a5508
 _020a57f4: .word data_ov00_020dc294
@@ -54766,7 +54766,7 @@ _020a58a8: .word data_ov00_020e5868
 	.global func_ov00_020a58ac
 	arm_func_start func_ov00_020a58ac
 func_ov00_020a58ac: ; 0x020a58ac
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	mov r6, #0
 	mov r7, r0
 	mov r5, r6
@@ -54814,7 +54814,7 @@ _020a593c:
 	blo _020a58c4
 	mov r4, #0
 	ldr r6, _020a59b4 ; =func_0203010c
-	mov sb, #4
+	mov r9, #4
 	mov r8, #0x10
 	mov r5, r4
 _020a595c:
@@ -54825,7 +54825,7 @@ _020a595c:
 	beq _020a599c
 	mov r0, r10
 	bl func_ov00_020a5ccc
-	mov r1, sb
+	mov r1, r9
 	mov r2, r8
 	mov r3, r6
 	add r0, r10, #0x20
@@ -54841,7 +54841,7 @@ _020a59a4:
 	add r4, r4, #1
 	cmp r4, #3
 	blt _020a595c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020a58ac
 _020a59b4: .word func_0203010c
@@ -54975,7 +54975,7 @@ _020a5b34: .word data_ov00_020e52e0
 	.global func_ov00_020a5b38
 	arm_func_start func_ov00_020a5b38
 func_ov00_020a5b38: ; 0x020a5b38
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #0x118
 	mov r6, r0
 	ldr r0, [r6, #4]
@@ -55050,32 +55050,32 @@ _020a5c40:
 	blx func_0203010c
 _020a5c4c:
 	add r10, r6, #0x20
-	mov sb, #0
+	mov r9, #0
 	add r8, sp, #8
 	mov r7, #0x10
 _020a5c5c:
 	mov r0, r4
 	mov r1, r8
-	mov r2, sb
+	mov r2, r9
 	bl func_ov00_020a5ae8
 	mov r0, r10
 	ldr r1, [r0]
 	ldr r1, [r1, #0xc]
 	blx r1
-	add r1, r6, sb, lsl #4
+	add r1, r6, r9, lsl #4
 	mov r0, r10
 	str r8, [r1, #0x24]
 	ldr r2, [r0]
 	mov r1, r7
 	ldr r2, [r2, #8]
 	blx r2
-	add sb, sb, #1
-	cmp sb, #4
+	add r9, r9, #1
+	cmp r9, #4
 	add r10, r10, #0x10
 	blt _020a5c5c
 	str r5, [r6]
 	add sp, sp, #0x118
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020a5b38
 _020a5cb4: .word data_027e0ce0
@@ -55156,13 +55156,13 @@ _020a5d70: .word func_ov00_020c0bdc
 	.global func_ov00_020a5d74
 	arm_func_start func_ov00_020a5d74
 func_ov00_020a5d74: ; 0x020a5d74
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	mov r10, r0
-	mov sb, r1
+	mov r9, r1
 	bl func_ov00_020a5d50
 	movs r4, r0
 	mov r7, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	mov r11, r7
 _020a5d94:
 	mov r0, r10
@@ -55186,7 +55186,7 @@ _020a5dc8:
 	beq _020a5dec
 	mov r0, r8
 	mov r1, r6
-	mov r2, sb
+	mov r2, r9
 	bl func_02019434
 _020a5dec:
 	add r6, r6, #1
@@ -55196,19 +55196,19 @@ _020a5df8:
 	add r7, r7, #1
 	cmp r7, r4
 	blo _020a5d94
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	arm_func_end func_ov00_020a5d74
 
 	.global func_ov00_020a5e08
 	arm_func_start func_ov00_020a5e08
 func_ov00_020a5e08: ; 0x020a5e08
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	mov r10, r0
-	mov sb, r1
+	mov r9, r1
 	bl func_ov00_020a5d50
 	movs r4, r0
 	mov r7, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	mov r11, r7
 _020a5e28:
 	mov r0, r10
@@ -55232,7 +55232,7 @@ _020a5e5c:
 	beq _020a5e80
 	mov r0, r8
 	mov r1, r6
-	mov r2, sb
+	mov r2, r9
 	bl func_020193f0
 _020a5e80:
 	add r6, r6, #1
@@ -55242,7 +55242,7 @@ _020a5e8c:
 	add r7, r7, #1
 	cmp r7, r4
 	blo _020a5e28
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	arm_func_end func_ov00_020a5e08
 
 	.global func_ov00_020a5e9c
@@ -56188,7 +56188,7 @@ func_ov00_020a6908: ; 0x020a6908
 	.global func_ov00_020a6924
 	arm_func_start func_ov00_020a6924
 func_ov00_020a6924: ; 0x020a6924
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0xf0
 	ldr r2, _020a6de4 ; =data_027e0f94
 	mov r10, r0
@@ -56197,7 +56197,7 @@ func_ov00_020a6924: ; 0x020a6924
 	str r3, [sp, #0x7c]
 	str r0, [sp, #0x80]
 	ldr r0, [r2, #8]
-	mov sb, r1
+	mov r9, r1
 	str r0, [sp, #0x84]
 	ldr r0, [r10, #4]
 	ldr r0, [r0, #0x15c]
@@ -56206,7 +56206,7 @@ func_ov00_020a6924: ; 0x020a6924
 	cmp r0, #0x54
 	beq _020a6b9c
 	add sp, sp, #0xf0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _020a6970:
 	ldr r0, _020a6de8 ; =data_027e10a4
 	add r1, sp, #0x70
@@ -56324,13 +56324,13 @@ _020a6ae0:
 	add r1, sp, #0x7c
 	mov r0, r10
 	bl func_ov00_02090c58
-	cmp sb, #0
+	cmp r9, #0
 	bne _020a6b48
 	add r1, sp, #0x7c
 	mov r0, r10
 	bl func_ov00_02090b38
 	add sp, sp, #0xf0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _020a6b48:
 	ldr r2, [r10, #4]
 	mov r0, r10
@@ -56352,7 +56352,7 @@ _020a6b48:
 	mov r0, r10
 	bl func_ov00_02090b38
 	add sp, sp, #0xf0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _020a6b9c:
 	add r0, r10, #0x18
 	add r3, sp, #0x40
@@ -56410,7 +56410,7 @@ _020a6c2c:
 	mov r1, r7
 	add r0, r10, #0x3c
 	bl Approach_thunk
-	cmp sb, #0
+	cmp r9, #0
 	streq r6, [r10, #0x38]
 	streq r7, [r10, #0x3c]
 _020a6c84:
@@ -56428,7 +56428,7 @@ _020a6c84:
 	mov r0, r10
 	sub r1, r7, r1
 	bl func_ov00_02090c10
-	cmp sb, #0
+	cmp r9, #0
 	bne _020a6cf0
 	mov r0, r10
 	mov r1, r11
@@ -56449,7 +56449,7 @@ _020a6cf0:
 	add r1, sp, #0x7c
 	mov r0, r10
 	bl func_ov00_02090c58
-	cmp sb, #0
+	cmp r9, #0
 	bne _020a6d24
 	add r1, sp, #0x7c
 	mov r0, r10
@@ -56484,12 +56484,12 @@ _020a6d70:
 	str r0, [r10, #0x1c]
 	ldr r0, [r10, #0x2c]
 	str r0, [r10, #0x20]
-	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmltia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r0, sp, #0x28
 	bl func_01fffb4c
 	cmp r0, #0
 	addeq sp, sp, #0xf0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r0, sp, #0x28
 	mov r1, r8
 	bl func_01fffbec
@@ -56504,7 +56504,7 @@ _020a6d70:
 	ldr r0, [sp, #0x3c]
 	str r0, [r10, #0x20]
 	add sp, sp, #0xf0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020a6924
 _020a6de4: .word data_027e0f94
@@ -61629,7 +61629,7 @@ _020df78c: .word data_ov00_020e2fa8
 	.global func_ov00_020df790
 	arm_func_start func_ov00_020df790
 func_ov00_020df790: ; 0x020df790
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x238
 	sub sp, sp, #0x400
 	add r3, sp, #0x600
@@ -61704,9 +61704,9 @@ func_ov00_020df790: ; 0x020df790
 	and r3, r4, #0xff
 	strh r0, [r2, #0xe0]
 	strb r3, [r7, #0x80]
-	mov sb, #0xb
+	mov r9, #0xb
 	strb ip, [r7, #0x81]
-	str sb, [r7, #0x84]
+	str r9, [r7, #0x84]
 	str r0, [r7, #0x88]
 	str r10, [r7, #0x8c]
 	ldrsh r5, [r2, #0xe0]
@@ -61718,7 +61718,7 @@ func_ov00_020df790: ; 0x020df790
 	strb ip, [r7, #0x97]
 	strb r3, [r7, #0x98]
 	strb ip, [r7, #0x99]
-	str sb, [r7, #0xb8]
+	str r9, [r7, #0xb8]
 	str r0, [r7, #0xbc]
 	str r10, [r7, #0xc0]
 	ldrsh r5, [r2, #0xc8]
@@ -61728,26 +61728,26 @@ func_ov00_020df790: ; 0x020df790
 	strb ip, [r7, #0xcb]
 	strb r3, [r7, #0xcc]
 	strb ip, [r7, #0xcd]
-	str sb, [r7, #0xd0]
+	str r9, [r7, #0xd0]
 	str r1, [sp, #0x5e4]
 	str r1, [sp, #0x5cc]
 	mov r1, #0x1d
 	str r0, [r7, #0xd4]
-	str sb, [sp, #0x5d8]
+	str r9, [sp, #0x5d8]
 	str r0, [sp, #0x5dc]
 	str r10, [sp, #0x5e0]
 	strb r0, [sp, #0x5ea]
 	strb r0, [sp, #0x5eb]
 	strb r4, [sp, #0x5ec]
 	strb r0, [sp, #0x5ed]
-	str sb, [sp, #0x5c0]
+	str r9, [sp, #0x5c0]
 	str r0, [sp, #0x5c4]
 	str r10, [sp, #0x5c8]
 	strb r0, [sp, #0x5d2]
 	strb r0, [sp, #0x5d3]
 	strb r4, [sp, #0x5d4]
 	strb r0, [sp, #0x5d5]
-	str sb, [sp, #0x5a8]
+	str r9, [sp, #0x5a8]
 	str r0, [sp, #0x5ac]
 	str r10, [sp, #0x5b0]
 	str r1, [sp, #0x5b4]
@@ -61767,7 +61767,7 @@ func_ov00_020df790: ; 0x020df790
 	strh r0, [r2, #0x98]
 	strb r3, [r7, #0xe4]
 	strb ip, [r7, #0xe5]
-	str sb, [r7, #0x104]
+	str r9, [r7, #0x104]
 	str r0, [r7, #0x108]
 	str r10, [r7, #0x10c]
 	strh r0, [r2, #0x80]
@@ -61776,7 +61776,7 @@ func_ov00_020df790: ; 0x020df790
 	ldr r6, _020e075c ; =data_ov00_020e31ec
 	str r1, [r7, #0x110]
 	ldr r1, _020e075c ; =data_ov00_020e31ec
-	str sb, [sp, #0x590]
+	str r9, [sp, #0x590]
 	strh r5, [r1, #0x14]
 	mov r1, #0xa
 	strb r1, [r7, #0x116]
@@ -61784,7 +61784,7 @@ func_ov00_020df790: ; 0x020df790
 	strb r3, [r7, #0x118]
 	strb ip, [r7, #0x119]
 	mov r1, #3
-	str sb, [r7, #0x11c]
+	str r9, [r7, #0x11c]
 	str r1, [sp, #0x59c]
 	mov r1, #0xa
 	str r0, [r7, #0x120]
@@ -61801,7 +61801,7 @@ func_ov00_020df790: ; 0x020df790
 	strb r0, [sp, #0x5a3]
 	strb r4, [sp, #0x5a4]
 	strb r0, [sp, #0x5a5]
-	str sb, [sp, #0x578]
+	str r9, [sp, #0x578]
 	str r0, [sp, #0x57c]
 	str r0, [sp, #0x580]
 	str lr, [sp, #0x584]
@@ -62112,7 +62112,7 @@ func_ov00_020df790: ; 0x020df790
 	strb r0, [sp, #0x43d]
 	str r0, [sp, #0x414]
 	str r10, [sp, #0x418]
-	str sb, [sp, #0x41c]
+	str r9, [sp, #0x41c]
 	strh r0, [r6, #0x18]
 	mov r1, #4
 	strb r1, [sp, #0x422]
@@ -62149,7 +62149,7 @@ func_ov00_020df790: ; 0x020df790
 	str r1, [sp, #0x3e0]
 	mov r1, #0xc
 	str r1, [sp, #0x3ec]
-	str sb, [r7, #0x370]
+	str r9, [r7, #0x370]
 	str r0, [sp, #0x3e4]
 	str r10, [sp, #0x3e8]
 	add r5, sp, #0x308
@@ -62368,7 +62368,7 @@ func_ov00_020df790: ; 0x020df790
 	strb r11, [r7, #0x4bf]
 	strb r3, [r7, #0x4c0]
 	strb ip, [r7, #0x4c1]
-	str sb, [r7, #0x4e0]
+	str r9, [r7, #0x4e0]
 	str r0, [r7, #0x4e4]
 	str r10, [r7, #0x4e8]
 	strh r0, [r5, #0x10]
@@ -62377,7 +62377,7 @@ func_ov00_020df790: ; 0x020df790
 	str r2, [sp, #0x32c]
 	str r2, [r7, #0x4ec]
 	ldr r2, _020e0768 ; =data_ov00_020e34ec
-	str sb, [sp, #0x320]
+	str r9, [sp, #0x320]
 	strh r1, [r2, #0xf0]
 	mov r1, #0xa
 	mov r6, r1
@@ -62385,7 +62385,7 @@ func_ov00_020df790: ; 0x020df790
 	strb r8, [r7, #0x4f3]
 	strb r3, [r7, #0x4f4]
 	strb ip, [r7, #0x4f5]
-	str sb, [r7, #0x4f8]
+	str r9, [r7, #0x4f8]
 	str r0, [r7, #0x4fc]
 	str r0, [sp, #0x324]
 	str r10, [sp, #0x328]
@@ -62406,7 +62406,7 @@ func_ov00_020df790: ; 0x020df790
 	mov r1, #2
 	strb r4, [sp, #0x334]
 	strb r0, [sp, #0x335]
-	str sb, [sp, #0x308]
+	str r9, [sp, #0x308]
 	str r0, [sp, #0x30c]
 	str r0, [sp, #0x310]
 	str lr, [sp, #0x314]
@@ -62931,7 +62931,7 @@ _020e0774:
 	strb r3, [r7, #0x89c]
 	strb ip, [r7, #0x89d]
 	strh r0, [sp, #0xc0]
-	str sb, [r7, #0x8bc]
+	str r9, [r7, #0x8bc]
 	str r0, [r7, #0x8c0]
 	ldrsh r2, [sp, #0xc0]
 	str r10, [r7, #0x8c4]
@@ -62952,7 +62952,7 @@ _020e0774:
 	strb r0, [sp, #0xdb]
 	strb r4, [sp, #0xdc]
 	strb r0, [sp, #0xdd]
-	str sb, [sp, #0xb0]
+	str r9, [sp, #0xb0]
 	str r0, [sp, #0xb4]
 	str r10, [sp, #0xb8]
 	str r1, [sp, #0xbc]
@@ -62961,7 +62961,7 @@ _020e0774:
 	strb r4, [sp, #0xc4]
 	strb r0, [sp, #0xc5]
 	strb ip, [r7, #0x8d1]
-	str sb, [sp, #0x98]
+	str r9, [sp, #0x98]
 	str r0, [sp, #0x9c]
 	str r0, [sp, #0xa0]
 	str lr, [sp, #0xa4]
@@ -62970,7 +62970,7 @@ _020e0774:
 	strb r0, [sp, #0xab]
 	strb r4, [sp, #0xac]
 	strb r0, [sp, #0xad]
-	str sb, [r7, #0x8d4]
+	str r9, [r7, #0x8d4]
 	str r0, [r7, #0x8d8]
 	str r0, [r7, #0x8dc]
 	ldrsh r1, [sp, #0xa8]
@@ -62981,7 +62981,7 @@ _020e0774:
 	strb ip, [r7, #0x8e7]
 	strb r3, [r7, #0x8e8]
 	strb ip, [r7, #0x8e9]
-	str sb, [r7, #0x908]
+	str r9, [r7, #0x908]
 	str r0, [r7, #0x90c]
 	mov r2, #0x1e
 	str r10, [r7, #0x910]
@@ -63001,7 +63001,7 @@ _020e0774:
 	mov r6, #0x1f
 	ldrsh r8, [sp, #0x78]
 	str lr, [r7, #0x92c]
-	str sb, [sp, #0x80]
+	str r9, [sp, #0x80]
 	strh r8, [r5, #0x30]
 	strb ip, [r7, #0x932]
 	strb ip, [r7, #0x933]
@@ -63022,13 +63022,13 @@ _020e0774:
 	strb r4, [sp, #0x7c]
 	strb r0, [sp, #0x7d]
 	strb ip, [r7, #0x935]
-	str sb, [sp, #0x50]
+	str r9, [sp, #0x50]
 	str r0, [sp, #0x54]
 	str r10, [sp, #0x58]
 	str r6, [sp, #0x5c]
 	strh r0, [sp, #0x60]
 	strb r0, [sp, #0x62]
-	str sb, [r7, #0x954]
+	str r9, [r7, #0x954]
 	str r0, [r7, #0x958]
 	str r10, [r7, #0x95c]
 	str r6, [r7, #0x960]
@@ -63051,7 +63051,7 @@ _020e0774:
 	strb ip, [r7, #0x97f]
 	strb r3, [r7, #0x980]
 	strb ip, [r7, #0x981]
-	str sb, [r7, #0x9a0]
+	str r9, [r7, #0x9a0]
 	str r0, [r7, #0x9a4]
 	str r10, [r7, #0x9a8]
 	ldrsh r2, [sp, #0x30]
@@ -63085,7 +63085,7 @@ _020e0774:
 	strb r0, [sp, #0x4b]
 	strb r4, [sp, #0x4c]
 	strb r0, [sp, #0x4d]
-	str sb, [sp, #0x20]
+	str r9, [sp, #0x20]
 	str r0, [sp, #0x24]
 	str r10, [sp, #0x28]
 	str r6, [sp, #0x2c]
@@ -63104,7 +63104,7 @@ _020e0774:
 	bl func_0204f8d4
 	add sp, sp, #0x238
 	add sp, sp, #0x400
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 _020e0e94: .word data_ov00_020e37ec
 _020e0e98: .word data_ov00_020e38ec

--- a/asm/ov00/ov00_0207af9c.s
+++ b/asm/ov00/ov00_0207af9c.s
@@ -1347,11 +1347,11 @@ _0207bb48: .word data_ov00_020d8798
 	.global func_ov00_0207bb4c
 	arm_func_start func_ov00_0207bb4c
 func_ov00_0207bb4c: ; 0x0207bb4c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	mov sl, r0
 	ldr r0, [sl]
 	cmp r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	bl func_01ffa8d4
 	ldr r5, _0207bc30 ; =0x04000440
 	mov r7, #3
@@ -1359,14 +1359,14 @@ func_ov00_0207bb4c: ; 0x0207bb4c
 	mov r0, #0
 	ldr r8, _0207bc34 ; =data_ov00_020d8860
 	str r0, [r5, #0x14]
-	mov fp, r0
+	mov r11, r0
 	mov r4, #1
 _0207bb84:
 	ldr r0, [sl]
 	tst r0, r4, lsl r7
 	beq _0207bc20
 	mov r0, r8
-	str fp, [r5]
+	str r11, [r5]
 	bl func_02005628
 	ldr r1, _0207bc38 ; =data_027e0384
 	mov r0, r8
@@ -1407,7 +1407,7 @@ _0207bc20:
 	sub r8, r8, #0x40
 	subs r7, r7, #1
 	bpl _0207bb84
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_0207bb4c
 _0207bc30: .word 0x04000440
@@ -2192,7 +2192,7 @@ func_ov00_0207c1f8: ; 0x0207c1f8
 	.global func_ov00_0207c260
 	arm_func_start func_ov00_0207c260
 func_ov00_0207c260: ; 0x0207c260
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	ldr r6, [sp, #0x28]
 	ldr r5, [sp, #0x2c]
 	mov sb, r1
@@ -2200,8 +2200,8 @@ func_ov00_0207c260: ; 0x0207c260
 	mov sl, r0
 	mov r7, r3
 	cmp sb, r8
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
-	orr fp, r5, #0x8000
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	orr r11, r5, #0x8000
 _0207c288:
 	ldr r0, [r7]
 	cmp r0, #0x1000
@@ -2214,7 +2214,7 @@ _0207c288:
 	ldr r2, [r7]
 	mov r0, r4
 	cmp r2, #0x1000
-	movge ip, fp
+	movge ip, r11
 	movlt ip, r5
 	cmp r2, #0x1000
 	subge r2, r2, #0x1000
@@ -2226,7 +2226,7 @@ _0207c288:
 	cmp sb, r8
 	add r7, r7, #4
 	bne _0207c288
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	arm_func_end func_ov00_0207c260
 
 	.global func_ov00_0207c2e8
@@ -4537,7 +4537,7 @@ func_ov00_0207ddf4: ; 0x0207ddf4
 	.global func_ov00_0207ddf8
 	arm_func_start func_ov00_0207ddf8
 func_ov00_0207ddf8: ; 0x0207ddf8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	mov r7, #0
 	mov sl, r0
 	mov sb, r1
@@ -4545,7 +4545,7 @@ func_ov00_0207ddf8: ; 0x0207ddf8
 	mvn r5, #0
 	mov r6, r7
 	mov r4, r7
-	mov fp, #4
+	mov r11, #4
 _0207de1c:
 	cmp sb, #0
 	beq _0207de44
@@ -4561,14 +4561,14 @@ _0207de2c:
 _0207de44:
 	mov r0, r4
 	mov r1, r8
-	mov r2, fp
+	mov r2, r11
 	bl func_020078f4
 _0207de54:
 	add r7, r7, #1
 	cmp r7, #2
 	add r8, r8, #4
 	blt _0207de1c
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	arm_func_end func_ov00_0207ddf8
 
 	.global func_ov00_0207de68
@@ -4766,7 +4766,7 @@ func_ov00_0207e08c: ; 0x0207e08c
 	.global func_ov00_0207e0f0
 	arm_func_start func_ov00_0207e0f0
 func_ov00_0207e0f0: ; 0x0207e0f0
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x14
 	mov sl, r0
 	ldr r2, [sl, #0x13c]
@@ -4774,19 +4774,19 @@ func_ov00_0207e0f0: ; 0x0207e0f0
 	cmp r2, #0
 	addeq sp, sp, #0x14
 	mvneq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, [r2, #8]
 	adds r0, r2, r0
 	str r0, [sp, #4]
 	addeq sp, sp, #0x14
 	mvneq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldrh r1, [r0]
 	adds r0, r0, r1
 	str r0, [sp, #0xc]
 	addeq sp, sp, #0x14
 	mvneq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldrb r1, [r0, #1]
 	mov r0, #0
 	str r0, [sp, #8]
@@ -4817,8 +4817,8 @@ _0207e15c:
 	add r2, r0, #4
 	ldr r0, [sp, #8]
 	mul r0, r1, r0
-	add fp, r2, r0
-	ldrb r1, [fp, #2]
+	add r11, r2, r0
+	ldrb r1, [r11, #2]
 	ldrh r0, [r2, r0]
 	cmp r1, #0
 	str r0, [sp, #0x10]
@@ -4851,14 +4851,14 @@ _0207e218:
 	cmp r0, #0
 	addeq sp, sp, #0x14
 	moveq r0, r6
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r0, r6, #1
 	mov r0, r0, lsl #0x10
 	cmp sb, r0, lsr #16
 	mov r6, r0, lsr #0x10
 	bgt _0207e218
 _0207e250:
-	ldrb r0, [fp, #2]
+	ldrb r0, [r11, #2]
 	add r5, r5, #1
 	cmp r5, r0
 	blt _0207e1d0
@@ -4874,13 +4874,13 @@ _0207e260:
 _0207e280:
 	mvn r0, #0
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	arm_func_end func_ov00_0207e0f0
 
 	.global func_ov00_0207e28c
 	arm_func_start func_ov00_0207e28c
 func_ov00_0207e28c: ; 0x0207e28c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x14
 	mov sl, r0
 	ldr r2, [sl, #0x13c]
@@ -4888,19 +4888,19 @@ func_ov00_0207e28c: ; 0x0207e28c
 	cmp r2, #0
 	addeq sp, sp, #0x14
 	mvneq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, [r2, #8]
 	adds r0, r2, r0
 	str r0, [sp, #4]
 	addeq sp, sp, #0x14
 	mvneq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldrh r1, [r0, #2]
 	adds r0, r0, r1
 	str r0, [sp, #0xc]
 	addeq sp, sp, #0x14
 	mvneq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldrb r1, [r0, #1]
 	mov r0, #0
 	str r0, [sp, #8]
@@ -4932,8 +4932,8 @@ _0207e2f8:
 	add r2, r0, #4
 	ldr r0, [sp, #8]
 	mul r0, r1, r0
-	add fp, r2, r0
-	ldrb r1, [fp, #2]
+	add r11, r2, r0
+	ldrb r1, [r11, #2]
 	ldrh r0, [r2, r0]
 	cmp r1, #0
 	str r0, [sp, #0x10]
@@ -4972,14 +4972,14 @@ _0207e3d0:
 	cmp r0, #0
 	addeq sp, sp, #0x14
 	moveq r0, r6
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r0, r6, #1
 	mov r0, r0, lsl #0x10
 	cmp sb, r0, lsr #16
 	mov r6, r0, lsr #0x10
 	bgt _0207e3d0
 _0207e408:
-	ldrb r0, [fp, #2]
+	ldrb r0, [r11, #2]
 	add r5, r5, #1
 	cmp r5, r0
 	blt _0207e370
@@ -4995,7 +4995,7 @@ _0207e418:
 _0207e438:
 	mvn r0, #0
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	arm_func_end func_ov00_0207e28c
 
 	.global func_ov00_0207e444
@@ -5071,7 +5071,7 @@ func_ov00_0207e4b0: ; 0x0207e4b0
 	.global func_ov00_0207e4b8
 	arm_func_start func_ov00_0207e4b8
 func_ov00_0207e4b8: ; 0x0207e4b8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x7c
 	ldr r3, _0207e92c ; =data_027e0e60
 	mov sb, r1
@@ -5165,7 +5165,7 @@ _0207e5e4:
 	cmp r0, #0
 	ldrne r0, [sp, #0x14]
 	addne sp, sp, #0x7c
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r2, sp, #0x14
 	mov r0, r8
 	mov r1, sb
@@ -5177,7 +5177,7 @@ _0207e5e4:
 	cmp r1, r0
 	blt _0207e724
 	add sp, sp, #0x7c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0207e63c:
 	ldrb r0, [r8, #0xe]
 	cmp r0, #0
@@ -5200,7 +5200,7 @@ _0207e63c:
 	ldr r2, [r2, #0x60]
 	blx r2
 	add sp, sp, #0x7c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0207e694:
 	add r2, sp, #0x10
 	mov r0, r8
@@ -5209,7 +5209,7 @@ _0207e694:
 	cmp r0, #0
 	ldrne r0, [sp, #0x10]
 	addne sp, sp, #0x7c
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r2, sp, #0x10
 	mov r0, r8
 	mov r1, sb
@@ -5220,7 +5220,7 @@ _0207e694:
 	ldr r1, [sb, #4]
 	cmp r1, r0
 	addge sp, sp, #0x7c
-	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0207e6e0:
 	mov r0, r8
 	ldr r3, [r0]
@@ -5238,7 +5238,7 @@ _0207e6e0:
 	ldr r2, [r2, #0x60]
 	blx r2
 	add sp, sp, #0x7c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0207e724:
 	mov r0, #0x20
 	str r0, [sp]
@@ -5271,14 +5271,14 @@ _0207e724:
 	ble _0207e8a0
 	ldr sl, _0207e934 ; =data_ov00_020ec824
 	ldr sb, _0207e930 ; =data_027e0f6c
-	mov fp, #0x4c
+	mov r11, #0x4c
 _0207e7a4:
 	mov r0, r7, lsl #0x1
 	ldrh r1, [sl, r0]
 	ldr r2, [sb]
 	add r0, sp, #0x30
 	ldr r3, [r2, #0x20]
-	mul r2, r1, fp
+	mul r2, r1, r11
 	add ip, r3, r2
 	ldrh lr, [r3, r2]
 	ldrh r3, [ip, #2]
@@ -5358,7 +5358,7 @@ _0207e8a0:
 	bl func_0204f754
 	add sp, sp, #0x7c
 	add r0, r5, r4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0207e8f4:
 	mov r0, r8
 	ldr r2, [r0]
@@ -5373,7 +5373,7 @@ _0207e8f4:
 	bl func_0204f754
 	mov r0, r4
 	add sp, sp, #0x7c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_0207e4b8
 _0207e92c: .word data_027e0e60
@@ -5413,7 +5413,7 @@ func_ov00_0207e96c: ; 0x0207e96c
 	.global func_ov00_0207e970
 	arm_func_start func_ov00_0207e970
 func_ov00_0207e970: ; 0x0207e970
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0xc4
 	ldr r4, _0207ee00 ; =data_027e0e60
 	mov sb, r1
@@ -5523,7 +5523,7 @@ _0207ea9c:
 	str r1, [r7]
 	mov r0, #0x1000
 	stmib r7, {r0, r1}
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0207eb04:
 	mov r0, #0x20
 	str r0, [sp]
@@ -5563,14 +5563,14 @@ _0207eb04:
 	ble _0207ed48
 	ldr sl, _0207ee08 ; =data_ov00_020ec864
 	ldr sb, _0207ee04 ; =data_027e0f6c
-	mov fp, #0x4c
+	mov r11, #0x4c
 _0207eba0:
 	mov r0, r6, lsl #0x1
 	ldrh r1, [sl, r0]
 	ldr r2, [sb]
 	add r0, sp, #0x78
 	ldr r3, [r2, #0x20]
-	mul r2, r1, fp
+	mul r2, r1, r11
 	add ip, r3, r2
 	ldrh lr, [r3, r2]
 	ldrh r3, [ip, #2]
@@ -5720,7 +5720,7 @@ _0207edd0:
 	mov r2, #0x10
 	bl func_0204f754
 	add sp, sp, #0xc4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_0207e970
 _0207ee00: .word data_027e0e60
@@ -5732,7 +5732,7 @@ _0207ee10: .word func_ov00_0207e96c
 	.global func_ov00_0207ee14
 	arm_func_start func_ov00_0207ee14
 func_ov00_0207ee14: ; 0x0207ee14
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x74
 	ldr r0, _0207efdc ; =data_027e0e60
 	mov sb, r1
@@ -5772,14 +5772,14 @@ func_ov00_0207ee14: ; 0x0207ee14
 	ble _0207efbc
 	ldr sl, _0207efe4 ; =data_ov00_020ec8a4
 	ldr sb, _0207efe0 ; =data_027e0f6c
-	mov fp, #0x4c
+	mov r11, #0x4c
 _0207eeb8:
 	mov r0, r8, lsl #0x1
 	ldrh r1, [sl, r0]
 	ldr r2, [sb]
 	add r0, sp, #0x28
 	ldr r3, [r2, #0x20]
-	mul r2, r1, fp
+	mul r2, r1, r11
 	add ip, r3, r2
 	ldrh lr, [r3, r2]
 	ldrh r3, [ip, #2]
@@ -5848,7 +5848,7 @@ _0207efbc:
 	bl func_0204f754
 	mov r0, r7
 	add sp, sp, #0x74
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_0207ee14
 _0207efdc: .word data_027e0e60
@@ -8066,7 +8066,7 @@ _02080b14:
 	.global func_ov00_02080b24
 	arm_func_start func_ov00_02080b24
 func_ov00_02080b24: ; 0x02080b24
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x14
 	ldr r3, [r0]
 	mov r2, #4
@@ -8076,7 +8076,7 @@ func_ov00_02080b24: ; 0x02080b24
 	blx r3
 	cmp r0, #0
 	addne sp, sp, #0x14
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, [sp]
 	ldrh r0, [r0, #0x30]
 	cmp r0, #0x60
@@ -8089,10 +8089,10 @@ func_ov00_02080b24: ; 0x02080b24
 	str r0, [sp, #4]
 	cmp r0, #0
 	ldr r0, [sp]
-	ldrh fp, [r0, #0x2a]
+	ldrh r11, [r0, #0x2a]
 	ble _02080c4c
 _02080b88:
-	cmp fp, #0
+	cmp r11, #0
 	mov sb, #0
 	ble _02080c3c
 	and r0, r8, #0xff
@@ -8138,7 +8138,7 @@ _02080c08:
 	movgt r7, r0
 _02080c30:
 	add sb, sb, #1
-	cmp sb, fp
+	cmp sb, r11
 	blt _02080b9c
 _02080c3c:
 	ldr r0, [sp, #4]
@@ -8148,7 +8148,7 @@ _02080c3c:
 _02080c4c:
 	cmp r6, #0
 	addeq sp, sp, #0x14
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r1, [r6, #4]
 	ldr r0, [sp]
 	bic r1, r1, #1
@@ -8193,7 +8193,7 @@ _02080cd0:
 	ldr r0, [sp]
 	strh r1, [r0, #0x30]
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	arm_func_end func_ov00_02080b24
 
 	.global func_ov00_02080d08
@@ -14093,7 +14093,7 @@ _02085104: .word data_027e0f6c
 	.global func_ov00_02085108
 	arm_func_start func_ov00_02085108
 func_ov00_02085108: ; 0x02085108
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x2c
 	ldr r0, _02085274 ; =data_027e0f64
 	str r1, [sp]
@@ -14131,10 +14131,10 @@ _02085188:
 	cmp r0, r7
 	blt _02085250
 	ldr r0, [sp, #0xc]
-	ldr fp, _02085278 ; =data_027e0e60
+	ldr r11, _02085278 ; =data_027e0e60
 	and r5, r0, #0xff
 _020851a4:
-	ldr r0, [fp]
+	ldr r0, [r11]
 	add r1, sp, #0x14
 	strb r5, [sp, #0x14]
 	strb r6, [sp, #0x15]
@@ -14173,7 +14173,7 @@ _020851a4:
 	ldr r1, [r4, #0x20]
 	str r1, [r0, #8]
 	ldrsb r0, [r4, #0x12]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02085244:
 	sub r6, r6, #1
 	cmp r6, r7
@@ -14188,7 +14188,7 @@ _02085250:
 _02085268:
 	mov r0, #0
 	add sp, sp, #0x2c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_02085108
 _02085274: .word data_027e0f64
@@ -14197,7 +14197,7 @@ _02085278: .word data_027e0e60
 	.global func_ov00_0208527c
 	arm_func_start func_ov00_0208527c
 func_ov00_0208527c: ; 0x0208527c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x2c
 	ldr r3, _020853f4 ; =data_027e0f64
 	mov r4, r0
@@ -14214,7 +14214,7 @@ func_ov00_0208527c: ; 0x0208527c
 	strb r1, [sp, #0xe]
 	ldrb r1, [sp, #0x15]
 	ldr r0, [r0]
-	ldrb fp, [sp, #0x14]
+	ldrb r11, [sp, #0x14]
 	str r1, [sp, #8]
 	bl func_ov00_0208b180
 	mov r1, r0
@@ -14231,12 +14231,12 @@ func_ov00_0208527c: ; 0x0208527c
 	mov r5, r0
 	mov r0, r4
 	bl func_ov00_02083368
-	cmp fp, #0
+	cmp r11, #0
 	ldr r1, [sp, #8]
-	movle fp, #0
+	movle r11, #0
 	cmp r1, r5
 	ldr r1, [sp, #4]
-	subge fp, r5, #1
+	subge r11, r5, #1
 	cmp r1, #0
 	movle r1, #0
 	strle r1, [sp, #4]
@@ -14248,7 +14248,7 @@ func_ov00_0208527c: ; 0x0208527c
 	str r0, [sp, #0x1c]
 	str r0, [sp, #0x20]
 	ldr r0, [sp, #8]
-	cmp fp, r0
+	cmp r11, r0
 	bgt _020853e8
 	ldr r4, _020853f8 ; =data_027e0e60
 	add r6, sp, #0x10
@@ -14257,7 +14257,7 @@ _02085358:
 	mov r0, r8
 	cmp r0, sb
 	bgt _020853d8
-	and r7, fp, #0xff
+	and r7, r11, #0xff
 _0208536c:
 	ldr r0, [r4]
 	mov r1, r6
@@ -14282,20 +14282,20 @@ _0208536c:
 	ldr r1, [r5, #0x20]
 	str r1, [r0, #8]
 	ldrsb r0, [r5, #0x12]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _020853cc:
 	add r8, r8, #1
 	cmp r8, sb
 	ble _0208536c
 _020853d8:
 	ldr r0, [sp, #8]
-	add fp, fp, #1
-	cmp fp, r0
+	add r11, r11, #1
+	cmp r11, r0
 	ble _02085358
 _020853e8:
 	mov r0, #0
 	add sp, sp, #0x2c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_0208527c
 _020853f4: .word data_027e0f64
@@ -14304,7 +14304,7 @@ _020853f8: .word data_027e0e60
 	.global func_ov00_020853fc
 	arm_func_start func_ov00_020853fc
 func_ov00_020853fc: ; 0x020853fc
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x2c
 	ldr r3, _0208558c ; =data_027e0f64
 	mov r5, r0
@@ -14339,19 +14339,19 @@ func_ov00_020853fc: ; 0x020853fc
 	mov r4, r0
 	mov r0, r5
 	bl func_ov00_02083368
-	mov fp, #0
+	mov r11, #0
 	ldr r1, [sp, #8]
-	str fp, [sp, #0x24]
+	str r11, [sp, #0x24]
 	cmp r1, #0
 	movle r1, #0
 	strle r1, [sp, #8]
 	ldr r1, [sp, #4]
-	str fp, [sp, #0x18]
+	str r11, [sp, #0x18]
 	cmp r1, r4
 	subge r1, r4, #1
 	strge r1, [sp, #8]
 	ldr r1, [sp]
-	str fp, [sp, #0x1c]
+	str r11, [sp, #0x1c]
 	cmp r1, #0
 	movle r1, #0
 	strle r1, [sp]
@@ -14359,7 +14359,7 @@ func_ov00_020853fc: ; 0x020853fc
 	subge r8, r0, #1
 	ldr r1, [sp, #8]
 	ldr r0, [sp, #4]
-	str fp, [sp, #0x20]
+	str r11, [sp, #0x20]
 	cmp r1, r0
 	bgt _02085580
 _020854e4:
@@ -14392,7 +14392,7 @@ _020854fc:
 	mov r1, sl
 	bl func_ov00_0208b7d0
 	cmp r0, #0
-	movne fp, r5
+	movne r11, r5
 	strne r4, [sb]
 _0208555c:
 	add r7, r7, #1
@@ -14406,9 +14406,9 @@ _02085568:
 	cmp r1, r0
 	ble _020854e4
 _02085580:
-	mov r0, fp
+	mov r0, r11
 	add sp, sp, #0x2c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020853fc
 _0208558c: .word data_027e0f64
@@ -14642,11 +14642,11 @@ _020858ac: .word data_027e077c
 	.global func_ov00_020858b0
 	arm_func_start func_ov00_020858b0
 func_ov00_020858b0: ; 0x020858b0
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x1c
 	mov sb, r2
 	mov sl, r0
-	mov fp, r1
+	mov r11, r1
 	cmp sb, #1
 	bne _020858e4
 	ldr r0, _02085a2c ; =data_027e0f64
@@ -14671,7 +14671,7 @@ _020858f8:
 	mvn r3, #0
 	add r0, sp, #0x18
 	mov r1, sl
-	mov r2, fp
+	mov r2, r11
 	str r3, [sp, #8]
 	bl func_ov00_02083a1c
 	ldrb r3, [sp, #0x18]
@@ -14721,7 +14721,7 @@ _02085980:
 	beq _02085a04
 	ldrb r1, [sp, #0x18]
 	ldr ip, [r0]
-	mov r3, fp
+	mov r3, r11
 	cmp r7, r1
 	ldreqb r1, [sp, #0x19]
 	ldr ip, [ip, #0x38]
@@ -14743,7 +14743,7 @@ _02085a10:
 _02085a20:
 	ldr r0, [sp, #8]
 	add sp, sp, #0x1c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020858b0
 _02085a2c: .word data_027e0f64
@@ -14909,20 +14909,20 @@ _02085c54:
 	.global func_ov00_02085c60
 	arm_func_start func_ov00_02085c60
 func_ov00_02085c60: ; 0x02085c60
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0xfc
-	ldr fp, [sp, #0x120]
+	ldr r11, [sp, #0x120]
 	ldr r8, [sp, #0x124]
 	ldr r7, [sp, #0x128]
 	ldr r6, [sp, #0x12c]
-	cmp fp, #0
+	cmp r11, #0
 	mov sl, r0
 	mov sb, r1
 	mov r5, r2
 	mov r4, r3
 	addeq sp, sp, #0xfc
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r1, sp, #0x88
 	str r1, [sp]
 	ldr r0, _0208603c ; =data_027e0d3c
@@ -14954,9 +14954,9 @@ func_ov00_02085c60: ; 0x02085c60
 	bl func_01ff9bf8
 	mov r1, #0xc000
 	mov r2, #0
-	umull r5, r3, fp, r1
-	mla r3, fp, r2, r3
-	mov r4, fp, asr #0x1f
+	umull r5, r3, r11, r1
+	mla r3, r11, r2, r3
+	mov r4, r11, asr #0x1f
 	adds r2, r5, #0x800
 	mla r3, r4, r1, r3
 	adc r1, r3, #0
@@ -15001,14 +15001,14 @@ _02085d9c:
 	bl func_01ff9bf8
 	mov r1, r4, lsl #0xb
 	mov r0, #0x800
-	adds r2, r0, fp, lsl #11
-	orr r1, r1, fp, lsr #21
+	adds r2, r0, r11, lsl #11
+	orr r1, r1, r11, lsr #21
 	add r0, sp, #0x58
 	adc r1, r1, #0
 	mov r5, r2, lsr #0xc
 	orr r5, r5, r1, lsl #20
 	bl func_01ff9cec
-	cmp r0, fp
+	cmp r0, r11
 	blt _02085e30
 	add r0, sp, #0x58
 	mov r1, r0
@@ -15028,11 +15028,11 @@ _02085d9c:
 	bl func_01ff9bc4
 _02085e30:
 	mov r4, #0
-	mov r0, fp, lsl #0x1
+	mov r0, r11, lsl #0x1
 	str r4, [sp, #0x48]
 	str r0, [sp, #0x4c]
 	str r4, [sp, #0x50]
-	str fp, [sp, #0x54]
+	str r11, [sp, #0x54]
 _02085e48:
 	add r0, sp, #0x48
 	stmia sp, {r0, r8}
@@ -15063,7 +15063,7 @@ _02085e48:
 	str r2, [sp, #0x38]
 	bl func_01ff9d4c
 	add r0, sp, #0x30
-	mov r1, fp
+	mov r1, r11
 	bl func_01fffbec
 	add r0, sp, #0x3c
 	add r1, sp, #0x30
@@ -15126,7 +15126,7 @@ _02085f84:
 	ldr r1, [sp, #0x20]
 	add sp, sp, #0xfc
 	str r1, [sb, #0x64]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02085fb8:
 	ldr r1, [sp, #0x70]
 	ldr r0, [sp, #0x74]
@@ -15160,7 +15160,7 @@ _02085fb8:
 	ldr r1, [sp, #0x18]
 	str r1, [sb, #0x64]
 	add sp, sp, #0xfc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_02085c60
 _0208603c: .word data_027e0d3c
@@ -15169,7 +15169,7 @@ _02086040: .word 0x0000ffff
 	.global func_ov00_02086044
 	arm_func_start func_ov00_02086044
 func_ov00_02086044: ; 0x02086044
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0xb0
 	add r5, sp, #0x98
 	mov sb, r2
@@ -15206,7 +15206,7 @@ func_ov00_02086044: ; 0x02086044
 	ldr r1, [sp, #0xac]
 	mov r0, sl
 	bl func_ov00_020839f8
-	mov fp, r0
+	mov r11, r0
 	add r5, sp, #0x8c
 	ldmia sb, {r0, r1, r2}
 	stmia r5, {r0, r1, r2}
@@ -15239,7 +15239,7 @@ func_ov00_02086044: ; 0x02086044
 _02086150:
 	ldr r7, [sp, #0xc]
 	mov r0, r7
-	cmp r0, fp
+	cmp r0, r11
 	bgt _02086264
 	and r5, r6, #0xff
 _02086164:
@@ -15276,7 +15276,7 @@ _02086164:
 	cmp r0, #0
 	addne sp, sp, #0xb0
 	movne r0, #1
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _020861ec:
 	mov r0, sl
 	add r1, sp, #0x10
@@ -15304,10 +15304,10 @@ _020861ec:
 	cmp r0, #0
 	addne sp, sp, #0xb0
 	movne r0, #1
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02086258:
 	add r7, r7, #1
-	cmp r7, fp
+	cmp r7, r11
 	ble _02086164
 _02086264:
 	ldr r0, [sp, #8]
@@ -15317,7 +15317,7 @@ _02086264:
 _02086274:
 	mov r0, #0
 	add sp, sp, #0xb0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_02086044
 _02086280: .word data_027e0e60
@@ -16337,7 +16337,7 @@ _020870cc: .word func_ov00_0208e420
 	.global func_ov00_020870d0
 	arm_func_start func_ov00_020870d0
 func_ov00_020870d0: ; 0x020870d0
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0xc
 	mov sb, r0
 	ldr r1, [sb, #8]
@@ -16377,7 +16377,7 @@ _02087120:
 	orr r8, r8, r2, lsl #20
 	orr r1, r1, r0, lsl #20
 	add r0, r8, r1
-	mov fp, r7, asr #0x1f
+	mov r11, r7, asr #0x1f
 	mov r5, r6, asr #0x1f
 	bl func_01ff9958
 	bl func_01ff992c
@@ -16397,7 +16397,7 @@ _02087120:
 	str r3, [sp, #4]
 	str r3, [sb, #0x110]
 	umull ip, r3, r4, r7
-	mla r3, r4, fp, r3
+	mla r3, r4, r11, r3
 	mov r2, r1, lsl #0xc
 	str sl, [sp]
 	str sl, [sp, #4]
@@ -16439,7 +16439,7 @@ _02087120:
 	str r0, [sp, #8]
 	str sl, [sb, #0x138]
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020870d0
 _02087268: .word data_02050f54
@@ -17880,11 +17880,11 @@ func_ov00_02088494: ; 0x02088494
 	.global func_ov00_020884b4
 	arm_func_start func_ov00_020884b4
 func_ov00_020884b4: ; 0x020884b4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x98
 	mov r5, r0
 	ldr r0, [r5, #0x15c]
-	mov fp, r1
+	mov r11, r1
 	sub r0, r0, #0xb
 	mov r4, r2
 	str r3, [sp, #4]
@@ -17899,7 +17899,7 @@ _020884e0: ; jump table
 	b _020884f4 ; case 4
 _020884f4:
 	add sp, sp, #0x98
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _020884fc:
 	ldr r1, [r5, #0x160]
 	mov r0, r5
@@ -17998,7 +17998,7 @@ _020885cc:
 	ldr r0, [r5, #0x154]
 	ldr r0, [r0, #0x14]
 	strh r3, [r0, #0x14]
-	str fp, [r5, #0x1a4]
+	str r11, [r5, #0x1a4]
 	str r3, [r5, #0x1a8]
 	ldr r1, [r5, #0x15c]
 	mov r0, #0x68
@@ -18006,46 +18006,46 @@ _020885cc:
 	mul r3, r1, r0
 	ldr r4, _020888e4 ; =data_ov00_020d8aa8
 	str ip, [sp, #0x3c]
-	add fp, r4, r3
-	ldrb r2, [fp, #0x60]
-	ldrb r1, [fp, #0x61]
+	add r11, r4, r3
+	ldrb r2, [r11, #0x60]
+	ldrb r1, [r11, #0x61]
 	ldr r3, [r4, r3]
 	strb r2, [sp, #0x90]
-	ldr r2, [fp, #4]
+	ldr r2, [r11, #4]
 	strb r1, [sp, #0x91]
-	ldr r1, [fp, #8]
+	ldr r1, [r11, #8]
 	str r2, [sp, #0x34]
-	ldr r2, [fp, #0x28]
+	ldr r2, [r11, #0x28]
 	str r1, [sp, #0x38]
-	ldr r1, [fp, #0x2c]
+	ldr r1, [r11, #0x2c]
 	str r2, [sp, #0x58]
-	ldr r2, [fp, #0x30]
+	ldr r2, [r11, #0x30]
 	str r1, [sp, #0x5c]
-	ldr r1, [fp, #0x34]
+	ldr r1, [r11, #0x34]
 	str r2, [sp, #0x60]
-	ldr r2, [fp, #0x38]
+	ldr r2, [r11, #0x38]
 	str r1, [sp, #0x64]
-	ldr r1, [fp, #0x3c]
+	ldr r1, [r11, #0x3c]
 	str r2, [sp, #0x68]
-	ldr r2, [fp, #0x40]
+	ldr r2, [r11, #0x40]
 	str r1, [sp, #0x6c]
-	ldr r1, [fp, #0x44]
+	ldr r1, [r11, #0x44]
 	str r2, [sp, #0x70]
-	ldr r2, [fp, #0x48]
+	ldr r2, [r11, #0x48]
 	str r1, [sp, #0x74]
-	ldr r1, [fp, #0x4c]
+	ldr r1, [r11, #0x4c]
 	str r2, [sp, #0x78]
-	ldr r2, [fp, #0x50]
+	ldr r2, [r11, #0x50]
 	str r1, [sp, #0x7c]
-	ldr r1, [fp, #0x54]
-	ldrb r0, [fp, #0x62]
-	ldrb r4, [fp, #0x63]
+	ldr r1, [r11, #0x54]
+	ldrb r0, [r11, #0x62]
+	ldrb r4, [r11, #0x63]
 	str r3, [sp, #0x30]
-	ldrb r3, [fp, #0x64]
+	ldrb r3, [r11, #0x64]
 	str r2, [sp, #0x80]
-	ldr r2, [fp, #0x58]
+	ldr r2, [r11, #0x58]
 	str r1, [sp, #0x84]
-	ldr r1, [fp, #0x5c]
+	ldr r1, [r11, #0x5c]
 	str r2, [sp, #0x88]
 	str r1, [sp, #0x8c]
 	strb r0, [sp, #0x92]
@@ -18062,14 +18062,14 @@ _02088764:
 	mul r7, r1, r0
 	ldr r8, _020888e4 ; =data_ov00_020d8aa8
 	add r0, r8, r7
-	ldr fp, [r8, r7]
+	ldr r11, [r8, r7]
 	ldr sl, [r0, #4]
 	ldr sb, [r0, #8]
 	ldr r8, [r0, #0xc]
 	ldr r7, [r0, #0x10]
 	ldr ip, [r0, #0x14]
-	str fp, [sp, #0x30]
-	ldr fp, [r0, #0x18]
+	str r11, [sp, #0x30]
+	ldr r11, [r0, #0x18]
 	str sl, [sp, #0x34]
 	ldr sl, [r0, #0x1c]
 	str sb, [sp, #0x38]
@@ -18080,8 +18080,8 @@ _02088764:
 	ldr r7, [r0, #0x28]
 	str ip, [sp, #0x44]
 	ldr ip, [r0, #0x2c]
-	str fp, [sp, #0x48]
-	ldr fp, [r0, #0x30]
+	str r11, [sp, #0x48]
+	ldr r11, [r0, #0x30]
 	str sl, [sp, #0x4c]
 	ldr sl, [r0, #0x34]
 	str sb, [sp, #0x50]
@@ -18097,8 +18097,8 @@ _02088764:
 	ldrb r1, [r0, #0x64]
 	str ip, [sp, #0x5c]
 	ldr ip, [r0, #0x44]
-	str fp, [sp, #0x60]
-	ldr fp, [r0, #0x48]
+	str r11, [sp, #0x60]
+	ldr r11, [r0, #0x48]
 	str sl, [sp, #0x64]
 	ldr sl, [r0, #0x4c]
 	str sb, [sp, #0x68]
@@ -18109,7 +18109,7 @@ _02088764:
 	ldr r7, [r0, #0x58]
 	ldr r0, [r0, #0x5c]
 	str ip, [sp, #0x74]
-	str fp, [sp, #0x78]
+	str r11, [sp, #0x78]
 	str sl, [sp, #0x7c]
 	str sb, [sp, #0x80]
 	str r8, [sp, #0x84]
@@ -18155,7 +18155,7 @@ _02088858:
 	str r1, [r5, #0x2b0]
 	strb r0, [r5, #0x2ec]
 	add sp, sp, #0x98
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020884b4
 _020888e4: .word data_ov00_020d8aa8
@@ -22712,7 +22712,7 @@ _0208c4f4: .word data_027e0fc8
 	.global func_ov00_0208c4f8
 	arm_func_start func_ov00_0208c4f8
 func_ov00_0208c4f8: ; 0x0208c4f8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x48
 	mov r6, r0
 	bl func_ov00_0208c968
@@ -22722,7 +22722,7 @@ func_ov00_0208c4f8: ; 0x0208c4f8
 	mov r5, r0
 	cmp r5, r1
 	addeq sp, sp, #0x48
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, _0208c924 ; =data_027e0d38
 	ldr r0, [r0]
 	bl func_ov00_02078b40
@@ -22735,7 +22735,7 @@ func_ov00_0208c4f8: ; 0x0208c4f8
 	cmp r5, r0
 	beq _0208c560
 	add sp, sp, #0x48
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0208c558:
 	ldr r5, _0208c930 ; =0x53485254
 	b _0208c564
@@ -22822,16 +22822,16 @@ _0208c670:
 	ldr sl, [r3, #0x10]
 	mla r8, r7, r0, r8
 	ldr r6, [r3, #0xc]
-	adds fp, sl, r4
+	adds r11, sl, r4
 	mla r8, r6, r2, r8
 	ldr sb, [r3, #0x14]
-	umull r4, r2, r7, fp
+	umull r4, r2, r7, r11
 	adc r0, sb, r8
 	mla r2, r7, r0, r2
-	str fp, [r3]
+	str r11, [r3]
 	adds r4, sl, r4
 	str r0, [r3, #4]
-	mla r2, r6, fp, r2
+	mla r2, r6, r11, r2
 	str r4, [r3]
 	adc r7, sb, r2
 	umull r4, r8, r0, r1
@@ -22863,13 +22863,13 @@ _0208c708:
 	bl func_ov00_020c4048
 	movs r1, r0
 	addmi sp, sp, #0x48
-	ldmmiia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmmiia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, _0208c954 ; =data_027e0fe4
 	ldr r0, [r0]
 	bl _ZN12ActorManager13FindActorByIdEj
 	cmp r0, #0
 	addeq sp, sp, #0x48
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r3, [r0, #4]
 	ldr r2, _0208c934 ; =0x464c544d
 	cmp r3, r2
@@ -22883,13 +22883,13 @@ _0208c708:
 	cmp r3, r1
 	beq _0208c7d0
 	add sp, sp, #0x48
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0208c784:
 	ldr r1, _0208c93c ; =0x464c4254
 	cmp r3, r1
 	beq _0208c7d0
 	add sp, sp, #0x48
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0208c798:
 	ldr r1, _0208c940 ; =0x4c53544d
 	cmp r3, r1
@@ -22899,13 +22899,13 @@ _0208c798:
 	cmp r3, r1
 	beq _0208c7d0
 	add sp, sp, #0x48
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0208c7bc:
 	ldr r1, _0208c92c ; =0x52555059
 	cmp r3, r1
 	beq _0208c838
 	add sp, sp, #0x48
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0208c7d0:
 	ldr r2, _0208c944 ; =data_027e0764
 	ldr r1, _0208c95c ; =0x0000019a
@@ -22932,7 +22932,7 @@ _0208c7d0:
 	str r1, [r0, #0x64]
 	add sp, sp, #0x48
 	str r3, [r0, #0x68]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0208c838:
 	ldr r3, _0208c944 ; =data_027e0764
 	ldr r1, _0208c960 ; =0x00002001
@@ -22943,15 +22943,15 @@ _0208c838:
 	ldr r6, [r3, #0xc]
 	ldr sb, [r3, #0x10]
 	mla sl, r6, r4, sl
-	adds fp, sb, r5
+	adds r11, sb, r5
 	ldr r8, [r3, #0x14]
-	umull r5, r4, r7, fp
+	umull r5, r4, r7, r11
 	adc r2, r8, sl
 	mla r4, r7, r2, r4
 	adds ip, sb, r5
-	mla r4, r6, fp, r4
+	mla r4, r6, r11, r4
 	adc lr, r8, r4
-	str fp, [r3]
+	str r11, [r3]
 	str r2, [r3, #4]
 	umull r5, sl, r2, r1
 	mov r4, #0
@@ -22961,13 +22961,13 @@ _0208c838:
 	sub r5, sl, #0x1000
 	ldr r2, _0208c964 ; =0x51eb851f
 	mov sl, r5, lsr #0x1f
-	smull fp, r5, r2, r5
+	smull r11, r5, r2, r5
 	add r5, sl, r5, asr #4
-	umull fp, sl, r7, ip
+	umull r11, sl, r7, ip
 	mla sl, r7, lr, sl
 	mla sl, r6, ip, sl
 	stmia r3, {ip, lr}
-	adds sb, sb, fp
+	adds sb, sb, r11
 	str sb, [r3]
 	adc ip, r8, sl
 	str ip, [r3, #4]
@@ -22991,7 +22991,7 @@ _0208c838:
 	str r7, [r0, #0x64]
 	str r5, [r0, #0x68]
 	add sp, sp, #0x48
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_0208c4f8
 _0208c920: .word 0x4e554c4c
@@ -23394,7 +23394,7 @@ func_ov00_0208cd1c: ; 0x0208cd1c
 	.global func_ov00_0208cd48
 	arm_func_start func_ov00_0208cd48
 func_ov00_0208cd48: ; 0x0208cd48
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x224
 	sub sp, sp, #0x400
 	movs r5, r2
@@ -23405,7 +23405,7 @@ func_ov00_0208cd48: ; 0x0208cd48
 	bl func_ov00_0208ce84
 	add sp, sp, #0x224
 	add sp, sp, #0x400
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0208cd78:
 	ldr r4, _0208ce78 ; =func_ov00_0207f100
 	ldr r3, _0208ce7c ; =func_ov00_0208d018
@@ -23431,18 +23431,18 @@ _0208cd78:
 	add sp, sp, #0x224
 	add sp, sp, #0x400
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0208cddc:
 	cmp r6, #0
 	mov r7, #0
 	ble _0208ce54
-	add fp, sp, #0xc
+	add r11, sp, #0xc
 	add r8, sp, #0x24
-	add r5, fp, #0xc
+	add r5, r11, #0xc
 _0208cdf4:
 	str sb, [sp, #8]
 	ldmia r8, {r0, r1, r2}
-	stmia fp, {r0, r1, r2}
+	stmia r11, {r0, r1, r2}
 	add r0, r8, #0xc
 	ldmia r0, {r0, r1, r2}
 	stmia r5, {r0, r1, r2}
@@ -23459,7 +23459,7 @@ _0208cdf4:
 	add sp, sp, #0x224
 	add sp, sp, #0x400
 	mov r0, r4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0208ce44:
 	add r7, r7, #1
 	cmp r7, r6
@@ -23474,7 +23474,7 @@ _0208ce54:
 	mov r0, #0
 	add sp, sp, #0x224
 	add sp, sp, #0x400
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_0208cd48
 _0208ce78: .word func_ov00_0207f100
@@ -23613,7 +23613,7 @@ func_ov00_0208d018: ; 0x0208d018
 	.global func_ov00_0208d01c
 	arm_func_start func_ov00_0208d01c
 func_ov00_0208d01c: ; 0x0208d01c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x244
 	sub sp, sp, #0x400
 	movs r5, r2
@@ -23630,7 +23630,7 @@ func_ov00_0208d01c: ; 0x0208d01c
 	bl func_ov00_0208d1f8
 	add sp, sp, #0x244
 	add sp, sp, #0x400
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0208d064:
 	ldr r4, _0208d1ec ; =func_ov00_0207f100
 	ldr r3, _0208d1f0 ; =func_ov00_0208d018
@@ -23656,7 +23656,7 @@ _0208d064:
 	add sp, sp, #0x244
 	add sp, sp, #0x400
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0208d0c8:
 	cmp r4, #1
 	bne _0208d138
@@ -23685,7 +23685,7 @@ _0208d0c8:
 	add sp, sp, #0x244
 	add sp, sp, #0x400
 	mov r0, r4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0208d138:
 	mov r5, #0
 	mov r6, r5
@@ -23693,7 +23693,7 @@ _0208d138:
 	ble _0208d1c8
 	add r0, sp, #0x10
 	add r7, sp, #0x44
-	add fp, r0, #0xc
+	add r11, r0, #0xc
 _0208d154:
 	str sl, [sp, #0xc]
 	add r3, sp, #0x10
@@ -23701,7 +23701,7 @@ _0208d154:
 	stmia r3, {r0, r1, r2}
 	add r0, r7, #0xc
 	ldmia r0, {r0, r1, r2}
-	stmia fp, {r0, r1, r2}
+	stmia r11, {r0, r1, r2}
 	ldr r0, [sp, #4]
 	add r1, sp, #0xc
 	mov r2, sb
@@ -23719,7 +23719,7 @@ _0208d154:
 	add sp, sp, #0x244
 	add sp, sp, #0x400
 	mov r0, r5
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0208d1b8:
 	add r6, r6, #1
 	cmp r6, r4
@@ -23734,7 +23734,7 @@ _0208d1c8:
 	mov r0, r5
 	add sp, sp, #0x244
 	add sp, sp, #0x400
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_0208d01c
 _0208d1ec: .word func_ov00_0207f100
@@ -23745,7 +23745,7 @@ _0208d1f4: .word data_027e0e60
 	arm_func_start func_ov00_0208d1f8
 func_ov00_0208d1f8: ; 0x0208d1f8
 	stmdb sp!, {r0, r1, r2, r3}
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x1c
 	mov sl, r0
 	ldr r1, [sl, #0xc]
@@ -23755,12 +23755,12 @@ func_ov00_0208d1f8: ; 0x0208d1f8
 	str r3, [sp, #4]
 	str r1, [sp, #0x18]
 	cmp r1, r0
-	ldr fp, [sp, #0x50]
+	ldr r11, [sp, #0x50]
 	mov sb, #0
 	beq _0208d2fc
 _0208d230:
 	ldr r0, [sp, #4]
-	add r1, sb, fp
+	add r1, sb, r11
 	cmp r1, r0
 	bhs _0208d2fc
 	ldr r1, [sl, #0xc]
@@ -23802,7 +23802,7 @@ _0208d2a4:
 	cmp r1, #0
 	beq _0208d2dc
 	ldr r0, [sp]
-	add r0, r0, fp, lsl #2
+	add r0, r0, r11, lsl #2
 	str r1, [r0, sb, lsl #2]
 	add sb, sb, #1
 _0208d2dc:
@@ -23817,7 +23817,7 @@ _0208d2dc:
 _0208d2fc:
 	mov r0, sb
 	add sp, sp, #0x1c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	add sp, sp, #0x10
 	bx lr
 	arm_func_end func_ov00_0208d1f8
@@ -23825,7 +23825,7 @@ _0208d2fc:
 	.global func_ov00_0208d310
 	arm_func_start func_ov00_0208d310
 func_ov00_0208d310: ; 0x0208d310
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x2c
 	mov sl, r0
 	ldr r4, [sl, #0xc]
@@ -23842,7 +23842,7 @@ func_ov00_0208d310: ; 0x0208d310
 	add r6, sb, #4
 	add r5, sb, #0x10
 	add r4, r0, #0xc
-	add fp, r2, r8, lsl #2
+	add r11, r2, r8, lsl #2
 _0208d358:
 	ldr r0, [sp]
 	add r1, r7, r8
@@ -23872,7 +23872,7 @@ _0208d358:
 	beq _0208d3f0
 	ldr r0, [r2]
 	cmp r0, #0
-	strne r0, [fp, r7, lsl #2]
+	strne r0, [r11, r7, lsl #2]
 	ldr r0, [sp, #8]
 	ldr r1, [sl, #0xc]
 	add r2, r0, #4
@@ -23885,7 +23885,7 @@ _0208d358:
 _0208d3f0:
 	mov r0, r7
 	add sp, sp, #0x2c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	arm_func_end func_ov00_0208d310
 
 	.global func_ov00_0208d3fc
@@ -23937,12 +23937,12 @@ _0208d488:
 	.global func_ov00_0208d494
 	arm_func_start func_ov00_0208d494
 func_ov00_0208d494: ; 0x0208d494
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x14
 	mov sl, r0
 	ldr r1, [sl, #0xc]
 	ldr r0, [sl, #0x10]
-	mov fp, r2
+	mov r11, r2
 	add r0, r1, r0, lsl #2
 	str r3, [sp]
 	str r1, [sp, #0x10]
@@ -24018,7 +24018,7 @@ _0208d584:
 	ldr r1, [r0]
 	add r2, r2, #4
 	cmp r1, #0
-	addne r0, fp, sb, lsl #2
+	addne r0, r11, sb, lsl #2
 	strne r1, [r0, r8, lsl #2]
 	ldr r1, [sl, #0xc]
 	ldr r0, [sl, #0x10]
@@ -24030,7 +24030,7 @@ _0208d584:
 _0208d5d4:
 	mov r0, r8
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	arm_func_end func_ov00_0208d494
 
 	.global func_ov00_0208d5e0
@@ -24802,13 +24802,13 @@ func_ov00_0208df74: ; 0x0208df74
 	.global func_ov00_0208df78
 	arm_func_start func_ov00_0208df78
 func_ov00_0208df78: ; 0x0208df78
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x14
 	mov r6, r0
 	mov r0, r1, lsl #0xc
 	mov r5, r2
 	mov r1, #0xff000
-	mov fp, r3
+	mov r11, r3
 	ldr r4, [sp, #0x38]
 	bl Divide
 	mov r1, #0xbf000
@@ -24910,20 +24910,20 @@ _0208e0f8:
 	mla r1, sl, r6, r1
 	adc r2, r1, #0
 	umull r0, r1, r5, r7
-	str r2, [fp]
+	str r2, [r11]
 	adds r0, r0, #0x80000000
 	mov r0, r7, asr #0x1f
 	mla r1, r5, r0, r1
 	mla r1, sl, r7, r1
 	adc r0, r1, #0
-	str r0, [fp, #4]
+	str r0, [r11, #4]
 	umull r0, r1, r5, r8
 	adds r0, r0, #0x80000000
 	mov r0, r8, asr #0x1f
 	mla r1, r5, r0, r1
 	mla r1, sl, r8, r1
 	adc r0, r1, #0
-	str r0, [fp, #8]
+	str r0, [r11, #8]
 	cmp r4, #0
 	beq _0208e1bc
 	bl func_01ff99f4
@@ -24955,28 +24955,28 @@ _0208e0f8:
 _0208e1bc:
 	ldr r0, [sp, #0x10]
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	arm_func_end func_ov00_0208df78
 
 	.global func_ov00_0208e1c8
 	arm_func_start func_ov00_0208e1c8
 func_ov00_0208e1c8: ; 0x0208e1c8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x48
 	str r1, [sp]
 	add r1, sp, #8
 	bl func_02007a18
 	ldr r0, [sp]
 	bl func_01ff91f8
-	mov fp, #0
+	mov r11, #0
 _0208e1e8:
-	mov r3, fp
-	mov r1, fp
-	cmp fp, #4
+	mov r3, r11
+	mov r1, r11
+	cmp r11, #4
 	mov r2, #0
 	bge _0208e228
 	add r0, sp, #8
-	add r0, r0, fp, lsl #2
+	add r0, r0, r11, lsl #2
 _0208e204:
 	ldr r4, [r0, r1, lsl #4]
 	cmp r4, #0
@@ -24991,14 +24991,14 @@ _0208e228:
 	cmp r2, #0
 	addeq sp, sp, #0x48
 	mvneq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
-	cmp r3, fp
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	cmp r3, r11
 	beq _0208e288
 	ldr r1, [sp]
 	add r2, sp, #8
 	mov r0, #0
-	add r4, r1, fp, lsl #4
-	add r6, r2, fp, lsl #4
+	add r4, r1, r11, lsl #4
+	add r6, r2, r11, lsl #4
 	add r5, r2, r3, lsl #4
 	add r2, r1, r3, lsl #4
 _0208e25c:
@@ -25015,15 +25015,15 @@ _0208e25c:
 	blt _0208e25c
 _0208e288:
 	add r0, sp, #8
-	add r0, r0, fp, lsl #4
-	ldr r0, [r0, fp, lsl #2]
+	add r0, r0, r11, lsl #4
+	ldr r0, [r0, r11, lsl #2]
 	bl func_01ff992c
 	ldr r2, [sp]
 	mov r3, #0
 	mov lr, #0x80000000
 	add r4, sp, #8
-	add sb, r2, fp, lsl #4
-	add r2, r4, fp, lsl #4
+	add sb, r2, r11, lsl #4
+	add r2, r4, r11, lsl #4
 	mov r4, r3
 	mov r6, r3
 	mov r5, lr
@@ -25049,14 +25049,14 @@ _0208e2bc:
 	blt _0208e2bc
 	ldr r0, [sp]
 	add r1, sp, #8
-	add r6, r0, fp, lsl #4
+	add r6, r0, r11, lsl #4
 	add r0, sp, #8
-	add r1, r1, fp, lsl #2
+	add r1, r1, r11, lsl #2
 	mov ip, #0
-	add r0, r0, fp, lsl #4
+	add r0, r0, r11, lsl #4
 	str r1, [sp, #4]
 _0208e328:
-	cmp ip, fp
+	cmp ip, r11
 	beq _0208e3ac
 	ldr r1, [sp, #4]
 	ldr r4, [sp]
@@ -25094,12 +25094,12 @@ _0208e3ac:
 	add ip, ip, #1
 	cmp ip, #4
 	blt _0208e328
-	add fp, fp, #1
-	cmp fp, #4
+	add r11, r11, #1
+	cmp r11, #4
 	blt _0208e1e8
 	mov r0, #0
 	add sp, sp, #0x48
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	arm_func_end func_ov00_0208e1c8
 
 	.global func_ov00_0208e3d0
@@ -26569,7 +26569,7 @@ func_ov00_0208f768: ; 0x0208f768
 	.global func_ov00_0208f794
 	arm_func_start func_ov00_0208f794
 func_ov00_0208f794: ; 0x0208f794
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x28
 	mov sl, r0
 	add r1, sp, #4
@@ -26581,7 +26581,7 @@ func_ov00_0208f794: ; 0x0208f794
 	mov r2, #4
 	bl func_020078f4
 	ldr r6, _0208f9dc ; =data_ov00_020db010
-	ldr fp, _0208f9e0 ; =data_ov00_020db030
+	ldr r11, _0208f9e0 ; =data_ov00_020db030
 	ldr r4, _0208f9e4 ; =data_027e0e60
 	mov sb, #0
 	add r5, sp, #4
@@ -26589,7 +26589,7 @@ _0208f7d4:
 	ldrb r2, [sl, #0x14]
 	ldr r3, [r6, sb, lsl #2]
 	ldrb r0, [sl, #0x15]
-	ldr r1, [fp, sb, lsl #2]
+	ldr r1, [r11, sb, lsl #2]
 	adds r7, r3, r2
 	add r8, r1, r0
 	bmi _0208f868
@@ -26725,7 +26725,7 @@ _0208f9ac:
 	ldr r2, [r2, #0xc]
 	blx r2
 	add sp, sp, #0x28
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_0208f794
 _0208f9dc: .word data_ov00_020db010
@@ -27152,13 +27152,13 @@ _0208fef4: .word data_027e0e60
 	.global func_ov00_0208fef8
 	arm_func_start func_ov00_0208fef8
 func_ov00_0208fef8: ; 0x0208fef8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x80
 	str r0, [sp, #4]
 	ldr r0, [r0, #0x130]
 	cmp r0, #1
 	addeq sp, sp, #0x80
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, [sp, #4]
 	ldrh r0, [r0, #0x26]
 	cmp r0, #1
@@ -27166,13 +27166,13 @@ func_ov00_0208fef8: ; 0x0208fef8
 	cmp r0, #2
 	beq _0208ff48
 	add sp, sp, #0x80
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0208ff34:
 	ldr r0, _0209030c ; =data_ov00_020eec9c
 	mov r1, #0xb
 	bl func_ov00_020d77e4
 	add sp, sp, #0x80
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0208ff48:
 	ldr r0, _0209030c ; =data_ov00_020eec9c
 	mov r1, #0xb
@@ -27265,10 +27265,10 @@ _02090004:
 	str r3, [sp, #0x64]
 	ldr r3, [sp, #0x10]
 	add r0, sp, #0x5c
-	umull fp, sl, r3, sb
+	umull r11, sl, r3, sb
 	mov ip, r3
 	ldr r3, [sp, #0xc]
-	adds r8, r8, fp
+	adds r8, r8, r11
 	mla sl, ip, r3, sl
 	mla sl, lr, sb, sl
 	adc r3, r7, sl
@@ -27430,7 +27430,7 @@ _020902f8:
 	cmp r6, #5
 	blo _0208ffb4
 	add sp, sp, #0x80
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_0208fef8
 _0209030c: .word data_ov00_020eec9c
@@ -32171,7 +32171,7 @@ func_ov00_02093dd0: ; 0x02093dd0
 	.global func_ov00_02093e00
 	arm_func_start func_ov00_02093e00
 func_ov00_02093e00: ; 0x02093e00
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x70
 	mov sl, r0
 	ldr r1, [sl, #4]
@@ -32295,7 +32295,7 @@ _02093f80:
 	ldr r4, _020940cc ; =data_027e0e60
 	add r6, sp, #6
 	mov r5, #1
-	add fp, sp, #4
+	add r11, sp, #4
 _02093fec:
 	ldrb sb, [sl, #0x15]
 	add r0, sb, #2
@@ -32310,7 +32310,7 @@ _02094000:
 	strb sb, [sp, #7]
 	bl func_ov00_02082680
 	ldr r0, [r4]
-	mov r1, fp
+	mov r1, r11
 	mov r2, #1
 	strb r7, [sp, #4]
 	strb sb, [sp, #5]
@@ -32348,7 +32348,7 @@ _0209408c:
 	mov r2, r1
 	blx r3
 	add sp, sp, #0x70
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _020940ac:
 	mov r0, sl
 	ldr r3, [r0]
@@ -32357,7 +32357,7 @@ _020940ac:
 	mov r2, #1
 	blx r3
 	add sp, sp, #0x70
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_02093e00
 _020940cc: .word data_027e0e60
@@ -33663,7 +33663,7 @@ func_ov00_02094e58: ; 0x02094e58
 	.global func_ov00_02094e6c
 	arm_func_start func_ov00_02094e6c
 func_ov00_02094e6c: ; 0x02094e6c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #8
 	mov sl, r0
 	mov r0, #1
@@ -33715,14 +33715,14 @@ _02094f24:
 	cmp r8, #0
 	mov r5, #0
 	addle sp, sp, #8
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	mov r7, r5
-	mov fp, sb, lsl #0x1
+	mov r11, sb, lsl #0x1
 _02094f40:
 	ldr r0, _02094f88 ; =data_027e0ce0
 	ldr r4, [sl, #8]
 	ldr r1, [r0, #4]
-	mov r0, fp
+	mov r0, r11
 	mov r2, #4
 	add r6, r4, r7
 	bl func_0202e9f4
@@ -33735,7 +33735,7 @@ _02094f40:
 	add r7, r7, #0xc
 	blt _02094f40
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_02094e6c
 _02094f84: .word data_027e0e60
@@ -34588,7 +34588,7 @@ func_ov00_02095980: ; 0x02095980
 	.global func_ov00_02095998
 	arm_func_start func_ov00_02095998
 func_ov00_02095998: ; 0x02095998
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0xac
 	str r0, [sp, #4]
 	mov sb, r1
@@ -34615,7 +34615,7 @@ func_ov00_02095998: ; 0x02095998
 	add r4, r6, #0x1000
 	add r5, r7, #0x1000
 	str r0, [sp, #8]
-	add fp, sp, #0x94
+	add r11, sp, #0x94
 _02095a08:
 	ldr r0, [sp, #8]
 	cmp r8, #3
@@ -34640,11 +34640,11 @@ _02095a2c:
 	ldr r1, [sp, #0xa8]
 	str r0, [sp, #0x98]
 	str r0, [sp, #0x8c]
-	mov r0, fp
+	mov r0, r11
 	str r1, [sp, #0x9c]
 	str r1, [sp, #0x90]
 	add r1, sp, #0x64
-	mov r2, fp
+	mov r2, r11
 	str r5, [sp, #0x6c]
 	bl func_01ff9bf8
 	mov r0, #0x1000
@@ -34678,11 +34678,11 @@ _02095ac0:
 	ldr r1, [sp, #0xa8]
 	str r0, [sp, #0x98]
 	str r0, [sp, #0x8c]
-	mov r0, fp
+	mov r0, r11
 	str r1, [sp, #0x9c]
 	str r1, [sp, #0x90]
 	add r1, sp, #0x4c
-	mov r2, fp
+	mov r2, r11
 	str r5, [sp, #0x54]
 	bl func_01ff9bf8
 	mov r0, #0
@@ -34716,11 +34716,11 @@ _02095b54:
 	str r0, [sp, #0x98]
 	add r1, r1, r7
 	str r0, [sp, #0x8c]
-	mov r0, fp
+	mov r0, r11
 	str r1, [sp, #0x9c]
 	str r1, [sp, #0x90]
 	add r1, sp, #0x34
-	mov r2, fp
+	mov r2, r11
 	str r4, [sp, #0x34]
 	bl func_01ff9bf8
 	mov r0, #0x5000
@@ -34754,11 +34754,11 @@ _02095be8:
 	str r0, [sp, #0x98]
 	sub r1, r1, r7
 	str r0, [sp, #0x8c]
-	mov r0, fp
+	mov r0, r11
 	str r1, [sp, #0x9c]
 	str r1, [sp, #0x90]
 	add r1, sp, #0x1c
-	mov r2, fp
+	mov r2, r11
 	str r4, [sp, #0x1c]
 	bl func_01ff9bf8
 	mov r0, #0x5000
@@ -34813,7 +34813,7 @@ _02095c74:
 	strneb r1, [r0, #0x2c]
 	mov r0, #1
 	add sp, sp, #0xac
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_02095998
 _02095d04: .word data_027e0f6c
@@ -35076,7 +35076,7 @@ _02095fdc: .word data_027e0f70
 	.global func_ov00_02095fe0
 	arm_func_start func_ov00_02095fe0
 func_ov00_02095fe0: ; 0x02095fe0
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x34
 	ldr r2, _0209614c ; =data_027e0d3c
 	mov sl, r0
@@ -35085,7 +35085,7 @@ func_ov00_02095fe0: ; 0x02095fe0
 	bl func_ov00_02078f54
 	cmp r0, #0
 	addeq sp, sp, #0x34
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, _0209614c ; =data_027e0d3c
 	ldr r1, _02096150 ; =data_027e0e60
 	ldr r2, [r0]
@@ -35096,18 +35096,18 @@ func_ov00_02095fe0: ; 0x02095fe0
 	bl func_ov00_020835e4
 	cmp r0, #0
 	addeq sp, sp, #0x34
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r8, [sl]
 	ldr r1, [sl, #4]
 	mov r0, #0x30
 	mla r0, r1, r0, r8
 	cmp r8, r0
 	addeq sp, sp, #0x34
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r4, _02096150 ; =data_027e0e60
 	add r6, sp, #0x1c
 	add r5, sp, #0x28
-	add fp, sp, #0x10
+	add r11, sp, #0x10
 _02096060:
 	ldr r1, [r8]
 	ldr r0, [sp, #0xc]
@@ -35150,10 +35150,10 @@ _020960b0:
 	mov r2, r5
 	bl func_01ff9bf8
 	ldr r0, [r4]
-	mov r1, fp
+	mov r1, r11
 	bl func_ov00_0208340c
 	mov r0, r5
-	mov r1, fp
+	mov r1, r11
 	mov r2, r5
 	bl func_01ff9bc4
 	mov r2, r7
@@ -35170,7 +35170,7 @@ _02096128:
 	cmp r8, r0
 	bne _02096060
 	add sp, sp, #0x34
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_02095fe0
 _0209614c: .word data_027e0d3c
@@ -35241,7 +35241,7 @@ func_ov00_020961f8: ; 0x020961f8
 	.global func_ov00_0209621c
 	arm_func_start func_ov00_0209621c
 func_ov00_0209621c: ; 0x0209621c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x30
 	ldr r6, _02096320 ; =data_ov00_020eab04
 	mov r7, r0
@@ -35249,10 +35249,10 @@ func_ov00_0209621c: ; 0x0209621c
 	mov r5, #0
 	cmp r4, #0
 	addle sp, sp, #0x30
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add sb, sp, #0x10
 	mov r8, r5
-	add fp, sp, #0
+	add r11, sp, #0
 _0209624c:
 	ldrb sl, [r6, #0x34]
 	ldrb lr, [r6, #0x35]
@@ -35295,7 +35295,7 @@ _0209624c:
 	strb r0, [sp, #0x28]
 	mov r0, r7
 	strb r1, [sp, #0x29]
-	mov r1, fp
+	mov r1, r11
 	strb sl, [sp, #0x2a]
 	strb r3, [sp, #0x2b]
 	str r2, [sp, #0x2c]
@@ -35306,7 +35306,7 @@ _0209624c:
 	add r6, r6, #0x30
 	blt _0209624c
 	add sp, sp, #0x30
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_0209621c
 _02096320: .word data_ov00_020eab04
@@ -35314,7 +35314,7 @@ _02096320: .word data_ov00_020eab04
 	.global func_ov00_02096324
 	arm_func_start func_ov00_02096324
 func_ov00_02096324: ; 0x02096324
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	mov r7, r0
 	ldr r5, [r7]
 	ldr r2, [r7, #4]
@@ -35326,7 +35326,7 @@ func_ov00_02096324: ; 0x02096324
 	beq _0209640c
 	ldr r8, _02096414 ; =data_027e0f7c
 	mov sb, r4
-	mov fp, #0x30
+	mov r11, #0x30
 _02096358:
 	ldrb r0, [r5, #5]
 	cmp r0, #0
@@ -35338,7 +35338,7 @@ _02096358:
 	beq _020963f0
 	cmp r4, #8
 	bhs _0209640c
-	mla ip, r4, fp, r6
+	mla ip, r4, r11, r6
 	ldr r1, [r5]
 	add r0, r4, #1
 	str r1, [ip, #0x30]
@@ -35376,7 +35376,7 @@ _020963f0:
 	bne _02096358
 _0209640c:
 	strb r4, [r6, #6]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_02096324
 _02096414: .word data_027e0f7c
@@ -39997,7 +39997,7 @@ _02099eb4:
 	.global func_ov00_02099ecc
 	arm_func_start func_ov00_02099ecc
 func_ov00_02099ecc: ; 0x02099ecc
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	mov r7, r0
 	ldr sb, [r7]
 	ldr r8, [r7, #4]
@@ -40013,13 +40013,13 @@ func_ov00_02099ecc: ; 0x02099ecc
 	ldr r2, _0209a220 ; =0xb60b60b7
 	mla r4, r1, r3, r4
 	ldr r8, [r6, #4]
-	smull r1, fp, r2, r0
+	smull r1, r11, r2, r0
 	mla r4, r8, r3, r4
-	add fp, r0, fp
+	add r11, r0, r11
 	mov r0, r0, lsr #0x1f
 	mov lr, r5
 	cmp r5, ip
-	add fp, r0, fp, asr #7
+	add r11, r0, r11, asr #7
 	bhs _0209a06c
 _02099f2c:
 	cmp r4, #0
@@ -40216,8 +40216,8 @@ _0209a1d8:
 	str r1, [r7, #4]
 	str r2, [r6, #4]
 	ldr r1, [r7]
-	mla r0, fp, r0, r1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	mla r0, r11, r0, r1
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_02099ecc
 _0209a220: .word 0xb60b60b7
@@ -41376,13 +41376,13 @@ _0209afc0: .word func_0203010c
 	.global func_ov00_0209afc4
 	arm_func_start func_ov00_0209afc4
 func_ov00_0209afc4: ; 0x0209afc4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	movs r8, r2
 	mov sb, r0
 	mov sl, r1
-	mov fp, r3
+	mov r11, r3
 	mov r7, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0209afe0:
 	ldr r0, [sl, r7, lsl #2]
 	and r4, r0, #0xff
@@ -41690,7 +41690,7 @@ _0209b37c:
 _0209b388:
 	ldr r0, _0209b5a0 ; =data_ov00_020db058
 	ldr r0, [r0, r5, lsl #4]
-	cmp fp, r0
+	cmp r11, r0
 	bne _0209b588
 	mov r0, sb
 	mov r1, r5
@@ -41841,7 +41841,7 @@ _0209b588:
 	add r7, r7, #1
 	cmp r7, r8
 	blo _0209afe0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_0209afc4
 _0209b598: .word data_027e0f74
@@ -41851,7 +41851,7 @@ _0209b5a0: .word data_ov00_020db058
 	.global func_ov00_0209b5a4
 	arm_func_start func_ov00_0209b5a4
 func_ov00_0209b5a4: ; 0x0209b5a4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x28
 	mov sl, r0
 	ldr r2, [sl]
@@ -41863,7 +41863,7 @@ func_ov00_0209b5a4: ; 0x0209b5a4
 	beq _0209b648
 	ldr r6, _0209b6ec ; =data_ov00_020db058
 	mov r5, #4
-	mov fp, #0x10
+	mov r11, #0x10
 	mov r4, #0
 _0209b5dc:
 	ldr r7, [r8]
@@ -41880,7 +41880,7 @@ _0209b5dc:
 	ldr r3, _0209b6f0 ; =func_0203010c
 	mov r1, r5
 	add r0, r7, #0x20
-	mov r2, fp
+	mov r2, r11
 	bl func_0204f754
 	add r0, r7, #0xc
 	blx func_0203005c
@@ -41940,7 +41940,7 @@ _0209b6ac:
 	str r1, [sp, #0x14]
 	bl func_ov00_02080f94
 	add sp, sp, #0x28
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_0209b5a4
 _0209b6ec: .word data_ov00_020db058
@@ -46383,7 +46383,7 @@ func_ov00_0209ed30: ; 0x0209ed30
 	.global func_ov00_0209ee88
 	arm_func_start func_ov00_0209ee88
 func_ov00_0209ee88: ; 0x0209ee88
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x4c
 	ldr r7, [r2, #8]
 	ldr r8, [r2, #0xc]
@@ -46406,9 +46406,9 @@ func_ov00_0209ee88: ; 0x0209ee88
 	str r0, [sp, #0x14]
 	bl Divide
 	mov r4, r0
-	sub fp, r8, r6
+	sub r11, r8, r6
 	ldr r0, [sp, #0x1c]
-	mov r1, fp
+	mov r1, r11
 	bl Divide
 	str r0, [sp, #0x28]
 	mov r0, r5, asr #0x1f
@@ -46436,9 +46436,9 @@ func_ov00_0209ee88: ; 0x0209ee88
 	adc r0, r2, #0
 	mov r4, r3, lsr #0xc
 	orr r4, r4, r0, lsl #20
-	mov r1, fp
+	mov r1, r11
 	sub r0, sl, r6
-	mov fp, r4, asr #0x1f
+	mov r11, r4, asr #0x1f
 	str r0, [sp, #4]
 	bl Divide
 	str r0, [sp, #0x34]
@@ -46485,7 +46485,7 @@ func_ov00_0209ee88: ; 0x0209ee88
 	orr r2, r2, r3, lsl #20
 	ldr r3, [sp, #0x30]
 	umull r8, r5, r3, r4
-	mla r5, r3, fp, r5
+	mla r5, r3, r11, r5
 	mla r5, lr, r4, r5
 	adds r8, r8, #0x800
 	adc r3, r5, #0
@@ -46503,7 +46503,7 @@ func_ov00_0209ee88: ; 0x0209ee88
 	ldr r2, [sp, #0x38]
 	str r0, [sp, #0x44]
 	umull sl, sb, r2, r4
-	mla sb, r2, fp, sb
+	mla sb, r2, r11, sb
 	mov r3, r2, asr #0x1f
 	mla sb, r3, r4, sb
 	adds r3, sl, #0x800
@@ -46547,8 +46547,8 @@ func_ov00_0209ee88: ; 0x0209ee88
 	smull r2, r1, r0, r4
 	adds r2, r2, #0x800
 	adc r0, r1, #0
-	mov fp, r2, lsr #0xc
-	orr fp, fp, r0, lsl #20
+	mov r11, r2, lsr #0xc
+	orr r11, r11, r0, lsl #20
 	ldr r0, [sp, #0x3c]
 	mov r4, r5, asr #0x1f
 	mov r8, r0, asr #0x1f
@@ -46589,10 +46589,10 @@ func_ov00_0209ee88: ; 0x0209ee88
 	mov r2, r3, lsr #0xc
 	orr r2, r2, r1, lsl #20
 	add r0, r0, r2
-	add r0, fp, r0
+	add r0, r11, r0
 	add r0, ip, r0
 	add sp, sp, #0x4c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	arm_func_end func_ov00_0209ee88
 
 	.global func_ov00_0209f1d0
@@ -49582,7 +49582,7 @@ func_ov00_020a15dc: ; 0x020a15dc
 	.global func_ov00_020a15f0
 	arm_func_start func_ov00_020a15f0
 func_ov00_020a15f0: ; 0x020a15f0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #8
 	str r0, [sp]
 	ldr r1, [sp]
@@ -49600,7 +49600,7 @@ _020a1620:
 	add r1, r0, #8
 	ldr r0, [sp, #4]
 	ldr r6, _020a1704 ; =data_ov00_020e4ed8
-	ldr fp, _020a1708 ; =data_ov00_020e4eb8
+	ldr r11, _020a1708 ; =data_ov00_020e4eb8
 	ldr r4, _020a170c ; =data_027e0ce0
 	mov sl, sb
 	add r7, r1, r0
@@ -49622,7 +49622,7 @@ _020a165c:
 	strh r5, [r0, #0x14]
 	strh r5, [r0, #0x16]
 	str r5, [r0, #0x18]
-	str fp, [r0]
+	str r11, [r0]
 	mov r1, #1
 	str r1, [r0, #0x1c]
 _020a1690:
@@ -49657,7 +49657,7 @@ _020a16d0:
 	blo _020a1620
 	ldr r0, [sp]
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020a15f0
 _020a1704: .word data_ov00_020e4ed8
@@ -54123,7 +54123,7 @@ _020a4fc4: .word func_ov00_020a4fc8
 	.global func_ov00_020a4fc8
 	arm_func_start func_ov00_020a4fc8
 func_ov00_020a4fc8: ; 0x020a4fc8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x40
 	mov sl, r0
 	ldr r1, [sl]
@@ -54137,7 +54137,7 @@ func_ov00_020a4fc8: ; 0x020a4fc8
 	ldr r2, _020a5160 ; =data_02052f54
 	ldr r5, _020a5164 ; =data_ov00_020dc354
 	ldrsh r1, [r2, #2]
-	ldrsh fp, [r2]
+	ldrsh r11, [r2]
 	str r1, [sp]
 _020a5008:
 	add r1, sl, r6, lsl #2
@@ -54208,7 +54208,7 @@ _020a50a8:
 _020a5104:
 	ldr r2, [sp]
 	add r0, sp, #4
-	mov r1, fp
+	mov r1, r11
 	blx func_01ff8230
 _020a5114:
 	mov r0, r7
@@ -54230,7 +54230,7 @@ _020a5130:
 _020a5150:
 	bl func_01ffa8d4
 	add sp, sp, #0x40
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020a4fc8
 _020a515c: .word data_ov00_020dc294
@@ -54507,14 +54507,14 @@ _020a5504: .word data_ov00_020dc294
 	.global func_ov00_020a5508
 	arm_func_start func_ov00_020a5508
 func_ov00_020a5508: ; 0x020a5508
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0xb0
 	mov r4, r1
 	mov sl, r0
 	bl func_ov00_020a58ac
 	cmp r4, #4
 	addeq sp, sp, #0xb0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r2, [sl]
 	ldr r1, _020a57f4 ; =data_ov00_020dc294
 	mov r0, #0xc
@@ -54526,7 +54526,7 @@ func_ov00_020a5508: ; 0x020a5508
 	mov sb, #0
 	cmp r0, #0
 	addls sp, sp, #0xb0
-	ldmlsia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmlsia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r4, _020a57f8 ; =data_027e0ce0
 	mvn r5, #0
 _020a5560:
@@ -54612,7 +54612,7 @@ _020a5664:
 	mov r1, #2
 	add r2, r2, r8, lsl #4
 	bl func_ov00_020a5d5c
-	mov fp, r0
+	mov r11, r0
 	ldr r1, [r4, #4]
 	mov r0, #0x24
 	mov r2, #4
@@ -54624,7 +54624,7 @@ _020a5664:
 	mov r1, #0
 	bl func_ov00_020a5d10
 	mov r2, r0
-	mov r1, fp
+	mov r1, r11
 	mov r0, r6
 	mov r3, #4
 	bl func_ov00_020a581c
@@ -54701,7 +54701,7 @@ _020a57dc:
 	cmp sb, r0
 	blo _020a5560
 	add sp, sp, #0xb0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020a5508
 _020a57f4: .word data_ov00_020dc294
@@ -55156,21 +55156,21 @@ _020a5d70: .word func_ov00_020c0bdc
 	.global func_ov00_020a5d74
 	arm_func_start func_ov00_020a5d74
 func_ov00_020a5d74: ; 0x020a5d74
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	mov sl, r0
 	mov sb, r1
 	bl func_ov00_020a5d50
 	movs r4, r0
 	mov r7, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
-	mov fp, r7
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	mov r11, r7
 _020a5d94:
 	mov r0, sl
 	mov r1, r7
 	bl func_ov00_020a5d10
 	movs r8, r0
 	beq _020a5df8
-	mov r1, fp
+	mov r1, r11
 	bl func_02019654
 	cmp r0, #2
 	beq _020a5df8
@@ -55196,27 +55196,27 @@ _020a5df8:
 	add r7, r7, #1
 	cmp r7, r4
 	blo _020a5d94
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	arm_func_end func_ov00_020a5d74
 
 	.global func_ov00_020a5e08
 	arm_func_start func_ov00_020a5e08
 func_ov00_020a5e08: ; 0x020a5e08
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	mov sl, r0
 	mov sb, r1
 	bl func_ov00_020a5d50
 	movs r4, r0
 	mov r7, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
-	mov fp, r7
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	mov r11, r7
 _020a5e28:
 	mov r0, sl
 	mov r1, r7
 	bl func_ov00_020a5d10
 	movs r8, r0
 	beq _020a5e8c
-	mov r1, fp
+	mov r1, r11
 	bl func_02019654
 	cmp r0, #2
 	beq _020a5e8c
@@ -55242,7 +55242,7 @@ _020a5e8c:
 	add r7, r7, #1
 	cmp r7, r4
 	blo _020a5e28
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	arm_func_end func_ov00_020a5e08
 
 	.global func_ov00_020a5e9c
@@ -56188,7 +56188,7 @@ func_ov00_020a6908: ; 0x020a6908
 	.global func_ov00_020a6924
 	arm_func_start func_ov00_020a6924
 func_ov00_020a6924: ; 0x020a6924
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0xf0
 	ldr r2, _020a6de4 ; =data_027e0f94
 	mov sl, r0
@@ -56206,7 +56206,7 @@ func_ov00_020a6924: ; 0x020a6924
 	cmp r0, #0x54
 	beq _020a6b9c
 	add sp, sp, #0xf0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _020a6970:
 	ldr r0, _020a6de8 ; =data_027e10a4
 	add r1, sp, #0x70
@@ -56330,7 +56330,7 @@ _020a6ae0:
 	mov r0, sl
 	bl func_ov00_02090b38
 	add sp, sp, #0xf0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _020a6b48:
 	ldr r2, [sl, #4]
 	mov r0, sl
@@ -56352,7 +56352,7 @@ _020a6b48:
 	mov r0, sl
 	bl func_ov00_02090b38
 	add sp, sp, #0xf0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _020a6b9c:
 	add r0, sl, #0x18
 	add r3, sp, #0x40
@@ -56414,9 +56414,9 @@ _020a6c2c:
 	streq r6, [sl, #0x38]
 	streq r7, [sl, #0x3c]
 _020a6c84:
-	ldr fp, [sp, #0xac]
+	ldr r11, [sp, #0xac]
 	mov r0, sl
-	mov r1, fp
+	mov r1, r11
 	bl func_ov00_02090c1c
 	ldr r6, [sp, #0xa8]
 	ldr r1, [sl, #0x3c]
@@ -56431,7 +56431,7 @@ _020a6c84:
 	cmp sb, #0
 	bne _020a6cf0
 	mov r0, sl
-	mov r1, fp
+	mov r1, r11
 	bl func_ov00_02090afc
 	ldr r1, [sl, #0x3c]
 	mov r0, sl
@@ -56484,12 +56484,12 @@ _020a6d70:
 	str r0, [sl, #0x1c]
 	ldr r0, [sl, #0x2c]
 	str r0, [sl, #0x20]
-	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r0, sp, #0x28
 	bl func_01fffb4c
 	cmp r0, #0
 	addeq sp, sp, #0xf0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r0, sp, #0x28
 	mov r1, r8
 	bl func_01fffbec
@@ -56504,7 +56504,7 @@ _020a6d70:
 	ldr r0, [sp, #0x3c]
 	str r0, [sl, #0x20]
 	add sp, sp, #0xf0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020a6924
 _020a6de4: .word data_027e0f94
@@ -61629,7 +61629,7 @@ _020df78c: .word data_ov00_020e2fa8
 	.global func_ov00_020df790
 	arm_func_start func_ov00_020df790
 func_ov00_020df790: ; 0x020df790
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x238
 	sub sp, sp, #0x400
 	add r3, sp, #0x600
@@ -61878,12 +61878,12 @@ func_ov00_020df790: ; 0x020df790
 	str r1, [sp, #0x53c]
 	str r1, [r7, #0x1a8]
 	mov r1, #3
-	mov fp, r1
+	mov r11, r1
 	ldrsh r6, [r2, #0x38]
 	ldr r1, _020e075c ; =data_ov00_020e31ec
 	strh r6, [r1, #0xac]
 	strb ip, [r7, #0x1ae]
-	strb fp, [r7, #0x1af]
+	strb r11, [r7, #0x1af]
 	strb r3, [r7, #0x1b0]
 	strb ip, [r7, #0x1b1]
 	str r5, [r7, #0x1b4]
@@ -61914,7 +61914,7 @@ func_ov00_020df790: ; 0x020df790
 	add r6, r6, #8
 	strh r0, [r6, #0xf0]
 	strb ip, [r7, #0x1c6]
-	strb fp, [r7, #0x1c7]
+	strb r11, [r7, #0x1c7]
 	strb r3, [r7, #0x1c8]
 	strb ip, [r7, #0x1c9]
 	str r1, [r7, #0x1e8]
@@ -62014,7 +62014,7 @@ func_ov00_020df790: ; 0x020df790
 	ldr r1, _020e0760 ; =data_ov00_020e32ec
 	strh r2, [r1, #0x90]
 	strb ip, [r7, #0x292]
-	strb fp, [r7, #0x293]
+	strb r11, [r7, #0x293]
 	strb r3, [r7, #0x294]
 	strb ip, [r7, #0x295]
 	mov r1, #0x2c
@@ -62051,7 +62051,7 @@ func_ov00_020df790: ; 0x020df790
 	str sl, [sp, #0x460]
 	strh r0, [r6, #0x60]
 	strb ip, [r7, #0x2aa]
-	strb fp, [r7, #0x2ab]
+	strb r11, [r7, #0x2ab]
 	strb r3, [r7, #0x2ac]
 	strb ip, [r7, #0x2ad]
 	mov r1, #0xc
@@ -62345,7 +62345,7 @@ func_ov00_020df790: ; 0x020df790
 	ldr r1, _020e0768 ; =data_ov00_020e34ec
 	strh r2, [r1, #0xa4]
 	strb ip, [r7, #0x4a6]
-	strb fp, [r7, #0x4a7]
+	strb r11, [r7, #0x4a7]
 	strb r3, [r7, #0x4a8]
 	strb ip, [r7, #0x4a9]
 	mov r1, #0x2f
@@ -62365,7 +62365,7 @@ func_ov00_020df790: ; 0x020df790
 	strb r0, [sp, #0x34d]
 	strb ip, [r7, #0x4be]
 	strh r0, [r5, #0x28]
-	strb fp, [r7, #0x4bf]
+	strb r11, [r7, #0x4bf]
 	strb r3, [r7, #0x4c0]
 	strb ip, [r7, #0x4c1]
 	str sb, [r7, #0x4e0]
@@ -63104,7 +63104,7 @@ _020e0774:
 	bl func_0204f8d4
 	add sp, sp, #0x238
 	add sp, sp, #0x400
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 _020e0e94: .word data_ov00_020e37ec
 _020e0e98: .word data_ov00_020e38ec

--- a/asm/ov00/ov00_0207af9c.s
+++ b/asm/ov00/ov00_0207af9c.s
@@ -1347,11 +1347,11 @@ _0207bb48: .word data_ov00_020d8798
 	.global func_ov00_0207bb4c
 	arm_func_start func_ov00_0207bb4c
 func_ov00_0207bb4c: ; 0x0207bb4c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
-	mov sl, r0
-	ldr r0, [sl]
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	mov r10, r0
+	ldr r0, [r10]
 	cmp r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	bl func_01ffa8d4
 	ldr r5, _0207bc30 ; =0x04000440
 	mov r7, #3
@@ -1362,7 +1362,7 @@ func_ov00_0207bb4c: ; 0x0207bb4c
 	mov r11, r0
 	mov r4, #1
 _0207bb84:
-	ldr r0, [sl]
+	ldr r0, [r10]
 	tst r0, r4, lsl r7
 	beq _0207bc20
 	mov r0, r8
@@ -1392,7 +1392,7 @@ _0207bbec:
 	ldrb r0, [sb]
 	cmp r0, r7
 	bne _0207bc10
-	add r0, sl, r6, lsl #2
+	add r0, r10, r6, lsl #2
 	ldr r1, [r0, #4]
 	cmp r1, #0
 	beq _0207bc10
@@ -1407,7 +1407,7 @@ _0207bc20:
 	sub r8, r8, #0x40
 	subs r7, r7, #1
 	bpl _0207bb84
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_0207bb4c
 _0207bc30: .word 0x04000440
@@ -2192,22 +2192,22 @@ func_ov00_0207c1f8: ; 0x0207c1f8
 	.global func_ov00_0207c260
 	arm_func_start func_ov00_0207c260
 func_ov00_0207c260: ; 0x0207c260
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	ldr r6, [sp, #0x28]
 	ldr r5, [sp, #0x2c]
 	mov sb, r1
 	mov r8, r2
-	mov sl, r0
+	mov r10, r0
 	mov r7, r3
 	cmp sb, r8
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	orr r11, r5, #0x8000
 _0207c288:
 	ldr r0, [r7]
 	cmp r0, #0x1000
 	movge r0, #1
 	movlt r0, #0
-	add r1, sl, r0, lsl #2
+	add r1, r10, r0, lsl #2
 	mov r0, sb
 	ldr r4, [r1, #0x10]
 	bl func_ov00_020b7e6c
@@ -2226,7 +2226,7 @@ _0207c288:
 	cmp sb, r8
 	add r7, r7, #4
 	bne _0207c288
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	arm_func_end func_ov00_0207c260
 
 	.global func_ov00_0207c2e8
@@ -4537,11 +4537,11 @@ func_ov00_0207ddf4: ; 0x0207ddf4
 	.global func_ov00_0207ddf8
 	arm_func_start func_ov00_0207ddf8
 func_ov00_0207ddf8: ; 0x0207ddf8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	mov r7, #0
-	mov sl, r0
+	mov r10, r0
 	mov sb, r1
-	add r8, sl, #0x180
+	add r8, r10, #0x180
 	mvn r5, #0
 	mov r6, r7
 	mov r4, r7
@@ -4550,7 +4550,7 @@ _0207de1c:
 	cmp sb, #0
 	beq _0207de44
 	mov r2, r6
-	add r1, sl, r7, lsl #2
+	add r1, r10, r7, lsl #2
 _0207de2c:
 	add r0, r1, r2, lsl #2
 	add r2, r2, #1
@@ -4568,7 +4568,7 @@ _0207de54:
 	cmp r7, #2
 	add r8, r8, #4
 	blt _0207de1c
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	arm_func_end func_ov00_0207ddf8
 
 	.global func_ov00_0207de68
@@ -4766,27 +4766,27 @@ func_ov00_0207e08c: ; 0x0207e08c
 	.global func_ov00_0207e0f0
 	arm_func_start func_ov00_0207e0f0
 func_ov00_0207e0f0: ; 0x0207e0f0
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x14
-	mov sl, r0
-	ldr r2, [sl, #0x13c]
+	mov r10, r0
+	ldr r2, [r10, #0x13c]
 	str r1, [sp]
 	cmp r2, #0
 	addeq sp, sp, #0x14
 	mvneq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, [r2, #8]
 	adds r0, r2, r0
 	str r0, [sp, #4]
 	addeq sp, sp, #0x14
 	mvneq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldrh r1, [r0]
 	adds r0, r0, r1
 	str r0, [sp, #0xc]
 	addeq sp, sp, #0x14
 	mvneq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldrb r1, [r0, #1]
 	mov r0, #0
 	str r0, [sp, #8]
@@ -4797,7 +4797,7 @@ _0207e15c:
 	ldr r0, [sp, #0xc]
 	ldr r1, [sp, #0xc]
 	ldrh r3, [r0, #6]
-	mov r0, sl
+	mov r0, r10
 	ldr r2, [r0]
 	add r3, r1, r3
 	ldrh r1, [r3, #2]
@@ -4831,7 +4831,7 @@ _0207e1d0:
 	ldr r0, [sp]
 	cmp r0, r1
 	bne _0207e250
-	mov r0, sl
+	mov r0, r10
 	ldr r1, [r0]
 	ldr r1, [r1, #0xb4]
 	blx r1
@@ -4851,7 +4851,7 @@ _0207e218:
 	cmp r0, #0
 	addeq sp, sp, #0x14
 	moveq r0, r6
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	add r0, r6, #1
 	mov r0, r0, lsl #0x10
 	cmp sb, r0, lsr #16
@@ -4874,33 +4874,33 @@ _0207e260:
 _0207e280:
 	mvn r0, #0
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	arm_func_end func_ov00_0207e0f0
 
 	.global func_ov00_0207e28c
 	arm_func_start func_ov00_0207e28c
 func_ov00_0207e28c: ; 0x0207e28c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x14
-	mov sl, r0
-	ldr r2, [sl, #0x13c]
+	mov r10, r0
+	ldr r2, [r10, #0x13c]
 	str r1, [sp]
 	cmp r2, #0
 	addeq sp, sp, #0x14
 	mvneq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, [r2, #8]
 	adds r0, r2, r0
 	str r0, [sp, #4]
 	addeq sp, sp, #0x14
 	mvneq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldrh r1, [r0, #2]
 	adds r0, r0, r1
 	str r0, [sp, #0xc]
 	addeq sp, sp, #0x14
 	mvneq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldrb r1, [r0, #1]
 	mov r0, #0
 	str r0, [sp, #8]
@@ -4911,7 +4911,7 @@ _0207e2f8:
 	ldr r0, [sp, #0xc]
 	ldr r1, [sp, #0xc]
 	ldrh r3, [r0, #6]
-	mov r0, sl
+	mov r0, r10
 	ldr r2, [r0]
 	add r3, r1, r3
 	ldrh r1, [r3, #2]
@@ -4946,12 +4946,12 @@ _0207e370:
 	ldr r0, [sp]
 	cmp r0, r1
 	bne _0207e408
-	mov r0, sl
+	mov r0, r10
 	ldr r1, [r0]
 	ldr r1, [r1, #0xb4]
 	blx r1
 	mov r8, r0
-	mov r0, sl
+	mov r0, r10
 	ldr r1, [r0]
 	ldr r1, [r1, #0xb4]
 	blx r1
@@ -4972,7 +4972,7 @@ _0207e3d0:
 	cmp r0, #0
 	addeq sp, sp, #0x14
 	moveq r0, r6
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	add r0, r6, #1
 	mov r0, r0, lsl #0x10
 	cmp sb, r0, lsr #16
@@ -4995,7 +4995,7 @@ _0207e418:
 _0207e438:
 	mvn r0, #0
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	arm_func_end func_ov00_0207e28c
 
 	.global func_ov00_0207e444
@@ -5071,7 +5071,7 @@ func_ov00_0207e4b0: ; 0x0207e4b0
 	.global func_ov00_0207e4b8
 	arm_func_start func_ov00_0207e4b8
 func_ov00_0207e4b8: ; 0x0207e4b8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x7c
 	ldr r3, _0207e92c ; =data_027e0e60
 	mov sb, r1
@@ -5165,7 +5165,7 @@ _0207e5e4:
 	cmp r0, #0
 	ldrne r0, [sp, #0x14]
 	addne sp, sp, #0x7c
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	add r2, sp, #0x14
 	mov r0, r8
 	mov r1, sb
@@ -5177,7 +5177,7 @@ _0207e5e4:
 	cmp r1, r0
 	blt _0207e724
 	add sp, sp, #0x7c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0207e63c:
 	ldrb r0, [r8, #0xe]
 	cmp r0, #0
@@ -5200,7 +5200,7 @@ _0207e63c:
 	ldr r2, [r2, #0x60]
 	blx r2
 	add sp, sp, #0x7c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0207e694:
 	add r2, sp, #0x10
 	mov r0, r8
@@ -5209,7 +5209,7 @@ _0207e694:
 	cmp r0, #0
 	ldrne r0, [sp, #0x10]
 	addne sp, sp, #0x7c
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	add r2, sp, #0x10
 	mov r0, r8
 	mov r1, sb
@@ -5220,7 +5220,7 @@ _0207e694:
 	ldr r1, [sb, #4]
 	cmp r1, r0
 	addge sp, sp, #0x7c
-	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0207e6e0:
 	mov r0, r8
 	ldr r3, [r0]
@@ -5238,7 +5238,7 @@ _0207e6e0:
 	ldr r2, [r2, #0x60]
 	blx r2
 	add sp, sp, #0x7c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0207e724:
 	mov r0, #0x20
 	str r0, [sp]
@@ -5269,12 +5269,12 @@ _0207e724:
 	stmia r4, {r0, r1, r2}
 	cmp r5, #0
 	ble _0207e8a0
-	ldr sl, _0207e934 ; =data_ov00_020ec824
+	ldr r10, _0207e934 ; =data_ov00_020ec824
 	ldr sb, _0207e930 ; =data_027e0f6c
 	mov r11, #0x4c
 _0207e7a4:
 	mov r0, r7, lsl #0x1
-	ldrh r1, [sl, r0]
+	ldrh r1, [r10, r0]
 	ldr r2, [sb]
 	add r0, sp, #0x30
 	ldr r3, [r2, #0x20]
@@ -5358,7 +5358,7 @@ _0207e8a0:
 	bl func_0204f754
 	add sp, sp, #0x7c
 	add r0, r5, r4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0207e8f4:
 	mov r0, r8
 	ldr r2, [r0]
@@ -5373,7 +5373,7 @@ _0207e8f4:
 	bl func_0204f754
 	mov r0, r4
 	add sp, sp, #0x7c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_0207e4b8
 _0207e92c: .word data_027e0e60
@@ -5413,7 +5413,7 @@ func_ov00_0207e96c: ; 0x0207e96c
 	.global func_ov00_0207e970
 	arm_func_start func_ov00_0207e970
 func_ov00_0207e970: ; 0x0207e970
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0xc4
 	ldr r4, _0207ee00 ; =data_027e0e60
 	mov sb, r1
@@ -5523,7 +5523,7 @@ _0207ea9c:
 	str r1, [r7]
 	mov r0, #0x1000
 	stmib r7, {r0, r1}
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0207eb04:
 	mov r0, #0x20
 	str r0, [sp]
@@ -5561,12 +5561,12 @@ _0207eb04:
 	cmp r4, #0
 	stmia r3, {r0, r1, r2}
 	ble _0207ed48
-	ldr sl, _0207ee08 ; =data_ov00_020ec864
+	ldr r10, _0207ee08 ; =data_ov00_020ec864
 	ldr sb, _0207ee04 ; =data_027e0f6c
 	mov r11, #0x4c
 _0207eba0:
 	mov r0, r6, lsl #0x1
-	ldrh r1, [sl, r0]
+	ldrh r1, [r10, r0]
 	ldr r2, [sb]
 	add r0, sp, #0x78
 	ldr r3, [r2, #0x20]
@@ -5720,7 +5720,7 @@ _0207edd0:
 	mov r2, #0x10
 	bl func_0204f754
 	add sp, sp, #0xc4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_0207e970
 _0207ee00: .word data_027e0e60
@@ -5732,7 +5732,7 @@ _0207ee10: .word func_ov00_0207e96c
 	.global func_ov00_0207ee14
 	arm_func_start func_ov00_0207ee14
 func_ov00_0207ee14: ; 0x0207ee14
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x74
 	ldr r0, _0207efdc ; =data_027e0e60
 	mov sb, r1
@@ -5770,12 +5770,12 @@ func_ov00_0207ee14: ; 0x0207ee14
 	cmp r5, #0
 	stmia r4, {r0, r1, r2}
 	ble _0207efbc
-	ldr sl, _0207efe4 ; =data_ov00_020ec8a4
+	ldr r10, _0207efe4 ; =data_ov00_020ec8a4
 	ldr sb, _0207efe0 ; =data_027e0f6c
 	mov r11, #0x4c
 _0207eeb8:
 	mov r0, r8, lsl #0x1
-	ldrh r1, [sl, r0]
+	ldrh r1, [r10, r0]
 	ldr r2, [sb]
 	add r0, sp, #0x28
 	ldr r3, [r2, #0x20]
@@ -5832,7 +5832,7 @@ _0207eeb8:
 	ldr r1, [sp, #0xc]
 	cmp r1, r6
 	movlt r0, r8, lsl #0x1
-	ldrlth r7, [sl, r0]
+	ldrlth r7, [r10, r0]
 	movlt r6, r1
 _0207efa8:
 	add r0, r8, #1
@@ -5848,7 +5848,7 @@ _0207efbc:
 	bl func_0204f754
 	mov r0, r7
 	add sp, sp, #0x74
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_0207ee14
 _0207efdc: .word data_027e0e60
@@ -6010,7 +6010,7 @@ _0207f1f0: .word data_027e0e60
 	.global func_ov00_0207f1f4
 	arm_func_start func_ov00_0207f1f4
 func_ov00_0207f1f4: ; 0x0207f1f4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #0x3c
 	ldr r0, _0207f318 ; =data_027e0e60
 	mov sb, r1
@@ -6043,10 +6043,10 @@ func_ov00_0207f1f4: ; 0x0207f1f4
 	mov r6, #0
 	ble _0207f30c
 	ldr r4, _0207f320 ; =data_ov00_020ec924
-	ldr sl, _0207f31c ; =data_027e0f6c
+	ldr r10, _0207f31c ; =data_027e0f6c
 _0207f27c:
 	mov r0, r6, lsl #0x1
-	ldr r1, [sl]
+	ldr r1, [r10]
 	ldrh r0, [r4, r0]
 	ldr r1, [r1, #0x40]
 	ldr r7, [r1, r0, lsl #2]
@@ -6077,7 +6077,7 @@ _0207f27c:
 	add sp, sp, #0x3c
 	mov r0, #1
 	str r1, [r8]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 _0207f300:
 	add r6, r6, #1
 	cmp r6, r5
@@ -6085,7 +6085,7 @@ _0207f300:
 _0207f30c:
 	mov r0, #0
 	add sp, sp, #0x3c
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov00_0207f1f4
 _0207f318: .word data_027e0e60
@@ -6836,11 +6836,11 @@ func_ov00_0207fb5c: ; 0x0207fb5c
 	.global func_ov00_0207fb64
 	arm_func_start func_ov00_0207fb64
 func_ov00_0207fb64: ; 0x0207fb64
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #0x18
-	mov sl, r0
-	ldr r6, [sl, #0x10c]
-	ldr r0, [sl, #0x110]
+	mov r10, r0
+	ldr r6, [r10, #0x10c]
+	ldr r0, [r10, #0x110]
 	mov sb, r1
 	add r0, r6, r0, lsl #2
 	mov r8, r2
@@ -6878,9 +6878,9 @@ _0207fbf8:
 	cmp r5, r7
 	addhs sp, sp, #0x18
 	movhs r0, r5
-	ldmhsia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
-	ldr r1, [sl, #0x10c]
-	ldr r0, [sl, #0x110]
+	ldmhsia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldr r1, [r10, #0x10c]
+	ldr r0, [r10, #0x110]
 	add r6, r6, #4
 	add r0, r1, r0, lsl #2
 	cmp r6, r0
@@ -6888,7 +6888,7 @@ _0207fbf8:
 _0207fc20:
 	mov r0, r5
 	add sp, sp, #0x18
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	arm_func_end func_ov00_0207fb64
 
 	.global func_ov00_0207fc2c
@@ -6958,10 +6958,10 @@ _0207fcd8:
 	.global func_ov00_0207fce0
 	arm_func_start func_ov00_0207fce0
 func_ov00_0207fce0: ; 0x0207fce0
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
-	mov sl, r0
-	ldr r6, [sl, #0x10c]
-	ldr r0, [sl, #0x110]
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	mov r10, r0
+	ldr r6, [r10, #0x10c]
+	ldr r0, [r10, #0x110]
 	mov sb, r1
 	add r0, r6, r0, lsl #2
 	mov r8, r2
@@ -6980,8 +6980,8 @@ _0207fd0c:
 	blx r2
 	cmp r0, #0
 	strne r5, [r8, r4, lsl #2]
-	ldr r1, [sl, #0x10c]
-	ldr r0, [sl, #0x110]
+	ldr r1, [r10, #0x10c]
+	ldr r0, [r10, #0x110]
 	add r6, r6, #4
 	add r0, r1, r0, lsl #2
 	addne r4, r4, #1
@@ -6989,7 +6989,7 @@ _0207fd0c:
 	bne _0207fd0c
 _0207fd50:
 	mov r0, r4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	arm_func_end func_ov00_0207fce0
 
 	.global func_ov00_0207fd58
@@ -7320,13 +7320,13 @@ _02080120:
 	.global func_ov00_02080140
 	arm_func_start func_ov00_02080140
 func_ov00_02080140: ; 0x02080140
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #0x50
 	ldr sb, [r1]
 	mov r4, r0
 	str sb, [sp, #0x38]
 	ldr r8, [r1, #4]
-	mov sl, #0x18
+	mov r10, #0x18
 	str r8, [sp, #0x3c]
 	ldr r7, [r1, #8]
 	add r0, sp, #0x1c
@@ -7356,12 +7356,12 @@ func_ov00_02080140: ; 0x02080140
 	ldr r1, [r4, #0x118]
 	ldr r5, [r4, #0x11c]
 	str r1, [sp, #0x18]
-	mla r2, r5, sl, r1
+	mla r2, r5, r10, r1
 	str r2, [sp, #0x14]
 	bl func_ov00_02080324
 	ldr r0, [r4, #0x118]
 	ldr r2, [r4, #0x11c]
-	mov r1, sl
+	mov r1, r10
 	mla r5, r2, r1, r0
 	ldr r1, [sp, #0x1c]
 	cmp r1, r5
@@ -7445,7 +7445,7 @@ _02080310:
 _02080318:
 	ldrb r0, [sp, #0x4c]
 	add sp, sp, #0x50
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	arm_func_end func_ov00_02080140
 
 	.global func_ov00_02080324
@@ -8066,17 +8066,17 @@ _02080b14:
 	.global func_ov00_02080b24
 	arm_func_start func_ov00_02080b24
 func_ov00_02080b24: ; 0x02080b24
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x14
 	ldr r3, [r0]
 	mov r2, #4
 	ldr r3, [r3, #0x58]
 	str r0, [sp]
-	mov sl, r1
+	mov r10, r1
 	blx r3
 	cmp r0, #0
 	addne sp, sp, #0x14
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, [sp]
 	ldrh r0, [r0, #0x30]
 	cmp r0, #0x60
@@ -8114,12 +8114,12 @@ _02080b9c:
 	cmp r0, #0x42
 	bne _02080c30
 	cmp r6, #0
-	ldrb r0, [sl]
+	ldrb r0, [r10]
 	bne _02080c08
 	sub r0, r8, r0
 	mov r6, r5
 	bl func_02042f68
-	ldrb r1, [sl, #1]
+	ldrb r1, [r10, #1]
 	mov r4, r0
 	sub r0, sb, r1
 	bl func_02042f68
@@ -8128,7 +8128,7 @@ _02080b9c:
 _02080c08:
 	sub r0, r8, r0
 	bl func_02042f68
-	ldrb r1, [sl, #1]
+	ldrb r1, [r10, #1]
 	mov r4, r0
 	sub r0, sb, r1
 	bl func_02042f68
@@ -8148,7 +8148,7 @@ _02080c3c:
 _02080c4c:
 	cmp r6, #0
 	addeq sp, sp, #0x14
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r1, [r6, #4]
 	ldr r0, [sp]
 	bic r1, r1, #1
@@ -8181,7 +8181,7 @@ _02080c4c:
 	strh r1, [r0, #0x30]
 _02080cd0:
 	ldr r0, [sp]
-	mov r1, sl
+	mov r1, r10
 	ldr r4, [r0]
 	mov r2, #4
 	ldr r4, [r4, #0x98]
@@ -8193,7 +8193,7 @@ _02080cd0:
 	ldr r0, [sp]
 	strh r1, [r0, #0x30]
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	arm_func_end func_ov00_02080b24
 
 	.global func_ov00_02080d08
@@ -14093,7 +14093,7 @@ _02085104: .word data_027e0f6c
 	.global func_ov00_02085108
 	arm_func_start func_ov00_02085108
 func_ov00_02085108: ; 0x02085108
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x2c
 	ldr r0, _02085274 ; =data_027e0f64
 	str r1, [sp]
@@ -14148,7 +14148,7 @@ _020851a4:
 	ldr sb, [r4, #0x1c]
 	ldr r1, [r1, #0x60]
 	ldr r8, [r4, #0x18]
-	ldr sl, [r4, #0x20]
+	ldr r10, [r4, #0x20]
 	blx r1
 	add sb, sb, r0
 	mov r0, r4
@@ -14160,7 +14160,7 @@ _020851a4:
 	mov r1, #2
 	str r8, [sp, #0x1c]
 	str sb, [sp, #0x20]
-	str sl, [sp, #0x24]
+	str r10, [sp, #0x24]
 	bl func_0202b8e4
 	cmp r0, #0
 	beq _02085244
@@ -14173,7 +14173,7 @@ _020851a4:
 	ldr r1, [r4, #0x20]
 	str r1, [r0, #8]
 	ldrsb r0, [r4, #0x12]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02085244:
 	sub r6, r6, #1
 	cmp r6, r7
@@ -14188,7 +14188,7 @@ _02085250:
 _02085268:
 	mov r0, #0
 	add sp, sp, #0x2c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_02085108
 _02085274: .word data_027e0f64
@@ -14197,12 +14197,12 @@ _02085278: .word data_027e0e60
 	.global func_ov00_0208527c
 	arm_func_start func_ov00_0208527c
 func_ov00_0208527c: ; 0x0208527c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x2c
 	ldr r3, _020853f4 ; =data_027e0f64
 	mov r4, r0
 	ldr r0, [r3]
-	mov sl, r1
+	mov r10, r1
 	str r2, [sp]
 	bl func_ov00_0208b180
 	mov r1, r0
@@ -14269,7 +14269,7 @@ _0208536c:
 	ldr r1, [r5, #4]
 	tst r1, #4
 	beq _020853cc
-	mov r1, sl
+	mov r1, r10
 	bl func_ov00_0208b73c
 	cmp r0, #0
 	beq _020853cc
@@ -14282,7 +14282,7 @@ _0208536c:
 	ldr r1, [r5, #0x20]
 	str r1, [r0, #8]
 	ldrsb r0, [r5, #0x12]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _020853cc:
 	add r8, r8, #1
 	cmp r8, sb
@@ -14295,7 +14295,7 @@ _020853d8:
 _020853e8:
 	mov r0, #0
 	add sp, sp, #0x2c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_0208527c
 _020853f4: .word data_027e0f64
@@ -14304,12 +14304,12 @@ _020853f8: .word data_027e0e60
 	.global func_ov00_020853fc
 	arm_func_start func_ov00_020853fc
 func_ov00_020853fc: ; 0x020853fc
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x2c
 	ldr r3, _0208558c ; =data_027e0f64
 	mov r5, r0
 	ldr r0, [r3]
-	mov sl, r1
+	mov r10, r1
 	mov sb, r2
 	bl func_ov00_0208b180
 	mov r1, r0
@@ -14381,7 +14381,7 @@ _020854fc:
 	ldr r0, [r5, #4]
 	tst r0, #4
 	beq _0208555c
-	mov r1, sl
+	mov r1, r10
 	add r0, r5, #0x18
 	bl func_01ff9ec0
 	ldr r1, [sb]
@@ -14389,7 +14389,7 @@ _020854fc:
 	cmp r4, r1
 	bge _0208555c
 	mov r0, r5
-	mov r1, sl
+	mov r1, r10
 	bl func_ov00_0208b7d0
 	cmp r0, #0
 	movne r11, r5
@@ -14408,7 +14408,7 @@ _02085568:
 _02085580:
 	mov r0, r11
 	add sp, sp, #0x2c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020853fc
 _0208558c: .word data_027e0f64
@@ -14642,10 +14642,10 @@ _020858ac: .word data_027e077c
 	.global func_ov00_020858b0
 	arm_func_start func_ov00_020858b0
 func_ov00_020858b0: ; 0x020858b0
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x1c
 	mov sb, r2
-	mov sl, r0
+	mov r10, r0
 	mov r11, r1
 	cmp sb, #1
 	bne _020858e4
@@ -14662,15 +14662,15 @@ _020858e4:
 	ldr r0, [r0, #4]
 	bl func_ov00_02088000
 _020858f8:
-	mov r0, sl
+	mov r0, r10
 	bl func_ov00_0208335c
 	str r0, [sp, #0x10]
-	mov r0, sl
+	mov r0, r10
 	bl func_ov00_02083368
 	str r0, [sp, #0xc]
 	mvn r3, #0
 	add r0, sp, #0x18
-	mov r1, sl
+	mov r1, r10
 	mov r2, r11
 	str r3, [sp, #8]
 	bl func_ov00_02083a1c
@@ -14703,7 +14703,7 @@ _02085980:
 	ldr r0, [sp, #0xc]
 	cmp r8, r0
 	bge _02085a04
-	mov r0, sl
+	mov r0, r10
 	add r1, sp, #0x16
 	strb r4, [sp, #0x16]
 	strb r8, [sp, #0x17]
@@ -14712,7 +14712,7 @@ _02085980:
 	rsbmi r0, r0, #0
 	cmp r0, #0xcd
 	bgt _02085a04
-	mov r0, sl
+	mov r0, r10
 	add r1, sp, #0x14
 	strb r4, [sp, #0x14]
 	strb r8, [sp, #0x15]
@@ -14743,7 +14743,7 @@ _02085a10:
 _02085a20:
 	ldr r0, [sp, #8]
 	add sp, sp, #0x1c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020858b0
 _02085a2c: .word data_027e0f64
@@ -14909,20 +14909,20 @@ _02085c54:
 	.global func_ov00_02085c60
 	arm_func_start func_ov00_02085c60
 func_ov00_02085c60: ; 0x02085c60
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0xfc
 	ldr r11, [sp, #0x120]
 	ldr r8, [sp, #0x124]
 	ldr r7, [sp, #0x128]
 	ldr r6, [sp, #0x12c]
 	cmp r11, #0
-	mov sl, r0
+	mov r10, r0
 	mov sb, r1
 	mov r5, r2
 	mov r4, r3
 	addeq sp, sp, #0xfc
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	add r1, sp, #0x88
 	str r1, [sp]
 	ldr r0, _0208603c ; =data_027e0d3c
@@ -15040,7 +15040,7 @@ _02085e48:
 	str r6, [sp, #0xc]
 	mov r0, #0
 	str r0, [sp, #0x10]
-	mov r0, sl
+	mov r0, r10
 	mov r1, sb
 	add r2, sp, #0x70
 	add r3, sp, #0x64
@@ -15101,7 +15101,7 @@ _02085e48:
 	str r6, [sp, #0xc]
 	add r2, sp, #0x3c
 	str r3, [sp, #0x10]
-	mov r0, sl
+	mov r0, r10
 	add r1, sp, #0x94
 	mov r3, r2
 	bl func_01ffbe78
@@ -15126,7 +15126,7 @@ _02085f84:
 	ldr r1, [sp, #0x20]
 	add sp, sp, #0xfc
 	str r1, [sb, #0x64]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02085fb8:
 	ldr r1, [sp, #0x70]
 	ldr r0, [sp, #0x74]
@@ -15160,7 +15160,7 @@ _02085fb8:
 	ldr r1, [sp, #0x18]
 	str r1, [sb, #0x64]
 	add sp, sp, #0xfc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_02085c60
 _0208603c: .word data_027e0d3c
@@ -15169,11 +15169,11 @@ _02086040: .word 0x0000ffff
 	.global func_ov00_02086044
 	arm_func_start func_ov00_02086044
 func_ov00_02086044: ; 0x02086044
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0xb0
 	add r5, sp, #0x98
 	mov sb, r2
-	mov sl, r0
+	mov r10, r0
 	str r1, [sp]
 	ldmia sb, {r0, r1, r2}
 	stmia r5, {r0, r1, r2}
@@ -15192,19 +15192,19 @@ func_ov00_02086044: ; 0x02086044
 	mov r1, r8
 	bl func_ov00_0208ee00
 	ldr r1, [sp, #0x98]
-	mov r0, sl
+	mov r0, r10
 	bl func_ov00_020839d4
 	mov r6, r0
 	ldr r1, [sp, #0xa0]
-	mov r0, sl
+	mov r0, r10
 	bl func_ov00_020839f8
 	str r0, [sp, #0xc]
 	ldr r1, [sp, #0xa4]
-	mov r0, sl
+	mov r0, r10
 	bl func_ov00_020839d4
 	str r0, [sp, #8]
 	ldr r1, [sp, #0xac]
-	mov r0, sl
+	mov r0, r10
 	bl func_ov00_020839f8
 	mov r11, r0
 	add r5, sp, #0x8c
@@ -15222,15 +15222,15 @@ func_ov00_02086044: ; 0x02086044
 	add r2, sp, #0x80
 	bl func_01ff9bf8
 	ldr r1, [sb]
-	mov r0, sl
+	mov r0, r10
 	bl func_ov00_020839d4
 	mov r4, r0
 	ldr r1, [sb, #8]
-	mov r0, sl
+	mov r0, r10
 	bl func_ov00_020839f8
 	mov r2, r0
 	mov r1, r4
-	mov r0, sl
+	mov r0, r10
 	bl func_ov00_02083e34
 	str r0, [sp, #4]
 	ldr r0, [sp, #8]
@@ -15243,7 +15243,7 @@ _02086150:
 	bgt _02086264
 	and r5, r6, #0xff
 _02086164:
-	mov r0, sl
+	mov r0, r10
 	mov r1, r6
 	mov r2, r7
 	bl func_ov00_02083e34
@@ -15276,9 +15276,9 @@ _02086164:
 	cmp r0, #0
 	addne sp, sp, #0xb0
 	movne r0, #1
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _020861ec:
-	mov r0, sl
+	mov r0, r10
 	add r1, sp, #0x10
 	strb r5, [sp, #0x10]
 	strb r7, [sp, #0x11]
@@ -15304,7 +15304,7 @@ _020861ec:
 	cmp r0, #0
 	addne sp, sp, #0xb0
 	movne r0, #1
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02086258:
 	add r7, r7, #1
 	cmp r7, r11
@@ -15317,7 +15317,7 @@ _02086264:
 _02086274:
 	mov r0, #0
 	add sp, sp, #0xb0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_02086044
 _02086280: .word data_027e0e60
@@ -16337,7 +16337,7 @@ _020870cc: .word func_ov00_0208e420
 	.global func_ov00_020870d0
 	arm_func_start func_ov00_020870d0
 func_ov00_020870d0: ; 0x020870d0
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0xc
 	mov sb, r0
 	ldr r1, [sb, #8]
@@ -16387,27 +16387,27 @@ _02087120:
 	bl func_01ff9958
 	bl func_01ff992c
 	umull ip, r3, r4, r6
-	mov sl, #0
+	mov r10, #0
 	mla r3, r4, r5, r3
 	mla r3, r8, r6, r3
 	adds ip, ip, #0x80000000
 	adc lr, r3, #0
 	rsb r3, lr, #0
-	str sl, [sb, #0x10c]
+	str r10, [sb, #0x10c]
 	str r3, [sp, #4]
 	str r3, [sb, #0x110]
 	umull ip, r3, r4, r7
 	mla r3, r4, r11, r3
 	mov r2, r1, lsl #0xc
-	str sl, [sp]
-	str sl, [sp, #4]
+	str r10, [sp]
+	str r10, [sp, #4]
 	mla r3, r8, r7, r3
 	adds r4, ip, #0x80000000
 	adc r3, r3, #0
 	rsb r3, r3, #0
 	str r3, [sb, #0x114]
-	str sl, [sb, #0x118]
-	str sl, [sb, #0x11c]
+	str r10, [sb, #0x118]
+	str r10, [sb, #0x11c]
 	str r3, [sp, #8]
 	str lr, [sb, #0x120]
 	str r3, [sb, #0x124]
@@ -16423,23 +16423,23 @@ _02087120:
 	adc r0, r2, #0
 	rsb r0, r0, #0
 	str r0, [sp, #8]
-	str sl, [sb, #0x128]
+	str r10, [sb, #0x128]
 	rsb r1, r3, #0
 	str r1, [sb, #0x13c]
-	str sl, [sb, #0x140]
+	str r10, [sb, #0x140]
 	str r0, [sb, #0x144]
-	str sl, [sb, #0x148]
+	str r10, [sb, #0x148]
 	str r3, [sb, #0x12c]
-	str sl, [sp]
-	str sl, [sb, #0x130]
+	str r10, [sp]
+	str r10, [sb, #0x130]
 	str r1, [sp]
 	str r0, [sb, #0x134]
 	str r3, [sp]
-	str sl, [sp, #4]
+	str r10, [sp, #4]
 	str r0, [sp, #8]
-	str sl, [sb, #0x138]
+	str r10, [sb, #0x138]
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020870d0
 _02087268: .word data_02050f54
@@ -16770,7 +16770,7 @@ _02087694:
 	.global func_ov00_020876bc
 	arm_func_start func_ov00_020876bc
 func_ov00_020876bc: ; 0x020876bc
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #0x88
 	mov r7, r0
 	mov r6, r1
@@ -16780,7 +16780,7 @@ func_ov00_020876bc: ; 0x020876bc
 	cmp r0, #0
 	addne sp, sp, #0x88
 	movne r0, #0
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	ldr r0, [r7, #0x15c]
 	bl func_ov00_02087d84
 	ldr r1, [r0, #4]
@@ -16811,7 +16811,7 @@ _02087724:
 	ldr r0, [r7, #0x264]
 	ldr r2, [r7, #0x268]
 	ldr r1, [r7, #0x26c]
-	ldr sl, [r7, #0x270]
+	ldr r10, [r7, #0x270]
 	ldr r8, [r7, #0x274]
 	str r3, [sp, #0x60]
 	str r0, [sp, #0x64]
@@ -16823,7 +16823,7 @@ _02087724:
 	str r1, [sp, #0x54]
 	ldmia r0, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
-	str sl, [sp, #0x58]
+	str r10, [sp, #0x58]
 	add r0, sp, #0x54
 	add r8, sp, #0x44
 	ldmia r0, {r0, r1, r2}
@@ -16837,13 +16837,13 @@ _02087724:
 	bl func_ov00_0209da90
 	b _02087830
 _020877c0:
-	ldr sl, [r7, #0x260]
+	ldr r10, [r7, #0x260]
 	ldr r2, [r7, #0x264]
 	ldr r1, [r7, #0x268]
 	ldr sb, [r7, #0x26c]
 	ldr r8, [r7, #0x270]
 	ldr lr, [r7, #0x274]
-	str sl, [sp, #0x2c]
+	str r10, [sp, #0x2c]
 	ldrsh ip, [r7, #4]
 	add r0, sp, #0x2c
 	add r3, sp, #4
@@ -16852,12 +16852,12 @@ _020877c0:
 	ldmia r0, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
 	add r0, sp, #0x20
-	add sl, sp, #0x10
+	add r10, sp, #0x10
 	str sb, [sp, #0x20]
 	str r8, [sp, #0x24]
 	str lr, [sp, #0x28]
 	ldmia r0, {r0, r1, r2}
-	stmia sl, {r0, r1, r2}
+	stmia r10, {r0, r1, r2}
 	strh ip, [sp, #0x1c]
 	mov r0, #0
 	str r0, [sp]
@@ -16872,7 +16872,7 @@ _02087830:
 	mov r3, r4
 	bl func_ov00_02087338
 	add sp, sp, #0x88
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020876bc
 _0208784c: .word data_027e0e60
@@ -16880,7 +16880,7 @@ _0208784c: .word data_027e0e60
 	.global func_ov00_02087850
 	arm_func_start func_ov00_02087850
 func_ov00_02087850: ; 0x02087850
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #0x88
 	mov r7, r0
 	mov r6, r1
@@ -16890,7 +16890,7 @@ func_ov00_02087850: ; 0x02087850
 	cmp r0, #0
 	addne sp, sp, #0x88
 	movne r0, #0
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	ldr r0, [r7, #0x15c]
 	bl func_ov00_02087d84
 	ldr r1, [r0, #4]
@@ -16921,7 +16921,7 @@ _020878b8:
 	ldr r0, [r7, #0x264]
 	ldr r2, [r7, #0x268]
 	ldr r1, [r7, #0x26c]
-	ldr sl, [r7, #0x270]
+	ldr r10, [r7, #0x270]
 	ldr r8, [r7, #0x274]
 	str r3, [sp, #0x60]
 	str r0, [sp, #0x64]
@@ -16933,7 +16933,7 @@ _020878b8:
 	str r1, [sp, #0x54]
 	ldmia r0, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
-	str sl, [sp, #0x58]
+	str r10, [sp, #0x58]
 	add r0, sp, #0x54
 	add r8, sp, #0x44
 	ldmia r0, {r0, r1, r2}
@@ -16947,13 +16947,13 @@ _020878b8:
 	bl func_ov00_0209da90
 	b _020879c4
 _02087954:
-	ldr sl, [r7, #0x260]
+	ldr r10, [r7, #0x260]
 	ldr r2, [r7, #0x264]
 	ldr r1, [r7, #0x268]
 	ldr sb, [r7, #0x26c]
 	ldr r8, [r7, #0x270]
 	ldr lr, [r7, #0x274]
-	str sl, [sp, #0x2c]
+	str r10, [sp, #0x2c]
 	ldrsh ip, [r7, #4]
 	add r0, sp, #0x2c
 	add r3, sp, #4
@@ -16962,12 +16962,12 @@ _02087954:
 	ldmia r0, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
 	add r0, sp, #0x20
-	add sl, sp, #0x10
+	add r10, sp, #0x10
 	str sb, [sp, #0x20]
 	str r8, [sp, #0x24]
 	str lr, [sp, #0x28]
 	ldmia r0, {r0, r1, r2}
-	stmia sl, {r0, r1, r2}
+	stmia r10, {r0, r1, r2}
 	strh ip, [sp, #0x1c]
 	mov r0, #0
 	str r0, [sp]
@@ -16982,7 +16982,7 @@ _020879c4:
 	mov r3, r4
 	bl func_ov00_02087400
 	add sp, sp, #0x88
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov00_02087850
 _020879e0: .word data_027e0e60
@@ -17880,7 +17880,7 @@ func_ov00_02088494: ; 0x02088494
 	.global func_ov00_020884b4
 	arm_func_start func_ov00_020884b4
 func_ov00_020884b4: ; 0x020884b4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x98
 	mov r5, r0
 	ldr r0, [r5, #0x15c]
@@ -17899,7 +17899,7 @@ _020884e0: ; jump table
 	b _020884f4 ; case 4
 _020884f4:
 	add sp, sp, #0x98
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _020884fc:
 	ldr r1, [r5, #0x160]
 	mov r0, r5
@@ -17945,7 +17945,7 @@ _02088588:
 	ldr r7, [r0, #0x18]
 	ldr r8, [r0, #0x1c]
 	ldr sb, [r0, #0x20]
-	ldr sl, [r0, #0x24]
+	ldr r10, [r0, #0x24]
 	mov r1, #4
 	str r1, [r5, #0x15c]
 	mov r0, #0xff
@@ -18056,22 +18056,22 @@ _020885cc:
 	str r7, [sp, #0x48]
 	str r8, [sp, #0x4c]
 	str sb, [sp, #0x50]
-	str sl, [sp, #0x54]
+	str r10, [sp, #0x54]
 	b _02088858
 _02088764:
 	mul r7, r1, r0
 	ldr r8, _020888e4 ; =data_ov00_020d8aa8
 	add r0, r8, r7
 	ldr r11, [r8, r7]
-	ldr sl, [r0, #4]
+	ldr r10, [r0, #4]
 	ldr sb, [r0, #8]
 	ldr r8, [r0, #0xc]
 	ldr r7, [r0, #0x10]
 	ldr ip, [r0, #0x14]
 	str r11, [sp, #0x30]
 	ldr r11, [r0, #0x18]
-	str sl, [sp, #0x34]
-	ldr sl, [r0, #0x1c]
+	str r10, [sp, #0x34]
+	ldr r10, [r0, #0x1c]
 	str sb, [sp, #0x38]
 	ldr sb, [r0, #0x20]
 	str r8, [sp, #0x3c]
@@ -18082,8 +18082,8 @@ _02088764:
 	ldr ip, [r0, #0x2c]
 	str r11, [sp, #0x48]
 	ldr r11, [r0, #0x30]
-	str sl, [sp, #0x4c]
-	ldr sl, [r0, #0x34]
+	str r10, [sp, #0x4c]
+	ldr r10, [r0, #0x34]
 	str sb, [sp, #0x50]
 	ldr sb, [r0, #0x38]
 	str r8, [sp, #0x54]
@@ -18099,8 +18099,8 @@ _02088764:
 	ldr ip, [r0, #0x44]
 	str r11, [sp, #0x60]
 	ldr r11, [r0, #0x48]
-	str sl, [sp, #0x64]
-	ldr sl, [r0, #0x4c]
+	str r10, [sp, #0x64]
+	ldr r10, [r0, #0x4c]
 	str sb, [sp, #0x68]
 	ldr sb, [r0, #0x50]
 	str r8, [sp, #0x6c]
@@ -18110,7 +18110,7 @@ _02088764:
 	ldr r0, [r0, #0x5c]
 	str ip, [sp, #0x74]
 	str r11, [sp, #0x78]
-	str sl, [sp, #0x7c]
+	str r10, [sp, #0x7c]
 	str sb, [sp, #0x80]
 	str r8, [sp, #0x84]
 	str r7, [sp, #0x88]
@@ -18155,7 +18155,7 @@ _02088858:
 	str r1, [r5, #0x2b0]
 	strb r0, [r5, #0x2ec]
 	add sp, sp, #0x98
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020884b4
 _020888e4: .word data_ov00_020d8aa8
@@ -18163,7 +18163,7 @@ _020888e4: .word data_ov00_020d8aa8
 	.global func_ov00_020888e8
 	arm_func_start func_ov00_020888e8
 func_ov00_020888e8: ; 0x020888e8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #0x94
 	mov r7, r0
 	ldr r0, [r7, #0x15c]
@@ -18182,7 +18182,7 @@ _02088914: ; jump table
 	b _02088928 ; case 4
 _02088928:
 	add sp, sp, #0x94
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 _02088930:
 	ldr r1, [r7, #0x160]
 	mov r0, r7
@@ -18220,11 +18220,11 @@ _02088998:
 	strb r0, [sp, #8]
 	strh r3, [sp, #0x18]
 	strh r3, [sp, #0x1a]
-	mov sl, r3
+	mov r10, r3
 _020889c0:
 	add r0, r2, r3, lsl #1
 	add r3, r3, #1
-	strh sl, [r0, #0x18]
+	strh r10, [r0, #0x18]
 	cmp r3, #2
 	blo _020889c0
 	ldr r1, [sp, #4]
@@ -18263,7 +18263,7 @@ _020889c0:
 	str r0, [r1, #0x10]
 	ldr r0, [r7, #0x154]
 	ldr r0, [r0, #0x14]
-	strh sl, [r0, #0x14]
+	strh r10, [r0, #0x14]
 	str r3, [r7, #0x160]
 _02088a6c:
 	ldmia r8!, {r0, r1, r2, r3}
@@ -18313,7 +18313,7 @@ _02088a6c:
 	str r1, [r7, #0x2b0]
 	strb r0, [r7, #0x2ec]
 	add sp, sp, #0x94
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	arm_func_end func_ov00_020888e8
 
 	.global func_ov00_02088b2c
@@ -18486,7 +18486,7 @@ _02088cec:
 	.global func_ov00_02088d9c
 	arm_func_start func_ov00_02088d9c
 func_ov00_02088d9c: ; 0x02088d9c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #0x94
 	mov r7, r0
 	ldr r0, [r7, #0x15c]
@@ -18505,7 +18505,7 @@ _02088dc8: ; jump table
 	b _02088ddc ; case 4
 _02088ddc:
 	add sp, sp, #0x94
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 _02088de4:
 	ldr r1, [r7, #0x160]
 	mov r0, r7
@@ -18543,11 +18543,11 @@ _02088e4c:
 	strb r0, [sp, #8]
 	strh r3, [sp, #0x18]
 	strh r3, [sp, #0x1a]
-	mov sl, r3
+	mov r10, r3
 _02088e74:
 	add r0, r2, r3, lsl #1
 	add r3, r3, #1
-	strh sl, [r0, #0x18]
+	strh r10, [r0, #0x18]
 	cmp r3, #2
 	blo _02088e74
 	ldr r1, [sp, #4]
@@ -18599,9 +18599,9 @@ _02088e74:
 	str r0, [r1, #0x10]
 	ldr r0, [r7, #0x154]
 	ldr r0, [r0, #0x18]
-	strh sl, [r0, #0x14]
+	strh r10, [r0, #0x14]
 	str r6, [r7, #0x1a4]
-	str sl, [r7, #0x1a8]
+	str r10, [r7, #0x1a8]
 	ldr r0, [r7, #0x15c]
 	mla r6, r0, r3, lr
 _02088f60:
@@ -18650,7 +18650,7 @@ _02088f60:
 	str r1, [r7, #0x2a4]
 	strb r0, [r7, #0x2ec]
 	add sp, sp, #0x94
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov00_02088d9c
 _02089018: .word data_ov00_020d8aa8
@@ -21945,7 +21945,7 @@ func_ov00_0208ba58: ; 0x0208ba58
 	.global func_ov00_0208ba68
 	arm_func_start func_ov00_0208ba68
 func_ov00_0208ba68: ; 0x0208ba68
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #0x98
 	ldr r8, [sp, #0xbc]
 	ldr r7, [sp, #0xc0]
@@ -21955,18 +21955,18 @@ func_ov00_0208ba68: ; 0x0208ba68
 	mov sb, #0
 	ldr r0, _0208bedc ; =data_027e0d44
 	str sb, [lr]
-	ldr sl, [r0]
+	ldr r10, [r0]
 	ldr r4, [sp, #0xcc]
-	add sl, sl, r2, lsl #3
-	ldr sl, [sl, #8]
+	add r10, r10, r2, lsl #3
+	ldr r10, [r10, #8]
 	ldmib r4, {r0, ip}
-	mov sl, sl, lsl #0x10
-	mov sl, sl, lsr #0x10
-	bic sl, sl, #0xe0000000
-	orr sl, sl, r0, lsl #26
+	mov r10, r10, lsl #0x10
+	mov r10, r10, lsr #0x10
+	bic r10, r10, #0xe0000000
+	orr r10, r10, r0, lsl #26
 	ldr r0, [r4, #0xc]
-	orr sl, sl, ip, lsl #20
-	orr r0, sl, r0, lsl #23
+	orr r10, r10, ip, lsl #20
+	orr r0, r10, r0, lsl #23
 	orr r0, r0, #0x20000000
 	str r0, [lr, #0x64]
 	ldr r0, [r4, #4]
@@ -21976,9 +21976,9 @@ func_ov00_0208ba68: ; 0x0208ba68
 	cmp r0, #2
 	ldr r0, _0208bedc ; =data_027e0d44
 	moveq sb, #1
-	ldr sl, [r0]
+	ldr r10, [r0]
 	rsb sb, sb, #4
-	add r2, sl, r2, lsl #3
+	add r2, r10, r2, lsl #3
 	ldr r2, [r2, #0xc]
 	ldr r0, _0208bee0 ; =0x040004ac
 	mov r2, r2, lsl #0x10
@@ -21990,13 +21990,13 @@ _0208bb08:
 	ldrb r2, [sp, #0xd0]
 	ldrh ip, [r4]
 	ldrh r0, [r0]
-	ldr sl, _0208bee8 ; =0x040004c0
+	ldr r10, _0208bee8 ; =0x040004c0
 	mov sb, #0
 	orr r0, ip, r0, lsl #16
-	str r0, [sl]
+	str r0, [r10]
 	ldr r0, _0208beec ; =0x001f0081
-	str sb, [sl, #4]
-	str r0, [sl, #-0x1c]
+	str sb, [r10, #4]
+	str r0, [r10, #-0x1c]
 	cmp r2, #0
 	beq _0208bb78
 	ldr r0, _0208bef0 ; =data_027e0f64
@@ -22023,10 +22023,10 @@ _0208bb78:
 	ldr r1, [r1, #4]
 	add r2, sp, #0x58
 	str sb, [sp]
-	ldr sl, [r3, #4]
+	ldr r10, [r3, #4]
 	ldr sb, [r4, #0x18]
 	add r1, r1, #0x1c
-	add sb, sl, sb, asr #1
+	add sb, r10, sb, asr #1
 	str sb, [sp, #4]
 	ldr r3, [r3, #8]
 	str r3, [sp, #8]
@@ -22242,7 +22242,7 @@ _0208bebc:
 	mov r0, #1
 	str r0, [r1, #-0xbc]
 	add sp, sp, #0x98
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov00_0208ba68
 _0208bed8: .word 0x04000444
@@ -22712,7 +22712,7 @@ _0208c4f4: .word data_027e0fc8
 	.global func_ov00_0208c4f8
 	arm_func_start func_ov00_0208c4f8
 func_ov00_0208c4f8: ; 0x0208c4f8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x48
 	mov r6, r0
 	bl func_ov00_0208c968
@@ -22722,7 +22722,7 @@ func_ov00_0208c4f8: ; 0x0208c4f8
 	mov r5, r0
 	cmp r5, r1
 	addeq sp, sp, #0x48
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, _0208c924 ; =data_027e0d38
 	ldr r0, [r0]
 	bl func_ov00_02078b40
@@ -22735,7 +22735,7 @@ func_ov00_0208c4f8: ; 0x0208c4f8
 	cmp r5, r0
 	beq _0208c560
 	add sp, sp, #0x48
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0208c558:
 	ldr r5, _0208c930 ; =0x53485254
 	b _0208c564
@@ -22819,17 +22819,17 @@ _0208c670:
 	ldr r2, [r3]
 	ldmib r3, {r0, r7}
 	umull r4, r8, r7, r2
-	ldr sl, [r3, #0x10]
+	ldr r10, [r3, #0x10]
 	mla r8, r7, r0, r8
 	ldr r6, [r3, #0xc]
-	adds r11, sl, r4
+	adds r11, r10, r4
 	mla r8, r6, r2, r8
 	ldr sb, [r3, #0x14]
 	umull r4, r2, r7, r11
 	adc r0, sb, r8
 	mla r2, r7, r0, r2
 	str r11, [r3]
-	adds r4, sl, r4
+	adds r4, r10, r4
 	str r0, [r3, #4]
 	mla r2, r6, r11, r2
 	str r4, [r3]
@@ -22863,13 +22863,13 @@ _0208c708:
 	bl func_ov00_020c4048
 	movs r1, r0
 	addmi sp, sp, #0x48
-	ldmmiia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmmiia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, _0208c954 ; =data_027e0fe4
 	ldr r0, [r0]
 	bl _ZN12ActorManager13FindActorByIdEj
 	cmp r0, #0
 	addeq sp, sp, #0x48
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r3, [r0, #4]
 	ldr r2, _0208c934 ; =0x464c544d
 	cmp r3, r2
@@ -22883,13 +22883,13 @@ _0208c708:
 	cmp r3, r1
 	beq _0208c7d0
 	add sp, sp, #0x48
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0208c784:
 	ldr r1, _0208c93c ; =0x464c4254
 	cmp r3, r1
 	beq _0208c7d0
 	add sp, sp, #0x48
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0208c798:
 	ldr r1, _0208c940 ; =0x4c53544d
 	cmp r3, r1
@@ -22899,13 +22899,13 @@ _0208c798:
 	cmp r3, r1
 	beq _0208c7d0
 	add sp, sp, #0x48
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0208c7bc:
 	ldr r1, _0208c92c ; =0x52555059
 	cmp r3, r1
 	beq _0208c838
 	add sp, sp, #0x48
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0208c7d0:
 	ldr r2, _0208c944 ; =data_027e0764
 	ldr r1, _0208c95c ; =0x0000019a
@@ -22932,44 +22932,44 @@ _0208c7d0:
 	str r1, [r0, #0x64]
 	add sp, sp, #0x48
 	str r3, [r0, #0x68]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0208c838:
 	ldr r3, _0208c944 ; =data_027e0764
 	ldr r1, _0208c960 ; =0x00002001
 	ldr r4, [r3]
 	ldmib r3, {r2, r7}
-	umull r5, sl, r7, r4
-	mla sl, r7, r2, sl
+	umull r5, r10, r7, r4
+	mla r10, r7, r2, r10
 	ldr r6, [r3, #0xc]
 	ldr sb, [r3, #0x10]
-	mla sl, r6, r4, sl
+	mla r10, r6, r4, r10
 	adds r11, sb, r5
 	ldr r8, [r3, #0x14]
 	umull r5, r4, r7, r11
-	adc r2, r8, sl
+	adc r2, r8, r10
 	mla r4, r7, r2, r4
 	adds ip, sb, r5
 	mla r4, r6, r11, r4
 	adc lr, r8, r4
 	str r11, [r3]
 	str r2, [r3, #4]
-	umull r5, sl, r2, r1
+	umull r5, r10, r2, r1
 	mov r4, #0
 	mov r5, r4
-	mla sl, r2, r5, sl
-	mla sl, r4, r1, sl
-	sub r5, sl, #0x1000
+	mla r10, r2, r5, r10
+	mla r10, r4, r1, r10
+	sub r5, r10, #0x1000
 	ldr r2, _0208c964 ; =0x51eb851f
-	mov sl, r5, lsr #0x1f
+	mov r10, r5, lsr #0x1f
 	smull r11, r5, r2, r5
-	add r5, sl, r5, asr #4
-	umull r11, sl, r7, ip
-	mla sl, r7, lr, sl
-	mla sl, r6, ip, sl
+	add r5, r10, r5, asr #4
+	umull r11, r10, r7, ip
+	mla r10, r7, lr, r10
+	mla r10, r6, ip, r10
 	stmia r3, {ip, lr}
 	adds sb, sb, r11
 	str sb, [r3]
-	adc ip, r8, sl
+	adc ip, r8, r10
 	str ip, [r3, #4]
 	ldr r3, _0208c95c ; =0x0000019a
 	umull r3, r6, lr, r3
@@ -22991,7 +22991,7 @@ _0208c838:
 	str r7, [r0, #0x64]
 	str r5, [r0, #0x68]
 	add sp, sp, #0x48
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_0208c4f8
 _0208c920: .word 0x4e554c4c
@@ -23394,18 +23394,18 @@ func_ov00_0208cd1c: ; 0x0208cd1c
 	.global func_ov00_0208cd48
 	arm_func_start func_ov00_0208cd48
 func_ov00_0208cd48: ; 0x0208cd48
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x224
 	sub sp, sp, #0x400
 	movs r5, r2
-	mov sl, r0
+	mov r10, r0
 	mov sb, r1
 	bne _0208cd78
 	str sb, [sp, #4]
 	bl func_ov00_0208ce84
 	add sp, sp, #0x224
 	add sp, sp, #0x400
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0208cd78:
 	ldr r4, _0208ce78 ; =func_ov00_0207f100
 	ldr r3, _0208ce7c ; =func_ov00_0208d018
@@ -23431,7 +23431,7 @@ _0208cd78:
 	add sp, sp, #0x224
 	add sp, sp, #0x400
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0208cddc:
 	cmp r6, #0
 	mov r7, #0
@@ -23446,7 +23446,7 @@ _0208cdf4:
 	add r0, r8, #0xc
 	ldmia r0, {r0, r1, r2}
 	stmia r5, {r0, r1, r2}
-	mov r0, sl
+	mov r0, r10
 	add r1, sp, #8
 	bl func_ov00_0208cf28
 	movs r4, r0
@@ -23459,7 +23459,7 @@ _0208cdf4:
 	add sp, sp, #0x224
 	add sp, sp, #0x400
 	mov r0, r4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0208ce44:
 	add r7, r7, #1
 	cmp r7, r6
@@ -23474,7 +23474,7 @@ _0208ce54:
 	mov r0, #0
 	add sp, sp, #0x224
 	add sp, sp, #0x400
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_0208cd48
 _0208ce78: .word func_ov00_0207f100
@@ -23613,24 +23613,24 @@ func_ov00_0208d018: ; 0x0208d018
 	.global func_ov00_0208d01c
 	arm_func_start func_ov00_0208d01c
 func_ov00_0208d01c: ; 0x0208d01c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x244
 	sub sp, sp, #0x400
 	movs r5, r2
 	str r0, [sp, #4]
-	mov sl, r1
+	mov r10, r1
 	mov sb, r3
 	ldr r8, [sp, #0x668]
 	bne _0208d064
 	mov r4, #0
 	mov r2, sb
 	mov r3, r8
-	str sl, [sp, #8]
+	str r10, [sp, #8]
 	str r4, [sp]
 	bl func_ov00_0208d1f8
 	add sp, sp, #0x244
 	add sp, sp, #0x400
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0208d064:
 	ldr r4, _0208d1ec ; =func_ov00_0207f100
 	ldr r3, _0208d1f0 ; =func_ov00_0208d018
@@ -23656,13 +23656,13 @@ _0208d064:
 	add sp, sp, #0x244
 	add sp, sp, #0x400
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0208d0c8:
 	cmp r4, #1
 	bne _0208d138
 	add r0, sp, #0x44
 	add r3, sp, #0x2c
-	str sl, [sp, #0x28]
+	str r10, [sp, #0x28]
 	ldmia r0, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
 	add r0, sp, #0x50
@@ -23685,7 +23685,7 @@ _0208d0c8:
 	add sp, sp, #0x244
 	add sp, sp, #0x400
 	mov r0, r4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0208d138:
 	mov r5, #0
 	mov r6, r5
@@ -23695,7 +23695,7 @@ _0208d138:
 	add r7, sp, #0x44
 	add r11, r0, #0xc
 _0208d154:
-	str sl, [sp, #0xc]
+	str r10, [sp, #0xc]
 	add r3, sp, #0x10
 	ldmia r7, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
@@ -23719,7 +23719,7 @@ _0208d154:
 	add sp, sp, #0x244
 	add sp, sp, #0x400
 	mov r0, r5
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0208d1b8:
 	add r6, r6, #1
 	cmp r6, r4
@@ -23734,7 +23734,7 @@ _0208d1c8:
 	mov r0, r5
 	add sp, sp, #0x244
 	add sp, sp, #0x400
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_0208d01c
 _0208d1ec: .word func_ov00_0207f100
@@ -23745,11 +23745,11 @@ _0208d1f4: .word data_027e0e60
 	arm_func_start func_ov00_0208d1f8
 func_ov00_0208d1f8: ; 0x0208d1f8
 	stmdb sp!, {r0, r1, r2, r3}
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x1c
-	mov sl, r0
-	ldr r1, [sl, #0xc]
-	ldr r0, [sl, #0x10]
+	mov r10, r0
+	ldr r1, [r10, #0xc]
+	ldr r0, [r10, #0x10]
 	str r2, [sp]
 	add r0, r1, r0, lsl #2
 	str r3, [sp, #4]
@@ -23763,8 +23763,8 @@ _0208d230:
 	add r1, sb, r11
 	cmp r1, r0
 	bhs _0208d2fc
-	ldr r1, [sl, #0xc]
-	ldr r0, [sl, #0x10]
+	ldr r1, [r10, #0xc]
+	ldr r0, [r10, #0x10]
 	ldr r8, [sp, #0x44]
 	add r7, r1, r0, lsl #2
 	ldr r6, [sp, #0x18]
@@ -23791,8 +23791,8 @@ _0208d278:
 	cmp r0, #0
 	beq _0208d270
 _0208d2a4:
-	ldr r1, [sl, #0xc]
-	ldr r0, [sl, #0x10]
+	ldr r1, [r10, #0xc]
+	ldr r0, [r10, #0x10]
 	ldr r2, [sp, #0x10]
 	add r0, r1, r0, lsl #2
 	cmp r2, r0
@@ -23807,8 +23807,8 @@ _0208d2a4:
 	add sb, sb, #1
 _0208d2dc:
 	ldr r2, [sp, #0x10]
-	ldr r1, [sl, #0xc]
-	ldr r0, [sl, #0x10]
+	ldr r1, [r10, #0xc]
+	ldr r0, [r10, #0x10]
 	add r2, r2, #4
 	add r0, r1, r0, lsl #2
 	str r2, [sp, #0x18]
@@ -23817,7 +23817,7 @@ _0208d2dc:
 _0208d2fc:
 	mov r0, sb
 	add sp, sp, #0x1c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	add sp, sp, #0x10
 	bx lr
 	arm_func_end func_ov00_0208d1f8
@@ -23825,11 +23825,11 @@ _0208d2fc:
 	.global func_ov00_0208d310
 	arm_func_start func_ov00_0208d310
 func_ov00_0208d310: ; 0x0208d310
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x2c
-	mov sl, r0
-	ldr r4, [sl, #0xc]
-	ldr r0, [sl, #0x10]
+	mov r10, r0
+	ldr r4, [r10, #0xc]
+	ldr r0, [r10, #0x10]
 	mov sb, r1
 	add r0, r4, r0, lsl #2
 	str r3, [sp]
@@ -23855,8 +23855,8 @@ _0208d358:
 	stmia ip, {r0, r1, r2}
 	ldmia r5, {r0, r1, r2}
 	stmia r4, {r0, r1, r2}
-	ldr r2, [sl, #0xc]
-	ldr r1, [sl, #0x10]
+	ldr r2, [r10, #0xc]
+	ldr r1, [r10, #0x10]
 	add r3, sp, #0x10
 	add r2, r2, r1, lsl #2
 	add r1, sp, #0xc
@@ -23864,8 +23864,8 @@ _0208d358:
 	add r0, sp, #8
 	str r2, [sp, #4]
 	bl func_ov00_0208cfa4
-	ldr r1, [sl, #0xc]
-	ldr r0, [sl, #0x10]
+	ldr r1, [r10, #0xc]
+	ldr r0, [r10, #0x10]
 	ldr r2, [sp, #8]
 	add r0, r1, r0, lsl #2
 	cmp r2, r0
@@ -23874,9 +23874,9 @@ _0208d358:
 	cmp r0, #0
 	strne r0, [r11, r7, lsl #2]
 	ldr r0, [sp, #8]
-	ldr r1, [sl, #0xc]
+	ldr r1, [r10, #0xc]
 	add r2, r0, #4
-	ldr r0, [sl, #0x10]
+	ldr r0, [r10, #0x10]
 	addne r7, r7, #1
 	add r0, r1, r0, lsl #2
 	str r2, [sp, #0xc]
@@ -23885,7 +23885,7 @@ _0208d358:
 _0208d3f0:
 	mov r0, r7
 	add sp, sp, #0x2c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	arm_func_end func_ov00_0208d310
 
 	.global func_ov00_0208d3fc
@@ -23937,11 +23937,11 @@ _0208d488:
 	.global func_ov00_0208d494
 	arm_func_start func_ov00_0208d494
 func_ov00_0208d494: ; 0x0208d494
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x14
-	mov sl, r0
-	ldr r1, [sl, #0xc]
-	ldr r0, [sl, #0x10]
+	mov r10, r0
+	ldr r1, [r10, #0xc]
+	ldr r0, [r10, #0x10]
 	mov r11, r2
 	add r0, r1, r0, lsl #2
 	str r3, [sp]
@@ -23955,8 +23955,8 @@ _0208d4c8:
 	add r1, r8, sb
 	cmp r1, r0
 	bhs _0208d5d4
-	ldr r1, [sl, #0xc]
-	ldr r0, [sl, #0x10]
+	ldr r1, [r10, #0xc]
+	ldr r0, [r10, #0x10]
 	ldr r6, [sp, #0x10]
 	add r7, r1, r0, lsl #2
 	str r7, [sp, #0xc]
@@ -24007,8 +24007,8 @@ _0208d57c:
 	cmp r0, #0
 	beq _0208d500
 _0208d584:
-	ldr r1, [sl, #0xc]
-	ldr r0, [sl, #0x10]
+	ldr r1, [r10, #0xc]
+	ldr r0, [r10, #0x10]
 	ldr r2, [sp, #8]
 	add r0, r1, r0, lsl #2
 	cmp r2, r0
@@ -24020,8 +24020,8 @@ _0208d584:
 	cmp r1, #0
 	addne r0, r11, sb, lsl #2
 	strne r1, [r0, r8, lsl #2]
-	ldr r1, [sl, #0xc]
-	ldr r0, [sl, #0x10]
+	ldr r1, [r10, #0xc]
+	ldr r0, [r10, #0x10]
 	addne r8, r8, #1
 	add r0, r1, r0, lsl #2
 	str r2, [sp, #0x10]
@@ -24030,7 +24030,7 @@ _0208d584:
 _0208d5d4:
 	mov r0, r8
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	arm_func_end func_ov00_0208d494
 
 	.global func_ov00_0208d5e0
@@ -24802,7 +24802,7 @@ func_ov00_0208df74: ; 0x0208df74
 	.global func_ov00_0208df78
 	arm_func_start func_ov00_0208df78
 func_ov00_0208df78: ; 0x0208df78
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x14
 	mov r6, r0
 	mov r0, r1, lsl #0xc
@@ -24835,12 +24835,12 @@ _0208dfe0:
 	sub r2, r5, #0x800
 	mov r0, r6
 	mov r8, r2, lsl #0x1
-	mov sl, r1, lsl #0x1
+	mov r10, r1, lsl #0x1
 	bl func_ov00_0208e3d0
 	mov r5, r0
 	ldr r0, [r5, #0x1c]
 	ldr r1, [r5, #0xc]
-	smull r2, r0, sl, r0
+	smull r2, r0, r10, r0
 	smlal r2, r0, r8, r1
 	mov r2, r2, lsr #0xc
 	orr r2, r2, r0, lsl #20
@@ -24852,7 +24852,7 @@ _0208dfe0:
 	bl func_01ff9a50
 	ldr r0, [r5, #0x10]
 	ldr r2, [r5]
-	smull r3, r0, sl, r0
+	smull r3, r0, r10, r0
 	smlal r3, r0, r8, r2
 	mov r2, r3, lsr #0xc
 	orr r2, r2, r0, lsl #20
@@ -24861,14 +24861,14 @@ _0208dfe0:
 	add r6, r6, r2
 	ldr r2, [r5, #0x14]
 	ldr r1, [r5, #0x34]
-	smull r7, r2, sl, r2
+	smull r7, r2, r10, r2
 	smlal r7, r2, r8, r3
 	mov r3, r7, lsr #0xc
 	orr r3, r3, r2, lsl #20
 	add r7, r1, r3
 	ldr r1, [r5, #0x18]
 	ldr r2, [r5, #8]
-	smull r3, r1, sl, r1
+	smull r3, r1, r10, r1
 	smlal r3, r1, r8, r2
 	mov r2, r3, lsr #0xc
 	ldr r0, [r5, #0x38]
@@ -24897,7 +24897,7 @@ _0208e0c4:
 	sub r8, r8, r0
 	bl func_01ff99f4
 	mov r5, r0
-	mov sl, r1
+	mov r10, r1
 	cmp r4, #0
 	beq _0208e0f8
 	ldr r0, [sp, #8]
@@ -24907,21 +24907,21 @@ _0208e0f8:
 	umull r2, r1, r5, r6
 	adds r2, r2, #0x80000000
 	mla r1, r5, r0, r1
-	mla r1, sl, r6, r1
+	mla r1, r10, r6, r1
 	adc r2, r1, #0
 	umull r0, r1, r5, r7
 	str r2, [r11]
 	adds r0, r0, #0x80000000
 	mov r0, r7, asr #0x1f
 	mla r1, r5, r0, r1
-	mla r1, sl, r7, r1
+	mla r1, r10, r7, r1
 	adc r0, r1, #0
 	str r0, [r11, #4]
 	umull r0, r1, r5, r8
 	adds r0, r0, #0x80000000
 	mov r0, r8, asr #0x1f
 	mla r1, r5, r0, r1
-	mla r1, sl, r8, r1
+	mla r1, r10, r8, r1
 	adc r0, r1, #0
 	str r0, [r11, #8]
 	cmp r4, #0
@@ -24955,13 +24955,13 @@ _0208e0f8:
 _0208e1bc:
 	ldr r0, [sp, #0x10]
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	arm_func_end func_ov00_0208df78
 
 	.global func_ov00_0208e1c8
 	arm_func_start func_ov00_0208e1c8
 func_ov00_0208e1c8: ; 0x0208e1c8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x48
 	str r1, [sp]
 	add r1, sp, #8
@@ -24991,7 +24991,7 @@ _0208e228:
 	cmp r2, #0
 	addeq sp, sp, #0x48
 	mvneq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	cmp r3, r11
 	beq _0208e288
 	ldr r1, [sp]
@@ -25030,19 +25030,19 @@ _0208e288:
 _0208e2bc:
 	ldr r8, [r2, r3, lsl #2]
 	mov r7, r8, asr #0x1f
-	umull ip, sl, r0, r8
+	umull ip, r10, r0, r8
 	adds ip, ip, lr
-	mla sl, r0, r7, sl
-	mla sl, r1, r8, sl
-	adc r7, sl, r4
+	mla r10, r0, r7, r10
+	mla r10, r1, r8, r10
+	adc r7, r10, r4
 	str r7, [r2, r3, lsl #2]
 	ldr r8, [sb, r3, lsl #2]
 	mov r7, r8, asr #0x1f
-	umull ip, sl, r0, r8
+	umull ip, r10, r0, r8
 	adds ip, ip, r5
-	mla sl, r0, r7, sl
-	mla sl, r1, r8, sl
-	adc r7, sl, r6
+	mla r10, r0, r7, r10
+	mla r10, r1, r8, r10
+	adc r7, r10, r6
 	str r7, [sb, r3, lsl #2]
 	add r3, r3, #1
 	cmp r3, #4
@@ -25065,7 +25065,7 @@ _0208e328:
 	mov lr, #0
 	mov r2, r3, asr #0x1f
 	add r1, r1, ip, lsl #4
-	add sl, r4, ip, lsl #4
+	add r10, r4, ip, lsl #4
 _0208e350:
 	ldr r5, [r0, lr, lsl #2]
 	ldr sb, [r1, lr, lsl #2]
@@ -25077,7 +25077,7 @@ _0208e350:
 	orr r4, r4, r7, lsl #20
 	subs r4, sb, r4
 	str r4, [r1, lr, lsl #2]
-	ldr sb, [sl, lr, lsl #2]
+	ldr sb, [r10, lr, lsl #2]
 	ldr r5, [r6, lr, lsl #2]
 	mov r4, r5, asr #0x1f
 	umull r8, r7, r3, r5
@@ -25086,7 +25086,7 @@ _0208e350:
 	mov r4, r8, lsr #0xc
 	orr r4, r4, r7, lsl #20
 	subs r4, sb, r4
-	str r4, [sl, lr, lsl #2]
+	str r4, [r10, lr, lsl #2]
 	add lr, lr, #1
 	cmp lr, #4
 	blt _0208e350
@@ -25099,7 +25099,7 @@ _0208e3ac:
 	blt _0208e1e8
 	mov r0, #0
 	add sp, sp, #0x48
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	arm_func_end func_ov00_0208e1c8
 
 	.global func_ov00_0208e3d0
@@ -26326,7 +26326,7 @@ _0208f420:
 	.global func_ov00_0208f478
 	arm_func_start func_ov00_0208f478
 func_ov00_0208f478: ; 0x0208f478
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #0x24
 	mov sb, r0
 	mov r8, r1
@@ -26345,22 +26345,22 @@ func_ov00_0208f478: ; 0x0208f478
 	ldr r0, [sp, #0xc]
 	ldr r5, [sp, #0x14]
 	smull r3, r2, r0, r0
-	smull ip, sl, r4, r4
+	smull ip, r10, r4, r4
 	smull r1, r0, r5, r5
 	adds r5, ip, #0x800
-	adc r4, sl, #0
+	adc r4, r10, #0
 	adds r3, r3, #0x800
 	adc r2, r2, #0
 	adds r1, r1, #0x800
 	mov r3, r3, lsr #0xc
-	mov sl, r5, lsr #0xc
+	mov r10, r5, lsr #0xc
 	adc r0, r0, #0
 	mov r1, r1, lsr #0xc
 	orr r3, r3, r2, lsl #20
 	orr r1, r1, r0, lsl #20
-	orr sl, sl, r4, lsl #20
+	orr r10, r10, r4, lsl #20
 	add r0, r3, r1
-	cmp r0, sl
+	cmp r0, r10
 	mov r0, #0
 	bgt _0208f544
 	ldr r3, [sb, #4]
@@ -26373,11 +26373,11 @@ func_ov00_0208f478: ; 0x0208f478
 	strle r0, [r6]
 	addle sp, sp, #0x24
 	movle r0, #1
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 _0208f538:
 	add sp, sp, #0x24
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 _0208f544:
 	add r0, sp, #0x18
 	mov r1, r0
@@ -26390,7 +26390,7 @@ _0208f544:
 	add r0, sp, #0xc
 	mov r1, r0
 	bl func_01ff9c2c
-	sub r1, r0, sl
+	sub r1, r0, r10
 	smull r2, r0, r5, r5
 	adds r3, r2, #0x800
 	adc r2, r0, #0
@@ -26405,25 +26405,25 @@ _0208f544:
 	mov r1, #0
 	addmi sp, sp, #0x24
 	movmi r0, r1
-	ldmmiia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmmiia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	bl func_01ff9958
-	mov sl, r0
+	mov r10, r0
 	mov r0, r4, lsl #0x1
 	bl func_01ff992c
-	sub r3, sl, r5
-	add r2, r5, sl
+	sub r3, r10, r5
+	add r2, r5, r10
 	rsb r4, r2, #0
 	umull r5, ip, r0, r4
 	mov r2, r4, asr #0x1f
 	mla ip, r0, r2, ip
 	mov r2, r3, asr #0x1f
 	adds r5, r5, #0x80000000
-	umull sl, r5, r0, r3
+	umull r10, r5, r0, r3
 	mla r5, r0, r2, r5
 	mla ip, r1, r4, ip
 	mla r5, r1, r3, r5
 	adc r4, ip, #0
-	adds r0, sl, #0x80000000
+	adds r0, r10, #0x80000000
 	adc r0, r5, #0
 	cmp r4, #0
 	blt _0208f60c
@@ -26437,7 +26437,7 @@ _0208f60c:
 _0208f61c:
 	add sp, sp, #0x24
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 _0208f628:
 	add r3, sp, #0
 	ldmia r8, {r0, r1, r2}
@@ -26464,12 +26464,12 @@ _0208f628:
 _0208f680:
 	add sp, sp, #0x24
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 _0208f68c:
 	str r4, [r6]
 	mov r0, #1
 	add sp, sp, #0x24
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	arm_func_end func_ov00_0208f478
 
 	.global func_ov00_0208f69c
@@ -26569,9 +26569,9 @@ func_ov00_0208f768: ; 0x0208f768
 	.global func_ov00_0208f794
 	arm_func_start func_ov00_0208f794
 func_ov00_0208f794: ; 0x0208f794
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x28
-	mov sl, r0
+	mov r10, r0
 	add r1, sp, #4
 	mov r0, #0
 	mov r2, #4
@@ -26586,9 +26586,9 @@ func_ov00_0208f794: ; 0x0208f794
 	mov sb, #0
 	add r5, sp, #4
 _0208f7d4:
-	ldrb r2, [sl, #0x14]
+	ldrb r2, [r10, #0x14]
 	ldr r3, [r6, sb, lsl #2]
-	ldrb r0, [sl, #0x15]
+	ldrb r0, [r10, #0x15]
 	ldr r1, [r11, sb, lsl #2]
 	adds r7, r3, r2
 	add r8, r1, r0
@@ -26635,7 +26635,7 @@ _0208f868:
 	beq _0208f89c
 	tst r1, #8
 	movne r0, #0
-	strne r0, [sl, #0x38]
+	strne r0, [r10, #0x38]
 	bne _0208f9ac
 _0208f89c:
 	ands r3, r1, #1
@@ -26643,16 +26643,16 @@ _0208f89c:
 	tst r1, #2
 	beq _0208f8c0
 	mov r0, #0
-	str r0, [sl, #0x38]
+	str r0, [r10, #0x38]
 	sub r0, r0, #0x4000
-	strh r0, [sl, #0xc]
+	strh r0, [r10, #0xc]
 	b _0208f9ac
 _0208f8c0:
 	cmp r0, #0
 	beq _0208f8d8
 	tst r1, #2
 	movne r0, #1
-	strne r0, [sl, #0x38]
+	strne r0, [r10, #0x38]
 	bne _0208f9ac
 _0208f8d8:
 	ands r2, r1, #8
@@ -26660,9 +26660,9 @@ _0208f8d8:
 	tst r1, #2
 	beq _0208f8fc
 	mov r0, #1
-	str r0, [sl, #0x38]
+	str r0, [r10, #0x38]
 	mov r0, #0x4000
-	strh r0, [sl, #0xc]
+	strh r0, [r10, #0xc]
 	b _0208f9ac
 _0208f8fc:
 	cmp r2, #0
@@ -26670,9 +26670,9 @@ _0208f8fc:
 	beq _0208f920
 	mov r1, #1
 	mov r0, #0x8000
-	str r1, [sl, #0x38]
+	str r1, [r10, #0x38]
 	rsb r0, r0, #0
-	strh r0, [sl, #0xc]
+	strh r0, [r10, #0xc]
 	b _0208f9ac
 _0208f920:
 	cmp r0, #0
@@ -26680,24 +26680,24 @@ _0208f920:
 	beq _0208f944
 	mov r1, #1
 	mov r0, #0x4000
-	str r1, [sl, #0x38]
+	str r1, [r10, #0x38]
 	rsb r0, r0, #0
-	strh r0, [sl, #0xc]
+	strh r0, [r10, #0xc]
 	b _0208f9ac
 _0208f944:
 	cmp r0, #0
 	cmpeq r2, #0
 	beq _0208f97c
 	mov r0, #2
-	str r0, [sl, #0x38]
+	str r0, [r10, #0x38]
 	ldr r0, [sp, #4]
 	tst r0, #4
 	movne r0, #0
-	strneh r0, [sl, #0xc]
+	strneh r0, [r10, #0xc]
 	bne _0208f9ac
 	mov r0, #0x8000
 	rsb r0, r0, #0
-	strh r0, [sl, #0xc]
+	strh r0, [r10, #0xc]
 	b _0208f9ac
 _0208f97c:
 	cmp r3, #0
@@ -26706,26 +26706,26 @@ _0208f97c:
 	beq _0208f9ac
 _0208f98c:
 	mov r0, #2
-	str r0, [sl, #0x38]
+	str r0, [r10, #0x38]
 	ldr r0, [sp, #4]
 	tst r0, #1
 	mov r0, #0x4000
 	rsbne r0, r0, #0
-	strneh r0, [sl, #0xc]
-	streqh r0, [sl, #0xc]
+	strneh r0, [r10, #0xc]
+	streqh r0, [r10, #0xc]
 _0208f9ac:
 	ldr r0, _0208f9e8 ; =data_027e0f68
-	ldr r2, [sl, #0x38]
+	ldr r2, [r10, #0x38]
 	ldr r0, [r0]
 	mov r1, #0xe
 	bl func_ov00_0208ccdc
 	mov r1, r0
-	add r0, sl, #0x3c
+	add r0, r10, #0x3c
 	ldr r2, [r0]
 	ldr r2, [r2, #0xc]
 	blx r2
 	add sp, sp, #0x28
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_0208f794
 _0208f9dc: .word data_ov00_020db010
@@ -27152,13 +27152,13 @@ _0208fef4: .word data_027e0e60
 	.global func_ov00_0208fef8
 	arm_func_start func_ov00_0208fef8
 func_ov00_0208fef8: ; 0x0208fef8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x80
 	str r0, [sp, #4]
 	ldr r0, [r0, #0x130]
 	cmp r0, #1
 	addeq sp, sp, #0x80
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, [sp, #4]
 	ldrh r0, [r0, #0x26]
 	cmp r0, #1
@@ -27166,13 +27166,13 @@ func_ov00_0208fef8: ; 0x0208fef8
 	cmp r0, #2
 	beq _0208ff48
 	add sp, sp, #0x80
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0208ff34:
 	ldr r0, _0209030c ; =data_ov00_020eec9c
 	mov r1, #0xb
 	bl func_ov00_020d77e4
 	add sp, sp, #0x80
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0208ff48:
 	ldr r0, _0209030c ; =data_ov00_020eec9c
 	mov r1, #0xb
@@ -27231,7 +27231,7 @@ _02090004:
 	ldr r0, [r0, #8]
 	str r0, [sp, #0x10]
 	ldr r0, _0209031c ; =data_027e0764
-	ldr sl, [sp, #0x10]
+	ldr r10, [sp, #0x10]
 	ldr lr, [r0, #0xc]
 	ldr r0, [r0]
 	str r0, [sp, #0x14]
@@ -27240,38 +27240,38 @@ _02090004:
 	ldr r0, _0209031c ; =data_027e0764
 	ldr r3, [sp, #0x14]
 	ldr ip, [r0, #4]
-	umull sb, r3, sl, r3
-	mla r3, sl, ip, r3
-	ldr sl, [sp, #0x14]
+	umull sb, r3, r10, r3
+	mla r3, r10, ip, r3
+	ldr r10, [sp, #0x14]
 	adds sb, r8, sb
-	mla r3, lr, sl, r3
+	mla r3, lr, r10, r3
 	adc r3, r7, r3
 	str r3, [sp, #0xc]
 	ldr r3, _0209031c ; =data_027e0764
-	ldr sl, [sp, #0xc]
+	ldr r10, [sp, #0xc]
 	str sb, [r3]
-	str sl, [r3, #4]
-	mov r3, sl
-	mov sl, #0xb
-	umull sl, ip, r3, sl
-	mov sl, r3
+	str r10, [r3, #4]
+	mov r3, r10
+	mov r10, #0xb
+	umull r10, ip, r3, r10
+	mov r10, r3
 	mov r3, #0
-	mla ip, sl, r3, ip
-	mov sl, r3
+	mla ip, r10, r3, ip
+	mov r10, r3
 	mov r3, #0xb
-	mla ip, sl, r3, ip
+	mla ip, r10, r3, ip
 	sub r3, ip, #5
 	mov r3, r3, lsl #0xc
 	str r3, [sp, #0x64]
 	ldr r3, [sp, #0x10]
 	add r0, sp, #0x5c
-	umull r11, sl, r3, sb
+	umull r11, r10, r3, sb
 	mov ip, r3
 	ldr r3, [sp, #0xc]
 	adds r8, r8, r11
-	mla sl, ip, r3, sl
-	mla sl, lr, sb, sl
-	adc r3, r7, sl
+	mla r10, ip, r3, r10
+	mla r10, lr, sb, r10
+	adc r3, r7, r10
 	ldr r7, _0209031c ; =data_027e0764
 	mov r2, r0
 	str r8, [r7]
@@ -27430,7 +27430,7 @@ _020902f8:
 	cmp r6, #5
 	blo _0208ffb4
 	add sp, sp, #0x80
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_0208fef8
 _0209030c: .word data_ov00_020eec9c
@@ -32171,36 +32171,36 @@ func_ov00_02093dd0: ; 0x02093dd0
 	.global func_ov00_02093e00
 	arm_func_start func_ov00_02093e00
 func_ov00_02093e00: ; 0x02093e00
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x70
-	mov sl, r0
-	ldr r1, [sl, #4]
+	mov r10, r0
+	ldr r1, [r10, #4]
 	ldr r0, _020940cc ; =data_027e0e60
 	orr r1, r1, #0x800
-	str r1, [sl, #4]
-	ldr r2, [sl, #0x18]
+	str r1, [r10, #4]
+	ldr r2, [r10, #0x18]
 	add r1, sp, #8
 	add r2, r2, #0x800
-	str r2, [sl, #0x18]
-	ldrb r3, [sl, #0x15]
-	ldrb r2, [sl, #0x14]
+	str r2, [r10, #0x18]
+	ldrb r3, [r10, #0x15]
+	ldrb r2, [r10, #0x14]
 	ldr r0, [r0]
 	strb r2, [sp, #8]
 	strb r3, [sp, #9]
 	bl func_ov00_02083e58
-	str r0, [sl, #0x1c]
-	ldr r0, [sl, #0x20]
+	str r0, [r10, #0x1c]
+	ldr r0, [r10, #0x20]
 	add r0, r0, #0x800
-	str r0, [sl, #0x20]
-	ldrh r0, [sl, #0x24]
+	str r0, [r10, #0x20]
+	ldrh r0, [r10, #0x24]
 	cmp r0, #1
 	bne _02093e70
-	ldr r0, [sl, #0x1c]
+	ldr r0, [r10, #0x1c]
 	add r0, r0, #0x66
 	add r0, r0, #0x2600
-	str r0, [sl, #0x1c]
+	str r0, [r10, #0x1c]
 _02093e70:
-	add r4, sl, #0x18
+	add r4, r10, #0x18
 	ldmia r4, {r0, r1, r2}
 	add r5, sp, #0x64
 	stmia r5, {r0, r1, r2}
@@ -32228,10 +32228,10 @@ _02093e70:
 	mov r0, #0
 	bic r0, r0, #0x1f
 	orr r1, r0, #7
-	ldrh r0, [sl, #0x26]
+	ldrh r0, [r10, #0x26]
 	orr r1, r1, #0x10c00000
 	bic r1, r1, #0x6000
-	ldrh r4, [sl, #0x2a]
+	ldrh r4, [r10, #0x2a]
 	bic r1, r1, #0x3f0000
 	and r0, r0, #0xff
 	orr r0, r1, r0, lsl #16
@@ -32277,18 +32277,18 @@ _02093f80:
 	add r3, sp, #0x1c
 	ldmia r0, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
-	mov r0, sl
+	mov r0, r10
 	bl func_ov00_0208b9cc
 	mov r1, #0
 	mov r2, r0
 	str r1, [sp]
-	add r0, sl, #0x38
+	add r0, r10, #0x38
 	ldr r4, [r0]
 	ldr r3, [sp, #0xc]
 	ldr r4, [r4, #0x14]
 	add r1, sp, #0x10
 	blx r4
-	ldrb r8, [sl, #0x14]
+	ldrb r8, [r10, #0x14]
 	add r0, r8, #2
 	cmp r8, r0
 	bge _0209406c
@@ -32297,7 +32297,7 @@ _02093f80:
 	mov r5, #1
 	add r11, sp, #4
 _02093fec:
-	ldrb sb, [sl, #0x15]
+	ldrb sb, [r10, #0x15]
 	add r0, sb, #2
 	cmp sb, r0
 	bge _02094058
@@ -32320,44 +32320,44 @@ _02094000:
 	mov r2, sb
 	mov r3, #9
 	bl func_ov00_02084d24
-	ldrb r0, [sl, #0x15]
+	ldrb r0, [r10, #0x15]
 	add sb, sb, #1
 	add r0, r0, #2
 	cmp sb, r0
 	blt _02094000
 _02094058:
-	ldrb r0, [sl, #0x14]
+	ldrb r0, [r10, #0x14]
 	add r8, r8, #1
 	add r0, r0, #2
 	cmp r8, r0
 	blt _02093fec
 _0209406c:
-	ldrb r0, [sl, #0x2e]
+	ldrb r0, [r10, #0x2e]
 	cmp r0, #0
 	beq _0209408c
-	mov r0, sl
+	mov r0, r10
 	mov r1, #0
 	bl func_ov00_0208b9e4
 	cmp r0, #0
 	beq _020940ac
 _0209408c:
-	mov r0, sl
+	mov r0, r10
 	ldr r3, [r0]
 	mov r1, #1
 	ldr r3, [r3, #0x80]
 	mov r2, r1
 	blx r3
 	add sp, sp, #0x70
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _020940ac:
-	mov r0, sl
+	mov r0, r10
 	ldr r3, [r0]
 	mov r1, #0
 	ldr r3, [r3, #0x80]
 	mov r2, #1
 	blx r3
 	add sp, sp, #0x70
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_02093e00
 _020940cc: .word data_027e0e60
@@ -33663,31 +33663,31 @@ func_ov00_02094e58: ; 0x02094e58
 	.global func_ov00_02094e6c
 	arm_func_start func_ov00_02094e6c
 func_ov00_02094e6c: ; 0x02094e6c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #8
-	mov sl, r0
+	mov r10, r0
 	mov r0, #1
 	mov r6, r1
-	strb r0, [sl]
+	strb r0, [r10]
 	mov r5, r2
-	strh r6, [sl, #2]
+	strh r6, [r10, #2]
 	ldr r0, _02094f84 ; =data_027e0e60
-	strh r5, [sl, #4]
+	strh r5, [r10, #4]
 	ldr r0, [r0]
 	mov sb, r3
 	bl func_ov00_0208335c
-	ldrh r1, [sl, #2]
+	ldrh r1, [r10, #2]
 	bl func_02002c14
 	mov r1, r0, lsl #0xc
 	ldr r0, _02094f84 ; =data_027e0e60
-	str r1, [sl, #0xc]
+	str r1, [r10, #0xc]
 	ldr r0, [r0]
 	bl func_ov00_02083368
-	ldrh r1, [sl, #4]
+	ldrh r1, [r10, #4]
 	bl func_02002c14
 	mov r0, r0, lsl #0xc
-	str r0, [sl, #0x10]
-	ldr r0, [sl, #8]
+	str r0, [r10, #0x10]
+	ldr r0, [r10, #8]
 	cmp r0, #0
 	bne _02094f24
 	mul r4, r6, r5
@@ -33709,18 +33709,18 @@ func_ov00_02094e6c: ; 0x02094e6c
 	str r7, [sp, #4]
 	bl func_0204f558
 _02094f20:
-	str r0, [sl, #8]
+	str r0, [r10, #8]
 _02094f24:
 	mul r8, r6, r5
 	cmp r8, #0
 	mov r5, #0
 	addle sp, sp, #8
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	mov r7, r5
 	mov r11, sb, lsl #0x1
 _02094f40:
 	ldr r0, _02094f88 ; =data_027e0ce0
-	ldr r4, [sl, #8]
+	ldr r4, [r10, #8]
 	ldr r1, [r0, #4]
 	mov r0, r11
 	mov r2, #4
@@ -33735,7 +33735,7 @@ _02094f40:
 	add r7, r7, #0xc
 	blt _02094f40
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_02094e6c
 _02094f84: .word data_027e0e60
@@ -34588,7 +34588,7 @@ func_ov00_02095980: ; 0x02095980
 	.global func_ov00_02095998
 	arm_func_start func_ov00_02095998
 func_ov00_02095998: ; 0x02095998
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0xac
 	str r0, [sp, #4]
 	mov sb, r1
@@ -34605,7 +34605,7 @@ func_ov00_02095998: ; 0x02095998
 	mov r7, r0, asr #0x1
 	ldr r0, [sp, #4]
 	mov r8, #0
-	add sl, r0, #0x30
+	add r10, r0, #0x30
 	mov r0, r8
 	bic r0, r0, #0x1f
 	orr r0, r0, #1
@@ -34792,7 +34792,7 @@ _02095c74:
 	str r0, [sp, #0x84]
 	mov r0, #0
 	str r0, [sp]
-	mov r0, sl
+	mov r0, r10
 	ldr ip, [r0]
 	ldr r3, [sp, #0xc]
 	ldr ip, [ip, #0x14]
@@ -34800,11 +34800,11 @@ _02095c74:
 	mov r2, #3
 	blx ip
 	ldr r0, _02095d04 ; =data_027e0f6c
-	mov r1, sl
+	mov r1, r10
 	ldr r0, [r0]
 	bl func_ov00_02093a5c
 	add r8, r8, #1
-	add sl, sl, #0x2c
+	add r10, r10, #0x2c
 	cmp r8, #4
 	blo _02095a08
 	cmp sb, #0
@@ -34813,7 +34813,7 @@ _02095c74:
 	strneb r1, [r0, #0x2c]
 	mov r0, #1
 	add sp, sp, #0xac
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_02095998
 _02095d04: .word data_027e0f6c
@@ -35076,16 +35076,16 @@ _02095fdc: .word data_027e0f70
 	.global func_ov00_02095fe0
 	arm_func_start func_ov00_02095fe0
 func_ov00_02095fe0: ; 0x02095fe0
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x34
 	ldr r2, _0209614c ; =data_027e0d3c
-	mov sl, r0
+	mov r10, r0
 	ldr r0, [r2]
 	mov sb, r1
 	bl func_ov00_02078f54
 	cmp r0, #0
 	addeq sp, sp, #0x34
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, _0209614c ; =data_027e0d3c
 	ldr r1, _02096150 ; =data_027e0e60
 	ldr r2, [r0]
@@ -35096,14 +35096,14 @@ func_ov00_02095fe0: ; 0x02095fe0
 	bl func_ov00_020835e4
 	cmp r0, #0
 	addeq sp, sp, #0x34
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
-	ldr r8, [sl]
-	ldr r1, [sl, #4]
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldr r8, [r10]
+	ldr r1, [r10, #4]
 	mov r0, #0x30
 	mla r0, r1, r0, r8
 	cmp r8, r0
 	addeq sp, sp, #0x34
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r4, _02096150 ; =data_027e0e60
 	add r6, sp, #0x1c
 	add r5, sp, #0x28
@@ -35157,20 +35157,20 @@ _020960b0:
 	mov r2, r5
 	bl func_01ff9bc4
 	mov r2, r7
-	mov r0, sl
+	mov r0, r10
 	mov r1, r5
 	mov r3, sb
 	bl func_ov00_02096160
 _02096128:
-	ldr r2, [sl]
-	ldr r1, [sl, #4]
+	ldr r2, [r10]
+	ldr r1, [r10, #4]
 	mov r0, #0x30
 	mla r0, r1, r0, r2
 	add r8, r8, #0x30
 	cmp r8, r0
 	bne _02096060
 	add sp, sp, #0x34
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_02095fe0
 _0209614c: .word data_027e0d3c
@@ -35241,7 +35241,7 @@ func_ov00_020961f8: ; 0x020961f8
 	.global func_ov00_0209621c
 	arm_func_start func_ov00_0209621c
 func_ov00_0209621c: ; 0x0209621c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x30
 	ldr r6, _02096320 ; =data_ov00_020eab04
 	mov r7, r0
@@ -35249,12 +35249,12 @@ func_ov00_0209621c: ; 0x0209621c
 	mov r5, #0
 	cmp r4, #0
 	addle sp, sp, #0x30
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	add sb, sp, #0x10
 	mov r8, r5
 	add r11, sp, #0
 _0209624c:
-	ldrb sl, [r6, #0x34]
+	ldrb r10, [r6, #0x34]
 	ldrb lr, [r6, #0x35]
 	ldrb ip, [r6, #0x36]
 	ldrb r3, [r6, #0x37]
@@ -35263,7 +35263,7 @@ _0209624c:
 	ldr r1, [r6, #0x3c]
 	str r0, [sp]
 	add r0, r6, #0x40
-	strb sl, [sp, #4]
+	strb r10, [sp, #4]
 	strb lr, [sp, #5]
 	strb ip, [sp, #6]
 	strb r3, [sp, #7]
@@ -35271,13 +35271,13 @@ _0209624c:
 	str r1, [sp, #0xc]
 	ldmia r0, {r0, r1, r2}
 	stmia sb, {r0, r1, r2}
-	ldrh sl, [r6, #0x4c]
+	ldrh r10, [r6, #0x4c]
 	ldrh r3, [r6, #0x4e]
 	ldrh r2, [r6, #0x50]
 	ldrh r0, [r6, #0x52]
 	ldrb r1, [r6, #0x54]
-	strh sl, [sp, #0x1c]
-	ldrb sl, [r6, #0x55]
+	strh r10, [sp, #0x1c]
+	ldrb r10, [r6, #0x55]
 	strh r3, [sp, #0x1e]
 	ldrb r3, [r6, #0x56]
 	strh r2, [sp, #0x20]
@@ -35286,8 +35286,8 @@ _0209624c:
 	ldrsb r0, [r6, #0x58]
 	strb r1, [sp, #0x24]
 	ldrb r1, [r6, #0x59]
-	strb sl, [sp, #0x25]
-	ldrb sl, [r6, #0x5a]
+	strb r10, [sp, #0x25]
+	ldrb r10, [r6, #0x5a]
 	strb r3, [sp, #0x26]
 	ldrsb r3, [r6, #0x5b]
 	strb r2, [sp, #0x27]
@@ -35296,7 +35296,7 @@ _0209624c:
 	mov r0, r7
 	strb r1, [sp, #0x29]
 	mov r1, r11
-	strb sl, [sp, #0x2a]
+	strb r10, [sp, #0x2a]
 	strb r3, [sp, #0x2b]
 	str r2, [sp, #0x2c]
 	strb r8, [sp, #6]
@@ -35306,7 +35306,7 @@ _0209624c:
 	add r6, r6, #0x30
 	blt _0209624c
 	add sp, sp, #0x30
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_0209621c
 _02096320: .word data_ov00_020eab04
@@ -35314,7 +35314,7 @@ _02096320: .word data_ov00_020eab04
 	.global func_ov00_02096324
 	arm_func_start func_ov00_02096324
 func_ov00_02096324: ; 0x02096324
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	mov r7, r0
 	ldr r5, [r7]
 	ldr r2, [r7, #4]
@@ -35347,7 +35347,7 @@ _02096358:
 	add r3, ip, #0x40
 	strb r2, [ip, #0x34]
 	ldrb r2, [r5, #5]
-	add sl, r5, #0x1c
+	add r10, r5, #0x1c
 	and r4, r0, #0xff
 	strb r2, [ip, #0x35]
 	ldrb r0, [r5, #6]
@@ -35361,9 +35361,9 @@ _02096358:
 	str r0, [ip, #0x3c]
 	ldmia r1, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
-	ldmia sl!, {r0, r1, r2, r3}
+	ldmia r10!, {r0, r1, r2, r3}
 	stmia lr!, {r0, r1, r2, r3}
-	ldr r0, [sl]
+	ldr r0, [r10]
 	str r0, [lr]
 	strb sb, [ip, #0x36]
 _020963f0:
@@ -35376,7 +35376,7 @@ _020963f0:
 	bne _02096358
 _0209640c:
 	strb r4, [r6, #6]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_02096324
 _02096414: .word data_027e0f7c
@@ -38853,7 +38853,7 @@ _02098e38:
 	arm_func_start func_ov00_02098f04
 func_ov00_02098f04: ; 0x02098f04
 	stmdb sp!, {r0, r1, r2, r3}
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #8
 	ldr r8, [sp, #0x30]
 	ldr r4, [sp, #0x2c]
@@ -38873,14 +38873,14 @@ func_ov00_02098f04: ; 0x02098f04
 _02098f4c:
 	add r0, r5, r5, lsr #31
 	mov sb, r0, asr #0x1
-	mla sl, sb, r8, r4
+	mla r10, sb, r8, r4
 	mov r0, r6
-	mov r1, sl
+	mov r1, r10
 	bl func_ov00_02098b78
 	cmp r0, #0
 	movne r5, sb
 	bne _02098f80
-	add r4, sl, #0xb4
+	add r4, r10, #0xb4
 	add r0, sb, #1
 	str r4, [sp, #0x2c]
 	sub r5, r5, r0
@@ -38891,7 +38891,7 @@ _02098f88:
 	ldr r0, [sp, #0x2c]
 	str r0, [r7]
 	add sp, sp, #8
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	add sp, sp, #0x10
 	bx lr
 	.align 2, 0
@@ -39997,7 +39997,7 @@ _02099eb4:
 	.global func_ov00_02099ecc
 	arm_func_start func_ov00_02099ecc
 func_ov00_02099ecc: ; 0x02099ecc
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	mov r7, r0
 	ldr sb, [r7]
 	ldr r8, [r7, #4]
@@ -40031,7 +40031,7 @@ _02099f2c:
 	add r3, r4, #0x24
 	str r1, [r4, #4]
 	ldr r1, [lr, #8]
-	add sl, lr, #0x30
+	add r10, lr, #0x30
 	str r1, [r4, #8]
 	ldrb r1, [lr, #0xc]
 	add sb, r4, #0x30
@@ -40076,11 +40076,11 @@ _02099f2c:
 	ldmia r0, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
 _0209a000:
-	ldmia sl!, {r0, r1, r2, r3}
+	ldmia r10!, {r0, r1, r2, r3}
 	stmia sb!, {r0, r1, r2, r3}
 	subs r8, r8, #1
 	bne _0209a000
-	ldmia sl, {r0, r1}
+	ldmia r10, {r0, r1}
 	stmia sb, {r0, r1}
 	ldr r1, [lr, #0x98]
 	add r0, lr, #0xa4
@@ -40128,7 +40128,7 @@ _0209a090:
 	add ip, r5, #0x30
 	str r1, [r8, #8]
 	ldrb r1, [r5, #0xc]
-	add sl, r8, #0x30
+	add r10, r8, #0x30
 	mov sb, #6
 	strb r1, [r8, #0xc]
 	ldrb r1, [r5, #0xd]
@@ -40171,11 +40171,11 @@ _0209a090:
 	stmia r3, {r0, r1, r2}
 _0209a168:
 	ldmia ip!, {r0, r1, r2, r3}
-	stmia sl!, {r0, r1, r2, r3}
+	stmia r10!, {r0, r1, r2, r3}
 	subs sb, sb, #1
 	bne _0209a168
 	ldmia ip, {r0, r1}
-	stmia sl, {r0, r1}
+	stmia r10, {r0, r1}
 	ldr r1, [r5, #0x98]
 	add r0, r5, #0xa4
 	str r1, [r8, #0x98]
@@ -40217,7 +40217,7 @@ _0209a1d8:
 	str r2, [r6, #4]
 	ldr r1, [r7]
 	mla r0, r11, r0, r1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_02099ecc
 _0209a220: .word 0xb60b60b7
@@ -41325,7 +41325,7 @@ func_ov00_0209af04: ; 0x0209af04
 	.global func_ov00_0209af20
 	arm_func_start func_ov00_0209af20
 func_ov00_0209af20: ; 0x0209af20
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #4
 	mov sb, r0
 	ldr r8, [sb]
@@ -41338,20 +41338,20 @@ func_ov00_0209af20: ; 0x0209af20
 	mov r6, #0x10
 	mov r4, #0
 _0209af50:
-	ldr sl, [r8]
-	cmp sl, #0
+	ldr r10, [r8]
+	cmp r10, #0
 	beq _0209af90
 	beq _0209af8c
-	mov r0, sl
+	mov r0, r10
 	bl func_ov00_020a5ccc
 	mov r1, r7
 	mov r2, r6
 	mov r3, r5
-	add r0, sl, #0x20
+	add r0, r10, #0x20
 	bl func_0204f754
-	add r0, sl, #0xc
+	add r0, r10, #0xc
 	blx func_0203005c
-	mov r0, sl
+	mov r0, r10
 	bl _ZN9SysObjectdlEPv
 _0209af8c:
 	str r4, [r8]
@@ -41368,7 +41368,7 @@ _0209afa4:
 	sub r0, r0, r1
 	str r0, [sb, #4]
 	add sp, sp, #4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov00_0209af20
 _0209afc0: .word func_0203010c
@@ -41376,15 +41376,15 @@ _0209afc0: .word func_0203010c
 	.global func_ov00_0209afc4
 	arm_func_start func_ov00_0209afc4
 func_ov00_0209afc4: ; 0x0209afc4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	movs r8, r2
 	mov sb, r0
-	mov sl, r1
+	mov r10, r1
 	mov r11, r3
 	mov r7, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0209afe0:
-	ldr r0, [sl, r7, lsl #2]
+	ldr r0, [r10, r7, lsl #2]
 	and r4, r0, #0xff
 	mov r0, r0, asr #0x10
 	and r6, r0, #0xff
@@ -41841,7 +41841,7 @@ _0209b588:
 	add r7, r7, #1
 	cmp r7, r8
 	blo _0209afe0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_0209afc4
 _0209b598: .word data_027e0f74
@@ -41851,11 +41851,11 @@ _0209b5a0: .word data_ov00_020db058
 	.global func_ov00_0209b5a4
 	arm_func_start func_ov00_0209b5a4
 func_ov00_0209b5a4: ; 0x0209b5a4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x28
-	mov sl, r0
-	ldr r2, [sl]
-	ldr r0, [sl, #4]
+	mov r10, r0
+	ldr r2, [r10]
+	ldr r0, [r10, #4]
 	mov sb, r1
 	add r1, r2, r0, lsl #2
 	mov r8, r2
@@ -41889,8 +41889,8 @@ _0209b5dc:
 _0209b62c:
 	str r4, [r8]
 _0209b630:
-	ldr r2, [sl]
-	ldr r0, [sl, #4]
+	ldr r2, [r10]
+	ldr r0, [r10, #4]
 	add r8, r8, #4
 	add r1, r2, r0, lsl #2
 	cmp r8, r1
@@ -41925,22 +41925,22 @@ _0209b694:
 	cmp r3, r2
 	bne _0209b694
 _0209b6ac:
-	ldr r2, [sl]
-	ldr r0, [sl, #4]
+	ldr r2, [r10]
+	ldr r0, [r10, #4]
 	mov r3, #0
 	add r2, r2, r0, lsl #2
 	strb r3, [sp]
 	sub r0, sp, #4
 	strb r3, [r0]
 	ldr r3, [r0]
-	mov r0, sl
+	mov r0, r10
 	str r1, [sp, #0x24]
 	str r2, [sp, #0x18]
 	str r2, [sp, #0x10]
 	str r1, [sp, #0x14]
 	bl func_ov00_02080f94
 	add sp, sp, #0x28
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_0209b5a4
 _0209b6ec: .word data_ov00_020db058
@@ -46292,7 +46292,7 @@ func_ov00_0209ed2c: ; 0x0209ed2c
 	.global func_ov00_0209ed30
 	arm_func_start func_ov00_0209ed30
 func_ov00_0209ed30: ; 0x0209ed30
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	ldr r4, [sp, #0x20]
 	mov r6, r1
 	mov r7, r0
@@ -46334,10 +46334,10 @@ func_ov00_0209ed30: ; 0x0209ed30
 	ldr lr, [sp, #0x28]
 	rsb r3, r8, #0x1000
 	smull r2, r0, r3, r5
-	ldr sl, [sp, #0x24]
+	ldr r10, [sp, #0x24]
 	smull r6, r5, r7, r1
 	smull ip, r3, r7, r7
-	smull sl, r7, r8, sl
+	smull r10, r7, r8, r10
 	adds r6, r6, #0x800
 	adc r5, r5, #0
 	mov r6, r6, lsr #0xc
@@ -46370,26 +46370,26 @@ func_ov00_0209ed30: ; 0x0209ed30
 	adc r0, r0, #0
 	mov r2, r1, lsr #0xc
 	orr r2, r2, r0, lsl #20
-	adds r1, sl, #0x800
+	adds r1, r10, #0x800
 	adc r0, r7, #0
 	mov r1, r1, lsr #0xc
 	orr r1, r1, r0, lsl #20
 	add r0, r2, r1
 	add r0, r3, r0
 	add r0, r5, r0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	arm_func_end func_ov00_0209ed30
 
 	.global func_ov00_0209ee88
 	arm_func_start func_ov00_0209ee88
 func_ov00_0209ee88: ; 0x0209ee88
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x4c
 	ldr r7, [r2, #8]
 	ldr r8, [r2, #0xc]
-	mov sl, r0
+	mov r10, r0
 	ldr r3, [r2]
-	sub r0, r8, sl
+	sub r0, r8, r10
 	sub r4, r8, r7
 	str r1, [sp]
 	ldr r6, [r2, #4]
@@ -46401,7 +46401,7 @@ func_ov00_0209ee88: ; 0x0209ee88
 	str r2, [sp, #0x20]
 	bl Divide
 	mov r5, r0
-	sub r0, sl, r7
+	sub r0, r10, r7
 	mov r1, r4
 	str r0, [sp, #0x14]
 	bl Divide
@@ -46423,7 +46423,7 @@ func_ov00_0209ee88: ; 0x0209ee88
 	str r0, [sp, #0x2c]
 	sub r0, sb, r7
 	str r0, [sp, #0x18]
-	sub r0, sb, sl
+	sub r0, sb, r10
 	ldr r1, [sp, #0x18]
 	str r0, [sp, #0x10]
 	bl Divide
@@ -46437,7 +46437,7 @@ func_ov00_0209ee88: ; 0x0209ee88
 	mov r4, r3, lsr #0xc
 	orr r4, r4, r0, lsl #20
 	mov r1, r11
-	sub r0, sl, r6
+	sub r0, r10, r6
 	mov r11, r4, asr #0x1f
 	str r0, [sp, #4]
 	bl Divide
@@ -46473,7 +46473,7 @@ func_ov00_0209ee88: ; 0x0209ee88
 	ldr r1, [sp, #0xc]
 	mov lr, r2, asr #0x1f
 	ldr r2, [sp, #0x34]
-	sub r0, sl, r0
+	sub r0, r10, r0
 	umull ip, sb, r2, r5
 	mov r3, r2
 	ldr r2, [sp, #0x2c]
@@ -46497,28 +46497,28 @@ func_ov00_0209ee88: ; 0x0209ee88
 	mov r5, r0
 	mov r0, r1
 	sub r7, r1, r7
-	sub r0, r0, sl
+	sub r0, r0, r10
 	mov r1, r7
 	bl Divide
 	ldr r2, [sp, #0x38]
 	str r0, [sp, #0x44]
-	umull sl, sb, r2, r4
+	umull r10, sb, r2, r4
 	mla sb, r2, r11, sb
 	mov r3, r2, asr #0x1f
 	mla sb, r3, r4, sb
-	adds r3, sl, #0x800
+	adds r3, r10, #0x800
 	ldr r1, [sp, #8]
 	ldr r0, [sp, #4]
 	adc r2, sb, #0
 	mov r4, r3, lsr #0xc
 	orr r4, r4, r2, lsl #20
 	bl Divide
-	mov sl, r0
+	mov r10, r0
 	ldr r0, [sp, #0x14]
 	mov r1, r7
 	bl Divide
 	ldr r1, [sp, #0x40]
-	smull sb, r7, sl, r8
+	smull sb, r7, r10, r8
 	smull r3, lr, r1, r8
 	ldr r8, [sp, #0x44]
 	smull r2, r1, r8, r4
@@ -46530,10 +46530,10 @@ func_ov00_0209ee88: ; 0x0209ee88
 	ldr r4, [sp]
 	ldr r8, [r4, #0xc]
 	ldr r4, [r4, #8]
-	smull sl, r8, r0, r8
-	adds sl, sl, #0x800
+	smull r10, r8, r0, r8
+	adds r10, r10, #0x800
 	adc r0, r8, #0
-	mov ip, sl, lsr #0xc
+	mov ip, r10, lsr #0xc
 	adds r8, sb, #0x800
 	orr ip, ip, r0, lsl #20
 	adc r0, r7, #0
@@ -46556,11 +46556,11 @@ func_ov00_0209ee88: ; 0x0209ee88
 	ldr r7, [r0]
 	ldr r2, [r0, #4]
 	ldr r0, [sp, #0x3c]
-	umull sl, sb, r0, r6
+	umull r10, sb, r0, r6
 	mov r1, r0
 	ldr r0, [sp, #0x48]
 	mla sb, r1, r0, sb
-	adds r1, sl, #0x800
+	adds r1, r10, #0x800
 	mla sb, r8, r6, sb
 	adc r0, sb, #0
 	mov r1, r1, lsr #0xc
@@ -46592,7 +46592,7 @@ func_ov00_0209ee88: ; 0x0209ee88
 	add r0, r11, r0
 	add r0, ip, r0
 	add sp, sp, #0x4c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	arm_func_end func_ov00_0209ee88
 
 	.global func_ov00_0209f1d0
@@ -48221,7 +48221,7 @@ func_ov00_020a0554: ; 0x020a0554
 	.global func_ov00_020a05b0
 	arm_func_start func_ov00_020a05b0
 func_ov00_020a05b0: ; 0x020a05b0
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #0x20
 	mov sb, r0
 	mov r0, r1
@@ -48237,7 +48237,7 @@ func_ov00_020a05b0: ; 0x020a05b0
 	cmp r0, r2, lsl #1
 	addlo sp, sp, #0x20
 	movlo r0, #0
-	ldmloia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmloia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	add r1, sp, #0x1c
 	mov r0, sb
 	bl func_ov00_020a0554
@@ -48284,7 +48284,7 @@ func_ov00_020a05b0: ; 0x020a05b0
 	bl func_ov00_0209f8ac
 	add sp, sp, #0x20
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _020a06b0:
 	ldr r3, [r8]
 	ldr r0, [r8, #4]
@@ -48298,7 +48298,7 @@ _020a06b0:
 	cmp r5, r0
 	beq _020a081c
 	add r6, r7, r5
-	sub sl, sp, #4
+	sub r10, sp, #4
 _020a06e4:
 	ldr r0, [r5, #0x24]
 	ldr r2, [sp, #4]
@@ -48340,8 +48340,8 @@ _020a0770:
 	mov r2, #0
 	strb r0, [sp, #0x11]
 	mov r2, r2
-	strb r2, [sl]
-	ldr r2, [sl]
+	strb r2, [r10]
+	ldr r2, [r10]
 	mov r0, r8
 	add r1, sp, #0x18
 	bl func_ov00_020a0ae8
@@ -48367,8 +48367,8 @@ _020a07d4:
 	mov r2, #0
 	strb r0, [sp, #0x10]
 	mov r2, r2
-	strb r2, [sl]
-	ldr r2, [sl]
+	strb r2, [r10]
+	ldr r2, [r10]
 	mov r0, r8
 	add r1, sp, #0x14
 	bl func_ov00_020a0ae8
@@ -48394,7 +48394,7 @@ _020a081c:
 	blx r1
 	mov r0, #1
 	add sp, sp, #0x20
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	arm_func_end func_ov00_020a05b0
 
 	.global func_ov00_020a0848
@@ -49582,7 +49582,7 @@ func_ov00_020a15dc: ; 0x020a15dc
 	.global func_ov00_020a15f0
 	arm_func_start func_ov00_020a15f0
 func_ov00_020a15f0: ; 0x020a15f0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #8
 	str r0, [sp]
 	ldr r1, [sp]
@@ -49602,7 +49602,7 @@ _020a1620:
 	ldr r6, _020a1704 ; =data_ov00_020e4ed8
 	ldr r11, _020a1708 ; =data_ov00_020e4eb8
 	ldr r4, _020a170c ; =data_027e0ce0
-	mov sl, sb
+	mov r10, sb
 	add r7, r1, r0
 	mov r5, sb
 _020a1648:
@@ -49626,7 +49626,7 @@ _020a165c:
 	mov r1, #1
 	str r1, [r0, #0x1c]
 _020a1690:
-	str r0, [r7, sl]
+	str r0, [r7, r10]
 	b _020a16d0
 _020a1698:
 	ldr r1, [r4, #4]
@@ -49643,9 +49643,9 @@ _020a1698:
 	ldr r1, _020a1710 ; =data_ov00_020e4e98
 	str r1, [r0]
 _020a16cc:
-	str r0, [r7, sl]
+	str r0, [r7, r10]
 _020a16d0:
-	add sl, sl, #4
+	add r10, r10, #4
 	add sb, sb, #1
 	cmp sb, #2
 	blo _020a1648
@@ -49657,7 +49657,7 @@ _020a16d0:
 	blo _020a1620
 	ldr r0, [sp]
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020a15f0
 _020a1704: .word data_ov00_020e4ed8
@@ -49668,11 +49668,11 @@ _020a1710: .word data_ov00_020e4e98
 	.global func_ov00_020a1714
 	arm_func_start func_ov00_020a1714
 func_ov00_020a1714: ; 0x020a1714
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	mov r5, #0
 	mov sb, r0
 	add r7, sb, #8
-	mov sl, r5
+	mov r10, r5
 	mov r4, r5
 _020a172c:
 	mov r6, r4
@@ -49687,14 +49687,14 @@ _020a1734:
 _020a174c:
 	add r6, r6, #1
 	cmp r6, #2
-	str sl, [r8], #4
+	str r10, [r8], #4
 	blo _020a1734
 	add r5, r5, #1
 	cmp r5, #2
 	add r7, r7, #8
 	blo _020a172c
 	mov r0, sb
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	arm_func_end func_ov00_020a1714
 
 	.global func_ov00_020a1774
@@ -50687,7 +50687,7 @@ _020a23a0: .word data_027e0fac
 	.global func_ov00_020a23a4
 	arm_func_start func_ov00_020a23a4
 func_ov00_020a23a4: ; 0x020a23a4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #0x11c
 	mov sb, r0
 	ldr r2, [sb, #4]
@@ -50695,7 +50695,7 @@ func_ov00_020a23a4: ; 0x020a23a4
 	ldr r1, [r2, #0x15c]
 	cmp r1, #0x5c
 	addeq sp, sp, #0x11c
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	bl func_ov00_02090a7c
 	add r5, sp, #0xb4
 	mov r6, r0
@@ -50750,7 +50750,7 @@ _020a23d8:
 	ldr r0, [sp, #0x1c]
 	ldr r1, [sp, #0x24]
 	bl func_01ffa0f4
-	mov sl, r0, lsl #0x10
+	mov r10, r0, lsl #0x10
 	add r0, sp, #0x1c
 	add r3, sp, #4
 	ldmia r0, {r0, r1, r2}
@@ -50796,7 +50796,7 @@ _020a2538:
 	mov r2, r2, lsl #0x10
 	cmp r1, r2, asr #16
 	blt _020a2590
-	add r0, r0, sl, asr #16
+	add r0, r0, r10, asr #16
 	mov r0, r0, lsl #0x10
 	mov r7, r0, asr #0x10
 	b _020a2590
@@ -50812,7 +50812,7 @@ _020a2578:
 	add r2, r3, #0x8000
 	mov r2, r2, lsl #0x10
 	cmp r1, r2, asr #16
-	rsble r0, r0, sl, asr #16
+	rsble r0, r0, r10, asr #16
 	movle r0, r0, lsl #0x10
 	movle r7, r0, asr #0x10
 _020a2590:
@@ -50895,7 +50895,7 @@ _020a2680:
 	bl func_ov00_02090c58
 	cmp r8, #0
 	addne sp, sp, #0x11c
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	ldr r1, [sp, #0xe0]
 	mov r0, sb
 	bl func_ov00_02090e9c
@@ -50903,7 +50903,7 @@ _020a2680:
 	mov r0, sb
 	bl func_ov00_02090efc
 	add sp, sp, #0x11c
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020a23a4
 _020a26dc: .word data_027e0d38
@@ -54123,10 +54123,10 @@ _020a4fc4: .word func_ov00_020a4fc8
 	.global func_ov00_020a4fc8
 	arm_func_start func_ov00_020a4fc8
 func_ov00_020a4fc8: ; 0x020a4fc8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x40
-	mov sl, r0
-	ldr r1, [sl]
+	mov r10, r0
+	ldr r1, [r10]
 	mov r0, #0xc
 	mul r0, r1, r0
 	ldr r1, _020a515c ; =data_ov00_020dc294
@@ -54140,7 +54140,7 @@ func_ov00_020a4fc8: ; 0x020a4fc8
 	ldrsh r11, [r2]
 	str r1, [sp]
 _020a5008:
-	add r1, sl, r6, lsl #2
+	add r1, r10, r6, lsl #2
 	ldr r7, [r1, #0x10]
 	cmp r7, #0
 	beq _020a5130
@@ -54149,7 +54149,7 @@ _020a5008:
 	add r0, r0, r6, lsl #2
 	ldr sb, [r0, #4]
 	ldr r8, [r5, sb, lsl #5]
-	add r0, sl, r8, lsl #2
+	add r0, r10, r8, lsl #2
 	ldr r0, [r0, #4]
 	cmp r0, #0
 	beq _020a50a8
@@ -54157,20 +54157,20 @@ _020a5008:
 	mov r1, #0xa
 	bl func_ov00_02079e68
 	mov r4, r0
-	add r0, sl, r8, lsl #2
+	add r0, r10, r8, lsl #2
 	ldr r0, [r0, #4]
 	mov r1, #0
 	bl func_ov00_020a5d10
 	mov r1, r4
 	bl func_020197bc
-	ldrb r0, [sl, #0x37]
+	ldrb r0, [r10, #0x37]
 	mov r1, #0
 	cmp r0, #0
-	add r0, sl, r8, lsl #2
+	add r0, r10, r8, lsl #2
 	ldr r0, [r0, #4]
 	beq _020a5094
 	bl func_ov00_020a5d10
-	add r1, sl, r6, lsl #1
+	add r1, r10, r6, lsl #1
 	ldrsh r1, [r1, #0x3c]
 	and r1, r1, #0xff
 	bl func_020197fc
@@ -54184,11 +54184,11 @@ _020a5094:
 _020a50a8:
 	add r0, r5, sb, lsl #5
 	ldr r1, [r0, #0x14]
-	mov r0, sl
+	mov r0, r10
 	str r1, [sp, #0x28]
 	str r1, [sp, #0x2c]
 	str r1, [sp, #0x30]
-	ldrb r1, [sl, #0x34]
+	ldrb r1, [r10, #0x34]
 	mov r2, sb
 	add r3, sp, #0x34
 	bl func_ov00_020a5170
@@ -54219,7 +54219,7 @@ _020a5114:
 	add r3, sp, #0x34
 	blx r4
 _020a5130:
-	ldr r1, [sl]
+	ldr r1, [r10]
 	mov r0, #0xc
 	mul r0, r1, r0
 	ldr r1, _020a515c ; =data_ov00_020dc294
@@ -54230,7 +54230,7 @@ _020a5130:
 _020a5150:
 	bl func_01ffa8d4
 	add sp, sp, #0x40
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020a4fc8
 _020a515c: .word data_ov00_020dc294
@@ -54507,15 +54507,15 @@ _020a5504: .word data_ov00_020dc294
 	.global func_ov00_020a5508
 	arm_func_start func_ov00_020a5508
 func_ov00_020a5508: ; 0x020a5508
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0xb0
 	mov r4, r1
-	mov sl, r0
+	mov r10, r0
 	bl func_ov00_020a58ac
 	cmp r4, #4
 	addeq sp, sp, #0xb0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
-	ldr r2, [sl]
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldr r2, [r10]
 	ldr r1, _020a57f4 ; =data_ov00_020dc294
 	mov r0, #0xc
 	mla r0, r2, r0, r1
@@ -54526,7 +54526,7 @@ func_ov00_020a5508: ; 0x020a5508
 	mov sb, #0
 	cmp r0, #0
 	addls sp, sp, #0xb0
-	ldmlsia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmlsia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r4, _020a57f8 ; =data_027e0ce0
 	mvn r5, #0
 _020a5560:
@@ -54543,7 +54543,7 @@ _020a5560:
 	ldmia r7, {r0, r1, r2, r3}
 	stmia r6, {r0, r1, r2, r3}
 	ldr r8, [sp, #0x84]
-	add r0, sl, r8, lsl #2
+	add r0, r10, r8, lsl #2
 	ldr r0, [r0, #4]
 	cmp r0, #0
 	bne _020a562c
@@ -54575,7 +54575,7 @@ _020a5560:
 	add r0, r6, #0x20
 	bl func_0204f614
 _020a5610:
-	add r0, sl, r8, lsl #2
+	add r0, r10, r8, lsl #2
 	str r6, [r0, #4]
 	ldr r2, _020a5810 ; =data_ov00_020dc2c4
 	ldr r1, [sp, #0x84]
@@ -54589,7 +54589,7 @@ _020a562c:
 	bl _ZN9SysObjectnwEmPjj
 	movs r6, r0
 	beq _020a5664
-	add r0, sl, r8, lsl #2
+	add r0, r10, r8, lsl #2
 	ldr r0, [r0, #4]
 	mov r1, #0
 	bl func_ov00_020a5d10
@@ -54598,7 +54598,7 @@ _020a562c:
 	bl func_ov00_020a4c38
 	mov r6, r0
 _020a5664:
-	add r0, sl, sb, lsl #2
+	add r0, r10, sb, lsl #2
 	str r6, [r0, #0x10]
 	ldr r0, _020a5810 ; =data_ov00_020dc2c4
 	add r1, sp, #0x44
@@ -54606,7 +54606,7 @@ _020a5664:
 	mov r0, r7
 	mov r2, #2
 	bl func_ov00_020a5ae8
-	add r0, sl, r8, lsl #2
+	add r0, r10, r8, lsl #2
 	ldr r2, _020a5814 ; =data_ov00_020dc324
 	ldr r0, [r0, #4]
 	mov r1, #2
@@ -54619,7 +54619,7 @@ _020a5664:
 	bl _ZN9SysObjectnwEmPjj
 	movs r6, r0
 	beq _020a56e0
-	add r0, sl, r8, lsl #2
+	add r0, r10, r8, lsl #2
 	ldr r0, [r0, #4]
 	mov r1, #0
 	bl func_ov00_020a5d10
@@ -54630,12 +54630,12 @@ _020a5664:
 	bl func_ov00_020a581c
 	mov r6, r0
 _020a56e0:
-	add r0, sl, sb, lsl #2
+	add r0, r10, sb, lsl #2
 	str r6, [r0, #0x18]
 	mov r0, r6
 	mov r1, #0
 	bl func_ov00_020c0e5c
-	add r1, sl, sb, lsl #2
+	add r1, r10, sb, lsl #2
 	ldr r0, [r1, #0x10]
 	ldr r1, [r1, #0x18]
 	ldr r2, [r0]
@@ -54645,7 +54645,7 @@ _020a56e0:
 	add r1, sp, #4
 	mov r2, #1
 	bl func_ov00_020a5ae8
-	add r0, sl, r8, lsl #2
+	add r0, r10, r8, lsl #2
 	ldr r2, _020a5818 ; =data_ov00_020dc2f4
 	ldr r0, [r0, #4]
 	mov r1, #1
@@ -54658,7 +54658,7 @@ _020a56e0:
 	bl _ZN9SysObjectnwEmPjj
 	movs r7, r0
 	beq _020a5778
-	add r0, sl, r8, lsl #2
+	add r0, r10, r8, lsl #2
 	ldr r0, [r0, #4]
 	mov r1, #0
 	bl func_ov00_020a5d10
@@ -54669,7 +54669,7 @@ _020a56e0:
 	bl func_ov00_020a5864
 	mov r7, r0
 _020a5778:
-	add r0, sl, sb, lsl #2
+	add r0, r10, sb, lsl #2
 	str r7, [r0, #0x20]
 	mov r0, r7
 	mov r1, #0
@@ -54678,7 +54678,7 @@ _020a5778:
 	cmp r0, #1
 	bne _020a57c0
 	ldr r0, [sp, #0x90]
-	add r1, sl, sb, lsl #2
+	add r1, r10, sb, lsl #2
 	rsb r2, r0, #0
 	ldr r0, [r1, #0x10]
 	str r2, [r0, #0x5c]
@@ -54689,7 +54689,7 @@ _020a5778:
 	b _020a57dc
 _020a57c0:
 	ldr r2, [sp, #0x90]
-	add r1, sl, sb, lsl #2
+	add r1, r10, sb, lsl #2
 	ldr r0, [r1, #0x10]
 	str r2, [r0, #0x5c]
 	ldr r0, [r1, #0x10]
@@ -54701,7 +54701,7 @@ _020a57dc:
 	cmp sb, r0
 	blo _020a5560
 	add sp, sp, #0xb0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020a5508
 _020a57f4: .word data_ov00_020dc294
@@ -54766,7 +54766,7 @@ _020a58a8: .word data_ov00_020e5868
 	.global func_ov00_020a58ac
 	arm_func_start func_ov00_020a58ac
 func_ov00_020a58ac: ; 0x020a58ac
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	mov r6, #0
 	mov r7, r0
 	mov r5, r6
@@ -54819,20 +54819,20 @@ _020a593c:
 	mov r5, r4
 _020a595c:
 	add r0, r7, r4, lsl #2
-	ldr sl, [r0, #4]
-	cmp sl, #0
+	ldr r10, [r0, #4]
+	cmp r10, #0
 	beq _020a59a4
 	beq _020a599c
-	mov r0, sl
+	mov r0, r10
 	bl func_ov00_020a5ccc
 	mov r1, sb
 	mov r2, r8
 	mov r3, r6
-	add r0, sl, #0x20
+	add r0, r10, #0x20
 	bl func_0204f754
-	add r0, sl, #0xc
+	add r0, r10, #0xc
 	blx func_0203005c
-	mov r0, sl
+	mov r0, r10
 	bl _ZN9SysObjectdlEPv
 _020a599c:
 	add r0, r7, r4, lsl #2
@@ -54841,7 +54841,7 @@ _020a59a4:
 	add r4, r4, #1
 	cmp r4, #3
 	blt _020a595c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020a58ac
 _020a59b4: .word func_0203010c
@@ -54975,7 +54975,7 @@ _020a5b34: .word data_ov00_020e52e0
 	.global func_ov00_020a5b38
 	arm_func_start func_ov00_020a5b38
 func_ov00_020a5b38: ; 0x020a5b38
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #0x118
 	mov r6, r0
 	ldr r0, [r6, #4]
@@ -55049,7 +55049,7 @@ _020a5c40:
 	add r0, sp, #0x48
 	blx func_0203010c
 _020a5c4c:
-	add sl, r6, #0x20
+	add r10, r6, #0x20
 	mov sb, #0
 	add r8, sp, #8
 	mov r7, #0x10
@@ -55058,12 +55058,12 @@ _020a5c5c:
 	mov r1, r8
 	mov r2, sb
 	bl func_ov00_020a5ae8
-	mov r0, sl
+	mov r0, r10
 	ldr r1, [r0]
 	ldr r1, [r1, #0xc]
 	blx r1
 	add r1, r6, sb, lsl #4
-	mov r0, sl
+	mov r0, r10
 	str r8, [r1, #0x24]
 	ldr r2, [r0]
 	mov r1, r7
@@ -55071,11 +55071,11 @@ _020a5c5c:
 	blx r2
 	add sb, sb, #1
 	cmp sb, #4
-	add sl, sl, #0x10
+	add r10, r10, #0x10
 	blt _020a5c5c
 	str r5, [r6]
 	add sp, sp, #0x118
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020a5b38
 _020a5cb4: .word data_027e0ce0
@@ -55156,16 +55156,16 @@ _020a5d70: .word func_ov00_020c0bdc
 	.global func_ov00_020a5d74
 	arm_func_start func_ov00_020a5d74
 func_ov00_020a5d74: ; 0x020a5d74
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
-	mov sl, r0
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	mov r10, r0
 	mov sb, r1
 	bl func_ov00_020a5d50
 	movs r4, r0
 	mov r7, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	mov r11, r7
 _020a5d94:
-	mov r0, sl
+	mov r0, r10
 	mov r1, r7
 	bl func_ov00_020a5d10
 	movs r8, r0
@@ -55196,22 +55196,22 @@ _020a5df8:
 	add r7, r7, #1
 	cmp r7, r4
 	blo _020a5d94
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	arm_func_end func_ov00_020a5d74
 
 	.global func_ov00_020a5e08
 	arm_func_start func_ov00_020a5e08
 func_ov00_020a5e08: ; 0x020a5e08
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
-	mov sl, r0
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	mov r10, r0
 	mov sb, r1
 	bl func_ov00_020a5d50
 	movs r4, r0
 	mov r7, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	mov r11, r7
 _020a5e28:
-	mov r0, sl
+	mov r0, r10
 	mov r1, r7
 	bl func_ov00_020a5d10
 	movs r8, r0
@@ -55242,7 +55242,7 @@ _020a5e8c:
 	add r7, r7, #1
 	cmp r7, r4
 	blo _020a5e28
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	arm_func_end func_ov00_020a5e08
 
 	.global func_ov00_020a5e9c
@@ -56188,10 +56188,10 @@ func_ov00_020a6908: ; 0x020a6908
 	.global func_ov00_020a6924
 	arm_func_start func_ov00_020a6924
 func_ov00_020a6924: ; 0x020a6924
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0xf0
 	ldr r2, _020a6de4 ; =data_027e0f94
-	mov sl, r0
+	mov r10, r0
 	ldr r3, [r2]
 	ldr r0, [r2, #4]
 	str r3, [sp, #0x7c]
@@ -56199,14 +56199,14 @@ func_ov00_020a6924: ; 0x020a6924
 	ldr r0, [r2, #8]
 	mov sb, r1
 	str r0, [sp, #0x84]
-	ldr r0, [sl, #4]
+	ldr r0, [r10, #4]
 	ldr r0, [r0, #0x15c]
 	cmp r0, #0x4f
 	beq _020a6970
 	cmp r0, #0x54
 	beq _020a6b9c
 	add sp, sp, #0xf0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _020a6970:
 	ldr r0, _020a6de8 ; =data_027e10a4
 	add r1, sp, #0x70
@@ -56218,8 +56218,8 @@ _020a6970:
 	str r1, [sp, #0x7c]
 	str r0, [sp, #0x84]
 	str r4, [sp, #0x80]
-	ldr r3, [sl, #0x20]
-	ldr r2, [sl, #0x18]
+	ldr r3, [r10, #0x20]
+	ldr r2, [r10, #0x18]
 	add r0, sp, #0x10
 	add r1, sp, #0x7c
 	str r2, [sp, #0x10]
@@ -56229,11 +56229,11 @@ _020a6970:
 	mov r4, r0
 	cmp r4, #0x1800
 	bgt _020a6ad0
-	add r0, sl, #0x18
+	add r0, r10, #0x18
 	add r6, sp, #0x64
 	ldmia r0, {r0, r1, r2}
 	stmia r6, {r0, r1, r2}
-	ldr r5, [sl, #4]
+	ldr r5, [r10, #4]
 	add r1, sp, #4
 	ldr r2, [r5, #0x290]
 	mov r0, r6
@@ -56269,7 +56269,7 @@ _020a6a50:
 	add r1, sp, #0x64
 	mov r2, r0
 	bl func_01ff9bc4
-	ldr r2, [sl, #0x1c]
+	ldr r2, [r10, #0x1c]
 	ldr r1, [sp, #0x80]
 	ldr r0, _020a6dec ; =0x00001ccd
 	sub r1, r2, r1
@@ -56283,29 +56283,29 @@ _020a6a50:
 	orr r2, r2, r1, lsr #21
 	adc r2, r2, #0
 	mov r1, r0, lsr #0xc
-	add r0, sl, #0x30
+	add r0, r10, #0x30
 	orr r1, r1, r2, lsl #20
 	mov r2, #0xcd
 	bl Approach_thunk
 	b _020a6abc
 _020a6aac:
-	add r0, sl, #0x30
+	add r0, r10, #0x30
 	mov r1, #0
 	mov r2, #0xcd
 	bl Approach_thunk
 _020a6abc:
 	ldr r1, [sp, #0x80]
-	ldr r0, [sl, #0x30]
+	ldr r0, [r10, #0x30]
 	sub r0, r1, r0
 	str r0, [sp, #0x80]
 	b _020a6ae0
 _020a6ad0:
-	add r0, sl, #0x30
+	add r0, r10, #0x30
 	mov r1, #0
 	mov r2, #0xcd
 	bl Approach_thunk
 _020a6ae0:
-	add r0, sl, #0x18
+	add r0, r10, #0x18
 	add r3, sp, #0x58
 	ldmia r0, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
@@ -56318,22 +56318,22 @@ _020a6ae0:
 	bl func_01ffa0f4
 	mov r2, r0, lsl #0x10
 	add r1, sp, #0x7c
-	mov r0, sl
+	mov r0, r10
 	mov r2, r2, asr #0x10
 	bl func_ov00_02090e20
 	add r1, sp, #0x7c
-	mov r0, sl
+	mov r0, r10
 	bl func_ov00_02090c58
 	cmp sb, #0
 	bne _020a6b48
 	add r1, sp, #0x7c
-	mov r0, sl
+	mov r0, r10
 	bl func_ov00_02090b38
 	add sp, sp, #0xf0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _020a6b48:
-	ldr r2, [sl, #4]
-	mov r0, sl
+	ldr r2, [r10, #4]
+	mov r0, r10
 	ldr r1, [r2, #0x260]
 	str r1, [sp, #0x4c]
 	ldr r1, [r2, #0x264]
@@ -56349,12 +56349,12 @@ _020a6b48:
 	str r4, [sp]
 	bl func_0202b4e4
 	add r1, sp, #0x4c
-	mov r0, sl
+	mov r0, r10
 	bl func_ov00_02090b38
 	add sp, sp, #0xf0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _020a6b9c:
-	add r0, sl, #0x18
+	add r0, r10, #0x18
 	add r3, sp, #0x40
 	ldmia r0, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
@@ -56371,7 +56371,7 @@ _020a6b9c:
 	mov r4, r0, asr #0x10
 	str r2, [sp, #0x34]
 	ldr r2, [r1, #4]
-	add r0, sl, #0x24
+	add r0, r10, #0x24
 	str r2, [sp, #0x38]
 	ldr r1, [r1, #8]
 	add r3, sp, #0x28
@@ -56385,7 +56385,7 @@ _020a6b9c:
 	add r0, sp, #0x28
 	bl func_01ff9cec
 	mov r5, r0
-	mov r0, sl
+	mov r0, r10
 	bl func_ov00_02090a7c
 	mov r8, r0
 	add r7, sp, #0x88
@@ -56404,60 +56404,60 @@ _020a6c2c:
 	ldr r2, _020a6df0 ; =0x00000333
 	mov r6, r7, asr #0x1
 	mov r1, r6
-	add r0, sl, #0x38
+	add r0, r10, #0x38
 	bl Approach_thunk
 	ldr r2, _020a6df4 ; =0x00000666
 	mov r1, r7
-	add r0, sl, #0x3c
+	add r0, r10, #0x3c
 	bl Approach_thunk
 	cmp sb, #0
-	streq r6, [sl, #0x38]
-	streq r7, [sl, #0x3c]
+	streq r6, [r10, #0x38]
+	streq r7, [r10, #0x3c]
 _020a6c84:
 	ldr r11, [sp, #0xac]
-	mov r0, sl
+	mov r0, r10
 	mov r1, r11
 	bl func_ov00_02090c1c
 	ldr r6, [sp, #0xa8]
-	ldr r1, [sl, #0x3c]
-	mov r0, sl
+	ldr r1, [r10, #0x3c]
+	mov r0, r10
 	add r1, r6, r1
 	bl func_ov00_02090c04
 	ldr r7, [sp, #0xa4]
-	ldr r1, [sl, #0x38]
-	mov r0, sl
+	ldr r1, [r10, #0x38]
+	mov r0, r10
 	sub r1, r7, r1
 	bl func_ov00_02090c10
 	cmp sb, #0
 	bne _020a6cf0
-	mov r0, sl
+	mov r0, r10
 	mov r1, r11
 	bl func_ov00_02090afc
-	ldr r1, [sl, #0x3c]
-	mov r0, sl
+	ldr r1, [r10, #0x3c]
+	mov r0, r10
 	add r1, r6, r1
 	bl func_ov00_02090ae4
-	ldr r1, [sl, #0x38]
-	mov r0, sl
+	ldr r1, [r10, #0x38]
+	mov r0, r10
 	sub r1, r7, r1
 	bl func_ov00_02090af0
 _020a6cf0:
 	add r1, sp, #0x7c
-	mov r0, sl
+	mov r0, r10
 	mov r2, r4
 	bl func_ov00_02090e20
 	add r1, sp, #0x7c
-	mov r0, sl
+	mov r0, r10
 	bl func_ov00_02090c58
 	cmp sb, #0
 	bne _020a6d24
 	add r1, sp, #0x7c
-	mov r0, sl
+	mov r0, r10
 	bl func_ov00_02090b38
 	b _020a6d70
 _020a6d24:
-	ldr r2, [sl, #4]
-	mov r0, sl
+	ldr r2, [r10, #4]
+	mov r0, r10
 	ldr r1, [r2, #0x260]
 	str r1, [sp, #0x1c]
 	ldr r1, [r2, #0x264]
@@ -56473,23 +56473,23 @@ _020a6d24:
 	str r4, [sp]
 	bl func_0202b4e4
 	add r1, sp, #0x1c
-	mov r0, sl
+	mov r0, r10
 	bl func_ov00_02090b38
 _020a6d70:
-	ldr r0, [sl, #0x24]
+	ldr r0, [r10, #0x24]
 	cmp r5, r8
-	str r0, [sl, #0x18]
-	ldr r0, [sl, #0x28]
+	str r0, [r10, #0x18]
+	ldr r0, [r10, #0x28]
 	addlt sp, sp, #0xf0
-	str r0, [sl, #0x1c]
-	ldr r0, [sl, #0x2c]
-	str r0, [sl, #0x20]
-	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	str r0, [r10, #0x1c]
+	ldr r0, [r10, #0x2c]
+	str r0, [r10, #0x20]
+	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	add r0, sp, #0x28
 	bl func_01fffb4c
 	cmp r0, #0
 	addeq sp, sp, #0xf0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	add r0, sp, #0x28
 	mov r1, r8
 	bl func_01fffbec
@@ -56498,13 +56498,13 @@ _020a6d70:
 	mov r2, r0
 	bl func_01ff9bc4
 	ldr r0, [sp, #0x34]
-	str r0, [sl, #0x18]
+	str r0, [r10, #0x18]
 	ldr r0, [sp, #0x38]
-	str r0, [sl, #0x1c]
+	str r0, [r10, #0x1c]
 	ldr r0, [sp, #0x3c]
-	str r0, [sl, #0x20]
+	str r0, [r10, #0x20]
 	add sp, sp, #0xf0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020a6924
 _020a6de4: .word data_027e0f94
@@ -61629,7 +61629,7 @@ _020df78c: .word data_ov00_020e2fa8
 	.global func_ov00_020df790
 	arm_func_start func_ov00_020df790
 func_ov00_020df790: ; 0x020df790
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x238
 	sub sp, sp, #0x400
 	add r3, sp, #0x600
@@ -61640,16 +61640,16 @@ func_ov00_020df790: ; 0x020df790
 	strh r0, [r3, #0x28]
 	str r1, [r7, #0x20]
 	mov r2, #0xfb
-	mov sl, #1
+	mov r10, #1
 	str r2, [r7, #0x24]
-	str sl, [r7, #0x28]
+	str r10, [r7, #0x28]
 	ldrsh r2, [r3, #0x28]
 	mov r4, #0xff
 	rsb lr, r4, #0xfd
 	str r0, [r7, #0x2c]
 	strh r0, [r3, #0x10]
 	strh r2, [r7, #0x30]
-	strb sl, [r7, #0x32]
+	strb r10, [r7, #0x32]
 	add r2, sp, #0x500
 	strb r0, [r7, #0x33]
 	add r2, r2, #8
@@ -61663,22 +61663,22 @@ func_ov00_020df790: ; 0x020df790
 	mov r5, #0x34
 	str lr, [r7, #0x44]
 	strh r3, [r7, #0x48]
-	strb sl, [r7, #0x4a]
+	strb r10, [r7, #0x4a]
 	strb r0, [r7, #0x4b]
 	strb r4, [r7, #0x4c]
 	strb r0, [r7, #0x4d]
 	str r5, [r7, #0x6c]
 	str r0, [r7, #0x70]
-	str sl, [r7, #0x74]
+	str r10, [r7, #0x74]
 	ldrsh r3, [r2, #0xf8]
-	str sl, [r7, #0x78]
+	str r10, [r7, #0x78]
 	strh r3, [r7, #0x7c]
 	mov r3, #0xfb
 	str r1, [sp, #0x620]
 	str r3, [sp, #0x624]
-	str sl, [sp, #0x628]
+	str r10, [sp, #0x628]
 	str r0, [sp, #0x62c]
-	strb sl, [sp, #0x632]
+	strb r10, [sp, #0x632]
 	strb r0, [sp, #0x633]
 	strb r4, [sp, #0x634]
 	strb r0, [sp, #0x635]
@@ -61686,14 +61686,14 @@ func_ov00_020df790: ; 0x020df790
 	str r0, [sp, #0x60c]
 	str r0, [sp, #0x610]
 	str lr, [sp, #0x614]
-	strb sl, [sp, #0x61a]
+	strb r10, [sp, #0x61a]
 	strb r0, [sp, #0x61b]
 	strb r4, [sp, #0x61c]
 	strb r0, [sp, #0x61d]
 	str r5, [sp, #0x5f0]
 	str r0, [sp, #0x5f4]
-	str sl, [sp, #0x5f8]
-	str sl, [sp, #0x5fc]
+	str r10, [sp, #0x5f8]
+	str r10, [sp, #0x5fc]
 	strb r0, [sp, #0x602]
 	strb r0, [sp, #0x603]
 	strb r4, [sp, #0x604]
@@ -61708,7 +61708,7 @@ func_ov00_020df790: ; 0x020df790
 	strb ip, [r7, #0x81]
 	str sb, [r7, #0x84]
 	str r0, [r7, #0x88]
-	str sl, [r7, #0x8c]
+	str r10, [r7, #0x8c]
 	ldrsh r5, [r2, #0xe0]
 	mov r1, #2
 	str r1, [r7, #0x90]
@@ -61720,7 +61720,7 @@ func_ov00_020df790: ; 0x020df790
 	strb ip, [r7, #0x99]
 	str sb, [r7, #0xb8]
 	str r0, [r7, #0xbc]
-	str sl, [r7, #0xc0]
+	str r10, [r7, #0xc0]
 	ldrsh r5, [r2, #0xc8]
 	str r1, [r7, #0xc4]
 	strh r5, [r7, #0xc8]
@@ -61735,28 +61735,28 @@ func_ov00_020df790: ; 0x020df790
 	str r0, [r7, #0xd4]
 	str sb, [sp, #0x5d8]
 	str r0, [sp, #0x5dc]
-	str sl, [sp, #0x5e0]
+	str r10, [sp, #0x5e0]
 	strb r0, [sp, #0x5ea]
 	strb r0, [sp, #0x5eb]
 	strb r4, [sp, #0x5ec]
 	strb r0, [sp, #0x5ed]
 	str sb, [sp, #0x5c0]
 	str r0, [sp, #0x5c4]
-	str sl, [sp, #0x5c8]
+	str r10, [sp, #0x5c8]
 	strb r0, [sp, #0x5d2]
 	strb r0, [sp, #0x5d3]
 	strb r4, [sp, #0x5d4]
 	strb r0, [sp, #0x5d5]
 	str sb, [sp, #0x5a8]
 	str r0, [sp, #0x5ac]
-	str sl, [sp, #0x5b0]
+	str r10, [sp, #0x5b0]
 	str r1, [sp, #0x5b4]
 	strh r0, [r2, #0xb0]
 	strb r0, [sp, #0x5ba]
 	strb r0, [sp, #0x5bb]
 	strb r4, [sp, #0x5bc]
 	strb r0, [sp, #0x5bd]
-	str sl, [r7, #0xd8]
+	str r10, [r7, #0xd8]
 	ldrsh r5, [r2, #0xb0]
 	mov r6, #2
 	mov r8, r6
@@ -61769,7 +61769,7 @@ func_ov00_020df790: ; 0x020df790
 	strb ip, [r7, #0xe5]
 	str sb, [r7, #0x104]
 	str r0, [r7, #0x108]
-	str sl, [r7, #0x10c]
+	str r10, [r7, #0x10c]
 	strh r0, [r2, #0x80]
 	ldrsh r5, [r2, #0x98]
 	mov r1, #3
@@ -61797,7 +61797,7 @@ func_ov00_020df790: ; 0x020df790
 	mov r1, #4
 	str r1, [sp, #0x56c]
 	str r0, [sp, #0x594]
-	str sl, [sp, #0x598]
+	str r10, [sp, #0x598]
 	strb r0, [sp, #0x5a3]
 	strb r4, [sp, #0x5a4]
 	strb r0, [sp, #0x5a5]
@@ -61810,7 +61810,7 @@ func_ov00_020df790: ; 0x020df790
 	str lr, [r7, #0x128]
 	str r5, [sp, #0x560]
 	str r0, [sp, #0x564]
-	str sl, [sp, #0x568]
+	str r10, [sp, #0x568]
 	strh r0, [r2, #0x68]
 	mov r1, #2
 	strb r0, [sp, #0x572]
@@ -61826,7 +61826,7 @@ func_ov00_020df790: ; 0x020df790
 	strb ip, [r7, #0x131]
 	str r5, [r7, #0x150]
 	str r0, [r7, #0x154]
-	str sl, [r7, #0x158]
+	str r10, [r7, #0x158]
 	mov r1, #4
 	str r1, [r7, #0x15c]
 	str r5, [sp, #0x548]
@@ -61841,7 +61841,7 @@ func_ov00_020df790: ; 0x020df790
 	strb r0, [sp, #0x55d]
 	str r5, [sp, #0x530]
 	str r0, [sp, #0x534]
-	str sl, [sp, #0x538]
+	str r10, [sp, #0x538]
 	strh r0, [r2, #0x38]
 	mov r1, #3
 	strb r1, [sp, #0x543]
@@ -61874,7 +61874,7 @@ func_ov00_020df790: ; 0x020df790
 	str r5, [r7, #0x19c]
 	str r0, [r7, #0x1a0]
 	mov r1, #5
-	str sl, [r7, #0x1a4]
+	str r10, [r7, #0x1a4]
 	str r1, [sp, #0x53c]
 	str r1, [r7, #0x1a8]
 	mov r1, #3
@@ -61901,10 +61901,10 @@ func_ov00_020df790: ; 0x020df790
 	strb r0, [sp, #0x52d]
 	str r1, [sp, #0x500]
 	str r0, [sp, #0x504]
-	str sl, [sp, #0x508]
+	str r10, [sp, #0x508]
 	strh r0, [r2, #8]
 	strb r0, [sp, #0x512]
-	strb sl, [sp, #0x513]
+	strb r10, [sp, #0x513]
 	strb r4, [sp, #0x514]
 	strb r0, [sp, #0x515]
 	str r1, [sp, #0x4e8]
@@ -61920,18 +61920,18 @@ func_ov00_020df790: ; 0x020df790
 	str r1, [r7, #0x1e8]
 	str r0, [r7, #0x1ec]
 	mov r1, #6
-	str sl, [r7, #0x1f0]
+	str r10, [r7, #0x1f0]
 	strb r0, [sp, #0x4fa]
-	strb sl, [sp, #0x4fb]
+	strb r10, [sp, #0x4fb]
 	strb r4, [sp, #0x4fc]
 	strb r0, [sp, #0x4fd]
 	str r0, [sp, #0x4d4]
-	str sl, [sp, #0x4d8]
+	str r10, [sp, #0x4d8]
 	str r1, [sp, #0x50c]
 	str r1, [r7, #0x1f4]
 	ldrsh r2, [r2, #8]
 	ldr r1, _020e075c ; =data_ov00_020e31ec
-	and r5, sl, #0xff
+	and r5, r10, #0xff
 	strh r2, [r1, #0xf8]
 	strb ip, [r7, #0x1fa]
 	strb r5, [r7, #0x1fb]
@@ -61961,7 +61961,7 @@ func_ov00_020df790: ; 0x020df790
 	strb r0, [sp, #0x4e2]
 	strb r4, [sp, #0x4e4]
 	strb r0, [sp, #0x4e5]
-	str sl, [r7, #0x23c]
+	str r10, [r7, #0x23c]
 	str r0, [sp, #0x4bc]
 	str r0, [sp, #0x4c0]
 	str lr, [sp, #0x4c4]
@@ -61972,7 +61972,7 @@ func_ov00_020df790: ; 0x020df790
 	strb r4, [sp, #0x4cc]
 	strb r0, [sp, #0x4cd]
 	str r0, [sp, #0x4a4]
-	str sl, [sp, #0x4a8]
+	str r10, [sp, #0x4a8]
 	strh r0, [r6, #0xa8]
 	mov r1, #3
 	strb r1, [sp, #0x4b3]
@@ -62007,7 +62007,7 @@ func_ov00_020df790: ; 0x020df790
 	str r1, [r7, #0x280]
 	str r0, [r7, #0x284]
 	mov r1, #8
-	str sl, [r7, #0x288]
+	str r10, [r7, #0x288]
 	str r1, [sp, #0x4ac]
 	str r1, [r7, #0x28c]
 	ldrsh r2, [r6, #0xa8]
@@ -62038,7 +62038,7 @@ func_ov00_020df790: ; 0x020df790
 	strb r0, [sp, #0x49d]
 	str r1, [sp, #0x470]
 	str r0, [sp, #0x474]
-	str sl, [sp, #0x478]
+	str r10, [sp, #0x478]
 	strh r0, [r6, #0x78]
 	str r1, [sp, #0x458]
 	mov r1, #0xa
@@ -62048,7 +62048,7 @@ func_ov00_020df790: ; 0x020df790
 	strb r4, [sp, #0x484]
 	strb r0, [sp, #0x485]
 	str r0, [sp, #0x45c]
-	str sl, [sp, #0x460]
+	str r10, [sp, #0x460]
 	strh r0, [r6, #0x60]
 	strb ip, [r7, #0x2aa]
 	strb r11, [r7, #0x2ab]
@@ -62058,7 +62058,7 @@ func_ov00_020df790: ; 0x020df790
 	str r1, [r7, #0x2cc]
 	str r0, [r7, #0x2d0]
 	mov r1, #9
-	str sl, [r7, #0x2d4]
+	str r10, [r7, #0x2d4]
 	strb r0, [sp, #0x46a]
 	strb r0, [sp, #0x46b]
 	strb r4, [sp, #0x46c]
@@ -62075,7 +62075,7 @@ func_ov00_020df790: ; 0x020df790
 	mov r1, #0xc
 	str r1, [r7, #0x2e4]
 	str r0, [r7, #0x2e8]
-	str sl, [r7, #0x2ec]
+	str r10, [r7, #0x2ec]
 	mov r1, #0xa
 	str r1, [r7, #0x2f0]
 	ldrsh r2, [r6, #0x60]
@@ -62089,12 +62089,12 @@ func_ov00_020df790: ; 0x020df790
 	mov r1, #0xc
 	str r1, [r7, #0x318]
 	str r0, [r7, #0x31c]
-	str sl, [r7, #0x320]
+	str r10, [r7, #0x320]
 	ldrsh r2, [r6, #0x48]
 	str r1, [sp, #0x440]
 	mov r1, #0xa
 	str r0, [sp, #0x444]
-	str sl, [sp, #0x448]
+	str r10, [sp, #0x448]
 	str r1, [sp, #0x44c]
 	str r1, [r7, #0x324]
 	strb r0, [sp, #0x452]
@@ -62102,16 +62102,16 @@ func_ov00_020df790: ; 0x020df790
 	strb r4, [sp, #0x454]
 	strb r0, [sp, #0x455]
 	str r0, [sp, #0x428]
-	str sl, [sp, #0x42c]
+	str r10, [sp, #0x42c]
 	str r0, [sp, #0x430]
 	str lr, [sp, #0x434]
 	strh r0, [r6, #0x30]
 	strb r0, [sp, #0x43a]
-	strb sl, [sp, #0x43b]
+	strb r10, [sp, #0x43b]
 	strb r4, [sp, #0x43c]
 	strb r0, [sp, #0x43d]
 	str r0, [sp, #0x414]
-	str sl, [sp, #0x418]
+	str r10, [sp, #0x418]
 	str sb, [sp, #0x41c]
 	strh r0, [r6, #0x18]
 	mov r1, #4
@@ -62124,7 +62124,7 @@ func_ov00_020df790: ; 0x020df790
 	strb r3, [r7, #0x32c]
 	strb ip, [r7, #0x32d]
 	str r0, [r7, #0x330]
-	str sl, [r7, #0x334]
+	str r10, [r7, #0x334]
 	str r0, [r7, #0x338]
 	strb r4, [sp, #0x424]
 	strb r0, [sp, #0x425]
@@ -62139,7 +62139,7 @@ func_ov00_020df790: ; 0x020df790
 	str r1, [r7, #0x364]
 	str r0, [r7, #0x368]
 	str r1, [sp, #0x410]
-	str sl, [r7, #0x36c]
+	str r10, [r7, #0x36c]
 	str r1, [sp, #0x3f8]
 	mov r1, #0xc
 	str r1, [sp, #0x404]
@@ -62151,7 +62151,7 @@ func_ov00_020df790: ; 0x020df790
 	str r1, [sp, #0x3ec]
 	str sb, [r7, #0x370]
 	str r0, [sp, #0x3e4]
-	str sl, [sp, #0x3e8]
+	str r10, [sp, #0x3e8]
 	add r5, sp, #0x308
 	strh r0, [r5, #0xe8]
 	mov r1, #4
@@ -62187,11 +62187,11 @@ func_ov00_020df790: ; 0x020df790
 	mov r1, #0x29
 	str r1, [r7, #0x37c]
 	str r0, [r7, #0x380]
-	str sl, [r7, #0x384]
+	str r10, [r7, #0x384]
 	mov r1, #0xc
 	str r1, [r7, #0x388]
 	ldr r1, _020e0764 ; =data_ov00_020e33ec
-	str sl, [sp, #0x400]
+	str r10, [sp, #0x400]
 	strh r2, [r1, #0x8c]
 	ldr r1, [sp, #4]
 	strb r0, [sp, #0x40b]
@@ -62202,7 +62202,7 @@ func_ov00_020df790: ; 0x020df790
 	mov r1, #0x29
 	str r1, [r7, #0x3b0]
 	str r0, [r7, #0x3b4]
-	str sl, [r7, #0x3b8]
+	str r10, [r7, #0x3b8]
 	mov r1, #0xc
 	str r1, [r7, #0x3bc]
 	ldrsh r2, [r5, #0xe8]
@@ -62236,8 +62236,8 @@ func_ov00_020df790: ; 0x020df790
 	mov r1, #0xd
 	str r2, [sp, #0x3b0]
 	mov r2, #2
-	str sl, [r7, #0x404]
-	str sl, [sp, #0x3b8]
+	str r10, [r7, #0x404]
+	str r10, [sp, #0x3b8]
 	str r1, [sp, #0x3bc]
 	str r1, [r7, #0x408]
 	strb r0, [sp, #0x3c2]
@@ -62258,7 +62258,7 @@ func_ov00_020df790: ; 0x020df790
 	strb r4, [sp, #0x3ac]
 	strb r0, [sp, #0x3ad]
 	str r0, [sp, #0x384]
-	str sl, [sp, #0x388]
+	str r10, [sp, #0x388]
 	strh r0, [r5, #0x88]
 	strb r0, [sp, #0x392]
 	ldrsh r2, [r5, #0xb8]
@@ -62287,7 +62287,7 @@ func_ov00_020df790: ; 0x020df790
 	mov r2, #0x2e
 	str r2, [r7, #0x448]
 	str r0, [r7, #0x44c]
-	str sl, [r7, #0x450]
+	str r10, [r7, #0x450]
 	str r1, [r7, #0x454]
 	mov r1, r2
 	str r1, [sp, #0x368]
@@ -62303,7 +62303,7 @@ func_ov00_020df790: ; 0x020df790
 	strb r4, [sp, #0x37c]
 	strb r0, [sp, #0x37d]
 	str r0, [sp, #0x354]
-	str sl, [sp, #0x358]
+	str r10, [sp, #0x358]
 	strh r0, [r5, #0x58]
 	mov r1, #3
 	strb r1, [sp, #0x363]
@@ -62338,7 +62338,7 @@ func_ov00_020df790: ; 0x020df790
 	str r1, [r7, #0x494]
 	str r0, [r7, #0x498]
 	mov r1, #0xf
-	str sl, [r7, #0x49c]
+	str r10, [r7, #0x49c]
 	str r1, [sp, #0x35c]
 	str r1, [r7, #0x4a0]
 	ldrsh r2, [r5, #0x58]
@@ -62370,7 +62370,7 @@ func_ov00_020df790: ; 0x020df790
 	strb ip, [r7, #0x4c1]
 	str sb, [r7, #0x4e0]
 	str r0, [r7, #0x4e4]
-	str sl, [r7, #0x4e8]
+	str r10, [r7, #0x4e8]
 	strh r0, [r5, #0x10]
 	ldrsh r1, [r5, #0x28]
 	mov r2, #0x10
@@ -62388,7 +62388,7 @@ func_ov00_020df790: ; 0x020df790
 	str sb, [r7, #0x4f8]
 	str r0, [r7, #0x4fc]
 	str r0, [sp, #0x324]
-	str sl, [sp, #0x328]
+	str r10, [sp, #0x328]
 	str r0, [r7, #0x500]
 	ldrsh r1, [r5, #0x10]
 	ldr r2, _020e076c ; =data_ov00_020e35ec
@@ -62419,7 +62419,7 @@ func_ov00_020df790: ; 0x020df790
 	strh r0, [r5, #0xf8]
 	str r8, [r7, #0x52c]
 	str r0, [r7, #0x530]
-	str sl, [r7, #0x534]
+	str r10, [r7, #0x534]
 	ldrsh r1, [r5, #0xf8]
 	mov r6, #0x11
 	str r6, [r7, #0x538]
@@ -62433,7 +62433,7 @@ func_ov00_020df790: ; 0x020df790
 	mov r8, #4
 	str r8, [r7, #0x544]
 	str r0, [r7, #0x548]
-	str sl, [r7, #0x54c]
+	str r10, [r7, #0x54c]
 	strh r0, [r5, #0xc8]
 	ldrsh r8, [r5, #0xe0]
 	mov r1, #0x12
@@ -62447,20 +62447,20 @@ func_ov00_020df790: ; 0x020df790
 	mov r6, #4
 	str r6, [r7, #0x578]
 	str r0, [r7, #0x57c]
-	str sl, [r7, #0x580]
+	str r10, [r7, #0x580]
 	ldrsh r6, [r5, #0xc8]
 	str r1, [r7, #0x584]
 	strh r6, [r2, #0x88]
 	mov r6, #4
 	str r0, [sp, #0x2f4]
-	str sl, [sp, #0x2f8]
+	str r10, [sp, #0x2f8]
 	strb r0, [sp, #0x302]
 	strb r0, [sp, #0x303]
 	strb r4, [sp, #0x304]
 	strb r0, [sp, #0x305]
 	str r6, [sp, #0x2d8]
 	str r0, [sp, #0x2dc]
-	str sl, [sp, #0x2e0]
+	str r10, [sp, #0x2e0]
 	str r1, [sp, #0x2e4]
 	strb r0, [sp, #0x2ea]
 	strb r0, [sp, #0x2eb]
@@ -62468,7 +62468,7 @@ func_ov00_020df790: ; 0x020df790
 	strb r0, [sp, #0x2ed]
 	str r6, [sp, #0x2c0]
 	str r0, [sp, #0x2c4]
-	str sl, [sp, #0x2c8]
+	str r10, [sp, #0x2c8]
 	str r1, [sp, #0x2cc]
 	strb r0, [sp, #0x2d2]
 	strb r0, [sp, #0x2d3]
@@ -62482,7 +62482,7 @@ func_ov00_020df790: ; 0x020df790
 	mov r1, #0x37
 	str r1, [r7, #0x590]
 	str r0, [r7, #0x594]
-	str sl, [r7, #0x598]
+	str r10, [r7, #0x598]
 	strh r0, [r5, #0x98]
 	ldrsh r6, [r5, #0xb0]
 	mov r8, #0x37
@@ -62490,7 +62490,7 @@ func_ov00_020df790: ; 0x020df790
 	str r8, [sp, #0x2a8]
 	mov r8, #0x19
 	str r0, [sp, #0x2ac]
-	str sl, [sp, #0x2b0]
+	str r10, [sp, #0x2b0]
 	str r8, [sp, #0x2b4]
 	strb r0, [sp, #0x2ba]
 	strb r0, [sp, #0x2bb]
@@ -62507,13 +62507,13 @@ func_ov00_020df790: ; 0x020df790
 	mov r6, #0x13
 	str r1, [sp, #0x290]
 	str r0, [sp, #0x294]
-	str sl, [sp, #0x298]
+	str r10, [sp, #0x298]
 	str r6, [sp, #0x29c]
 	strb r0, [sp, #0x2a2]
 	strb r0, [sp, #0x2a3]
 	strb r4, [sp, #0x2a4]
 	strb r0, [sp, #0x2a5]
-	str sl, [r7, #0x5cc]
+	str r10, [r7, #0x5cc]
 	str r6, [r7, #0x5d0]
 	ldrsh r8, [r5, #0x98]
 	mov r6, #0xfb
@@ -62527,31 +62527,31 @@ func_ov00_020df790: ; 0x020df790
 	str r1, [r7, #0x5dc]
 	str r6, [r7, #0x5e0]
 	mov r6, #0x1c
-	str sl, [sp, #0x280]
+	str r10, [sp, #0x280]
 	str r6, [sp, #0x284]
 	strh r0, [r5, #0x80]
 	strb r0, [sp, #0x28a]
 	strb r0, [sp, #0x28b]
 	strb r4, [sp, #0x28c]
 	strb r0, [sp, #0x28d]
-	str sl, [r7, #0x5e4]
+	str r10, [r7, #0x5e4]
 	str r6, [r7, #0x5e8]
 	str r0, [sp, #0x264]
-	str sl, [sp, #0x268]
+	str r10, [sp, #0x268]
 	strh r0, [r5, #0x68]
 	strb r0, [sp, #0x272]
 	strb r0, [sp, #0x273]
 	strb r4, [sp, #0x274]
 	strb r0, [sp, #0x275]
 	str r0, [sp, #0x24c]
-	str sl, [sp, #0x250]
+	str r10, [sp, #0x250]
 	strh r0, [r5, #0x50]
 	strb r0, [sp, #0x25a]
 	strb r0, [sp, #0x25b]
 	strb r4, [sp, #0x25c]
 	strb r0, [sp, #0x25d]
 	str r0, [sp, #0x234]
-	str sl, [sp, #0x238]
+	str r10, [sp, #0x238]
 	strh r0, [r5, #0x38]
 	strb r0, [sp, #0x242]
 	strb r0, [sp, #0x243]
@@ -62569,7 +62569,7 @@ func_ov00_020df790: ; 0x020df790
 	strb ip, [r7, #0x5f1]
 	str r2, [r7, #0x610]
 	str r0, [r7, #0x614]
-	str sl, [r7, #0x618]
+	str r10, [r7, #0x618]
 	mov r2, #0x14
 	str r2, [sp, #0x26c]
 	str r2, [r7, #0x61c]
@@ -62583,7 +62583,7 @@ func_ov00_020df790: ; 0x020df790
 	mov r2, #0x36
 	str r2, [r7, #0x628]
 	str r0, [r7, #0x62c]
-	str sl, [r7, #0x630]
+	str r10, [r7, #0x630]
 	mov r2, #0x15
 	str r2, [sp, #0x254]
 	str r2, [r7, #0x634]
@@ -62598,7 +62598,7 @@ func_ov00_020df790: ; 0x020df790
 	mov r6, #0x36
 	str r6, [r7, #0x65c]
 	str r0, [r7, #0x660]
-	str sl, [r7, #0x664]
+	str r10, [r7, #0x664]
 	str r2, [r7, #0x668]
 	mov r2, r6
 	str r2, [sp, #0x218]
@@ -62611,7 +62611,7 @@ func_ov00_020df790: ; 0x020df790
 	strb r4, [sp, #0x22c]
 	strb r0, [sp, #0x22d]
 	str r0, [sp, #0x204]
-	str sl, [sp, #0x208]
+	str r10, [sp, #0x208]
 	strh r0, [r5, #8]
 	mov r2, #4
 	strb r2, [sp, #0x213]
@@ -62658,7 +62658,7 @@ _020e0774:
 	str r6, [sp, #0x200]
 	str r6, [r7, #0x6a8]
 	str r0, [r7, #0x6ac]
-	str sl, [r7, #0x6b0]
+	str r10, [r7, #0x6b0]
 	str r6, [sp, #0x1e8]
 	mov r6, #0x16
 	str r6, [sp, #0x20c]
@@ -62682,14 +62682,14 @@ _020e0774:
 	str lr, [r7, #0x6cc]
 	mov r5, #0xfb
 	str r5, [sp, #0x1d4]
-	str sl, [sp, #0x1d8]
+	str r10, [sp, #0x1d8]
 	strh r0, [r2, #0xd8]
 	str r5, [sp, #0x1bc]
 	strb r0, [sp, #0x1e2]
 	strb r0, [sp, #0x1e3]
 	strb r4, [sp, #0x1e4]
 	strb r0, [sp, #0x1e5]
-	str sl, [sp, #0x1c0]
+	str r10, [sp, #0x1c0]
 	strh r0, [r2, #0xc0]
 	strb r0, [sp, #0x1ca]
 	strb r0, [sp, #0x1cb]
@@ -62697,7 +62697,7 @@ _020e0774:
 	strb r0, [sp, #0x1cd]
 	str r1, [sp, #0x1a0]
 	str r0, [sp, #0x1a4]
-	str sl, [sp, #0x1a8]
+	str r10, [sp, #0x1a8]
 	ldrsh r6, [r2, #0xf0]
 	ldr r5, _020e0770 ; =data_ov00_020e36ec
 	strh r6, [r5, #0xd0]
@@ -62711,7 +62711,7 @@ _020e0774:
 	str r6, [r7, #0x6f4]
 	mov r5, #0xfb
 	str r5, [r7, #0x6f8]
-	str sl, [r7, #0x6fc]
+	str r10, [r7, #0x6fc]
 	mov r5, #0x17
 	str r6, [sp, #0x1b8]
 	str r5, [sp, #0x1dc]
@@ -62727,7 +62727,7 @@ _020e0774:
 	str r6, [r7, #0x70c]
 	mov r6, #0xfb
 	str r6, [r7, #0x710]
-	str sl, [r7, #0x714]
+	str r10, [r7, #0x714]
 	mov r6, #0x17
 	str r6, [r7, #0x718]
 	ldrsh r6, [r2, #0xc0]
@@ -62743,10 +62743,10 @@ _020e0774:
 	strb r0, [sp, #0x1b5]
 	str r1, [r7, #0x740]
 	str r0, [r7, #0x744]
-	str sl, [r7, #0x748]
+	str r10, [r7, #0x748]
 	str r1, [sp, #0x188]
 	str r0, [sp, #0x18c]
-	str sl, [sp, #0x190]
+	str r10, [sp, #0x190]
 	strh r0, [r2, #0x90]
 	mov r6, #0x37
 	str r6, [sp, #0x170]
@@ -62757,7 +62757,7 @@ _020e0774:
 	strb r4, [sp, #0x19c]
 	strb r0, [sp, #0x19d]
 	str r0, [sp, #0x174]
-	str sl, [sp, #0x178]
+	str r10, [sp, #0x178]
 	strh r0, [r2, #0x78]
 	mov r6, #0x18
 	strb r0, [sp, #0x182]
@@ -62774,7 +62774,7 @@ _020e0774:
 	strb ip, [r7, #0x755]
 	str r1, [r7, #0x758]
 	str r0, [r7, #0x75c]
-	str sl, [r7, #0x760]
+	str r10, [r7, #0x760]
 	mov r6, #0x1a
 	str r6, [sp, #0x194]
 	str r6, [r7, #0x764]
@@ -62787,7 +62787,7 @@ _020e0774:
 	mov r8, #0x37
 	str r8, [r7, #0x78c]
 	str r0, [r7, #0x790]
-	str sl, [r7, #0x794]
+	str r10, [r7, #0x794]
 	mov r8, #0x19
 	str r8, [r7, #0x798]
 	ldrsh r8, [r2, #0x78]
@@ -62806,7 +62806,7 @@ _020e0774:
 	strb r0, [sp, #0x16d]
 	str r1, [sp, #0x140]
 	str r0, [sp, #0x144]
-	str sl, [sp, #0x148]
+	str r10, [sp, #0x148]
 	str r6, [sp, #0x14c]
 	strh r0, [r2, #0x48]
 	strb r0, [sp, #0x152]
@@ -62815,7 +62815,7 @@ _020e0774:
 	strb r0, [sp, #0x155]
 	str r1, [sp, #0x128]
 	str r0, [sp, #0x12c]
-	str sl, [sp, #0x130]
+	str r10, [sp, #0x130]
 	strh r0, [r2, #0x30]
 	mov r8, #0x32
 	strb r0, [sp, #0x13a]
@@ -62835,7 +62835,7 @@ _020e0774:
 	strb ip, [r7, #0x7b9]
 	str r1, [r7, #0x7d8]
 	str r0, [r7, #0x7dc]
-	str sl, [r7, #0x7e0]
+	str r10, [r7, #0x7e0]
 	str r6, [r7, #0x7e4]
 	ldrsh r6, [r2, #0x48]
 	strh r6, [r5, #0xe8]
@@ -62845,7 +62845,7 @@ _020e0774:
 	strb ip, [r7, #0x7ed]
 	str r1, [r7, #0x7f0]
 	str r0, [r7, #0x7f4]
-	str sl, [r7, #0x7f8]
+	str r10, [r7, #0x7f8]
 	ldrsh r8, [r2, #0x30]
 	mov r6, #0x1b
 	ldr r5, _020e0e98 ; =data_ov00_020e38ec
@@ -62855,7 +62855,7 @@ _020e0774:
 	strb ip, [r7, #0x802]
 	str r1, [sp, #0x110]
 	str r0, [sp, #0x114]
-	str sl, [sp, #0x118]
+	str r10, [sp, #0x118]
 	str r6, [sp, #0x11c]
 	strh r0, [r2, #0x18]
 	strb r0, [sp, #0x122]
@@ -62867,7 +62867,7 @@ _020e0774:
 	strb ip, [r7, #0x805]
 	str r1, [r7, #0x824]
 	str r0, [r7, #0x828]
-	str sl, [r7, #0x82c]
+	str r10, [r7, #0x82c]
 	str r6, [r7, #0x830]
 	ldrsh r6, [r2, #0x18]
 	strh r0, [r2]
@@ -62901,14 +62901,14 @@ _020e0774:
 	strb r0, [sp, #0x10b]
 	strb r4, [sp, #0x10c]
 	strb r0, [sp, #0x10d]
-	str sl, [sp, #0xe8]
+	str r10, [sp, #0xe8]
 	str r8, [sp, #0xec]
 	strh r0, [sp, #0xf0]
 	strb r0, [sp, #0xf2]
 	strb r0, [sp, #0xf3]
 	strb r4, [sp, #0xf4]
 	strb r0, [sp, #0xf5]
-	str sl, [r7, #0x878]
+	str r10, [r7, #0x878]
 	ldrsh r2, [sp, #0xf0]
 	mov r1, r8
 	str r1, [r7, #0x87c]
@@ -62922,7 +62922,7 @@ _020e0774:
 	strh r0, [sp, #0xd8]
 	str r0, [r7, #0x88c]
 	ldrsh r2, [sp, #0xd8]
-	str sl, [r7, #0x890]
+	str r10, [r7, #0x890]
 	mov r1, #0x14
 	str r1, [r7, #0x894]
 	strh r2, [r5, #0x98]
@@ -62934,7 +62934,7 @@ _020e0774:
 	str sb, [r7, #0x8bc]
 	str r0, [r7, #0x8c0]
 	ldrsh r2, [sp, #0xc0]
-	str sl, [r7, #0x8c4]
+	str r10, [r7, #0x8c4]
 	mov r1, #0x1d
 	str r1, [r7, #0x8c8]
 	strh r2, [r5, #0xcc]
@@ -62947,14 +62947,14 @@ _020e0774:
 	str r1, [sp, #0xd4]
 	mov r1, #0x1d
 	str r0, [sp, #0xcc]
-	str sl, [sp, #0xd0]
+	str r10, [sp, #0xd0]
 	strb r0, [sp, #0xda]
 	strb r0, [sp, #0xdb]
 	strb r4, [sp, #0xdc]
 	strb r0, [sp, #0xdd]
 	str sb, [sp, #0xb0]
 	str r0, [sp, #0xb4]
-	str sl, [sp, #0xb8]
+	str r10, [sp, #0xb8]
 	str r1, [sp, #0xbc]
 	strb r0, [sp, #0xc2]
 	strb r0, [sp, #0xc3]
@@ -62984,7 +62984,7 @@ _020e0774:
 	str sb, [r7, #0x908]
 	str r0, [r7, #0x90c]
 	mov r2, #0x1e
-	str sl, [r7, #0x910]
+	str r10, [r7, #0x910]
 	ldrsh r6, [sp, #0x90]
 	ldr r5, _020e0e9c ; =data_ov00_020e39ec
 	str r2, [r7, #0x914]
@@ -63007,7 +63007,7 @@ _020e0774:
 	strb ip, [r7, #0x933]
 	strb r3, [r7, #0x934]
 	str r0, [sp, #0x84]
-	str sl, [sp, #0x88]
+	str r10, [sp, #0x88]
 	str r2, [sp, #0x8c]
 	strb r0, [sp, #0x92]
 	strb r0, [sp, #0x93]
@@ -63024,13 +63024,13 @@ _020e0774:
 	strb ip, [r7, #0x935]
 	str sb, [sp, #0x50]
 	str r0, [sp, #0x54]
-	str sl, [sp, #0x58]
+	str r10, [sp, #0x58]
 	str r6, [sp, #0x5c]
 	strh r0, [sp, #0x60]
 	strb r0, [sp, #0x62]
 	str sb, [r7, #0x954]
 	str r0, [r7, #0x958]
-	str sl, [r7, #0x95c]
+	str r10, [r7, #0x95c]
 	str r6, [r7, #0x960]
 	ldrsh r2, [sp, #0x60]
 	mov r6, #0x20
@@ -63053,7 +63053,7 @@ _020e0774:
 	strb ip, [r7, #0x981]
 	str sb, [r7, #0x9a0]
 	str r0, [r7, #0x9a4]
-	str sl, [r7, #0x9a8]
+	str r10, [r7, #0x9a8]
 	ldrsh r2, [sp, #0x30]
 	str r6, [r7, #0x9ac]
 	strh r0, [sp, #0x18]
@@ -63087,7 +63087,7 @@ _020e0774:
 	strb r0, [sp, #0x4d]
 	str sb, [sp, #0x20]
 	str r0, [sp, #0x24]
-	str sl, [sp, #0x28]
+	str r10, [sp, #0x28]
 	str r6, [sp, #0x2c]
 	strb r0, [sp, #0x32]
 	strb r0, [sp, #0x33]
@@ -63104,7 +63104,7 @@ _020e0774:
 	bl func_0204f8d4
 	add sp, sp, #0x238
 	add sp, sp, #0x400
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 _020e0e94: .word data_ov00_020e37ec
 _020e0e98: .word data_ov00_020e38ec

--- a/asm/ov00/ov00_020a8e04.s
+++ b/asm/ov00/ov00_020a8e04.s
@@ -808,14 +808,14 @@ _020a9c08:
 	.global func_ov00_020a9c14
 	arm_func_start func_ov00_020a9c14
 func_ov00_020a9c14: ; 0x020a9c14
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x94
 	mov r8, r2
 	movs sb, r1
 	cmpeq r8, #0
 	mov sl, r0
 	addeq sp, sp, #0x94
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r1, [sl, #0x68]
 	mov r0, sl
 	bl func_ov00_020a9624
@@ -827,7 +827,7 @@ func_ov00_020a9c14: ; 0x020a9c14
 	add r0, sp, #0x70
 	str r1, [sp]
 	bl func_01ff80d4
-	add fp, sp, #0
+	add r11, sp, #0
 	b _020a9c94
 _020a9c68:
 	mov r0, sl
@@ -842,7 +842,7 @@ _020a9c68:
 	add r1, r1, #0x28
 	bl func_01ff8690
 _020a9c94:
-	mov r0, fp
+	mov r0, r11
 	mov r2, r7
 	add r1, r5, r4
 	bl func_0201b2f8
@@ -886,7 +886,7 @@ _020a9c94:
 	mov r2, r0
 	bl func_01ff8690
 	add sp, sp, #0x94
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _020a9d48:
 	mov r1, r0, lsl #0x1
 	add r0, r1, #1
@@ -916,7 +916,7 @@ _020a9d48:
 	mov r2, r0
 	bl func_01ff8690
 	add sp, sp, #0x94
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020a9c14
 _020a9dbc: .word data_02050f54

--- a/asm/ov00/ov00_020a8e04.s
+++ b/asm/ov00/ov00_020a8e04.s
@@ -808,14 +808,14 @@ _020a9c08:
 	.global func_ov00_020a9c14
 	arm_func_start func_ov00_020a9c14
 func_ov00_020a9c14: ; 0x020a9c14
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x94
 	mov r8, r2
-	movs sb, r1
+	movs r9, r1
 	cmpeq r8, #0
 	mov r10, r0
 	addeq sp, sp, #0x94
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r1, [r10, #0x68]
 	mov r0, r10
 	bl func_ov00_020a9624
@@ -854,7 +854,7 @@ _020a9c94:
 	add r1, sp, #0x4c
 	bl func_01ff83a0
 	cmp r0, #0
-	mov r0, sb, asr #0x4
+	mov r0, r9, asr #0x4
 	bne _020a9d48
 	mov r2, r0, lsl #0x1
 	add r0, r2, #1
@@ -886,7 +886,7 @@ _020a9c94:
 	mov r2, r0
 	bl func_01ff8690
 	add sp, sp, #0x94
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _020a9d48:
 	mov r1, r0, lsl #0x1
 	add r0, r1, #1
@@ -916,7 +916,7 @@ _020a9d48:
 	mov r2, r0
 	bl func_01ff8690
 	add sp, sp, #0x94
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020a9c14
 _020a9dbc: .word data_02050f54
@@ -957,27 +957,27 @@ _020a9e10:
 	.global func_ov00_020a9e28
 	arm_func_start func_ov00_020a9e28
 func_ov00_020a9e28: ; 0x020a9e28
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	movs r6, r1
 	mov r7, r0
 	ldrne r0, [r6, #4]
 	mov r5, r2
 	ldrne r0, [r0, #8]
 	cmpne r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	mov r0, r6
 	mov r4, #0
 	bl func_ov00_020c0e94
 	cmp r0, #0
 	bls _020a9e9c
 	mov r8, r4
-	mov sb, #1
+	mov r9, #1
 _020a9e64:
 	ldr r0, [r7, #0x98]
 	mov r1, r4
 	ldrb r0, [r0, r4]
 	cmp r5, r0
-	moveq r2, sb
+	moveq r2, r9
 	movne r2, r8
 	mov r0, r6
 	bl func_ov00_020c0ea0
@@ -993,7 +993,7 @@ _020a9e9c:
 	mov r1, r6
 	ldr r2, [r2, #0x24]
 	blx r2
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	arm_func_end func_ov00_020a9e28
 
 	.global func_ov00_020a9eb4
@@ -1197,14 +1197,14 @@ func_ov00_020aa0f0: ; 0x020aa0f0
 	.global func_ov00_020aa124
 	arm_func_start func_ov00_020aa124
 func_ov00_020aa124: ; 0x020aa124
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	mov r8, r0
 	ldr r4, [r8, #0x94]
 	mov r7, r1
 	mov r6, r2
 	mov r5, r3
 	cmp r4, #0
-	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmltia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	ldr r1, [r0]
 	ldr r1, [r1, #8]
 	blx r1
@@ -1243,8 +1243,8 @@ func_ov00_020aa124: ; 0x020aa124
 	ldr r1, [r8, #0x94]
 	mov r2, r4
 	bl func_02019534
-	ldr sb, [r8, #0x84]
-	cmp sb, #0
+	ldr r9, [r8, #0x84]
+	cmp r9, #0
 	blt _020aa280
 	mov r0, r8
 	ldr r1, [r0]
@@ -1253,7 +1253,7 @@ func_ov00_020aa124: ; 0x020aa124
 	ldr r1, [r1, #8]
 	moveq r5, #0
 	blx r1
-	mov r1, sb
+	mov r1, r9
 	mov r2, r5
 	bl func_02019570
 	mov r0, r8
@@ -1287,7 +1287,7 @@ func_ov00_020aa124: ; 0x020aa124
 _020aa280:
 	ldr r5, [r8, #0x8c]
 	cmp r5, #0
-	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmltia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	ldrb r0, [sp, #0x20]
 	cmp r0, #0
 	mov r0, r8
@@ -1326,7 +1326,7 @@ _020aa280:
 	ldr r1, [r8, #0x8c]
 	mov r2, r4
 	bl func_02019534
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020aa124
 _020aa328: .word data_ov00_020e9360

--- a/asm/ov00/ov00_020a8e04.s
+++ b/asm/ov00/ov00_020a8e04.s
@@ -808,21 +808,21 @@ _020a9c08:
 	.global func_ov00_020a9c14
 	arm_func_start func_ov00_020a9c14
 func_ov00_020a9c14: ; 0x020a9c14
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x94
 	mov r8, r2
 	movs sb, r1
 	cmpeq r8, #0
-	mov sl, r0
+	mov r10, r0
 	addeq sp, sp, #0x94
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
-	ldr r1, [sl, #0x68]
-	mov r0, sl
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldr r1, [r10, #0x68]
+	mov r0, r10
 	bl func_ov00_020a9624
-	ldr r5, [sl, #8]
+	ldr r5, [r10, #8]
 	mov r6, r0
 	ldr r4, [r5, #4]
-	ldr r7, [sl, #0x68]
+	ldr r7, [r10, #0x68]
 	mvn r1, #0
 	add r0, sp, #0x70
 	str r1, [sp]
@@ -830,7 +830,7 @@ func_ov00_020a9c14: ; 0x020a9c14
 	add r11, sp, #0
 	b _020a9c94
 _020a9c68:
-	mov r0, sl
+	mov r0, r10
 	bl func_ov00_020a9624
 	mov r1, r0
 	ldr r0, [r1]
@@ -886,7 +886,7 @@ _020a9c94:
 	mov r2, r0
 	bl func_01ff8690
 	add sp, sp, #0x94
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _020a9d48:
 	mov r1, r0, lsl #0x1
 	add r0, r1, #1
@@ -916,7 +916,7 @@ _020a9d48:
 	mov r2, r0
 	bl func_01ff8690
 	add sp, sp, #0x94
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020a9c14
 _020a9dbc: .word data_02050f54

--- a/asm/ov00/ov00_020b1498.s
+++ b/asm/ov00/ov00_020b1498.s
@@ -491,7 +491,7 @@ _020b1a48: .word data_027e0e60
 	.global func_ov00_020b1a4c
 	arm_func_start func_ov00_020b1a4c
 func_ov00_020b1a4c: ; 0x020b1a4c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #0xc0
 	ldr r2, _020b1b48 ; =data_027e0e60
 	mov r8, r1
@@ -517,23 +517,23 @@ func_ov00_020b1a4c: ; 0x020b1a4c
 	bl func_ov00_020b199c
 	cmp r0, #0
 	addne sp, sp, #0xc0
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
-	ldr sl, _020b1b50 ; =data_ov00_020dc704
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldr r10, _020b1b50 ; =data_ov00_020dc704
 	add r7, sp, #0
 	mov r4, #0xc
 _020b1ac4:
-	ldmia sl!, {r0, r1, r2, r3}
+	ldmia r10!, {r0, r1, r2, r3}
 	stmia r7!, {r0, r1, r2, r3}
 	subs r4, r4, #1
 	bne _020b1ac4
-	ldr sl, _020b1b4c ; =func_ov00_020b1940
+	ldr r10, _020b1b4c ; =func_ov00_020b1940
 	mov r7, #0
 	add r4, sp, #0
 _020b1ae0:
 	add r0, r4, r7, lsl #3
 	ldr r3, [r4, r7, lsl #3]
 	ldr r1, [r0, #4]
-	mov r2, sl
+	mov r2, r10
 	add r0, r5, r3
 	add r1, r6, r1
 	bl func_ov00_020b199c
@@ -550,13 +550,13 @@ _020b1ae0:
 	add sp, sp, #0xc0
 	add r0, r1, r0, lsl #12
 	str r0, [sb, #8]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _020b1b34:
 	add r7, r7, #1
 	cmp r7, #0x18
 	blt _020b1ae0
 	add sp, sp, #0xc0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020b1a4c
 _020b1b48: .word data_027e0e60
@@ -5753,18 +5753,18 @@ _020b5cb0: .word 0x00000666
 	.global func_ov00_020b5cb4
 	arm_func_start func_ov00_020b5cb4
 func_ov00_020b5cb4: ; 0x020b5cb4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x244
 	mov r6, r2
 	mov r5, r3
-	mov sl, r1
+	mov r10, r1
 	mov r1, r6
 	mov r2, r5
 	mov r7, r0
 	ldr r4, [sp, #0x268]
 	bl func_ov00_020b5514
 	add r3, sp, #0x118
-	ldmia sl, {r0, r1, r2}
+	ldmia r10, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
 	mov r0, r7
 	bl func_ov00_020b510c
@@ -5802,7 +5802,7 @@ _020b5d14:
 	ldr r0, [r7, #0x2c]
 	str r0, [r7, #0x3c]
 	ldr sb, [r7, #0x2c]
-	ldmia sl, {r0, r11, ip}
+	ldmia r10, {r0, r11, ip}
 	add sb, r11, sb
 	str r0, [r7, #0x20]
 	str sb, [r7, #0x24]
@@ -6103,10 +6103,10 @@ _020b61d4:
 _020b61e0:
 	ldr r0, [r7, #0x20]
 	ldr r1, _020b6ac8 ; =data_027e0e60
-	stmia sl, {r0, r8}
+	stmia r10, {r0, r8}
 	ldr r2, [r7, #0x28]
 	add r0, sp, #0x14
-	str r2, [sl, #8]
+	str r2, [r10, #8]
 	ldr r1, [r1]
 	add r2, r7, #0x20
 	bl func_ov00_02083a1c
@@ -6135,7 +6135,7 @@ _020b61e0:
 	stmia r8, {r0, r1, r2}
 	ldr r3, [r7, #0x2c]
 	mov r0, r11
-	mov r1, sl
+	mov r1, r10
 	mov r2, r8
 	str r3, [sp, #0xd0]
 	bl func_01ff9bf8
@@ -6166,7 +6166,7 @@ _020b61e0:
 	ldr r0, [r0]
 	add r1, sp, #0x20
 	add r3, sp, #0x118
-	mov r2, sl
+	mov r2, r10
 	bl func_ov05_021082e4
 _020b62ec:
 	ldrsh r0, [r7, #0xc8]
@@ -6188,13 +6188,13 @@ _020b6310:
 	cmp r0, #0
 	movgt r8, #1
 _020b632c:
-	ldr r1, [sl]
+	ldr r1, [r10]
 	ldr r0, _020b6adc ; =data_027e0f78
 	str r1, [sp, #0x80]
-	ldr r1, [sl, #4]
+	ldr r1, [r10, #4]
 	ldr r0, [r0]
 	str r1, [sp, #0x84]
-	ldr r2, [sl, #8]
+	ldr r2, [r10, #8]
 	add r1, sp, #0x80
 	str r2, [sp, #0x88]
 	add r2, r7, #0x64
@@ -6205,7 +6205,7 @@ _020b632c:
 	cmpne r8, #0
 	beq _020b64f8
 	add r8, sp, #0x38
-	ldmia sl, {r0, r1, r2}
+	ldmia r10, {r0, r1, r2}
 	stmia r8, {r0, r1, r2}
 	add r3, sp, #0xb8
 	ldmia r8, {r0, r1, r2}
@@ -6217,13 +6217,13 @@ _020b632c:
 	ldr r0, _020b6ac8 ; =data_027e0e60
 	sub r1, r1, #0x1000
 	str r1, [sp, #0xb4]
-	ldr r2, [sl]
+	ldr r2, [r10]
 	ldr r0, [r0]
 	str r2, [sp, #0x74]
-	ldr r3, [sl, #4]
+	ldr r3, [r10, #4]
 	add r1, sp, #0x74
 	str r3, [sp, #0x78]
-	ldr r3, [sl, #8]
+	ldr r3, [r10, #8]
 	mov r2, #1
 	str r3, [sp, #0x7c]
 	bl func_ov00_02083ee0
@@ -6285,14 +6285,14 @@ _020b6494:
 	strb r0, [r7, #0x55]
 _020b64a4:
 	ldr r0, _020b6ac8 ; =data_027e0e60
-	ldr r1, [sl]
+	ldr r1, [r10]
 	ldr r8, [r0]
 	mov r0, r8
 	bl func_ov00_020839d4
 	mov r1, r0
 	mov r0, r8
 	bl func_ov00_02083c24
-	ldr r2, [sl]
+	ldr r2, [r10]
 	mov r1, #0
 	sub r2, r0, r2
 	mov r0, #0x148
@@ -6311,11 +6311,11 @@ _020b64f8:
 	cmp sb, #0
 	beq _020b6830
 	ldrsh r0, [r7, #0xc6]
-	mov sl, r8
+	mov r10, r8
 	cmp r0, #0
 	blt _020b6538
 	ldr r0, [r7, #0x74]
-	mov sl, #1
+	mov r10, #1
 	mov r0, r0, lsr #0xb
 	and r0, r0, #3
 	cmp r0, #1
@@ -6350,15 +6350,15 @@ _020b6538:
 	cmp r0, #0
 	moveq r0, #0
 	ldrne r0, [r0, #0xc]
-	mov sl, #1
+	mov r10, #1
 	and r0, r0, #0x1f
 	strh r0, [r7, #0xc6]
-	strb sl, [r7, #0xcc]
+	strb r10, [r7, #0xcc]
 	ldrsb r0, [sb, #0x12]
 	cmp r0, #0xd
-	moveq sl, #0
+	moveq r10, #0
 _020b65c0:
-	cmp sl, #0
+	cmp r10, #0
 	beq _020b65e0
 	ldrsh r0, [r7, #0x5a]
 	cmp r0, #2
@@ -6442,20 +6442,20 @@ _020b66e0:
 	blt _020b671c
 	sub r5, r3, r0
 	mov r3, r5, asr #0x1f
-	umull sl, sb, r2, r5
+	umull r10, sb, r2, r5
 	mla sb, r2, r3, sb
 	mla sb, r1, r5, sb
-	mov r1, sl, lsr #0xc
+	mov r1, r10, lsr #0xc
 	orr r1, r1, sb, lsl #20
 	add r0, r0, r1
 	b _020b673c
 _020b671c:
 	sub r5, r0, r3
 	mov r3, r5, asr #0x1f
-	umull sl, sb, r2, r5
+	umull r10, sb, r2, r5
 	mla sb, r2, r3, sb
 	mla sb, r1, r5, sb
-	mov r1, sl, lsr #0xc
+	mov r1, r10, lsr #0xc
 	orr r1, r1, sb, lsl #20
 	sub r0, r0, r1
 _020b673c:
@@ -6468,20 +6468,20 @@ _020b673c:
 	blt _020b677c
 	sub r5, r3, r0
 	mov r3, r5, asr #0x1f
-	umull sl, sb, r2, r5
+	umull r10, sb, r2, r5
 	mla sb, r2, r3, sb
 	mla sb, r1, r5, sb
-	mov r1, sl, lsr #0xc
+	mov r1, r10, lsr #0xc
 	orr r1, r1, sb, lsl #20
 	add r0, r0, r1
 	b _020b679c
 _020b677c:
 	sub r5, r0, r3
 	mov r3, r5, asr #0x1f
-	umull sl, sb, r2, r5
+	umull r10, sb, r2, r5
 	mla sb, r2, r3, sb
 	mla sb, r1, r5, sb
-	mov r1, sl, lsr #0xc
+	mov r1, r10, lsr #0xc
 	orr r1, r1, sb, lsl #20
 	sub r0, r0, r1
 _020b679c:
@@ -6494,10 +6494,10 @@ _020b679c:
 	blt _020b67e0
 	sub r5, r3, r0
 	mov r3, r5, asr #0x1f
-	umull sl, sb, r2, r5
+	umull r10, sb, r2, r5
 	mla sb, r2, r3, sb
 	mla sb, r1, r5, sb
-	mov r1, sl, lsr #0xc
+	mov r1, r10, lsr #0xc
 	orr r1, r1, sb, lsl #20
 	add r0, r0, r1
 	str r0, [r6, #4]
@@ -6505,10 +6505,10 @@ _020b679c:
 _020b67e0:
 	sub r5, r0, r3
 	mov r3, r5, asr #0x1f
-	umull sl, sb, r2, r5
+	umull r10, sb, r2, r5
 	mla sb, r2, r3, sb
 	mla sb, r1, r5, sb
-	mov r1, sl, lsr #0xc
+	mov r1, r10, lsr #0xc
 	orr r1, r1, sb, lsl #20
 	sub r0, r0, r1
 	str r0, [r6, #4]
@@ -6528,20 +6528,20 @@ _020b6824:
 _020b6830:
 	ldr r0, [r6, #4]
 	cmp r0, #0
-	ldrlt r1, [sl, #4]
+	ldrlt r1, [r10, #4]
 	sublt r0, r8, #0x1800
 	cmplt r1, r0
 	bge _020b68c0
 	ldr r1, [sp, #0x11c]
 	cmp r1, r0
 	blt _020b68c0
-	ldr r1, [sl]
+	ldr r1, [r10]
 	ldr r0, _020b6ac8 ; =data_027e0e60
 	str r1, [sp, #0x50]
-	ldr r2, [sl, #4]
+	ldr r2, [r10, #4]
 	ldr r1, [r0]
 	str r2, [sp, #0x54]
-	ldr r3, [sl, #8]
+	ldr r3, [r10, #8]
 	add r0, sp, #0x1c
 	add r2, sp, #0x50
 	str r3, [sp, #0x58]
@@ -6558,7 +6558,7 @@ _020b6830:
 	beq _020b68c0
 	mov r0, r4
 	ldr r3, [r0]
-	mov r2, sl
+	mov r2, r10
 	ldr r3, [r3, #0x70]
 	mov r1, #4
 	blx r3
@@ -6651,12 +6651,12 @@ _020b69c4:
 	add sp, sp, #0x244
 	bic r0, r0, #8
 	strh r0, [r7, #0xa4]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _020b6a08:
 	ldrsh r2, [r7, #0xc6]
 	cmp r2, #0
 	addge sp, sp, #0x244
-	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r1, [r7, #0x34]
 	ldr r0, [r7, #0x24]
 	cmp r1, r0
@@ -6679,19 +6679,19 @@ _020b6a08:
 	bic r1, r1, #4
 	strh r1, [r7, #0xa4]
 	str r0, [r6, #4]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _020b6a74:
 	ldrb r0, [sp, #0x23f]
 	cmp r0, #0
 	addeq sp, sp, #0x244
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldrh r1, [r7, #0xa4]
 	mov r0, #0
 	add sp, sp, #0x244
 	bic r1, r1, #8
 	strh r1, [r7, #0xa4]
 	str r0, [r6, #4]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _020b6aa0:
 	ldrb r0, [sp, #0x23c]
 	cmp r0, #0
@@ -6700,7 +6700,7 @@ _020b6aa0:
 	movne r0, #0
 	strneb r0, [r7, #0xbc]
 	add sp, sp, #0x244
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020b5cb4
 _020b6ac0: .word data_027e0ff8
@@ -9219,15 +9219,15 @@ func_ov00_020b88bc: ; 0x020b88bc
 	.global func_ov00_020b88c4
 	arm_func_start func_ov00_020b88c4
 func_ov00_020b88c4: ; 0x020b88c4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	movs sb, r1
-	mov sl, r0
+	mov r10, r0
 	movne r0, #0
 	strne r0, [sb]
-	ldrb r0, [sl, #0x290]
+	ldrb r0, [r10, #0x290]
 	cmp r0, #0
 	movne r0, #1
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, _020b8b78 ; =data_027e0618
 	ldr r0, [r0]
 	cmp r0, #6
@@ -9235,14 +9235,14 @@ func_ov00_020b88c4: ; 0x020b88c4
 	bl func_ov00_02079e3c
 	cmp r0, #0
 	movne r0, #1
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _020b8908:
 	ldr r0, _020b8b7c ; =data_027e0f90
 	ldr r0, [r0]
 	ldrsh r0, [r0, #0xa]
 	cmp r0, #0
 	movle r0, #1
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, _020b8b80 ; =data_027e0f64
 	ldr r0, [r0]
 	ldr r0, [r0, #4]
@@ -9268,7 +9268,7 @@ _020b8968:
 	bne _020b8978
 _020b8970:
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _020b8978:
 	ldr r0, _020b8b84 ; =data_027e0f74
 	ldr r0, [r0]
@@ -9280,10 +9280,10 @@ _020b8978:
 	bl func_ov00_02097750
 	cmp r0, #0
 	bne _020b8a04
-	ldrb r0, [sl, #0x11c]
+	ldrb r0, [r10, #0x11c]
 	cmp r0, #0
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	bl _ZN13LinkStateBase16GetLinkItemStateEv
 	bl _ZN13LinkStateItem16IsHammerEquippedEv
 	mvn r1, #0
@@ -9294,7 +9294,7 @@ _020b8978:
 	ldr r0, [r0]
 	bl _ZNK11ItemManager16GetEquippedFairyEv
 	mov r4, r0
-	mov r0, sl
+	mov r0, r10
 	ldr r1, [r0]
 	ldr r1, [r1, #0xb4]
 	blx r1
@@ -9305,13 +9305,13 @@ _020b89f0:
 	movne r0, #6
 	strne r0, [sb]
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _020b8a04:
 	ldr r0, _020b8b8c ; =data_ov00_020e8b08
 	ldr r7, [r0]
 	cmp r7, #0
 	beq _020b8ae0
-	ldr r2, [sl, #8]
+	ldr r2, [r10, #8]
 	mov r1, #0
 _020b8a1c:
 	add r0, r7, r1, lsl #3
@@ -9325,17 +9325,17 @@ _020b8a1c:
 	mov r0, #0
 _020b8a40:
 	cmp r0, #0
-	ldreqb r0, [sl, #0x28e]
+	ldreqb r0, [r10, #0x28e]
 	cmpeq r0, #0
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	mov r8, #0
 	ldr r4, _020b8b88 ; =gItemManager
 	mov r6, r8
 	mov r11, r8
 	mov r5, #1
 _020b8a68:
-	mov r0, sl
+	mov r0, r10
 	ldr r1, [r0]
 	ldr r1, [r1, #0xb4]
 	blx r1
@@ -9363,7 +9363,7 @@ _020b8ab8:
 	movne r0, #6
 	strne r0, [sb]
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _020b8ad4:
 	add r8, r8, #1
 	cmp r8, #3
@@ -9373,19 +9373,19 @@ _020b8ae0:
 	ldr r0, [r0]
 	bl _ZNK11ItemManager16GetEquippedFairyEv
 	mov r4, r0
-	mov r0, sl
+	mov r0, r10
 	ldr r1, [r0]
 	ldr r1, [r1, #0xb4]
 	blx r1
 	cmp r4, r0
 	bne _020b8b5c
-	mov r0, sl
+	mov r0, r10
 	ldr r1, [r0]
 	ldr r1, [r1, #0xb4]
 	blx r1
 	cmp r0, #0
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, _020b8b88 ; =gItemManager
 	mov r1, #0
 	ldr r0, [r0]
@@ -9397,19 +9397,19 @@ _020b8ae0:
 	movne r0, #6
 	strne r0, [sb]
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _020b8b54:
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _020b8b5c:
 	cmp sb, #0
 	movne r0, #6
 	strne r0, [sb]
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _020b8b70:
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020b88c4
 _020b8b78: .word data_027e0618
@@ -9855,7 +9855,7 @@ func_ov00_020b9178: ; 0x020b9178
 	.global func_ov00_020b917c
 	arm_func_start func_ov00_020b917c
 func_ov00_020b917c: ; 0x020b917c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #8
 	mov sb, r0
 	ldr r0, [sb, #0x130]
@@ -9867,7 +9867,7 @@ func_ov00_020b917c: ; 0x020b917c
 	mov r0, #1
 	strb r0, [sb, #0x11a]
 	mov r5, #0
-	ldr sl, _020b92cc ; =data_ov00_020dc81c
+	ldr r10, _020b92cc ; =data_ov00_020dc81c
 	ldr r11, _020b92d0 ; =data_027e0e58
 	strb r5, [sb, #0x290]
 	add r7, sb, #0x218
@@ -9883,7 +9883,7 @@ _020b91c0:
 	blx r1
 	mov r1, r0
 	mov r0, r6
-	ldr r2, [sl, r1, lsl #2]
+	ldr r2, [r10, r1, lsl #2]
 	str r4, [sp]
 	mov r1, r7
 	add r3, sb, #0x48
@@ -9947,7 +9947,7 @@ _020b92b8:
 	str r0, [sb, #0x138]
 	str r8, [sb, #0x130]
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020b917c
 _020b92cc: .word data_ov00_020dc81c
@@ -14970,7 +14970,7 @@ func_ov00_020bd0a8: ; 0x020bd0a8
 	.global func_ov00_020bd0bc
 	arm_func_start func_ov00_020bd0bc
 func_ov00_020bd0bc: ; 0x020bd0bc
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #0xc
 	mov r0, r1
 	mov r4, r2
@@ -15002,19 +15002,19 @@ func_ov00_020bd0bc: ; 0x020bd0bc
 	str r0, [sp, #4]
 	b _020bd1ec
 _020bd138:
-	ldr sl, [sp]
+	ldr r10, [sp]
 	ldr r7, [sp, #4]
 	mov r2, #0x97
 	ldr lr, [sp, #8]
-	umull r1, r0, sl, r2
+	umull r1, r0, r10, r2
 	mov r3, #0
 	umull sb, r8, r7, r2
 	umull r6, r5, lr, r2
 	adds r1, r1, #0x800
 	ldr ip, _020bd258 ; =data_027e0fcc
-	mla r0, sl, r3, r0
-	mov sl, sl, asr #0x1f
-	mla r0, sl, r2, r0
+	mla r0, r10, r3, r0
+	mov r10, r10, asr #0x1f
+	mla r0, r10, r2, r0
 	adc r0, r0, #0
 	mov r1, r1, lsr #0xc
 	orr r1, r1, r0, lsl #20
@@ -15073,7 +15073,7 @@ _020bd234:
 	mov r0, #1
 	strh r2, [r1, #0x5a]
 	add sp, sp, #0xc
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020bd0bc
 _020bd250: .word data_027e0f94
@@ -15652,7 +15652,7 @@ _020bd7d2:
 	.global func_ov00_020bd7d8
 	arm_func_start func_ov00_020bd7d8
 func_ov00_020bd7d8: ; 0x020bd7d8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0xc
 	mov r5, r0
 	mov r0, r1
@@ -15682,7 +15682,7 @@ func_ov00_020bd7d8: ; 0x020bd7d8
 	adc r6, r7, #0
 	mov r11, #0x80000000
 	cmp r6, r11, asr #19
-	mov sl, r2, asr #0x1f
+	mov r10, r2, asr #0x1f
 	mov ip, #0
 	mov r3, #0x800
 	blt _020bd868
@@ -15691,15 +15691,15 @@ func_ov00_020bd7d8: ; 0x020bd7d8
 _020bd868:
 	add sp, sp, #0xc
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _020bd874:
 	ldr lr, [r4, #0x20]
 	ldr sb, [r4]
 	umull r7, r6, lr, r2
 	ldr r8, [sp]
-	mla r6, lr, sl, r6
-	smull sl, r8, sb, r8
-	adds sb, sl, r3
+	mla r6, lr, r10, r6
+	smull r10, r8, sb, r8
+	adds sb, r10, r3
 	adc r8, r8, ip
 	mov sb, sb, lsr #0xc
 	orr sb, sb, r8, lsl #20
@@ -15741,11 +15741,11 @@ _020bd874:
 	stmib r5, {r0, ip}
 	add sp, sp, #0xc
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _020bd938:
 	mov r0, #0
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	arm_func_end func_ov00_020bd7d8
 
 	.global func_ov00_020bd944
@@ -15761,7 +15761,7 @@ func_ov00_020bd944: ; 0x020bd944
 	.global func_ov00_020bd958
 	arm_func_start func_ov00_020bd958
 func_ov00_020bd958: ; 0x020bd958
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #0xac
 	str r1, [sp]
 	mov r7, r0
@@ -15775,7 +15775,7 @@ func_ov00_020bd958: ; 0x020bd958
 	str r2, [sp, #4]
 	cmplo r4, r0
 	addhs sp, sp, #0xac
-	ldmhsia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmhsia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	ldr r0, _020bde24 ; =0x21230000
 	ldr r2, _020bde28 ; =0x040004a8
 	ldr r1, [sp, #0xd0]
@@ -15903,7 +15903,7 @@ _020bdb50:
 	beq _020bdc78
 _020bdb70:
 	ldr r1, [r7, #8]
-	ldr sl, [sp, #0x14]
+	ldr r10, [sp, #0x14]
 	add r1, r1, r5, lsl #4
 	ldrh r2, [r1, #0xc]
 	ldr r1, [sp, #0x34]
@@ -15917,14 +15917,14 @@ _020bdb70:
 	ldr r8, [sp, #0x10]
 	ldr r2, _020bde44 ; =data_02050f54
 	umull sb, r8, lr, r8
-	mla r8, lr, sl, r8
+	mla r8, lr, r10, r8
 	ldrsh r3, [r2, r3]
-	ldr sl, [sp, #0x10]
+	ldr r10, [sp, #0x10]
 	mov ip, lr, asr #0x1f
-	mla r8, ip, sl, r8
-	adds sl, sb, #0x800
+	mla r8, ip, r10, r8
+	adds r10, sb, #0x800
 	adc sb, r8, #0
-	mov r8, sl, lsr #0xc
+	mov r8, r10, lsr #0xc
 	orr r8, r8, sb, lsl #20
 	ldr sb, [sp, #8]
 	mov r2, r3, asr #0x1f
@@ -16009,7 +16009,7 @@ _020bdcf0:
 	ldr r0, [sp, #0x24]
 	cmp r0, #0
 	addeq sp, sp, #0xac
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	ldr r0, [sp, #0x20]
 	cmp r0, #0
 	bne _020bde08
@@ -16082,7 +16082,7 @@ _020bde08:
 	mov r0, #1
 	str r0, [r1, #-0xbc]
 	add sp, sp, #0xac
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020bd958
 _020bde24: .word 0x21230000
@@ -16205,13 +16205,13 @@ _020bdfbc: .word data_027e0f64
 	.global func_ov00_020bdfc0
 	arm_func_start func_ov00_020bdfc0
 func_ov00_020bdfc0: ; 0x020bdfc0
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #0x40
 	mov sb, r0
 	ldr r0, [sb]
 	cmp r0, #2
 	addlo sp, sp, #0x40
-	ldmloia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmloia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	ldr r2, [sb, #8]
 	ldr r0, _020be194 ; =data_027e0f64
 	ldr r1, [r2]
@@ -16251,7 +16251,7 @@ func_ov00_020bdfc0: ; 0x020bdfc0
 	cmp r0, #1
 	mov r8, #1
 	bls _020be130
-	ldr sl, _020be194 ; =data_027e0f64
+	ldr r10, _020be194 ; =data_027e0f64
 	mov r7, r4
 	add r6, sp, #0x1c
 	add r5, sp, #8
@@ -16263,7 +16263,7 @@ _020be08c:
 	add r2, r2, r1, lsl #4
 	str r0, [sp, #0x1c]
 	ldr r1, [r2, #4]
-	ldr r0, [sl]
+	ldr r0, [r10]
 	str r1, [sp, #0x20]
 	ldr r1, [r2, #8]
 	str r1, [sp, #0x24]
@@ -16309,7 +16309,7 @@ _020be130:
 	add r1, r0, r1, lsl #4
 	ldrsh r0, [r1, #-0x14]
 	strh r0, [r1, #-4]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _020be158:
 	ldr r3, [sp, #0x10]
 	ldr r0, [sp, #0x18]
@@ -16325,7 +16325,7 @@ _020be158:
 	ldr r0, [sb, #8]
 	strh r2, [r0, #0x1c]
 	add sp, sp, #0x40
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020bdfc0
 _020be194: .word data_027e0f64
@@ -17964,7 +17964,7 @@ _020bf530:
 	.global func_ov00_020bf538
 	arm_func_start func_ov00_020bf538
 func_ov00_020bf538: ; 0x020bf538
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x1b4
 	mov r4, r0
 	ldr r0, [r4, #0x4c]
@@ -18161,17 +18161,17 @@ _020bf794:
 	umull r7, r6, r5, r0
 	str r2, [sp, #0x34]
 	adds r2, r7, #0x800
-	ldr sl, _020bff24 ; =0x0000ffff
+	ldr r10, _020bff24 ; =0x0000ffff
 	add sb, sp, #0x114
-	strh sl, [sb, #4]
-	strh sl, [sb, #6]
-	strh sl, [sb, #8]
-	strh sl, [sb, #0xa]
+	strh r10, [sb, #4]
+	strh r10, [sb, #6]
+	strh r10, [sb, #8]
+	strh r10, [sb, #0xa]
 	strh r3, [sb, #0xc]
 	mla r6, r5, r3, r6
 	mov sb, r5, asr #0x1f
 	mla r6, sb, r0, r6
-	ldr sl, [sp, #0xc8]
+	ldr r10, [sp, #0xc8]
 	ldr sb, [sp, #0xd4]
 	adc r5, r6, #0
 	mov r7, r2, lsr #0xc
@@ -18179,7 +18179,7 @@ _020bf794:
 	umull ip, r2, r1, r0
 	orr r7, r7, r5, lsl #20
 	sub r5, r8, r7
-	sub r6, sb, sl
+	sub r6, sb, r10
 	umull r8, r7, r6, r0
 	mla r2, r1, r3, r2
 	mla r7, r6, r3, r7
@@ -18200,7 +18200,7 @@ _020bf794:
 	mov r6, r6, lsr #0xc
 	orr r6, r6, r2, lsl #20
 	sub r2, lr, r6
-	sub r6, r1, sl
+	sub r6, r1, r10
 	umull r8, r7, r6, r0
 	mla r7, r6, r3, r7
 	str r5, [sp, #0xd4]
@@ -18627,7 +18627,7 @@ _020bff0c:
 	ldr r0, [r4, #0x44]
 	str r0, [r4, #0x48]
 	add sp, sp, #0x1b4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020bf538
 _020bff20: .word data_ov00_020dd290
@@ -20105,7 +20105,7 @@ func_ov00_020c10a0: ; 0x020c10a0
 	.global func_ov00_020c10d4
 	arm_func_start func_ov00_020c10d4
 func_ov00_020c10d4: ; 0x020c10d4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x44
 	mov r5, r0
 	add r0, r5, #0x100
@@ -20114,13 +20114,13 @@ func_ov00_020c10d4: ; 0x020c10d4
 	mov r8, r1
 	subs r1, r3, r2
 	addeq sp, sp, #0x44
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	cmp r1, #0
 	ldrlth r0, [r0, #0x80]
 	addlt r1, r1, r0
 	cmp r1, #2
 	addlt sp, sp, #0x44
-	ldmltia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmltia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	add r0, r5, #0x100
 	ldrh r0, [r0, #0x80]
 	mov r6, r0
@@ -20216,10 +20216,10 @@ func_ov00_020c10d4: ; 0x020c10d4
 	add r11, r5, #0x100
 _020c1288:
 	ldrh r0, [r11, #0x80]
-	add sl, r7, sb
+	add r10, r7, sb
 	add r1, sp, #0x1c
-	cmp sl, r0
-	subge sl, sl, r0
+	cmp r10, r0
+	subge r10, r10, r0
 	mov r0, r8, lsl #0x8
 	mov r0, r0, asr #0x10
 	mov r0, r0, lsl #0x10
@@ -20229,11 +20229,11 @@ _020c1288:
 	str r4, [sp, #0x1c]
 	bl func_01ffa9fc
 	mov r0, #0x18
-	mul r0, sl, r0
-	add sl, r5, r0
+	mul r0, r10, r0
+	add r10, r5, r0
 	ldr r1, [r5, r0]
 	ldr r0, [sp, #0x38]
-	ldr r3, [sl, #8]
+	ldr r3, [r10, #8]
 	ldr r2, [sp, #0x40]
 	sub r1, r1, r0
 	sub r2, r3, r2
@@ -20242,7 +20242,7 @@ _020c1288:
 	mov r0, r1, lsl #0x10
 	mov r1, r2, lsl #0x10
 	mov r0, r0, asr #0x10
-	ldr r3, [sl, #4]
+	ldr r3, [r10, #4]
 	mov r1, r1, lsr #0x10
 	ldr r2, [sp, #0x3c]
 	str r1, [sp, #0x18]
@@ -20270,15 +20270,15 @@ _020c1288:
 	add r1, sp, #0x10
 	mov r2, #1
 	bl func_01ffa9fc
-	ldr r2, [sl, #0x14]
+	ldr r2, [r10, #0x14]
 	ldr r1, [sp, #0x40]
-	ldr r0, [sl, #0xc]
+	ldr r0, [r10, #0xc]
 	sub r1, r2, r1
 	mov r1, r1, lsl #0x10
 	mov r1, r1, asr #0x10
 	mov r1, r1, lsl #0x10
 	ldr r3, [sp, #0x38]
-	ldr r2, [sl, #0x10]
+	ldr r2, [r10, #0x10]
 	mov r1, r1, lsr #0x10
 	str r1, [sp, #0xc]
 	ldr r1, [sp, #0x3c]
@@ -20316,7 +20316,7 @@ _020c13f0:
 	str r2, [sp, #4]
 	bl func_01ffa9fc
 	add sp, sp, #0x44
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020c10d4
 _020c141c: .word data_027e0d44

--- a/asm/ov00/ov00_020b1498.s
+++ b/asm/ov00/ov00_020b1498.s
@@ -491,11 +491,11 @@ _020b1a48: .word data_027e0e60
 	.global func_ov00_020b1a4c
 	arm_func_start func_ov00_020b1a4c
 func_ov00_020b1a4c: ; 0x020b1a4c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #0xc0
 	ldr r2, _020b1b48 ; =data_027e0e60
 	mov r8, r1
-	mov sb, r0
+	mov r9, r0
 	ldr r0, [r2]
 	ldr r1, [r8]
 	bl func_ov00_020839d4
@@ -507,17 +507,17 @@ func_ov00_020b1a4c: ; 0x020b1a4c
 	mov r6, r0
 	ldr r0, [r8]
 	ldr r2, _020b1b4c ; =func_ov00_020b1940
-	str r0, [sb]
+	str r0, [r9]
 	ldr r1, [r8, #4]
 	mov r0, r5
-	str r1, [sb, #4]
+	str r1, [r9, #4]
 	ldr r3, [r8, #8]
 	mov r1, r6
-	str r3, [sb, #8]
+	str r3, [r9, #8]
 	bl func_ov00_020b199c
 	cmp r0, #0
 	addne sp, sp, #0xc0
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	ldr r10, _020b1b50 ; =data_ov00_020dc704
 	add r7, sp, #0
 	mov r4, #0xc
@@ -544,19 +544,19 @@ _020b1ae0:
 	ldr r2, [r8]
 	add r0, sp, #4
 	add r1, r2, r1, lsl #12
-	str r1, [sb]
+	str r1, [r9]
 	ldr r1, [r8, #8]
 	ldr r0, [r0, r7, lsl #3]
 	add sp, sp, #0xc0
 	add r0, r1, r0, lsl #12
-	str r0, [sb, #8]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	str r0, [r9, #8]
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _020b1b34:
 	add r7, r7, #1
 	cmp r7, #0x18
 	blt _020b1ae0
 	add sp, sp, #0xc0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020b1a4c
 _020b1b48: .word data_027e0e60
@@ -2829,7 +2829,7 @@ _020b38d8: .word data_ov00_020e6194
 	.global func_ov00_020b38dc
 	arm_func_start func_ov00_020b38dc
 func_ov00_020b38dc: ; 0x020b38dc
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0xc8
 	mov r5, r2
 	mov r4, r0
@@ -2853,21 +2853,21 @@ _020b3920:
 _020b392c:
 	add sp, sp, #0xc8
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _020b3938:
 	mov r0, r4
 	mov r1, #1
 	bl _ZN13LinkStateBase18SetPlayerCharacterEi
 	add sp, sp, #0xc8
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _020b3950:
 	mov r0, r4
 	mov r1, #0
 	bl _ZN13LinkStateBase18SetPlayerCharacterEi
 	add sp, sp, #0xc8
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _020b3968:
 	mov r1, #4
 	mov r0, r4
@@ -2949,15 +2949,15 @@ _020b3a64:
 	ldr r1, _020b3d54 ; =0xffffee66
 	mov r2, r2, lsl #0x1
 	ldrsh r3, [r3, r2]
-	umull sb, r8, r7, r1
+	umull r9, r8, r7, r1
 	mvn r2, #0
 	umull r6, r5, r3, r1
-	adds sb, sb, #0x800
+	adds r9, r9, #0x800
 	mla r8, r7, r2, r8
 	mov r7, r7, asr #0x1f
 	mla r8, r7, r1, r8
 	adc r7, r8, #0
-	mov r8, sb, lsr #0xc
+	mov r8, r9, lsr #0xc
 	adds r6, r6, #0x800
 	mla r5, r3, r2, r5
 	mov r2, r3, asr #0x1f
@@ -3000,12 +3000,12 @@ _020b3b14:
 	mov r6, #0x800
 	sub r6, r6, #0x1800
 	umull lr, r8, r7, r6
-	adds sb, r3, #0x800
+	adds r9, r3, #0x800
 	mla r2, r1, ip, r2
 	mov r1, r1, asr #0x1f
 	mla r2, r1, r5, r2
 	adc r3, r2, #0
-	mov r5, sb, lsr #0xc
+	mov r5, r9, lsr #0xc
 	adds r2, lr, #0x800
 	mla r8, r7, ip, r8
 	mov r1, r7, asr #0x1f
@@ -3100,7 +3100,7 @@ _020b3cc4:
 	add r1, r1, #0x2000
 	str r1, [r0, #4]
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _020b3ce4:
 	mov r0, r4
 	bl _ZN13LinkStateBase12GetPlayerPosEv
@@ -3126,7 +3126,7 @@ _020b3ce4:
 	str r6, [r0, #4]
 	mov r0, #1
 	add sp, sp, #0xc8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020b38dc
 _020b3d48: .word data_027e0d38
@@ -4627,16 +4627,16 @@ _020b4d24: .word data_027e0e60
 	.global func_ov00_020b4d28
 	arm_func_start func_ov00_020b4d28
 func_ov00_020b4d28: ; 0x020b4d28
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	ldr r4, [r2, #8]
 	ldr r5, [r2]
 	rsbs r4, r4, #0
 	mov r7, r0
 	cmpeq r5, #0
 	mov r6, r1
-	mov sb, r3
+	mov r9, r3
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	cmp r5, #0
 	movge r0, r5
 	rsblt r0, r5, #0
@@ -4660,7 +4660,7 @@ func_ov00_020b4d28: ; 0x020b4d28
 	ldr r0, [r1]
 	add r1, r2, #0x1000
 	bl func_ov00_020839d4
-	ldr r2, [sb]
+	ldr r2, [r9]
 	mov r1, r0
 	cmp r2, #0
 	ble _020b4dd0
@@ -4680,20 +4680,20 @@ _020b4dd0:
 _020b4dec:
 	ldr r3, _020b5030 ; =data_027e0764
 	ldr r2, [r3]
-	ldmib r3, {r0, sb}
-	umull lr, ip, sb, r2
-	mla ip, sb, r0, ip
+	ldmib r3, {r0, r9}
+	umull lr, ip, r9, r2
+	mla ip, r9, r0, ip
 	ldr r0, [r3, #0xc]
-	ldr sb, [r3, #0x10]
+	ldr r9, [r3, #0x10]
 	mla ip, r0, r2, ip
 	ldr r2, [r3, #0x14]
-	adds r0, sb, lr
+	adds r0, r9, lr
 	adc ip, r2, ip
 	mov r2, ip, lsr #0x18
-	and sb, r2, #0xff
+	and r9, r2, #0xff
 	str r0, [r3]
-	mov r2, sb, lsr #0x1f
-	rsb r0, r2, sb, lsl #31
+	mov r2, r9, lsr #0x1f
+	rsb r0, r2, r9, lsl #31
 	str ip, [r3, #4]
 	adds r0, r2, r0, ror #31
 	bne _020b4e4c
@@ -4721,7 +4721,7 @@ _020b4e60:
 	blt _020b4e90
 _020b4e88:
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _020b4e90:
 	ldr r1, [r7, #0x20]
 	mov r0, r4
@@ -4753,7 +4753,7 @@ _020b4ec8:
 	ldr r0, [r1]
 	add r1, r2, #0x1000
 	bl func_ov00_020839f8
-	ldr r2, [sb, #8]
+	ldr r2, [r9, #8]
 	mov r1, r0
 	cmp r2, #0
 	ble _020b4f28
@@ -4773,20 +4773,20 @@ _020b4f28:
 _020b4f44:
 	ldr r3, _020b5030 ; =data_027e0764
 	ldr r2, [r3]
-	ldmib r3, {r0, sb}
-	umull lr, ip, sb, r2
-	mla ip, sb, r0, ip
+	ldmib r3, {r0, r9}
+	umull lr, ip, r9, r2
+	mla ip, r9, r0, ip
 	ldr r0, [r3, #0xc]
-	ldr sb, [r3, #0x10]
+	ldr r9, [r3, #0x10]
 	mla ip, r0, r2, ip
 	ldr r2, [r3, #0x14]
-	adds r0, sb, lr
+	adds r0, r9, lr
 	adc ip, r2, ip
 	mov r2, ip, lsr #0x18
-	and sb, r2, #0xff
+	and r9, r2, #0xff
 	str r0, [r3]
-	mov r2, sb, lsr #0x1f
-	rsb r0, r2, sb, lsl #31
+	mov r2, r9, lsr #0x1f
+	rsb r0, r2, r9, lsl #31
 	str ip, [r3, #4]
 	adds r0, r2, r0, ror #31
 	bne _020b4fa4
@@ -4814,7 +4814,7 @@ _020b4fb8:
 	blt _020b4fe8
 _020b4fe0:
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _020b4fe8:
 	ldr r1, [r7, #0x28]
 	mov r0, r5
@@ -4833,7 +4833,7 @@ _020b501c:
 	mov r0, #0
 	str r0, [r6, #4]
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020b4d28
 _020b502c: .word data_027e0e60
@@ -5753,7 +5753,7 @@ _020b5cb0: .word 0x00000666
 	.global func_ov00_020b5cb4
 	arm_func_start func_ov00_020b5cb4
 func_ov00_020b5cb4: ; 0x020b5cb4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x244
 	mov r6, r2
 	mov r5, r3
@@ -5801,19 +5801,19 @@ _020b5d14:
 	str r0, [r7, #0x38]
 	ldr r0, [r7, #0x2c]
 	str r0, [r7, #0x3c]
-	ldr sb, [r7, #0x2c]
+	ldr r9, [r7, #0x2c]
 	ldmia r10, {r0, r11, ip}
-	add sb, r11, sb
+	add r9, r11, r9
 	str r0, [r7, #0x20]
-	str sb, [r7, #0x24]
+	str r9, [r7, #0x24]
 	str ip, [r7, #0x28]
-	ldr sb, [r6]
+	ldr r9, [r6]
 	ldr r0, [lr]
-	str sb, [sp, #0x10c]
-	ldr sb, [r6, #4]
-	str sb, [sp, #0x110]
-	ldr sb, [r6, #8]
-	str sb, [sp, #0x114]
+	str r9, [sp, #0x10c]
+	ldr r9, [r6, #4]
+	str r9, [sp, #0x110]
+	ldr r9, [r6, #8]
+	str r9, [sp, #0x114]
 	str r3, [sp, #0x30]
 	str r8, [sp, #0x34]
 	bl func_ov05_0210826c
@@ -5925,9 +5925,9 @@ _020b5f34:
 	ldr r1, [r7, #0x9c]
 	ldr r0, [r7, #0x2c]
 	cmp r1, #0
-	add sb, r1, r0
+	add r9, r1, r0
 	ldrge r0, [r7, #0x24]
-	cmpge r0, sb
+	cmpge r0, r9
 	blt _020b6038
 	ldr r2, _020b6ac4 ; =0x0000ffff
 	add r0, sp, #0x114
@@ -5967,12 +5967,12 @@ _020b5f34:
 	ldr lr, _020b6ac8 ; =data_027e0e60
 	bic r11, r11, #2
 	mov r11, r11, lsl #0x10
-	str sb, [sp, #0xf4]
-	str sb, [sp, #0xe4]
-	ldrsh sb, [r7, #0x5a]
+	str r9, [sp, #0xf4]
+	str r9, [sp, #0xe4]
+	ldrsh r9, [r7, #0x5a]
 	mov r11, r11, lsr #0x10
 	add r1, sp, #0x184
-	str sb, [sp, #0x2c]
+	str r9, [sp, #0x2c]
 	str ip, [sp]
 	stmib sp, {r8, r11}
 	str r0, [sp, #0xc]
@@ -5995,7 +5995,7 @@ _020b6038:
 	ldr r1, [r7, #0x2c]
 	add r0, r0, #0xc
 	sub r8, r2, r1
-	ldrb sb, [sp, #0x23d]
+	ldrb r9, [sp, #0x23d]
 	bl func_ov00_020a5e9c
 	cmp r0, #0x2e
 	bne _020b6084
@@ -6009,7 +6009,7 @@ _020b6038:
 	strlth r0, [r7, #0xc8]
 	blt _020b6110
 _020b6084:
-	cmp sb, #0
+	cmp r9, #0
 	bne _020b60d4
 	mov r0, #0xa000
 	ldr r2, [r7, #0x94]
@@ -6027,7 +6027,7 @@ _020b6084:
 	str r1, [sp, #0x1fc]
 	str r0, [sp, #0x200]
 	str r1, [sp, #0x204]
-	mov sb, #1
+	mov r9, #1
 	b _020b6110
 _020b60d4:
 	ldrsh r0, [r7, #0xc8]
@@ -6308,7 +6308,7 @@ _020b64a4:
 _020b64f8:
 	mov r8, #0
 	mov r11, r8
-	cmp sb, #0
+	cmp r9, #0
 	beq _020b6830
 	ldrsh r0, [r7, #0xc6]
 	mov r10, r8
@@ -6335,7 +6335,7 @@ _020b6538:
 	ldr r0, [r0]
 	bl func_ov00_020840c4
 	ldr r1, [r0]
-	mov sb, r0
+	mov r9, r0
 	ldr r1, [r1, #0x54]
 	blx r1
 	cmp r0, #0
@@ -6343,7 +6343,7 @@ _020b6538:
 	ldrneb r0, [r0, #5]
 	cmp r0, #0
 	beq _020b65c0
-	mov r0, sb
+	mov r0, r9
 	ldr r1, [r0]
 	ldr r1, [r1, #0x54]
 	blx r1
@@ -6354,7 +6354,7 @@ _020b6538:
 	and r0, r0, #0x1f
 	strh r0, [r7, #0xc6]
 	strb r10, [r7, #0xcc]
-	ldrsb r0, [sb, #0x12]
+	ldrsb r0, [r9, #0x12]
 	cmp r0, #0xd
 	moveq r10, #0
 _020b65c0:
@@ -6402,11 +6402,11 @@ _020b6658:
 	add r1, sp, #0x1fc
 	mov r0, r6
 	bl func_01ff9c2c
-	mov sb, r0
+	mov r9, r0
 	add r0, sp, #0x1fc
 	bl func_01ff9cec
 	mov r1, r0
-	rsb r0, sb, #0
+	rsb r0, r9, #0
 	bl Divide
 	add r1, sp, #0x1fc
 	mov r2, r6
@@ -6442,21 +6442,21 @@ _020b66e0:
 	blt _020b671c
 	sub r5, r3, r0
 	mov r3, r5, asr #0x1f
-	umull r10, sb, r2, r5
-	mla sb, r2, r3, sb
-	mla sb, r1, r5, sb
+	umull r10, r9, r2, r5
+	mla r9, r2, r3, r9
+	mla r9, r1, r5, r9
 	mov r1, r10, lsr #0xc
-	orr r1, r1, sb, lsl #20
+	orr r1, r1, r9, lsl #20
 	add r0, r0, r1
 	b _020b673c
 _020b671c:
 	sub r5, r0, r3
 	mov r3, r5, asr #0x1f
-	umull r10, sb, r2, r5
-	mla sb, r2, r3, sb
-	mla sb, r1, r5, sb
+	umull r10, r9, r2, r5
+	mla r9, r2, r3, r9
+	mla r9, r1, r5, r9
 	mov r1, r10, lsr #0xc
-	orr r1, r1, sb, lsl #20
+	orr r1, r1, r9, lsl #20
 	sub r0, r0, r1
 _020b673c:
 	str r0, [r6]
@@ -6468,21 +6468,21 @@ _020b673c:
 	blt _020b677c
 	sub r5, r3, r0
 	mov r3, r5, asr #0x1f
-	umull r10, sb, r2, r5
-	mla sb, r2, r3, sb
-	mla sb, r1, r5, sb
+	umull r10, r9, r2, r5
+	mla r9, r2, r3, r9
+	mla r9, r1, r5, r9
 	mov r1, r10, lsr #0xc
-	orr r1, r1, sb, lsl #20
+	orr r1, r1, r9, lsl #20
 	add r0, r0, r1
 	b _020b679c
 _020b677c:
 	sub r5, r0, r3
 	mov r3, r5, asr #0x1f
-	umull r10, sb, r2, r5
-	mla sb, r2, r3, sb
-	mla sb, r1, r5, sb
+	umull r10, r9, r2, r5
+	mla r9, r2, r3, r9
+	mla r9, r1, r5, r9
 	mov r1, r10, lsr #0xc
-	orr r1, r1, sb, lsl #20
+	orr r1, r1, r9, lsl #20
 	sub r0, r0, r1
 _020b679c:
 	str r0, [r6, #8]
@@ -6494,22 +6494,22 @@ _020b679c:
 	blt _020b67e0
 	sub r5, r3, r0
 	mov r3, r5, asr #0x1f
-	umull r10, sb, r2, r5
-	mla sb, r2, r3, sb
-	mla sb, r1, r5, sb
+	umull r10, r9, r2, r5
+	mla r9, r2, r3, r9
+	mla r9, r1, r5, r9
 	mov r1, r10, lsr #0xc
-	orr r1, r1, sb, lsl #20
+	orr r1, r1, r9, lsl #20
 	add r0, r0, r1
 	str r0, [r6, #4]
 	b _020b6824
 _020b67e0:
 	sub r5, r0, r3
 	mov r3, r5, asr #0x1f
-	umull r10, sb, r2, r5
-	mla sb, r2, r3, sb
-	mla sb, r1, r5, sb
+	umull r10, r9, r2, r5
+	mla r9, r2, r3, r9
+	mla r9, r1, r5, r9
 	mov r1, r10, lsr #0xc
-	orr r1, r1, sb, lsl #20
+	orr r1, r1, r9, lsl #20
 	sub r0, r0, r1
 	str r0, [r6, #4]
 	b _020b6824
@@ -6651,12 +6651,12 @@ _020b69c4:
 	add sp, sp, #0x244
 	bic r0, r0, #8
 	strh r0, [r7, #0xa4]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _020b6a08:
 	ldrsh r2, [r7, #0xc6]
 	cmp r2, #0
 	addge sp, sp, #0x244
-	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmgeia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r1, [r7, #0x34]
 	ldr r0, [r7, #0x24]
 	cmp r1, r0
@@ -6679,19 +6679,19 @@ _020b6a08:
 	bic r1, r1, #4
 	strh r1, [r7, #0xa4]
 	str r0, [r6, #4]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _020b6a74:
 	ldrb r0, [sp, #0x23f]
 	cmp r0, #0
 	addeq sp, sp, #0x244
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldrh r1, [r7, #0xa4]
 	mov r0, #0
 	add sp, sp, #0x244
 	bic r1, r1, #8
 	strh r1, [r7, #0xa4]
 	str r0, [r6, #4]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _020b6aa0:
 	ldrb r0, [sp, #0x23c]
 	cmp r0, #0
@@ -6700,7 +6700,7 @@ _020b6aa0:
 	movne r0, #0
 	strneb r0, [r7, #0xbc]
 	add sp, sp, #0x244
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020b5cb4
 _020b6ac0: .word data_027e0ff8
@@ -9219,15 +9219,15 @@ func_ov00_020b88bc: ; 0x020b88bc
 	.global func_ov00_020b88c4
 	arm_func_start func_ov00_020b88c4
 func_ov00_020b88c4: ; 0x020b88c4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
-	movs sb, r1
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
+	movs r9, r1
 	mov r10, r0
 	movne r0, #0
-	strne r0, [sb]
+	strne r0, [r9]
 	ldrb r0, [r10, #0x290]
 	cmp r0, #0
 	movne r0, #1
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, _020b8b78 ; =data_027e0618
 	ldr r0, [r0]
 	cmp r0, #6
@@ -9235,14 +9235,14 @@ func_ov00_020b88c4: ; 0x020b88c4
 	bl func_ov00_02079e3c
 	cmp r0, #0
 	movne r0, #1
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _020b8908:
 	ldr r0, _020b8b7c ; =data_027e0f90
 	ldr r0, [r0]
 	ldrsh r0, [r0, #0xa]
 	cmp r0, #0
 	movle r0, #1
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, _020b8b80 ; =data_027e0f64
 	ldr r0, [r0]
 	ldr r0, [r0, #4]
@@ -9268,7 +9268,7 @@ _020b8968:
 	bne _020b8978
 _020b8970:
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _020b8978:
 	ldr r0, _020b8b84 ; =data_027e0f74
 	ldr r0, [r0]
@@ -9283,7 +9283,7 @@ _020b8978:
 	ldrb r0, [r10, #0x11c]
 	cmp r0, #0
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	bl _ZN13LinkStateBase16GetLinkItemStateEv
 	bl _ZN13LinkStateItem16IsHammerEquippedEv
 	mvn r1, #0
@@ -9301,11 +9301,11 @@ _020b8978:
 	cmp r4, r0
 	beq _020b8b70
 _020b89f0:
-	cmp sb, #0
+	cmp r9, #0
 	movne r0, #6
-	strne r0, [sb]
+	strne r0, [r9]
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _020b8a04:
 	ldr r0, _020b8b8c ; =data_ov00_020e8b08
 	ldr r7, [r0]
@@ -9328,7 +9328,7 @@ _020b8a40:
 	ldreqb r0, [r10, #0x28e]
 	cmpeq r0, #0
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	mov r8, #0
 	ldr r4, _020b8b88 ; =gItemManager
 	mov r6, r8
@@ -9359,11 +9359,11 @@ _020b8a94:
 _020b8ab8:
 	cmp r0, #0
 	beq _020b8ad4
-	cmp sb, #0
+	cmp r9, #0
 	movne r0, #6
-	strne r0, [sb]
+	strne r0, [r9]
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _020b8ad4:
 	add r8, r8, #1
 	cmp r8, #3
@@ -9385,7 +9385,7 @@ _020b8ae0:
 	blx r1
 	cmp r0, #0
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, _020b8b88 ; =gItemManager
 	mov r1, #0
 	ldr r0, [r0]
@@ -9393,23 +9393,23 @@ _020b8ae0:
 	ldrb r0, [r0, #0x28e]
 	cmp r0, #0
 	beq _020b8b54
-	cmp sb, #0
+	cmp r9, #0
 	movne r0, #6
-	strne r0, [sb]
+	strne r0, [r9]
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _020b8b54:
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _020b8b5c:
-	cmp sb, #0
+	cmp r9, #0
 	movne r0, #6
-	strne r0, [sb]
+	strne r0, [r9]
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _020b8b70:
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020b88c4
 _020b8b78: .word data_027e0618
@@ -9855,28 +9855,28 @@ func_ov00_020b9178: ; 0x020b9178
 	.global func_ov00_020b917c
 	arm_func_start func_ov00_020b917c
 func_ov00_020b917c: ; 0x020b917c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #8
-	mov sb, r0
-	ldr r0, [sb, #0x130]
+	mov r9, r0
+	ldr r0, [r9, #0x130]
 	mov r8, r1
 	cmp r0, #0
 	bne _020b9214
 	cmp r8, #0
 	beq _020b9214
 	mov r0, #1
-	strb r0, [sb, #0x11a]
+	strb r0, [r9, #0x11a]
 	mov r5, #0
 	ldr r10, _020b92cc ; =data_ov00_020dc81c
 	ldr r11, _020b92d0 ; =data_027e0e58
-	strb r5, [sb, #0x290]
-	add r7, sb, #0x218
+	strb r5, [r9, #0x290]
+	add r7, r9, #0x218
 	mov r4, #2
 _020b91c0:
 	ldr r0, [r7]
 	cmp r0, #0
 	bne _020b91fc
-	mov r0, sb
+	mov r0, r9
 	ldr r1, [r0]
 	ldr r6, [r11]
 	ldr r1, [r1, #0xb4]
@@ -9886,14 +9886,14 @@ _020b91c0:
 	ldr r2, [r10, r1, lsl #2]
 	str r4, [sp]
 	mov r1, r7
-	add r3, sb, #0x48
+	add r3, r9, #0x48
 	bl func_ov00_0207c1f8
 _020b91fc:
 	add r5, r5, #1
 	cmp r5, #2
 	add r7, r7, #4
 	blo _020b91c0
-	mov r0, sb
+	mov r0, r9
 	bl func_ov00_020b92d8
 _020b9214:
 	cmp r8, #9
@@ -9912,9 +9912,9 @@ _020b9220: ; jump table
 	b _020b92b8 ; case 9
 _020b9248:
 	mov r0, #0
-	add r5, sb, #0x218
-	add r4, sb, #0x220
-	strb r0, [sb, #0x11a]
+	add r5, r9, #0x218
+	add r4, r9, #0x220
+	strb r0, [r9, #0x11a]
 	cmp r5, r4
 	beq _020b92b8
 _020b9260:
@@ -9926,28 +9926,28 @@ _020b9260:
 	b _020b92b8
 _020b9278:
 	mvn r1, #0
-	str r1, [sb, #0x280]
+	str r1, [r9, #0x280]
 	ldr r0, _020b92d4 ; =data_027e0e60
-	str r1, [sb, #0x284]
+	str r1, [r9, #0x284]
 	ldr r1, [r0]
 	add r0, sp, #4
-	add r2, sb, #0x48
+	add r2, r9, #0x48
 	bl func_ov00_02083a1c
 	ldrb r0, [sp, #4]
-	strb r0, [sb, #0x288]
+	strb r0, [r9, #0x288]
 	ldrb r0, [sp, #5]
-	strb r0, [sb, #0x289]
+	strb r0, [r9, #0x289]
 	b _020b92b8
 _020b92ac:
-	add r0, sb, #0x200
+	add r0, r9, #0x200
 	mov r1, #0
 	strh r1, [r0, #0x8a]
 _020b92b8:
 	mov r0, #0
-	str r0, [sb, #0x138]
-	str r8, [sb, #0x130]
+	str r0, [r9, #0x138]
+	str r8, [r9, #0x130]
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020b917c
 _020b92cc: .word data_ov00_020dc81c
@@ -11546,7 +11546,7 @@ _020ba870: .word gItemManager
 	.global func_ov00_020ba874
 	arm_func_start func_ov00_020ba874
 func_ov00_020ba874: ; 0x020ba874
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x24
 	ldr r4, _020bac50 ; =data_027e0fc8
 	mov r6, r0
@@ -11563,7 +11563,7 @@ func_ov00_020ba874: ; 0x020ba874
 _020ba8ac:
 	add sp, sp, #0x24
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _020ba8b8:
 	mov r0, r8
 	ldr r3, [r0]
@@ -11575,7 +11575,7 @@ _020ba8b8:
 	cmp r0, #8
 	addeq sp, sp, #0x24
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	ldr r0, _020bac54 ; =data_027e0f74
 	ldr r0, [r0]
 	bl func_ov00_02097bbc
@@ -11587,7 +11587,7 @@ _020ba8b8:
 	cmp r0, #0
 	addeq sp, sp, #0x24
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _020ba914:
 	ldr r0, _020bac58 ; =data_027e0c68
 	mov r2, r7
@@ -11596,7 +11596,7 @@ _020ba914:
 	cmp r0, #0
 	addeq sp, sp, #0x24
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	mov r0, r6
 	ldr r1, [r0]
 	ldr r1, [r1, #0xb8]
@@ -11647,12 +11647,12 @@ _020ba958:
 	ldrsh lr, [r2, lr]
 	ldr r0, [r0]
 	mov r2, r1, asr #0x1f
-	mov sb, r2, lsl #0xc
+	mov r9, r2, lsl #0xc
 	mov r2, lr, asr #0x1f
 	mov r8, r2, lsl #0xc
 	adds r2, r7, r1, lsl #12
-	orr sb, sb, r1, lsr #20
-	adc r1, sb, #0
+	orr r9, r9, r1, lsr #20
+	adc r1, r9, #0
 	mov r2, r2, lsr #0xc
 	orr r2, r2, r1, lsl #20
 	add ip, ip, r2
@@ -11800,7 +11800,7 @@ _020bac10:
 	blx r2
 	mov r0, #1
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020ba874
 _020bac50: .word data_027e0fc8
@@ -14350,19 +14350,19 @@ _020bc95c: .word data_027e0e60
 	.global func_ov00_020bc960
 	arm_func_start func_ov00_020bc960
 func_ov00_020bc960: ; 0x020bc960
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x18
 	ldr r4, _020bca44 ; =data_027e0f74
 	mov r8, #0
 	mov r7, r0
 	sub lr, r8, #2
-	mov sb, #0x47
+	mov r9, #0x47
 	mov ip, #0xff
 	ldr r0, [r4]
 	mov r6, r1
 	mov r5, r2
 	mov r4, r3
-	str sb, [sp]
+	str r9, [sp]
 	str r8, [sp, #4]
 	str r8, [sp, #8]
 	str lr, [sp, #0xc]
@@ -14403,11 +14403,11 @@ func_ov00_020bc960: ; 0x020bc960
 	bl func_ov00_020bb544
 	add sp, sp, #0x18
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _020bca38:
 	mov r0, #0
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020bc960
 _020bca44: .word data_027e0f74
@@ -14970,7 +14970,7 @@ func_ov00_020bd0a8: ; 0x020bd0a8
 	.global func_ov00_020bd0bc
 	arm_func_start func_ov00_020bd0bc
 func_ov00_020bd0bc: ; 0x020bd0bc
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #0xc
 	mov r0, r1
 	mov r4, r2
@@ -15008,7 +15008,7 @@ _020bd138:
 	ldr lr, [sp, #8]
 	umull r1, r0, r10, r2
 	mov r3, #0
-	umull sb, r8, r7, r2
+	umull r9, r8, r7, r2
 	umull r6, r5, lr, r2
 	adds r1, r1, #0x800
 	ldr ip, _020bd258 ; =data_027e0fcc
@@ -15019,7 +15019,7 @@ _020bd138:
 	mov r1, r1, lsr #0xc
 	orr r1, r1, r0, lsl #20
 	str r1, [sp]
-	adds r1, sb, #0x800
+	adds r1, r9, #0x800
 	mla r8, r7, r3, r8
 	mov r0, r7, asr #0x1f
 	mla r8, r0, r2, r8
@@ -15073,7 +15073,7 @@ _020bd234:
 	mov r0, #1
 	strh r2, [r1, #0x5a]
 	add sp, sp, #0xc
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020bd0bc
 _020bd250: .word data_027e0f94
@@ -15652,7 +15652,7 @@ _020bd7d2:
 	.global func_ov00_020bd7d8
 	arm_func_start func_ov00_020bd7d8
 func_ov00_020bd7d8: ; 0x020bd7d8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0xc
 	mov r5, r0
 	mov r0, r1
@@ -15691,25 +15691,25 @@ func_ov00_020bd7d8: ; 0x020bd7d8
 _020bd868:
 	add sp, sp, #0xc
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _020bd874:
 	ldr lr, [r4, #0x20]
-	ldr sb, [r4]
+	ldr r9, [r4]
 	umull r7, r6, lr, r2
 	ldr r8, [sp]
 	mla r6, lr, r10, r6
-	smull r10, r8, sb, r8
-	adds sb, r10, r3
+	smull r10, r8, r9, r8
+	adds r9, r10, r3
 	adc r8, r8, ip
-	mov sb, sb, lsr #0xc
-	orr sb, sb, r8, lsl #20
+	mov r9, r9, lsr #0xc
+	orr r9, r9, r8, lsl #20
 	mov r8, lr, asr #0x1f
 	mla r6, r8, r2, r6
 	adds r7, r7, r3
 	adc r2, r6, ip
 	mov r6, r7, lsr #0xc
 	orr r6, r6, r2, lsl #20
-	add r6, sb, r6
+	add r6, r9, r6
 	umull r2, r7, r0, r6
 	adds r2, r2, r11
 	mov r2, r6, asr #0x1f
@@ -15720,9 +15720,9 @@ _020bd874:
 	ldr r7, [r4, #0x14]
 	ldr r6, [sp, #4]
 	ldr r2, [sp, #8]
-	smull sb, r8, r7, r6
+	smull r9, r8, r7, r6
 	ldr r4, [r4, #0x24]
-	adds r7, sb, r3
+	adds r7, r9, r3
 	smull r6, r2, r4, r2
 	adc r4, r8, ip
 	adds r3, r6, r3
@@ -15741,11 +15741,11 @@ _020bd874:
 	stmib r5, {r0, ip}
 	add sp, sp, #0xc
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _020bd938:
 	mov r0, #0
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	arm_func_end func_ov00_020bd7d8
 
 	.global func_ov00_020bd944
@@ -15761,7 +15761,7 @@ func_ov00_020bd944: ; 0x020bd944
 	.global func_ov00_020bd958
 	arm_func_start func_ov00_020bd958
 func_ov00_020bd958: ; 0x020bd958
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #0xac
 	str r1, [sp]
 	mov r7, r0
@@ -15775,7 +15775,7 @@ func_ov00_020bd958: ; 0x020bd958
 	str r2, [sp, #4]
 	cmplo r4, r0
 	addhs sp, sp, #0xac
-	ldmhsia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmhsia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	ldr r0, _020bde24 ; =0x21230000
 	ldr r2, _020bde28 ; =0x040004a8
 	ldr r1, [sp, #0xd0]
@@ -15916,29 +15916,29 @@ _020bdb70:
 	ldrsh lr, [r2, #2]
 	ldr r8, [sp, #0x10]
 	ldr r2, _020bde44 ; =data_02050f54
-	umull sb, r8, lr, r8
+	umull r9, r8, lr, r8
 	mla r8, lr, r10, r8
 	ldrsh r3, [r2, r3]
 	ldr r10, [sp, #0x10]
 	mov ip, lr, asr #0x1f
 	mla r8, ip, r10, r8
-	adds r10, sb, #0x800
-	adc sb, r8, #0
+	adds r10, r9, #0x800
+	adc r9, r8, #0
 	mov r8, r10, lsr #0xc
-	orr r8, r8, sb, lsl #20
-	ldr sb, [sp, #8]
+	orr r8, r8, r9, lsl #20
+	ldr r9, [sp, #8]
 	mov r2, r3, asr #0x1f
-	umull lr, ip, r3, sb
-	ldr sb, [sp, #0xc]
+	umull lr, ip, r3, r9
+	ldr r9, [sp, #0xc]
 	add r0, r0, r8
-	mla ip, r3, sb, ip
+	mla ip, r3, r9, ip
 	ldr r3, [sp, #8]
 	mov r0, r0, lsl #0xa
 	mov r0, r0, asr #0x10
 	mla ip, r2, r3, ip
-	adds sb, lr, #0x800
+	adds r9, lr, #0x800
 	adc r3, ip, #0
-	mov r2, sb, lsr #0xc
+	mov r2, r9, lsr #0xc
 	orr r2, r2, r3, lsl #20
 	add r1, r1, r2
 	mov r1, r1, lsl #0xa
@@ -16009,7 +16009,7 @@ _020bdcf0:
 	ldr r0, [sp, #0x24]
 	cmp r0, #0
 	addeq sp, sp, #0xac
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	ldr r0, [sp, #0x20]
 	cmp r0, #0
 	bne _020bde08
@@ -16082,7 +16082,7 @@ _020bde08:
 	mov r0, #1
 	str r0, [r1, #-0xbc]
 	add sp, sp, #0xac
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020bd958
 _020bde24: .word 0x21230000
@@ -16205,14 +16205,14 @@ _020bdfbc: .word data_027e0f64
 	.global func_ov00_020bdfc0
 	arm_func_start func_ov00_020bdfc0
 func_ov00_020bdfc0: ; 0x020bdfc0
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #0x40
-	mov sb, r0
-	ldr r0, [sb]
+	mov r9, r0
+	ldr r0, [r9]
 	cmp r0, #2
 	addlo sp, sp, #0x40
-	ldmloia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
-	ldr r2, [sb, #8]
+	ldmloia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
+	ldr r2, [r9, #8]
 	ldr r0, _020be194 ; =data_027e0f64
 	ldr r1, [r2]
 	ldr r0, [r0]
@@ -16228,7 +16228,7 @@ func_ov00_020bdfc0: ; 0x020bdfc0
 	add r3, sp, #0x14
 	str r4, [sp]
 	bl func_01ffe468
-	ldr r2, [sb, #8]
+	ldr r2, [r9, #8]
 	ldr r0, _020be194 ; =data_027e0f64
 	ldr r1, [r2, #0x10]
 	ldr r0, [r0]
@@ -16244,7 +16244,7 @@ func_ov00_020bdfc0: ; 0x020bdfc0
 	add r2, sp, #0x10
 	add r3, sp, #0xc
 	bl func_01ffe468
-	ldr r0, [sb]
+	ldr r0, [r9]
 	cmp r0, #2
 	bls _020be158
 	sub r0, r0, #1
@@ -16257,7 +16257,7 @@ func_ov00_020bdfc0: ; 0x020bdfc0
 	add r5, sp, #8
 	add r4, sp, #4
 _020be08c:
-	ldr r2, [sb, #8]
+	ldr r2, [r9, #8]
 	add r1, r8, #1
 	ldr r0, [r2, r1, lsl #4]
 	add r2, r2, r1, lsl #4
@@ -16282,7 +16282,7 @@ _020be08c:
 	sub r0, r3, r0
 	sub r1, r2, r1
 	bl func_01ffa0f4
-	ldr r1, [sb, #8]
+	ldr r1, [r9, #8]
 	add r1, r1, r8, lsl #4
 	strh r0, [r1, #0xc]
 _020be0fc:
@@ -16294,22 +16294,22 @@ _020be0fc:
 	str r2, [sp, #0x14]
 	str r1, [sp, #0x10]
 	str r0, [sp, #0xc]
-	ldr r0, [sb]
+	ldr r0, [r9]
 	add r8, r8, #1
 	sub r0, r0, #1
 	cmp r8, r0
 	blo _020be08c
 _020be130:
-	ldr r1, [sb, #8]
+	ldr r1, [r9, #8]
 	add sp, sp, #0x40
 	ldrsh r0, [r1, #0x1c]
 	strh r0, [r1, #0xc]
-	ldr r1, [sb]
-	ldr r0, [sb, #8]
+	ldr r1, [r9]
+	ldr r0, [r9, #8]
 	add r1, r0, r1, lsl #4
 	ldrsh r0, [r1, #-0x14]
 	strh r0, [r1, #-4]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _020be158:
 	ldr r3, [sp, #0x10]
 	ldr r0, [sp, #0x18]
@@ -16319,13 +16319,13 @@ _020be158:
 	sub r1, r2, r1
 	bl func_01ffa0f4
 	mov r0, r0, lsl #0x10
-	ldr r1, [sb, #8]
+	ldr r1, [r9, #8]
 	mov r2, r0, asr #0x10
 	strh r2, [r1, #0xc]
-	ldr r0, [sb, #8]
+	ldr r0, [r9, #8]
 	strh r2, [r0, #0x1c]
 	add sp, sp, #0x40
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020bdfc0
 _020be194: .word data_027e0f64
@@ -17964,7 +17964,7 @@ _020bf530:
 	.global func_ov00_020bf538
 	arm_func_start func_ov00_020bf538
 func_ov00_020bf538: ; 0x020bf538
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x1b4
 	mov r4, r0
 	ldr r0, [r4, #0x4c]
@@ -18162,24 +18162,24 @@ _020bf794:
 	str r2, [sp, #0x34]
 	adds r2, r7, #0x800
 	ldr r10, _020bff24 ; =0x0000ffff
-	add sb, sp, #0x114
-	strh r10, [sb, #4]
-	strh r10, [sb, #6]
-	strh r10, [sb, #8]
-	strh r10, [sb, #0xa]
-	strh r3, [sb, #0xc]
+	add r9, sp, #0x114
+	strh r10, [r9, #4]
+	strh r10, [r9, #6]
+	strh r10, [r9, #8]
+	strh r10, [r9, #0xa]
+	strh r3, [r9, #0xc]
 	mla r6, r5, r3, r6
-	mov sb, r5, asr #0x1f
-	mla r6, sb, r0, r6
+	mov r9, r5, asr #0x1f
+	mla r6, r9, r0, r6
 	ldr r10, [sp, #0xc8]
-	ldr sb, [sp, #0xd4]
+	ldr r9, [sp, #0xd4]
 	adc r5, r6, #0
 	mov r7, r2, lsr #0xc
 	sub r1, lr, r1
 	umull ip, r2, r1, r0
 	orr r7, r7, r5, lsl #20
 	sub r5, r8, r7
-	sub r6, sb, r10
+	sub r6, r9, r10
 	umull r8, r7, r6, r0
 	mla r2, r1, r3, r2
 	mla r7, r6, r3, r7
@@ -18193,7 +18193,7 @@ _020bf794:
 	adc r5, r7, #0
 	mov r6, r6, lsr #0xc
 	orr r6, r6, r5, lsl #20
-	sub r5, sb, r6
+	sub r5, r9, r6
 	adds r6, ip, #0x800
 	ldr r1, [sp, #0xe0]
 	adc r2, r2, #0
@@ -18627,7 +18627,7 @@ _020bff0c:
 	ldr r0, [r4, #0x44]
 	str r0, [r4, #0x48]
 	add sp, sp, #0x1b4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020bf538
 _020bff20: .word data_ov00_020dd290
@@ -20105,7 +20105,7 @@ func_ov00_020c10a0: ; 0x020c10a0
 	.global func_ov00_020c10d4
 	arm_func_start func_ov00_020c10d4
 func_ov00_020c10d4: ; 0x020c10d4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x44
 	mov r5, r0
 	add r0, r5, #0x100
@@ -20114,13 +20114,13 @@ func_ov00_020c10d4: ; 0x020c10d4
 	mov r8, r1
 	subs r1, r3, r2
 	addeq sp, sp, #0x44
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	cmp r1, #0
 	ldrlth r0, [r0, #0x80]
 	addlt r1, r1, r0
 	cmp r1, #2
 	addlt sp, sp, #0x44
-	ldmltia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmltia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r0, r5, #0x100
 	ldrh r0, [r0, #0x80]
 	mov r6, r0
@@ -20140,18 +20140,18 @@ func_ov00_020c10d4: ; 0x020c10d4
 	mla r1, r7, r0, r5
 	ldr r0, _020c141c ; =data_027e0d44
 	add r3, sp, #0x38
-	ldr sb, [r0]
+	ldr r9, [r0]
 	ldmia r1, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
 	ldr r1, [r5, #0x188]
 	ldr r2, [r5, #0x18c]
-	add r1, sb, r1, lsl #3
-	ldr sb, [r1, #8]
+	add r1, r9, r1, lsl #3
+	ldr r9, [r1, #8]
 	ldr r3, [r5, #0x190]
-	mov sb, sb, lsl #0x10
-	mov sb, sb, lsr #0x10
-	bic sb, sb, #0xe0000000
-	orr r2, sb, r2, lsl #26
+	mov r9, r9, lsl #0x10
+	mov r9, r9, lsr #0x10
+	bic r9, r9, #0xe0000000
+	orr r2, r9, r2, lsl #26
 	ldr r4, [r5, #0x194]
 	orr r2, r2, r3, lsl #20
 	orr r2, r2, r4, lsl #23
@@ -20211,12 +20211,12 @@ func_ov00_020c10d4: ; 0x020c10d4
 	mov r2, #1
 	bl func_01ffa9fc
 	cmp r6, #0
-	mov sb, r8
+	mov r9, r8
 	ble _020c13f0
 	add r11, r5, #0x100
 _020c1288:
 	ldrh r0, [r11, #0x80]
-	add r10, r7, sb
+	add r10, r7, r9
 	add r1, sp, #0x1c
 	cmp r10, r0
 	subge r10, r10, r0
@@ -20298,12 +20298,12 @@ _020c1288:
 	add r1, sp, #8
 	mov r2, #2
 	bl func_01ffa9fc
-	add r0, sb, #1
+	add r0, r9, #1
 	cmp r0, r6
 	ldrlt r0, [sp]
-	add sb, sb, #1
+	add r9, r9, #1
 	addlt r8, r8, r0
-	cmp sb, r6
+	cmp r9, r6
 	blt _020c1288
 _020c13f0:
 	mov r1, #0
@@ -20316,7 +20316,7 @@ _020c13f0:
 	str r2, [sp, #4]
 	bl func_01ffa9fc
 	add sp, sp, #0x44
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020c10d4
 _020c141c: .word data_027e0d44

--- a/asm/ov00/ov00_020b1498.s
+++ b/asm/ov00/ov00_020b1498.s
@@ -5753,7 +5753,7 @@ _020b5cb0: .word 0x00000666
 	.global func_ov00_020b5cb4
 	arm_func_start func_ov00_020b5cb4
 func_ov00_020b5cb4: ; 0x020b5cb4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x244
 	mov r6, r2
 	mov r5, r3
@@ -5802,8 +5802,8 @@ _020b5d14:
 	ldr r0, [r7, #0x2c]
 	str r0, [r7, #0x3c]
 	ldr sb, [r7, #0x2c]
-	ldmia sl, {r0, fp, ip}
-	add sb, fp, sb
+	ldmia sl, {r0, r11, ip}
+	add sb, r11, sb
 	str r0, [r7, #0x20]
 	str sb, [r7, #0x24]
 	str ip, [r7, #0x28]
@@ -5938,7 +5938,7 @@ _020b5f34:
 	strh r2, [r0, #0x9a]
 	strh r8, [r0, #0x9c]
 	ldr r1, _020b6ad0 ; =data_ov00_020e64a8
-	add fp, sp, #0xf0
+	add r11, sp, #0xf0
 	strb r8, [sp, #0x1d2]
 	strb r8, [sp, #0x1d3]
 	strb r8, [sp, #0x1d4]
@@ -5952,7 +5952,7 @@ _020b5f34:
 	add r0, r7, #0x30
 	str r1, [sp, #0x28]
 	ldmia r0, {r0, r1, r2}
-	stmia fp, {r0, r1, r2}
+	stmia r11, {r0, r1, r2}
 	ldr r0, [r7, #0x3c]
 	add r3, sp, #0xe0
 	str r0, [sp, #0xfc]
@@ -5960,21 +5960,21 @@ _020b5f34:
 	ldmia r0, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
 	ldr ip, [r7, #0x2c]
-	mov r2, fp
+	mov r2, r11
 	str ip, [sp, #0xec]
-	ldrh fp, [r7, #0xa4]
+	ldrh r11, [r7, #0xa4]
 	add r0, sp, #0x28
 	ldr lr, _020b6ac8 ; =data_027e0e60
-	bic fp, fp, #2
-	mov fp, fp, lsl #0x10
+	bic r11, r11, #2
+	mov r11, r11, lsl #0x10
 	str sb, [sp, #0xf4]
 	str sb, [sp, #0xe4]
 	ldrsh sb, [r7, #0x5a]
-	mov fp, fp, lsr #0x10
+	mov r11, r11, lsr #0x10
 	add r1, sp, #0x184
 	str sb, [sp, #0x2c]
 	str ip, [sp]
-	stmib sp, {r8, fp}
+	stmib sp, {r8, r11}
 	str r0, [sp, #0xc]
 	str r8, [sp, #0x10]
 	ldr r0, [lr]
@@ -6071,12 +6071,12 @@ _020b6110:
 _020b6168:
 	add r0, sp, #0xd4
 	bl func_01ff9cec
-	mov fp, r0
+	mov r11, r0
 	bl func_ov23_02177e7c
 	add r1, r0, r0, lsl #2
 	mov r0, r1, asr #0x1
 	add r0, r1, r0, lsr #30
-	cmp fp, r0, asr #2
+	cmp r11, r0, asr #2
 	ble _020b61d4
 	add r0, sp, #0xd4
 	mov r1, r0
@@ -6129,12 +6129,12 @@ _020b61e0:
 	bl func_ov00_020b50f8
 	cmp r0, #0
 	bne _020b62ec
-	add fp, r7, #0x20
+	add r11, r7, #0x20
 	add r8, sp, #0xc4
-	ldmia fp, {r0, r1, r2}
+	ldmia r11, {r0, r1, r2}
 	stmia r8, {r0, r1, r2}
 	ldr r3, [r7, #0x2c]
-	mov r0, fp
+	mov r0, r11
 	mov r1, sl
 	mov r2, r8
 	str r3, [sp, #0xd0]
@@ -6146,7 +6146,7 @@ _020b61e0:
 	ldrb r1, [r7, #0xbe]
 	ldr r3, [sp, #0xd0]
 	ldr ip, [sp, #0xc4]
-	ldr fp, [sp, #0xc8]
+	ldr r11, [sp, #0xc8]
 	ldr r8, [sp, #0xcc]
 	mov r2, r3, lsl #0x1
 	cmp r1, #0
@@ -6155,7 +6155,7 @@ _020b61e0:
 	str r2, [sp, #0x9c]
 	add r1, sp, #0x8c
 	str ip, [sp, #0x8c]
-	str fp, [sp, #0x90]
+	str r11, [sp, #0x90]
 	str r8, [sp, #0x94]
 	str r1, [sp]
 	movne r0, #3
@@ -6307,7 +6307,7 @@ _020b64a4:
 	str r1, [r6]
 _020b64f8:
 	mov r8, #0
-	mov fp, r8
+	mov r11, r8
 	cmp sb, #0
 	beq _020b6830
 	ldrsh r0, [r7, #0xc6]
@@ -6515,7 +6515,7 @@ _020b67e0:
 	b _020b6824
 _020b6808:
 	ldr r0, [r7, #0xac]
-	mov fp, #1
+	mov r11, #1
 	str r0, [r6]
 	ldr r0, [r7, #0xb0]
 	str r0, [r6, #4]
@@ -6627,7 +6627,7 @@ _020b698c:
 _020b69a0:
 	ldrsh r0, [r7, #0x5c]
 	cmp r0, #0
-	cmpeq fp, #0
+	cmpeq r11, #0
 	bne _020b69c4
 	ldr r1, _020b6aec ; =data_ov00_020e647c
 	mov r0, r7
@@ -6651,12 +6651,12 @@ _020b69c4:
 	add sp, sp, #0x244
 	bic r0, r0, #8
 	strh r0, [r7, #0xa4]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _020b6a08:
 	ldrsh r2, [r7, #0xc6]
 	cmp r2, #0
 	addge sp, sp, #0x244
-	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r1, [r7, #0x34]
 	ldr r0, [r7, #0x24]
 	cmp r1, r0
@@ -6679,19 +6679,19 @@ _020b6a08:
 	bic r1, r1, #4
 	strh r1, [r7, #0xa4]
 	str r0, [r6, #4]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _020b6a74:
 	ldrb r0, [sp, #0x23f]
 	cmp r0, #0
 	addeq sp, sp, #0x244
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldrh r1, [r7, #0xa4]
 	mov r0, #0
 	add sp, sp, #0x244
 	bic r1, r1, #8
 	strh r1, [r7, #0xa4]
 	str r0, [r6, #4]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _020b6aa0:
 	ldrb r0, [sp, #0x23c]
 	cmp r0, #0
@@ -6700,7 +6700,7 @@ _020b6aa0:
 	movne r0, #0
 	strneb r0, [r7, #0xbc]
 	add sp, sp, #0x244
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020b5cb4
 _020b6ac0: .word data_027e0ff8
@@ -9219,7 +9219,7 @@ func_ov00_020b88bc: ; 0x020b88bc
 	.global func_ov00_020b88c4
 	arm_func_start func_ov00_020b88c4
 func_ov00_020b88c4: ; 0x020b88c4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	movs sb, r1
 	mov sl, r0
 	movne r0, #0
@@ -9227,7 +9227,7 @@ func_ov00_020b88c4: ; 0x020b88c4
 	ldrb r0, [sl, #0x290]
 	cmp r0, #0
 	movne r0, #1
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, _020b8b78 ; =data_027e0618
 	ldr r0, [r0]
 	cmp r0, #6
@@ -9235,14 +9235,14 @@ func_ov00_020b88c4: ; 0x020b88c4
 	bl func_ov00_02079e3c
 	cmp r0, #0
 	movne r0, #1
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _020b8908:
 	ldr r0, _020b8b7c ; =data_027e0f90
 	ldr r0, [r0]
 	ldrsh r0, [r0, #0xa]
 	cmp r0, #0
 	movle r0, #1
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, _020b8b80 ; =data_027e0f64
 	ldr r0, [r0]
 	ldr r0, [r0, #4]
@@ -9268,7 +9268,7 @@ _020b8968:
 	bne _020b8978
 _020b8970:
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _020b8978:
 	ldr r0, _020b8b84 ; =data_027e0f74
 	ldr r0, [r0]
@@ -9283,7 +9283,7 @@ _020b8978:
 	ldrb r0, [sl, #0x11c]
 	cmp r0, #0
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	bl _ZN13LinkStateBase16GetLinkItemStateEv
 	bl _ZN13LinkStateItem16IsHammerEquippedEv
 	mvn r1, #0
@@ -9305,7 +9305,7 @@ _020b89f0:
 	movne r0, #6
 	strne r0, [sb]
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _020b8a04:
 	ldr r0, _020b8b8c ; =data_ov00_020e8b08
 	ldr r7, [r0]
@@ -9328,11 +9328,11 @@ _020b8a40:
 	ldreqb r0, [sl, #0x28e]
 	cmpeq r0, #0
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	mov r8, #0
 	ldr r4, _020b8b88 ; =gItemManager
 	mov r6, r8
-	mov fp, r8
+	mov r11, r8
 	mov r5, #1
 _020b8a68:
 	mov r0, sl
@@ -9355,7 +9355,7 @@ _020b8a94:
 	add r1, r1, #1
 	cmp r1, #4
 	blt _020b8a94
-	mov r0, fp
+	mov r0, r11
 _020b8ab8:
 	cmp r0, #0
 	beq _020b8ad4
@@ -9363,7 +9363,7 @@ _020b8ab8:
 	movne r0, #6
 	strne r0, [sb]
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _020b8ad4:
 	add r8, r8, #1
 	cmp r8, #3
@@ -9385,7 +9385,7 @@ _020b8ae0:
 	blx r1
 	cmp r0, #0
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, _020b8b88 ; =gItemManager
 	mov r1, #0
 	ldr r0, [r0]
@@ -9397,19 +9397,19 @@ _020b8ae0:
 	movne r0, #6
 	strne r0, [sb]
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _020b8b54:
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _020b8b5c:
 	cmp sb, #0
 	movne r0, #6
 	strne r0, [sb]
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _020b8b70:
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020b88c4
 _020b8b78: .word data_027e0618
@@ -9855,7 +9855,7 @@ func_ov00_020b9178: ; 0x020b9178
 	.global func_ov00_020b917c
 	arm_func_start func_ov00_020b917c
 func_ov00_020b917c: ; 0x020b917c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #8
 	mov sb, r0
 	ldr r0, [sb, #0x130]
@@ -9868,7 +9868,7 @@ func_ov00_020b917c: ; 0x020b917c
 	strb r0, [sb, #0x11a]
 	mov r5, #0
 	ldr sl, _020b92cc ; =data_ov00_020dc81c
-	ldr fp, _020b92d0 ; =data_027e0e58
+	ldr r11, _020b92d0 ; =data_027e0e58
 	strb r5, [sb, #0x290]
 	add r7, sb, #0x218
 	mov r4, #2
@@ -9878,7 +9878,7 @@ _020b91c0:
 	bne _020b91fc
 	mov r0, sb
 	ldr r1, [r0]
-	ldr r6, [fp]
+	ldr r6, [r11]
 	ldr r1, [r1, #0xb4]
 	blx r1
 	mov r1, r0
@@ -9947,7 +9947,7 @@ _020b92b8:
 	str r0, [sb, #0x138]
 	str r8, [sb, #0x130]
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020b917c
 _020b92cc: .word data_ov00_020dc81c
@@ -15652,7 +15652,7 @@ _020bd7d2:
 	.global func_ov00_020bd7d8
 	arm_func_start func_ov00_020bd7d8
 func_ov00_020bd7d8: ; 0x020bd7d8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0xc
 	mov r5, r0
 	mov r0, r1
@@ -15680,8 +15680,8 @@ func_ov00_020bd7d8: ; 0x020bd7d8
 	mla r7, r1, r6, r7
 	adds r3, r8, #0x80000000
 	adc r6, r7, #0
-	mov fp, #0x80000000
-	cmp r6, fp, asr #19
+	mov r11, #0x80000000
+	cmp r6, r11, asr #19
 	mov sl, r2, asr #0x1f
 	mov ip, #0
 	mov r3, #0x800
@@ -15691,7 +15691,7 @@ func_ov00_020bd7d8: ; 0x020bd7d8
 _020bd868:
 	add sp, sp, #0xc
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _020bd874:
 	ldr lr, [r4, #0x20]
 	ldr sb, [r4]
@@ -15711,7 +15711,7 @@ _020bd874:
 	orr r6, r6, r2, lsl #20
 	add r6, sb, r6
 	umull r2, r7, r0, r6
-	adds r2, r2, fp
+	adds r2, r2, r11
 	mov r2, r6, asr #0x1f
 	mla r7, r0, r2, r7
 	mla r7, r1, r6, r7
@@ -15736,16 +15736,16 @@ _020bd874:
 	mov r2, r3, asr #0x1f
 	mla r4, r0, r2, r4
 	mla r4, r1, r3, r4
-	adds r6, r6, fp
+	adds r6, r6, r11
 	adc r0, r4, ip
 	stmib r5, {r0, ip}
 	add sp, sp, #0xc
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _020bd938:
 	mov r0, #0
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	arm_func_end func_ov00_020bd7d8
 
 	.global func_ov00_020bd944
@@ -17964,7 +17964,7 @@ _020bf530:
 	.global func_ov00_020bf538
 	arm_func_start func_ov00_020bf538
 func_ov00_020bf538: ; 0x020bf538
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x1b4
 	mov r4, r0
 	ldr r0, [r4, #0x4c]
@@ -18010,7 +18010,7 @@ func_ov00_020bf538: ; 0x020bf538
 	add r1, sp, #0xe4
 	str r2, [sp, #0xe4]
 	ldr r2, [r0, #4]
-	mov fp, r6
+	mov r11, r6
 	str r2, [sp, #0xe8]
 	ldr r2, [r0, #8]
 	mov r0, r4
@@ -18146,7 +18146,7 @@ _020bf794:
 	str r3, [sp, #0xcc]
 	str r2, [sp, #0xd0]
 	str r1, [sp, #0xd4]
-	mov fp, #1
+	mov r11, #1
 	bl func_ov00_020be990
 	add r5, sp, #0xc0
 	ldmia r0, {r0, r1, r2}
@@ -18231,7 +18231,7 @@ _020bf794:
 	str r1, [sp, #0x2c]
 	sub r0, r0, #0xcd
 	str r0, [sp]
-	mov r0, fp
+	mov r0, r11
 	str r0, [sp, #4]
 	mov r1, #0xd
 	str r1, [sp, #8]
@@ -18446,7 +18446,7 @@ _020bfc78:
 _020bfc80:
 	ldrb r0, [r4, #0x6d]
 	cmp r0, #0
-	cmpne fp, #0
+	cmpne r11, #0
 	beq _020bfd10
 	ldr r0, _020bff60 ; =data_ov00_020ee588
 	ldr r3, [sp, #0xcc]
@@ -18627,7 +18627,7 @@ _020bff0c:
 	ldr r0, [r4, #0x44]
 	str r0, [r4, #0x48]
 	add sp, sp, #0x1b4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020bf538
 _020bff20: .word data_ov00_020dd290
@@ -20105,7 +20105,7 @@ func_ov00_020c10a0: ; 0x020c10a0
 	.global func_ov00_020c10d4
 	arm_func_start func_ov00_020c10d4
 func_ov00_020c10d4: ; 0x020c10d4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x44
 	mov r5, r0
 	add r0, r5, #0x100
@@ -20114,13 +20114,13 @@ func_ov00_020c10d4: ; 0x020c10d4
 	mov r8, r1
 	subs r1, r3, r2
 	addeq sp, sp, #0x44
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	cmp r1, #0
 	ldrlth r0, [r0, #0x80]
 	addlt r1, r1, r0
 	cmp r1, #2
 	addlt sp, sp, #0x44
-	ldmltia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmltia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r0, r5, #0x100
 	ldrh r0, [r0, #0x80]
 	mov r6, r0
@@ -20213,9 +20213,9 @@ func_ov00_020c10d4: ; 0x020c10d4
 	cmp r6, #0
 	mov sb, r8
 	ble _020c13f0
-	add fp, r5, #0x100
+	add r11, r5, #0x100
 _020c1288:
-	ldrh r0, [fp, #0x80]
+	ldrh r0, [r11, #0x80]
 	add sl, r7, sb
 	add r1, sp, #0x1c
 	cmp sl, r0
@@ -20316,7 +20316,7 @@ _020c13f0:
 	str r2, [sp, #4]
 	bl func_01ffa9fc
 	add sp, sp, #0x44
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020c10d4
 _020c141c: .word data_027e0d44

--- a/asm/ov00/ov00_020c3e54.s
+++ b/asm/ov00/ov00_020c3e54.s
@@ -208,11 +208,11 @@ _020c4040:
 	.global func_ov00_020c4048
 	arm_func_start func_ov00_020c4048
 func_ov00_020c4048: ; 0x020c4048
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	ldr r4, _020c42cc ; =data_027e0fe4
 	mov r11, r1
 	ldr r7, [r4]
-	mov sl, r2
+	mov r10, r2
 	ldrh r2, [r7]
 	mov sb, r3
 	ldr r8, [sp, #0x28]
@@ -235,7 +235,7 @@ _020c407c:
 	strne r0, [r8]
 	strne r0, [r8, #4]
 	mvn r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _020c40b4:
 	str r11, [r0, #4]
 	ldr r1, [r7, #0xc]
@@ -244,11 +244,11 @@ _020c40b4:
 	ldr r0, [r6]
 	str r5, [r0, #0xc]
 	ldr r1, [r6]
-	ldr r0, [sl]
+	ldr r0, [r10]
 	str r0, [r1, #0x14]
-	ldr r0, [sl, #4]
+	ldr r0, [r10, #4]
 	str r0, [r1, #0x18]
-	ldr r0, [sl, #8]
+	ldr r0, [r10, #8]
 	str r0, [r1, #0x1c]
 	ldrh r2, [sb]
 	ldrh r1, [sb, #2]
@@ -307,17 +307,17 @@ _020c40b4:
 	ldr r1, [r6]
 	str r2, [r1, #0x144]
 	ldr r2, [r6]
-	ldr r1, [sl]
+	ldr r1, [r10]
 	str r1, [r2, #0x48]
-	ldr r1, [sl, #4]
+	ldr r1, [r10, #4]
 	str r1, [r2, #0x4c]
-	ldr r1, [sl, #8]
+	ldr r1, [r10, #8]
 	str r1, [r2, #0x50]
-	ldr r1, [sl]
+	ldr r1, [r10]
 	str r1, [r2, #0x54]
-	ldr r1, [sl, #4]
+	ldr r1, [r10, #4]
 	str r1, [r2, #0x58]
-	ldr r1, [sl, #8]
+	ldr r1, [r10, #8]
 	str r1, [r2, #0x5c]
 	ldr r0, [r0]
 	bl func_ov00_02082d28
@@ -358,7 +358,7 @@ _020c40b4:
 	strne r0, [r8]
 	strne r0, [r8, #4]
 	mvn r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _020c429c:
 	add r5, r5, #1
 	cmp r5, r2
@@ -373,7 +373,7 @@ _020c42ac:
 	strne r0, [r8, #4]
 _020c42c4:
 	mov r0, r4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020c4048
 _020c42cc: .word data_027e0fe4
@@ -838,7 +838,7 @@ _020c4878:
 	.global func_ov00_020c4898
 	arm_func_start func_ov00_020c4898
 func_ov00_020c4898: ; 0x020c4898
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	mov r8, r0
 	mov r7, r1
 	mov r6, r2
@@ -846,12 +846,12 @@ func_ov00_020c4898: ; 0x020c4898
 	mov r4, #0
 	add r5, r0, #0x14
 	mov sb, r4
-	mov sl, #1
+	mov r10, #1
 _020c48bc:
 	ldrsb r0, [r5, #2]
 	cmp r0, #0
 	cmpne r0, #4
-	movne r0, sl
+	movne r0, r10
 	moveq r0, sb
 	cmp r0, #0
 	beq _020c48ec
@@ -865,7 +865,7 @@ _020c48ec:
 	cmp r4, #4
 	add r5, r5, #4
 	blt _020c48bc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	arm_func_end func_ov00_020c4898
 
 	.global func_ov00_020c4900
@@ -1009,7 +1009,7 @@ _020c4ae4: .word data_027e0ff0
 	.global func_ov00_020c4ae8
 	arm_func_start func_ov00_020c4ae8
 func_ov00_020c4ae8: ; 0x020c4ae8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0xc
 	ldr r4, [r0, #4]
 	str r0, [sp]
@@ -1019,7 +1019,7 @@ func_ov00_020c4ae8: ; 0x020c4ae8
 	mov r0, r5
 	cmp r4, #0
 	str r1, [sp, #4]
-	mov sl, r2
+	mov r10, r2
 	mov sb, r3
 	sub r4, r0, #0x80000001
 	ble _020c4bf4
@@ -1031,7 +1031,7 @@ _020c4b20:
 	add r7, r2, r1, lsl #3
 	cmp r0, #0
 	beq _020c4bd8
-	mov r0, sl
+	mov r0, r10
 	ldr r2, [r0]
 	mov r1, r7
 	ldr r2, [r2]
@@ -1045,7 +1045,7 @@ _020c4b20:
 	ble _020c4bd8
 	mov r8, r6
 _020c4b70:
-	mov r0, sl
+	mov r0, r10
 	ldr r3, [r0]
 	mov r1, r7
 	mov r2, r6
@@ -1083,15 +1083,15 @@ _020c4bd8:
 _020c4bf4:
 	ldr r0, [sp, #8]
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	arm_func_end func_ov00_020c4ae8
 
 	.global func_ov00_020c4c00
 	arm_func_start func_ov00_020c4c00
 func_ov00_020c4c00: ; 0x020c4c00
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x40
-	mov sl, r1
+	mov r10, r1
 	mov sb, r3
 	bl func_ov00_020c4ae8
 	cmp r0, #0
@@ -1112,7 +1112,7 @@ func_ov00_020c4c00: ; 0x020c4c00
 	ldmia r5, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
 	mov r1, r3
-	mov r0, sl
+	mov r0, r10
 	bl func_ov00_020ce2f0
 	mov r6, r0
 	ldrsb r0, [sb]
@@ -1140,9 +1140,9 @@ _020c4c84:
 	mov r3, r4
 	add r0, sp, #0x28
 	mov r1, r5
-	mov r2, sl
+	mov r2, r10
 	bl func_ov00_020ce440
-	mov r0, sl
+	mov r0, r10
 	mov r1, r4
 	bl func_ov00_020ce2f0
 	cmp r6, r0
@@ -1173,11 +1173,11 @@ _020c4d0c:
 	add sp, sp, #0x40
 	strb r1, [sb, #2]
 	strb r11, [sb, #3]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _020c4d4c:
 	mov r0, #0
 	add sp, sp, #0x40
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020c4c00
 _020c4d58: .word data_027e0ff0
@@ -1185,10 +1185,10 @@ _020c4d58: .word data_027e0ff0
 	.global func_ov00_020c4d5c
 	arm_func_start func_ov00_020c4d5c
 func_ov00_020c4d5c: ; 0x020c4d5c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x204
 	mov r11, r0
-	mov sl, r1
+	mov r10, r1
 	add r3, sp, #4
 	str r2, [sp]
 	mov r7, #0
@@ -1212,7 +1212,7 @@ _020c4da8:
 	add sb, r2, r1, lsl #3
 	cmp r0, #0
 	beq _020c4e34
-	mov r0, sl
+	mov r0, r10
 	ldr r2, [r0]
 	mov r1, sb
 	ldr r2, [r2]
@@ -1225,7 +1225,7 @@ _020c4da8:
 	cmp r8, #0
 	ble _020c4e34
 _020c4df0:
-	mov r0, sl
+	mov r0, r10
 	ldr r3, [r0]
 	mov r1, sb
 	ldr r3, [r3, #4]
@@ -1285,11 +1285,11 @@ _020c4ea8:
 	ldrsb r2, [r3, #1]
 	mov r0, #1
 	strb r2, [r1, #1]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _020c4ed4:
 	mov r0, #0
 	add sp, sp, #0x204
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020c4d5c
 _020c4ee0: .word data_027e0764
@@ -1403,9 +1403,9 @@ _020c500c:
 	.global func_ov00_020c5014
 	arm_func_start func_ov00_020c5014
 func_ov00_020c5014: ; 0x020c5014
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
-	mov sl, r0
-	ldr r0, [sl]
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	mov r10, r0
+	ldr r0, [r10]
 	mov r11, #0
 	ldrb r4, [r0, #1]
 	mov sb, r1
@@ -1419,7 +1419,7 @@ func_ov00_020c5014: ; 0x020c5014
 _020c5048:
 	cmp r8, #0
 	beq _020c5090
-	ldr r3, [sl]
+	ldr r3, [r10]
 	mov r1, #0
 	ldrb r0, [r3, #5]
 	mov r2, r1
@@ -1437,7 +1437,7 @@ _020c5088:
 	cmp r1, #0
 	bne _020c50b0
 _020c5090:
-	ldr r0, [sl, #4]
+	ldr r0, [r10, #4]
 	mov r1, sb
 	add r0, r0, r7
 	add r0, r0, #4
@@ -1455,7 +1455,7 @@ _020c50c0:
 	cmp r0, #0
 	strne r6, [r0]
 	mov r0, r11
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	arm_func_end func_ov00_020c5014
 
 	.global func_ov00_020c50d4
@@ -3473,7 +3473,7 @@ _020c69e4: .word func_ov00_020c69a0
 	.global func_ov00_020c69e8
 	arm_func_start func_ov00_020c69e8
 func_ov00_020c69e8: ; 0x020c69e8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0xc
 	mov r7, r0
 	ldr r3, [r7, #4]
@@ -3502,7 +3502,7 @@ func_ov00_020c69e8: ; 0x020c69e8
 	mov r0, r7
 	bl func_ov00_020c69a0
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _020c6a60:
 	bl func_ov00_020c6d34
 	mov r4, r0
@@ -3516,13 +3516,13 @@ _020c6a60:
 	ldr r2, [r2, #4]
 	str r0, [sp, #8]
 	mla sb, r0, r1, r2
-	mla sl, r5, r1, r2
+	mla r10, r5, r1, r2
 	mla r8, r4, r1, r2
-	ldr r2, [sl, #0xc]
+	ldr r2, [r10, #0xc]
 	ldr r1, [r6, #8]
 	ldr r0, [r6]
 	sub r11, r2, r1
-	ldr r2, [sl, #4]
+	ldr r2, [r10, #4]
 	mov r1, r11
 	sub r0, r2, r0
 	str r0, [sp, #4]
@@ -3530,17 +3530,17 @@ _020c6a60:
 	mov r0, r0, lsl #0x10
 	mov r6, r0, asr #0x10
 	ldr r3, [r8, #4]
-	ldr r0, [sl, #4]
+	ldr r0, [r10, #4]
 	ldr r2, [r8, #0xc]
-	ldr r1, [sl, #0xc]
+	ldr r1, [r10, #0xc]
 	sub r0, r3, r0
 	sub r1, r2, r1
 	bl func_01ffa0f4
 	mov r8, r0, lsl #0x10
 	ldr r3, [sb, #4]
-	ldr r0, [sl, #4]
+	ldr r0, [r10, #4]
 	ldr r2, [sb, #0xc]
-	ldr r1, [sl, #0xc]
+	ldr r1, [r10, #0xc]
 	sub r0, r3, r0
 	sub r1, r2, r1
 	bl func_01ffa0f4
@@ -3555,7 +3555,7 @@ _020c6a60:
 	mov r1, #0
 	bl func_ov00_020c69a0
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _020c6b30:
 	ldr r0, [sp, #8]
 	cmp r5, r0
@@ -3564,7 +3564,7 @@ _020c6b30:
 	mov r1, #1
 	bl func_ov00_020c69a0
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _020c6b50:
 	sub r0, r6, r1, asr #16
 	mov r0, r0, lsl #0x10
@@ -3582,12 +3582,12 @@ _020c6b50:
 	mov r1, #1
 	bl func_ov00_020c69a0
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _020c6b94:
 	mov r1, #0
 	bl func_ov00_020c69a0
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020c69e8
 _020c6ba4: .word data_027e0764
@@ -6152,7 +6152,7 @@ func_ov00_020c8d28: ; 0x020c8d28
 	.global func_ov00_020c8d4c
 	arm_func_start func_ov00_020c8d4c
 func_ov00_020c8d4c: ; 0x020c8d4c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0xc
 	ldrsb r2, [r1]
 	mov r11, r0
@@ -6166,12 +6166,12 @@ func_ov00_020c8d4c: ; 0x020c8d4c
 	ldr r0, _020c8e40 ; =0x00007fff
 	ldrsb r8, [r11, #0x12]
 	ldrsb sb, [r11, #0x13]
-	add sl, r6, #0x14
+	add r10, r6, #0x14
 	mov r7, #0x2000
 	mov r5, #0
 	rsb r4, r0, #0
 _020c8d94:
-	ldrsb r0, [sl, #2]
+	ldrsb r0, [r10, #2]
 	sub r0, r0, #1
 	mov r0, r0, lsl #0x18
 	mov r0, r0, asr #0x18
@@ -6179,7 +6179,7 @@ _020c8d94:
 	cmp r0, #1
 	bhi _020c8e1c
 	ldr r0, _020c8e3c ; =data_027e0ff0
-	mov r1, sl
+	mov r1, r10
 	ldr r0, [r0]
 	bl func_ov00_020c47cc
 	add r0, r0, #4
@@ -6203,18 +6203,18 @@ _020c8d94:
 	movlt r0, r0, asr #0x10
 _020c8e0c:
 	cmp r0, r7
-	ldrltsb r8, [sl]
-	ldrltsb sb, [sl, #1]
+	ldrltsb r8, [r10]
+	ldrltsb sb, [r10, #1]
 	movlt r7, r0
 _020c8e1c:
 	add r5, r5, #1
 	cmp r5, #4
-	add sl, sl, #4
+	add r10, r10, #4
 	blt _020c8d94
 	strb r8, [r11, #0x10]
 	strb sb, [r11, #0x11]
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020c8d4c
 _020c8e3c: .word data_027e0ff0
@@ -6763,9 +6763,9 @@ _020c9558: .word data_027e0ff0
 	.global func_ov00_020c955c
 	arm_func_start func_ov00_020c955c
 func_ov00_020c955c: ; 0x020c955c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	ldr r3, _020c95fc ; =data_027e0ff0
-	mov sl, r0
+	mov r10, r0
 	ldr r0, [r3]
 	mov sb, r1
 	mov r1, r2
@@ -6796,15 +6796,15 @@ _020c95c0:
 	blt _020c958c
 	mvn r0, #0
 	cmp r6, r0
-	streqb r0, [sl]
-	streqb r0, [sl, #1]
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	streqb r0, [r10]
+	streqb r0, [r10, #1]
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	add r1, r4, r6, lsl #2
 	ldrsb r0, [r1, #0x14]
-	strb r0, [sl]
+	strb r0, [r10]
 	ldrsb r0, [r1, #0x15]
-	strb r0, [sl, #1]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	strb r0, [r10, #1]
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020c955c
 _020c95fc: .word data_027e0ff0
@@ -6812,9 +6812,9 @@ _020c95fc: .word data_027e0ff0
 	.global func_ov00_020c9600
 	arm_func_start func_ov00_020c9600
 func_ov00_020c9600: ; 0x020c9600
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	ldr r3, _020c96a0 ; =data_027e0ff0
-	mov sl, r0
+	mov r10, r0
 	ldr r0, [r3]
 	mov sb, r1
 	mov r1, r2
@@ -6845,15 +6845,15 @@ _020c9664:
 	blt _020c9630
 	mvn r0, #0
 	cmp r6, r0
-	streqb r0, [sl]
-	streqb r0, [sl, #1]
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	streqb r0, [r10]
+	streqb r0, [r10, #1]
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	add r1, r4, r6, lsl #2
 	ldrsb r0, [r1, #0x14]
-	strb r0, [sl]
+	strb r0, [r10]
 	ldrsb r0, [r1, #0x15]
-	strb r0, [sl, #1]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	strb r0, [r10, #1]
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020c9600
 _020c96a0: .word data_027e0ff0
@@ -12065,7 +12065,7 @@ _020cd628: .word data_02050f54
 	.global func_ov00_020cd62c
 	arm_func_start func_ov00_020cd62c
 func_ov00_020cd62c: ; 0x020cd62c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x24
 	mov r4, r0
 	ldrsh r0, [r4, #0x34]
@@ -12089,7 +12089,7 @@ func_ov00_020cd62c: ; 0x020cd62c
 	cmp r5, r0
 	moveq r0, #0
 	streqh r0, [r4, #0x34]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _020cd690:
 	mov r2, r5
 	mov r3, r6
@@ -12125,13 +12125,13 @@ _020cd690:
 	mov r0, r0, lsl #0x10
 	ldr r6, [r1]
 	ldmib r1, {r5, r8}
-	umull sl, sb, r8, r6
+	umull r10, sb, r8, r6
 	mla sb, r8, r5, sb
 	ldr r7, [r1, #0xc]
 	ldr ip, [r1, #0x10]
 	mla sb, r7, r6, sb
 	ldr r11, [r1, #0x14]
-	adds r7, ip, sl
+	adds r7, ip, r10
 	ldr r5, _020cd8d8 ; =data_027e0764
 	adc r6, r11, sb
 	str r7, [r5]
@@ -12171,14 +12171,14 @@ _020cd690:
 	mov r0, #0x1e
 	add sp, sp, #0x24
 	strh r0, [r4, #0x34]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _020cd7d4:
 	add r1, r4, #0x18
 	bl _ZN5Actor12XzDistanceToEP5Vec3p
 	ldr r1, [r4, #0x30]
 	cmp r0, r1
 	addle sp, sp, #0x24
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r1, [r4]
 	add r2, sp, #0
 	add r0, r4, #0x18
@@ -12195,10 +12195,10 @@ _020cd7d4:
 	umull r8, r7, r6, lr
 	mla r7, r6, ip, r7
 	ldr r5, [r11, #0xc]
-	ldr sl, [r11, #0x10]
+	ldr r10, [r11, #0x10]
 	mla r7, r5, lr, r7
 	ldr sb, [r11, #0x14]
-	adds r5, sl, r8
+	adds r5, r10, r8
 	adc r6, sb, r7
 	stmia r11, {r5, r6}
 	ldr r5, _020cd8dc ; =0x00001c73
@@ -12237,7 +12237,7 @@ _020cd7d4:
 	mov r0, #0x1e
 	strh r0, [r4, #0x34]
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020cd62c
 _020cd8d8: .word data_027e0764
@@ -13001,14 +13001,14 @@ func_ov00_020ce2f0: ; 0x020ce2f0
 	.global func_ov00_020ce340
 	arm_func_start func_ov00_020ce340
 func_ov00_020ce340: ; 0x020ce340
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
-	mov sl, r0
-	ldr r4, [sl, #8]
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	mov r10, r0
+	ldr r4, [r10, #8]
 	ldr r0, [r2, #8]
 	ldr r5, [r2]
 	sub r8, r0, r4
 	smull r2, r0, r8, r8
-	ldr r6, [sl]
+	ldr r6, [r10]
 	adds r4, r2, #0x800
 	sub r7, r5, r6
 	smull r2, r6, r7, r7
@@ -13031,7 +13031,7 @@ func_ov00_020ce340: ; 0x020ce340
 	mov r5, r1, asr #0x1f
 	mov r1, #0
 	movle r0, r1
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	bl func_01ff9958
 	mov r4, r0
 	mov r0, r7
@@ -13052,19 +13052,19 @@ func_ov00_020ce340: ; 0x020ce340
 	orr r4, r4, r2, lsl #20
 	umull r3, r2, r6, r0
 	mla r2, r6, r1, r2
-	ldr r7, [sl]
+	ldr r7, [r10]
 	adds r1, r3, #0x800
 	mla r2, r5, r0, r2
 	add r4, r7, r4
 	str r4, [sb]
-	ldr r4, [sl, #8]
+	ldr r4, [r10, #8]
 	adc r0, r2, #0
 	mov r1, r1, lsr #0xc
 	orr r1, r1, r0, lsl #20
 	add r0, r4, r1
 	str r0, [sb, #8]
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	arm_func_end func_ov00_020ce340
 
 	.global func_ov00_020ce440
@@ -13347,7 +13347,7 @@ func_ov00_020ce704: ; 0x020ce704
 	.global func_ov00_020ce740
 	arm_func_start func_ov00_020ce740
 func_ov00_020ce740: ; 0x020ce740
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #4
 	ldr r1, _020ce8c4 ; =data_027e0618
 	mov r7, r0
@@ -13362,7 +13362,7 @@ func_ov00_020ce740: ; 0x020ce740
 	cmp r0, #0
 	bne _020ce818
 	mov r6, #0
-	ldr sl, _020ce8c8 ; =data_ov00_020eec9c
+	ldr r10, _020ce8c8 ; =data_ov00_020eec9c
 	mov sb, #1
 	mov r8, #0x3c
 	mov r4, r6
@@ -13379,7 +13379,7 @@ _020ce78c:
 	ldr r0, [r7]
 	cmp r0, #0
 	bne _020ce7cc
-	mov r0, sl
+	mov r0, r10
 	mov r1, sb
 	bl func_ov00_020d77e4
 	str r8, [r7]
@@ -13451,7 +13451,7 @@ _020ce8b4:
 	mov r0, #0
 	strb r0, [r7, #0x38]
 	add sp, sp, #4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020ce740
 _020ce8c4: .word data_027e0618
@@ -14879,9 +14879,9 @@ _020cf860: .word data_027e0618
 	.global func_ov00_020cf864
 	arm_func_start func_ov00_020cf864
 func_ov00_020cf864: ; 0x020cf864
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	mov r6, #0
-	mov sl, r0
+	mov r10, r0
 	mov sb, r1
 	mov r7, r6
 	mov r8, r6
@@ -14891,7 +14891,7 @@ func_ov00_020cf864: ; 0x020cf864
 _020cf888:
 	tst sb, r5, lsl r7
 	beq _020cf8e4
-	ldr r0, [sl, #0x14]
+	ldr r0, [r10, #0x14]
 	add r1, r0, r8
 	ldrsh r0, [r0, r8]
 	ldrsh r2, [r1, #2]
@@ -14912,14 +14912,14 @@ _020cf8d0:
 	movle r0, r6
 	mov r6, r0
 	cmp r0, #0x1000
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _020cf8e4:
 	add r7, r7, #1
 	cmp r7, #0xc
 	add r8, r8, #6
 	blt _020cf888
 	mov r0, r6
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	arm_func_end func_ov00_020cf864
 
 	.global func_ov00_020cf8fc
@@ -16495,7 +16495,7 @@ _020d0b78: .word data_ov00_020df27c
 	.global func_ov00_020d0b7c
 	arm_func_start func_ov00_020d0b7c
 func_ov00_020d0b7c: ; 0x020d0b7c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x50
 	ldrsh r4, [sp, #0x7c]
 	mov r5, r0
@@ -16515,7 +16515,7 @@ func_ov00_020d0b7c: ; 0x020d0b7c
 	str r5, [sp, #8]
 	bl func_ov00_020d0a80
 	add sp, sp, #0x50
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _020d0bd0:
 	ldr r1, _020d1034 ; =0x00007fff
 	bl func_ov00_020d0a54
@@ -16612,7 +16612,7 @@ _020d0d04:
 	add r1, r7, r7, lsr #31
 	mov r0, r1, asr #0x1
 	mov r11, r2, lsl #0xc
-	mov sl, r0, lsl #0xc
+	mov r10, r0, lsl #0xc
 	smull r1, r0, r11, r6
 	adds r2, r1, #0x800
 	adc r1, r0, #0
@@ -16626,7 +16626,7 @@ _020d0d04:
 	mov r2, #1
 	str r2, [r1]
 	str r0, [sp, #0x28]
-	smull r1, r0, sl, r5
+	smull r1, r0, r10, r5
 	adds r2, r1, #0x800
 	adc r1, r0, #0
 	mov r0, r2, lsr #0xc
@@ -16637,18 +16637,18 @@ _020d0d04:
 	add r0, r0, #0x800
 	add r0, sb, r0, asr #12
 	bl func_ov05_0210e288
-	smull r2, r1, sl, r6
+	smull r2, r1, r10, r6
 	adds r2, r2, #0x800
 	adc r1, r1, #0
-	mov sl, r2, lsr #0xc
-	orr sl, sl, r1, lsl #20
+	mov r10, r2, lsr #0xc
+	orr r10, r10, r1, lsl #20
 	smull r2, r1, r11, r5
 	adds r2, r2, #0x800
 	adc r1, r1, #0
 	mov r11, r2, lsr #0xc
 	orr r11, r11, r1, lsl #20
 	str r0, [sp, #0x30]
-	add r0, r11, sl
+	add r0, r11, r10
 	add r0, r0, #0x800
 	add r0, r8, r0, asr #12
 	bl func_ov05_0210e2a4
@@ -16710,7 +16710,7 @@ _020d0d04:
 	mov r0, r2, lsr #0xc
 	orr r0, r0, r1, lsl #20
 	str r0, [sp, #0x44]
-	add r0, r0, sl
+	add r0, r0, r10
 	add r0, r0, #0x800
 	add r0, r8, r0, asr #12
 	bl func_ov05_0210e2a4
@@ -16730,15 +16730,15 @@ _020d0d04:
 	rsb r1, r7, #0
 	add r1, r1, r1, lsr #31
 	mov r1, r1, asr #0x1
-	mov sl, r1, lsl #0xc
+	mov r10, r1, lsl #0xc
 	ldr r1, _020d1050 ; =0x04000488
 	orr r0, r0, r3, lsr #16
 	str r2, [r1]
 	str r0, [r1, #0xc]
-	umull r2, r1, sl, r5
+	umull r2, r1, r10, r5
 	ldr r0, [sp, #0x28]
-	mov r7, sl, asr #0x1f
-	mla r1, sl, r0, r1
+	mov r7, r10, asr #0x1f
+	mla r1, r10, r0, r1
 	mla r1, r7, r5, r1
 	adds r2, r2, #0x800
 	adc r0, r1, #0
@@ -16749,10 +16749,10 @@ _020d0d04:
 	add r0, sb, r0, asr #12
 	bl func_ov05_0210e288
 	str r0, [sp, #0x4c]
-	umull r2, r1, sl, r6
+	umull r2, r1, r10, r6
 	ldr r0, [sp, #0x20]
 	adds r2, r2, #0x800
-	mla r1, sl, r0, r1
+	mla r1, r10, r0, r1
 	mla r1, r7, r6, r1
 	adc r0, r1, #0
 	mov r4, r2, lsr #0xc
@@ -16801,7 +16801,7 @@ _020d0d04:
 	mov r0, #0
 	str r0, [r2, #0x7c]
 	add sp, sp, #0x50
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020d0b7c
 _020d1034: .word 0x00007fff
@@ -17395,7 +17395,7 @@ _020d1630:
 	.global func_ov00_020d1650
 	arm_func_start func_ov00_020d1650
 func_ov00_020d1650: ; 0x020d1650
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	mov r5, r0
 	bl func_0204b068
 	mov r3, #0
@@ -17411,7 +17411,7 @@ _020d167c:
 	sub r11, r6, #1
 	mov ip, #0
 	mov lr, r2
-	mov sl, ip
+	mov r10, ip
 	cmp r11, #0
 	ble _020d16b8
 _020d1698:
@@ -17420,8 +17420,8 @@ _020d1698:
 	mov lr, r6
 	mla r7, ip, r8, r7
 	mov ip, r7
-	add sl, sl, #1
-	cmp sl, r11
+	add r10, r10, #1
+	cmp r10, r11
 	blt _020d1698
 _020d16b8:
 	mov r6, r4, lsl #0x1
@@ -17429,33 +17429,33 @@ _020d16b8:
 	add r4, r4, #1
 	sub r7, r6, #0x30
 	mov r6, r7, asr #0x1f
-	umull r11, sl, lr, r7
-	mla sl, lr, r6, sl
-	mla sl, ip, r7, sl
+	umull r11, r10, lr, r7
+	mla r10, lr, r6, r10
+	mla r10, ip, r7, r10
 	adds r3, r3, r11
-	adc r1, r1, sl
+	adc r1, r1, r10
 	cmp r4, r0
 	blt _020d167c
 _020d16e8:
 	mov r0, r3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	arm_func_end func_ov00_020d1650
 
 	.global func_ov00_020d16f0
 	arm_func_start func_ov00_020d16f0
 func_ov00_020d16f0: ; 0x020d16f0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	mov r8, r2
 	mov sb, r1
 	cmp r8, #0
-	mov sl, r0
+	mov r10, r0
 	cmpeq sb, #0
 	mov r0, #0
 	bne _020d1720
 	mov r1, #0x30
-	strh r1, [sl]
-	strh r0, [sl, #2]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	strh r1, [r10]
+	strh r0, [r10, #2]
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _020d1720:
 	mov r0, sb
 	mov r1, r8
@@ -17463,9 +17463,9 @@ _020d1720:
 	mov r6, r0
 	mov r0, r6, lsl #0x1
 	mov r7, #0
-	strh r7, [sl, r0]
+	strh r7, [r10, r0]
 	cmp r6, #0
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	mov r5, #0xa
 	mov r11, r7
 	mov r4, #0x30
@@ -17477,7 +17477,7 @@ _020d1750:
 	bl func_02002bb8
 	adds r1, r0, r4
 	sub r0, r6, r7
-	add r0, sl, r0, lsl #1
+	add r0, r10, r0, lsl #1
 	strh r1, [r0, #-2]
 	mov r0, sb
 	mov r1, r8
@@ -17489,7 +17489,7 @@ _020d1750:
 	mov r8, r1
 	cmp r7, r6
 	blt _020d1750
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	arm_func_end func_ov00_020d16f0
 
 	.global func_ov00_020d17a0
@@ -18758,7 +18758,7 @@ _020d28b0: .word data_027e0fe4
 	.global func_ov00_020d28b4
 	arm_func_start func_ov00_020d28b4
 func_ov00_020d28b4: ; 0x020d28b4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #0x28
 	mov r8, r0
 	strb r1, [r8, #0x55]
@@ -18774,7 +18774,7 @@ func_ov00_020d28b4: ; 0x020d28b4
 	ldr r2, [r2, #0x34]
 	mov r4, r0
 	blx r2
-	ldr sl, _020d29cc ; =data_027e0fe4
+	ldr r10, _020d29cc ; =data_027e0fe4
 	add r7, r8, #0x20
 	mov r5, #0
 	mvn sb, #0
@@ -18782,7 +18782,7 @@ _020d2904:
 	ldr r0, [r6]
 	cmp r0, sb
 	beq _020d2934
-	ldr r0, [sl]
+	ldr r0, [r10]
 	mov r1, r7
 	bl _ZN12ActorManager8GetActorEP8ActorRef
 	cmp r0, #0
@@ -18830,7 +18830,7 @@ _020d2934:
 _020d29c0:
 	mov r0, #1
 	add sp, sp, #0x28
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020d28b4
 _020d29cc: .word data_027e0fe4
@@ -21250,21 +21250,21 @@ _020d461c:
 	.global func_ov00_020d4624
 	arm_func_start func_ov00_020d4624
 func_ov00_020d4624: ; 0x020d4624
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x70
 	movs r5, r1
-	mov sl, r0
+	mov r10, r0
 	beq _020d4648
 	add r1, sp, #0x64
-	add r0, sl, #0x48
+	add r0, r10, #0x48
 	bl func_ov00_020c522c
 	b _020d4660
 _020d4648:
-	ldr r0, [sl, #0x48]
+	ldr r0, [r10, #0x48]
 	str r0, [sp, #0x64]
-	ldr r0, [sl, #0x4c]
+	ldr r0, [r10, #0x4c]
 	str r0, [sp, #0x68]
-	ldr r0, [sl, #0x50]
+	ldr r0, [r10, #0x50]
 	str r0, [sp, #0x6c]
 _020d4660:
 	ldr r1, [sp, #0x68]
@@ -21315,14 +21315,14 @@ _020d4660:
 	bgt _020d4740
 	ldr r1, [sp, #0x64]
 	mov r0, #1
-	str r1, [sl, #0x158]
+	str r1, [r10, #0x158]
 	ldr r1, [sp, #0x68]
-	str r1, [sl, #0x15c]
+	str r1, [r10, #0x15c]
 	ldr r1, [sp, #0x6c]
 	add sp, sp, #0x70
-	str r1, [sl, #0x160]
-	str r4, [sl, #0x15c]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	str r1, [r10, #0x160]
+	str r4, [r10, #0x15c]
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _020d4740:
 	cmp r5, #0
 	beq _020d4764
@@ -21335,7 +21335,7 @@ _020d4740:
 	b _020d4770
 _020d4764:
 	add r1, sp, #0x58
-	add r0, sl, #0x48
+	add r0, r10, #0x48
 	bl func_ov00_020c522c
 _020d4770:
 	ldr r5, _020d4854 ; =data_ov00_020df2f8
@@ -21381,20 +21381,20 @@ _020d4790:
 	cmp sb, #0x10
 	bge _020d4834
 	ldr r0, [sp]
-	str r7, [sl, #0x158]
-	str r0, [sl, #0x160]
+	str r7, [r10, #0x158]
+	str r0, [r10, #0x160]
 	ldr r0, [sp, #4]
 	add sp, sp, #0x70
-	str r0, [sl, #0x15c]
+	str r0, [r10, #0x15c]
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _020d4834:
 	add r6, r6, #1
 	cmp r6, #4
 	blt _020d4790
 	mov r0, #0
 	add sp, sp, #0x70
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020d4624
 _020d484c: .word data_027e0e60
@@ -21631,30 +21631,30 @@ _020d4b50: .word 0x0000019a
 	.global func_ov00_020d4b54
 	arm_func_start func_ov00_020d4b54
 func_ov00_020d4b54: ; 0x020d4b54
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x64
 	ldr r1, _020d4ddc ; =data_ov00_020ee670
 	mov r7, #0
-	mov sl, r0
+	mov r10, r0
 	str r7, [r1, #0x14]
-	ldr r4, [sl, #0x98]
-	ldr r1, [sl, #0x48]
+	ldr r4, [r10, #0x98]
+	ldr r1, [r10, #0x48]
 	sub r8, r4, #0xc0
 	str r1, [sp, #0x58]
-	ldr r2, [sl, #0x4c]
+	ldr r2, [r10, #0x4c]
 	add r0, sp, #0x58
 	str r2, [sp, #0x5c]
-	ldr r3, [sl, #0x50]
+	ldr r3, [r10, #0x50]
 	add r1, sp, #0x4c
 	str r3, [sp, #0x60]
-	ldr r3, [sl, #0x54]
+	ldr r3, [r10, #0x54]
 	add r2, sp, #0x40
 	str r3, [sp, #0x4c]
-	ldr r4, [sl, #0x58]
+	ldr r4, [r10, #0x58]
 	mov r3, #1
 	str r3, [sp]
 	str r4, [sp, #0x50]
-	ldr r3, [sl, #0x5c]
+	ldr r3, [r10, #0x5c]
 	str r3, [sp, #0x54]
 	bl func_01ff9bf8
 	add r0, sp, #0x40
@@ -21703,19 +21703,19 @@ _020d4c4c:
 	mov sb, #0
 _020d4c64:
 	ldr r1, [sp, #0x28]
-	mov r0, sl
-	str r1, [sl, #0x48]
+	mov r0, r10
+	str r1, [r10, #0x48]
 	ldr r2, [sp, #0x2c]
 	mov r1, r5
-	str r2, [sl, #0x4c]
+	str r2, [r10, #0x4c]
 	ldr r2, [sp, #0x30]
-	str r2, [sl, #0x50]
+	str r2, [r10, #0x50]
 	ldr r2, [sp, #0x34]
-	str r2, [sl, #0x54]
+	str r2, [r10, #0x54]
 	ldr r2, [sp, #0x38]
-	str r2, [sl, #0x58]
+	str r2, [r10, #0x58]
 	ldr r2, [sp, #0x3c]
-	str r2, [sl, #0x5c]
+	str r2, [r10, #0x5c]
 	str r5, [r4, #0x18]
 	bl func_01fffd04
 	ldr r1, [r4, #0x18]
@@ -21723,13 +21723,13 @@ _020d4c64:
 	sub r0, r1, #1
 	cmp r0, #1
 	bhi _020d4cd4
-	mov r0, sl
+	mov r0, r10
 	mov r1, #0x1e
 	mov r2, #0x5000
 	bl func_ov00_020d454c
 	add sp, sp, #0x64
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _020d4cd4:
 	cmp r7, #0
 	bne _020d4d08
@@ -21743,21 +21743,21 @@ _020d4cd4:
 	bne _020d4c28
 	b _020d4d08
 _020d4d00:
-	add r0, sl, #0xb8
+	add r0, r10, #0xb8
 	bl func_ov00_02081ef4
 _020d4d08:
 	mov r0, #0x3000
-	ldr r1, [sl, #0x4c]
+	ldr r1, [r10, #0x4c]
 	rsb r0, r0, #0
 	cmp r1, r0
 	blt _020d4da8
-	ldr r1, [sl, #0x48]
+	ldr r1, [r10, #0x48]
 	ldr r0, _020d4de0 ; =data_027e0e60
 	str r1, [sp, #0x10]
-	ldr r1, [sl, #0x4c]
+	ldr r1, [r10, #0x4c]
 	ldr r0, [r0]
 	str r1, [sp, #0x14]
-	ldr r3, [sl, #0x50]
+	ldr r3, [r10, #0x50]
 	add r1, sp, #0x10
 	mov r2, #0
 	str r3, [sp, #0x18]
@@ -21766,13 +21766,13 @@ _020d4d08:
 	cmp r7, #0
 	beq _020d4d68
 	ldr r2, _020d4de4 ; =0x00000333
-	add r0, sl, #0x60
-	add r1, sl, #0xc4
+	add r0, r10, #0x60
+	add r1, r10, #0xc4
 	bl func_ov00_020b18d8
 	b _020d4db8
 _020d4d68:
 	ldr r0, _020d4de0 ; =data_027e0e60
-	ldr r5, [sl, #0x4c]
+	ldr r5, [r10, #0x4c]
 	ldr r0, [r0]
 	bl func_ov00_02084114
 	cmp r0, r5
@@ -21782,26 +21782,26 @@ _020d4d68:
 	movge r0, #0
 	strge r0, [sp]
 	bge _020d4db8
-	mov r0, sl
+	mov r0, r10
 	mov r1, #0x1e
 	mov r2, #0x5000
 	bl func_ov00_020d454c
 	b _020d4db8
 _020d4da8:
-	mov r0, sl
+	mov r0, r10
 	mov r1, #0x1e
 	mov r2, #0x5000
 	bl func_ov00_020d454c
 _020d4db8:
-	ldr r1, [sl, #0x48]
+	ldr r1, [r10, #0x48]
 	ldr r0, [sp]
-	str r1, [sl, #0x54]
-	ldr r1, [sl, #0x4c]
-	str r1, [sl, #0x58]
-	ldr r1, [sl, #0x50]
-	str r1, [sl, #0x5c]
+	str r1, [r10, #0x54]
+	ldr r1, [r10, #0x4c]
+	str r1, [r10, #0x58]
+	ldr r1, [r10, #0x50]
+	str r1, [r10, #0x5c]
 	add sp, sp, #0x64
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020d4b54
 _020d4ddc: .word data_ov00_020ee670
@@ -22555,25 +22555,25 @@ _020d5738: .word 0x0000019a
 	.global func_ov00_020d573c
 	arm_func_start func_ov00_020d573c
 func_ov00_020d573c: ; 0x020d573c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x10
-	mov sl, r0
+	mov r10, r0
 	str r1, [sp]
 	bl _ZN5Actor18func_ov00_020c313cEj
 	cmp r0, #0
 	beq _020d5888
-	mov r0, sl
+	mov r0, r10
 	bl _ZN5Actor20IncreaseActiveFramesEv
-	ldrb r0, [sl, #0x485]
+	ldrb r0, [r10, #0x485]
 	cmp r0, #0
 	beq _020d57b0
-	ldr r1, [sl, #0x48]
+	ldr r1, [r10, #0x48]
 	ldr r0, _020d58a8 ; =data_027e0e60
 	str r1, [sp, #4]
-	ldr r1, [sl, #0x4c]
+	ldr r1, [r10, #0x4c]
 	ldr r5, [r0]
 	str r1, [sp, #8]
-	ldr r3, [sl, #0x50]
+	ldr r3, [r10, #0x50]
 	add r1, sp, #4
 	mov r0, r5
 	mov r2, #0
@@ -22583,15 +22583,15 @@ func_ov00_020d573c: ; 0x020d573c
 	mov r0, r5
 	bl func_ov00_02084120
 	add r0, r4, r0
-	str r0, [sl, #0x4c]
+	str r0, [r10, #0x4c]
 _020d57b0:
-	ldr r0, [sl, #0x480]
+	ldr r0, [r10, #0x480]
 	mov r6, #0
 	cmp r0, #0
 	subne r0, r0, #1
-	strne r0, [sl, #0x480]
+	strne r0, [r10, #0x480]
 	bne _020d57d4
-	ldrb r0, [sl, #0x484]
+	ldrb r0, [r10, #0x484]
 	cmp r0, #0
 	moveq r6, #1
 _020d57d4:
@@ -22601,7 +22601,7 @@ _020d57d4:
 	mov r4, #0x1000
 	mov r11, #1
 _020d57e8:
-	add r0, sl, sb, lsl #2
+	add r0, r10, sb, lsl #2
 	ldr r8, [r0, #0x464]
 	ldrb r0, [r8, #0x100]
 	cmp r0, #0
@@ -22609,9 +22609,9 @@ _020d57e8:
 	cmp r6, #0
 	add r7, r7, #1
 	beq _020d5864
-	ldr r0, [sl, #0x47c]
+	ldr r0, [r10, #0x47c]
 	mov r1, r5
-	str r0, [sl, #0x480]
+	str r0, [r10, #0x480]
 	ldr r0, [r8, #0x10]
 	mov r6, r5
 	bl func_ov00_020c0e24
@@ -22637,21 +22637,21 @@ _020d5864:
 	add sb, sb, #1
 	cmp sb, #3
 	blt _020d57e8
-	ldrb r0, [sl, #0x484]
+	ldrb r0, [r10, #0x484]
 	cmp r0, #1
 	cmpeq r7, #3
 	bne _020d5888
-	mov r0, sl
+	mov r0, r10
 	bl _ZN5Actor4KillEv
 _020d5888:
 	ldr r1, [sp]
-	add r0, sl, #0xa4
-	add r2, sl, #0x48
+	add r0, r10, #0xa4
+	add r2, r10, #0x48
 	bl func_ov00_0207a1c8
 	mov r0, #1
-	strb r0, [sl, #0x484]
+	strb r0, [r10, #0x484]
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020d573c
 _020d58a8: .word data_027e0e60
@@ -22814,30 +22814,30 @@ func_ov00_020d6194: ; 0x020d6194
 	.global func_ov00_020d61b0
 	arm_func_start func_ov00_020d61b0
 func_ov00_020d61b0: ; 0x020d61b0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x10
-	mov sl, r0
-	ldrb r5, [sl, #0x38]
+	mov r10, r0
+	ldrb r5, [r10, #0x38]
 	mov sb, r1
 	mov r4, r2
 	cmp r5, #0
 	mov r11, r3
 	addeq sp, sp, #0x10
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
-	ldrb r1, [sl, #4]
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldrb r1, [r10, #4]
 	cmp r1, #0
 	beq _020d632c
 	cmp r1, #1
 	addeq r0, r1, #1
-	streqb r0, [sl, #4]
-	ldr r1, [sl, #0x10]
-	mov r0, sl
+	streqb r0, [r10, #4]
+	ldr r1, [r10, #0x10]
+	mov r0, r10
 	add r3, r1, #1
 	mov r1, sb
 	mov r2, r4
-	str r3, [sl, #0x10]
+	str r3, [r10, #0x10]
 	bl func_ov00_020d6394
-	ldr r0, [sl, #0x10]
+	ldr r0, [r10, #0x10]
 	cmp r0, #5
 	ble _020d62ec
 	mov r6, #0
@@ -22845,11 +22845,11 @@ func_ov00_020d61b0: ; 0x020d61b0
 	mov r7, #1
 	mov r4, r6
 _020d6228:
-	mov r0, sl
+	mov r0, r10
 	mov r1, r8
 	bl func_ov00_020d6178
 	mov r5, r0
-	mov r0, sl
+	mov r0, r10
 	add r1, r8, #1
 	bl func_ov00_020d6178
 	mov r1, r0
@@ -22863,8 +22863,8 @@ _020d6228:
 	blt _020d6228
 	cmp r7, #0
 	addeq sp, sp, #0x10
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
-	ldr r1, [sl, #8]
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldr r1, [r10, #8]
 	add r0, r1, #0x200
 	cmp r6, r0
 	movge r1, #0x7f
@@ -22872,7 +22872,7 @@ _020d6228:
 	cmp r6, r1
 	movlt r1, #0
 	blt _020d62b0
-	ldr r3, [sl, #0xc]
+	ldr r3, [r10, #0xc]
 	sub r0, r6, r1
 	rsb r1, r3, #0x7f
 	mul r2, r1, r0
@@ -22894,7 +22894,7 @@ _020d62b0:
 	str r4, [sp, #0xc]
 	bl func_ov00_020d80a4
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _020d62ec:
 	mov r0, sb, asr #0x2
 	mov r1, #0x40
@@ -22911,10 +22911,10 @@ _020d62ec:
 	str r4, [sp, #0xc]
 	bl func_ov00_020d80a4
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _020d632c:
 	bl func_ov00_020d6148
-	mov r0, sl
+	mov r0, r10
 	mov r1, sb
 	mov r2, r4
 	bl func_ov00_020d6394
@@ -22930,14 +22930,14 @@ _020d632c:
 	str r4, [sp, #0xc]
 	bl func_ov00_020d80a4
 	mov r1, #2
-	str r1, [sl, #8]
+	str r1, [r10, #8]
 	mov r0, #4
-	str r0, [sl, #0xc]
-	strb r1, [sl, #4]
+	str r0, [r10, #0xc]
+	strb r1, [r10, #4]
 	mov r0, r4
-	str r0, [sl, #0x10]
+	str r0, [r10, #0x10]
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020d61b0
 _020d6390: .word data_ov00_020eec9c
@@ -24844,12 +24844,12 @@ func_ov00_020d7880: ; 0x020d7880
 	.global func_ov00_020d78a0
 	arm_func_start func_ov00_020d78a0
 func_ov00_020d78a0: ; 0x020d78a0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	ldr r5, _020d7a78 ; =data_027e0764
 	mov sb, r1
 	ldr r7, [r5]
 	mov r8, r2
-	mov sl, r0
+	mov r10, r0
 	ldmib r5, {r2, r6, r11}
 	umull r1, r0, r6, r7
 	mla r0, r6, r2, r0
@@ -24864,7 +24864,7 @@ func_ov00_020d78a0: ; 0x020d78a0
 	str r1, [r5]
 	adc r2, r7, r0
 	str r2, [r5, #4]
-	ldr r0, [sl, #0x1c]
+	ldr r0, [r10, #0x1c]
 	mov r6, #0
 	mov r1, r6, lsl #0x2
 	and r0, r0, #1
@@ -24873,37 +24873,37 @@ func_ov00_020d78a0: ; 0x020d78a0
 	orr r1, r1, r2, lsr #30
 	bne _020d7948
 	cmp r1, #3
-	ldreqb r0, [sl, #8]
+	ldreqb r0, [r10, #8]
 	cmpeq r0, #0
-	ldreqb r0, [sl, #9]
+	ldreqb r0, [r10, #9]
 	cmpeq r0, #0
 	bne _020d7938
 	mov r0, #1
-	strb r0, [sl, #8]
+	strb r0, [r10, #8]
 	add r4, r4, #3
 	b _020d7974
 _020d7938:
 	mov r0, #0
-	strb r0, [sl, #8]
+	strb r0, [r10, #8]
 	add r4, r4, #1
 	b _020d7974
 _020d7948:
 	cmp r1, #3
-	ldreqb r0, [sl, #8]
+	ldreqb r0, [r10, #8]
 	cmpeq r0, #0
-	ldreqb r0, [sl, #9]
+	ldreqb r0, [r10, #9]
 	cmpeq r0, #0
 	movne r0, #0
-	strneb r0, [sl, #9]
+	strneb r0, [r10, #9]
 	bne _020d7974
 	mov r0, #1
-	strb r0, [sl, #9]
+	strb r0, [r10, #9]
 	add r4, r4, #2
 _020d7974:
-	ldr r0, [sl, #0x1c]
+	ldr r0, [r10, #0x1c]
 	cmp r3, #0
 	add r0, r0, #1
-	str r0, [sl, #0x1c]
+	str r0, [r10, #0x1c]
 	bge _020d79a4
 	mov r1, r4, lsl #0x10
 	ldr r0, _020d7a7c ; =data_027e0ffc
@@ -24911,7 +24911,7 @@ _020d7974:
 	mov r1, r1, lsr #0x10
 	mov r3, #0
 	bl func_ov00_020ceacc
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _020d79a4:
 	cmp r3, #0xf
 	movgt r3, #0xf
@@ -24936,7 +24936,7 @@ _020d79d8:
 	rsb r5, r3, #0
 	bl func_ov00_020cea80
 	mov r1, r0
-	mov r0, sl
+	mov r0, r10
 	bl func_ov00_020d75c8
 	mov r11, r0
 	ldr r0, _020d7a7c ; =data_027e0ffc
@@ -24950,24 +24950,24 @@ _020d79d8:
 	cmp sb, #0x11
 	moveq r0, r7, lsl #0x2
 	rsbeq r5, r0, #0
-	ldr r1, [sl, #0x20]
-	mov r0, sl
+	ldr r1, [r10, #0x20]
+	mov r0, r10
 	mov r2, r4
 	bl func_ov00_020d7524
 	ldr r1, _020d7a80 ; =0x0000ffff
-	mov r0, sl
+	mov r0, r10
 	mov r2, r5
 	bl func_0201f86c
-	mov r0, sl
+	mov r0, r10
 	mov r1, r8
 	bl func_0201f7a8
 	ldr r1, _020d7a80 ; =0x0000ffff
-	mov r0, sl
+	mov r0, r10
 	mov r2, r6
 	bl func_0201f88c
-	mov r0, sl
+	mov r0, r10
 	bl func_0201f710
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020d78a0
 _020d7a78: .word data_027e0764

--- a/asm/ov00/ov00_020c3e54.s
+++ b/asm/ov00/ov00_020c3e54.s
@@ -208,13 +208,13 @@ _020c4040:
 	.global func_ov00_020c4048
 	arm_func_start func_ov00_020c4048
 func_ov00_020c4048: ; 0x020c4048
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	ldr r4, _020c42cc ; =data_027e0fe4
 	mov r11, r1
 	ldr r7, [r4]
 	mov r10, r2
 	ldrh r2, [r7]
-	mov sb, r3
+	mov r9, r3
 	ldr r8, [sp, #0x28]
 	cmp r2, #0
 	ldr r6, [r7, #0x10]
@@ -235,7 +235,7 @@ _020c407c:
 	strne r0, [r8]
 	strne r0, [r8, #4]
 	mvn r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _020c40b4:
 	str r11, [r0, #4]
 	ldr r1, [r7, #0xc]
@@ -250,60 +250,60 @@ _020c40b4:
 	str r0, [r1, #0x18]
 	ldr r0, [r10, #8]
 	str r0, [r1, #0x1c]
-	ldrh r2, [sb]
-	ldrh r1, [sb, #2]
+	ldrh r2, [r9]
+	ldrh r1, [r9, #2]
 	ldr r0, [r6]
 	strh r2, [r0, #0x20]
 	strh r1, [r0, #0x22]
-	ldrh r2, [sb, #4]
-	ldrh r1, [sb, #6]
+	ldrh r2, [r9, #4]
+	ldrh r1, [r9, #6]
 	strh r2, [r0, #0x24]
 	strh r1, [r0, #0x26]
-	ldrb r2, [sb, #8]
-	ldrb r1, [sb, #9]
+	ldrb r2, [r9, #8]
+	ldrb r1, [r9, #9]
 	strb r2, [r0, #0x28]
 	strb r1, [r0, #0x29]
-	ldrb r2, [sb, #0xa]
-	ldrb r1, [sb, #0xb]
+	ldrb r2, [r9, #0xa]
+	ldrb r1, [r9, #0xb]
 	strb r2, [r0, #0x2a]
 	strb r1, [r0, #0x2b]
-	ldrsb r1, [sb, #0xc]
+	ldrsb r1, [r9, #0xc]
 	strb r1, [r0, #0x2c]
-	ldrb r1, [sb, #0xd]
+	ldrb r1, [r9, #0xd]
 	strb r1, [r0, #0x2d]
-	ldrb r1, [sb, #0xe]
+	ldrb r1, [r9, #0xe]
 	strb r1, [r0, #0x2e]
-	ldrsb r1, [sb, #0xf]
+	ldrsb r1, [r9, #0xf]
 	strb r1, [r0, #0x2f]
-	ldr r1, [sb, #0x10]
+	ldr r1, [r9, #0x10]
 	str r1, [r0, #0x30]
-	ldrsh r1, [sb, #0x14]
+	ldrsh r1, [r9, #0x14]
 	ldr r0, [r6]
 	strh r1, [r0, #0x78]
-	ldrsh r1, [sb, #0x14]
+	ldrsh r1, [r9, #0x14]
 	ldr r0, [r6]
 	strh r1, [r0, #0x12]
-	ldrsh r0, [sb, #0x14]
+	ldrsh r0, [r9, #0x14]
 	bl func_0202bbbc
 	ldr r2, [r6]
 	ldr r1, _020c42d0 ; =0x0000ffff
 	str r0, [r2, #0x74]
-	ldr r2, [sb, #0x18]
+	ldr r2, [r9, #0x18]
 	ldr r0, [r6]
 	cmp r2, r1
 	subge r1, r1, #0x10000
 	strge r1, [r0, #0x3c]
 	strlt r2, [r0, #0x3c]
 	ldr r2, [r6]
-	ldr r1, [sb, #0x1c]
+	ldr r1, [r9, #0x1c]
 	ldr r0, _020c42d4 ; =data_027e0e60
 	str r1, [r2, #0x34]
-	ldr r1, [sb, #0x20]
+	ldr r1, [r9, #0x20]
 	str r1, [r2, #0x38]
-	ldr r2, [sb, #0x24]
+	ldr r2, [r9, #0x24]
 	ldr r1, [r6]
 	str r2, [r1, #0x140]
-	ldr r2, [sb, #0x28]
+	ldr r2, [r9, #0x28]
 	ldr r1, [r6]
 	str r2, [r1, #0x144]
 	ldr r2, [r6]
@@ -358,7 +358,7 @@ _020c40b4:
 	strne r0, [r8]
 	strne r0, [r8, #4]
 	mvn r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _020c429c:
 	add r5, r5, #1
 	cmp r5, r2
@@ -373,7 +373,7 @@ _020c42ac:
 	strne r0, [r8, #4]
 _020c42c4:
 	mov r0, r4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020c4048
 _020c42cc: .word data_027e0fe4
@@ -614,7 +614,7 @@ func_ov00_020c45b0: ; 0x020c45b0
 	.global func_ov00_020c45c4
 	arm_func_start func_ov00_020c45c4
 func_ov00_020c45c4: ; 0x020c45c4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	mov r4, #0
 	ldr r7, _020c4644 ; =0x00000126
 	mov r6, r0
@@ -633,13 +633,13 @@ _020c45dc:
 	beq _020c4630
 	mov r0, r6
 	bl func_ov00_020c4588
-	movs sb, r0
+	movs r9, r0
 	beq _020c4630
 	mov r1, r8
 	bl func_02019654
 	cmp r0, #2
 	beq _020c4630
-	mov r0, sb
+	mov r0, r9
 	mov r1, r5
 	bl func_020196fc
 _020c4630:
@@ -647,7 +647,7 @@ _020c4630:
 	cmp r4, r7
 	add r6, r6, #0x38
 	blt _020c45dc
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020c45c4
 _020c4644: .word 0x00000126
@@ -655,7 +655,7 @@ _020c4644: .word 0x00000126
 	.global func_ov00_020c4648
 	arm_func_start func_ov00_020c4648
 func_ov00_020c4648: ; 0x020c4648
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	mov r4, #0
 	ldr r7, _020c46c8 ; =0x00000126
 	mov r6, r0
@@ -674,13 +674,13 @@ _020c4660:
 	beq _020c46b4
 	mov r0, r6
 	bl func_ov00_020c4588
-	movs sb, r0
+	movs r9, r0
 	beq _020c46b4
 	mov r1, r8
 	bl func_02019654
 	cmp r0, #2
 	beq _020c46b4
-	mov r0, sb
+	mov r0, r9
 	mov r1, r5
 	bl func_020196bc
 _020c46b4:
@@ -688,7 +688,7 @@ _020c46b4:
 	cmp r4, r7
 	add r6, r6, #0x38
 	blt _020c4660
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020c4648
 _020c46c8: .word 0x00000126
@@ -696,7 +696,7 @@ _020c46c8: .word 0x00000126
 	.global func_ov00_020c46cc
 	arm_func_start func_ov00_020c46cc
 func_ov00_020c46cc: ; 0x020c46cc
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	mov r4, #0
 	ldr r7, _020c4748 ; =0x00000126
 	mov r6, r0
@@ -714,13 +714,13 @@ _020c46e4:
 	beq _020c4734
 	mov r0, r6
 	bl func_ov00_020c4588
-	movs sb, r0
+	movs r9, r0
 	beq _020c4734
 	mov r1, r8
 	bl func_02019654
 	cmp r0, #2
 	beq _020c4734
-	mov r0, sb
+	mov r0, r9
 	mov r1, r5
 	bl func_020196fc
 _020c4734:
@@ -728,7 +728,7 @@ _020c4734:
 	cmp r4, r7
 	add r6, r6, #0x38
 	blt _020c46e4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020c46cc
 _020c4748: .word 0x00000126
@@ -736,7 +736,7 @@ _020c4748: .word 0x00000126
 	.global func_ov00_020c474c
 	arm_func_start func_ov00_020c474c
 func_ov00_020c474c: ; 0x020c474c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	mov r4, #0
 	ldr r7, _020c47c8 ; =0x00000126
 	mov r6, r0
@@ -754,13 +754,13 @@ _020c4764:
 	beq _020c47b4
 	mov r0, r6
 	bl func_ov00_020c4588
-	movs sb, r0
+	movs r9, r0
 	beq _020c47b4
 	mov r1, r8
 	bl func_02019654
 	cmp r0, #2
 	beq _020c47b4
-	mov r0, sb
+	mov r0, r9
 	mov r1, r5
 	bl func_020196bc
 _020c47b4:
@@ -768,7 +768,7 @@ _020c47b4:
 	cmp r4, r7
 	add r6, r6, #0x38
 	blt _020c4764
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020c474c
 _020c47c8: .word 0x00000126
@@ -838,21 +838,21 @@ _020c4878:
 	.global func_ov00_020c4898
 	arm_func_start func_ov00_020c4898
 func_ov00_020c4898: ; 0x020c4898
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	mov r8, r0
 	mov r7, r1
 	mov r6, r2
 	bl func_ov00_020c47cc
 	mov r4, #0
 	add r5, r0, #0x14
-	mov sb, r4
+	mov r9, r4
 	mov r10, #1
 _020c48bc:
 	ldrsb r0, [r5, #2]
 	cmp r0, #0
 	cmpne r0, #4
 	movne r0, r10
-	moveq r0, sb
+	moveq r0, r9
 	cmp r0, #0
 	beq _020c48ec
 	mov r0, r8
@@ -865,7 +865,7 @@ _020c48ec:
 	cmp r4, #4
 	add r5, r5, #4
 	blt _020c48bc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	arm_func_end func_ov00_020c4898
 
 	.global func_ov00_020c4900
@@ -1009,7 +1009,7 @@ _020c4ae4: .word data_027e0ff0
 	.global func_ov00_020c4ae8
 	arm_func_start func_ov00_020c4ae8
 func_ov00_020c4ae8: ; 0x020c4ae8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0xc
 	ldr r4, [r0, #4]
 	str r0, [sp]
@@ -1020,7 +1020,7 @@ func_ov00_020c4ae8: ; 0x020c4ae8
 	cmp r4, #0
 	str r1, [sp, #4]
 	mov r10, r2
-	mov sb, r3
+	mov r9, r3
 	sub r4, r0, #0x80000001
 	ble _020c4bf4
 _020c4b20:
@@ -1061,10 +1061,10 @@ _020c4b70:
 	cmp r0, r4
 	bge _020c4bc0
 	mov r4, r0
-	strb r5, [sb]
+	strb r5, [r9]
 	mov r0, #1
 	str r0, [sp, #8]
-	strb r6, [sb, #1]
+	strb r6, [r9, #1]
 _020c4bc0:
 	add r0, r6, #1
 	mov r0, r0, lsl #0x18
@@ -1083,21 +1083,21 @@ _020c4bd8:
 _020c4bf4:
 	ldr r0, [sp, #8]
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	arm_func_end func_ov00_020c4ae8
 
 	.global func_ov00_020c4c00
 	arm_func_start func_ov00_020c4c00
 func_ov00_020c4c00: ; 0x020c4c00
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x40
 	mov r10, r1
-	mov sb, r3
+	mov r9, r3
 	bl func_ov00_020c4ae8
 	cmp r0, #0
 	beq _020c4d4c
 	ldr r0, _020c4d58 ; =data_027e0ff0
-	mov r1, sb
+	mov r1, r9
 	ldr r0, [r0]
 	bl func_ov00_020c47cc
 	mov r4, r0
@@ -1115,11 +1115,11 @@ func_ov00_020c4c00: ; 0x020c4c00
 	mov r0, r10
 	bl func_ov00_020ce2f0
 	mov r6, r0
-	ldrsb r0, [sb]
+	ldrsb r0, [r9]
 	add r8, r4, #0x14
 	mov r7, #0
 	str r0, [sp]
-	ldrsb r11, [sb, #1]
+	ldrsb r11, [r9, #1]
 	add r5, sp, #0x1c
 	add r4, sp, #0x10
 _020c4c84:
@@ -1164,20 +1164,20 @@ _020c4d0c:
 	blt _020c4c84
 	ldr r1, [sp, #0x34]
 	mov r0, #1
-	str r1, [sb, #4]
+	str r1, [r9, #4]
 	ldr r1, [sp, #0x38]
-	str r1, [sb, #8]
+	str r1, [r9, #8]
 	ldr r1, [sp, #0x3c]
-	str r1, [sb, #0xc]
+	str r1, [r9, #0xc]
 	ldr r1, [sp]
 	add sp, sp, #0x40
-	strb r1, [sb, #2]
-	strb r11, [sb, #3]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	strb r1, [r9, #2]
+	strb r11, [r9, #3]
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _020c4d4c:
 	mov r0, #0
 	add sp, sp, #0x40
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020c4c00
 _020c4d58: .word data_027e0ff0
@@ -1185,7 +1185,7 @@ _020c4d58: .word data_027e0ff0
 	.global func_ov00_020c4d5c
 	arm_func_start func_ov00_020c4d5c
 func_ov00_020c4d5c: ; 0x020c4d5c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x204
 	mov r11, r0
 	mov r10, r1
@@ -1209,17 +1209,17 @@ _020c4da8:
 	ldr r2, [r11]
 	and r1, r5, #0xff
 	ldr r0, [r2, r1, lsl #3]
-	add sb, r2, r1, lsl #3
+	add r9, r2, r1, lsl #3
 	cmp r0, #0
 	beq _020c4e34
 	mov r0, r10
 	ldr r2, [r0]
-	mov r1, sb
+	mov r1, r9
 	ldr r2, [r2]
 	blx r2
 	cmp r0, #0
 	beq _020c4e34
-	ldr r0, [sb]
+	ldr r0, [r9]
 	mov r6, #0
 	ldrb r8, [r0, #1]
 	cmp r8, #0
@@ -1227,7 +1227,7 @@ _020c4da8:
 _020c4df0:
 	mov r0, r10
 	ldr r3, [r0]
-	mov r1, sb
+	mov r1, r9
 	ldr r3, [r3, #4]
 	mov r2, r6
 	blx r3
@@ -1285,11 +1285,11 @@ _020c4ea8:
 	ldrsb r2, [r3, #1]
 	mov r0, #1
 	strb r2, [r1, #1]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _020c4ed4:
 	mov r0, #0
 	add sp, sp, #0x204
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020c4d5c
 _020c4ee0: .word data_027e0764
@@ -1403,12 +1403,12 @@ _020c500c:
 	.global func_ov00_020c5014
 	arm_func_start func_ov00_020c5014
 func_ov00_020c5014: ; 0x020c5014
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	mov r10, r0
 	ldr r0, [r10]
 	mov r11, #0
 	ldrb r4, [r0, #1]
-	mov sb, r1
+	mov r9, r1
 	str r2, [sp]
 	mov r8, r3
 	mov r5, r11
@@ -1438,7 +1438,7 @@ _020c5088:
 	bne _020c50b0
 _020c5090:
 	ldr r0, [r10, #4]
-	mov r1, sb
+	mov r1, r9
 	add r0, r0, r7
 	add r0, r0, #4
 	bl func_01ff9ec0
@@ -1455,7 +1455,7 @@ _020c50c0:
 	cmp r0, #0
 	strne r6, [r0]
 	mov r0, r11
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	arm_func_end func_ov00_020c5014
 
 	.global func_ov00_020c50d4
@@ -2746,14 +2746,14 @@ func_ov00_020c604c: ; 0x020c604c
 	.global func_ov00_020c607c
 	arm_func_start func_ov00_020c607c
 func_ov00_020c607c: ; 0x020c607c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0xc
 	mov r4, #0x38
 	mul r6, r2, r4
 	ldr r2, _020c6108 ; =data_027e0fec
 	mov r4, r0
 	ldr r7, [r2]
-	mov sb, r1
+	mov r9, r1
 	add r0, r7, r6
 	mov r8, r3
 	bl func_ov00_020c4588
@@ -2762,7 +2762,7 @@ func_ov00_020c607c: ; 0x020c607c
 	bl func_ov00_020c45b0
 	str r5, [sp]
 	stmib sp, {r0, r8}
-	mov r1, sb
+	mov r1, r9
 	mov r0, r4
 	add r2, r4, #0x20
 	add r3, r4, #0x7c
@@ -2780,7 +2780,7 @@ func_ov00_020c607c: ; 0x020c607c
 	mov r0, r4
 	str r1, [r4, #0x7c]
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020c607c
 _020c6108: .word data_027e0fec
@@ -3473,7 +3473,7 @@ _020c69e4: .word func_ov00_020c69a0
 	.global func_ov00_020c69e8
 	arm_func_start func_ov00_020c69e8
 func_ov00_020c69e8: ; 0x020c69e8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0xc
 	mov r7, r0
 	ldr r3, [r7, #4]
@@ -3502,7 +3502,7 @@ func_ov00_020c69e8: ; 0x020c69e8
 	mov r0, r7
 	bl func_ov00_020c69a0
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _020c6a60:
 	bl func_ov00_020c6d34
 	mov r4, r0
@@ -3515,7 +3515,7 @@ _020c6a60:
 	mov r1, #0x24
 	ldr r2, [r2, #4]
 	str r0, [sp, #8]
-	mla sb, r0, r1, r2
+	mla r9, r0, r1, r2
 	mla r10, r5, r1, r2
 	mla r8, r4, r1, r2
 	ldr r2, [r10, #0xc]
@@ -3537,9 +3537,9 @@ _020c6a60:
 	sub r1, r2, r1
 	bl func_01ffa0f4
 	mov r8, r0, lsl #0x10
-	ldr r3, [sb, #4]
+	ldr r3, [r9, #4]
 	ldr r0, [r10, #4]
-	ldr r2, [sb, #0xc]
+	ldr r2, [r9, #0xc]
 	ldr r1, [r10, #0xc]
 	sub r0, r3, r0
 	sub r1, r2, r1
@@ -3555,7 +3555,7 @@ _020c6a60:
 	mov r1, #0
 	bl func_ov00_020c69a0
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _020c6b30:
 	ldr r0, [sp, #8]
 	cmp r5, r0
@@ -3564,7 +3564,7 @@ _020c6b30:
 	mov r1, #1
 	bl func_ov00_020c69a0
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _020c6b50:
 	sub r0, r6, r1, asr #16
 	mov r0, r0, lsl #0x10
@@ -3582,12 +3582,12 @@ _020c6b50:
 	mov r1, #1
 	bl func_ov00_020c69a0
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _020c6b94:
 	mov r1, #0
 	bl func_ov00_020c69a0
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020c69e8
 _020c6ba4: .word data_027e0764
@@ -6152,7 +6152,7 @@ func_ov00_020c8d28: ; 0x020c8d28
 	.global func_ov00_020c8d4c
 	arm_func_start func_ov00_020c8d4c
 func_ov00_020c8d4c: ; 0x020c8d4c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0xc
 	ldrsb r2, [r1]
 	mov r11, r0
@@ -6165,7 +6165,7 @@ func_ov00_020c8d4c: ; 0x020c8d4c
 	mov r6, r0
 	ldr r0, _020c8e40 ; =0x00007fff
 	ldrsb r8, [r11, #0x12]
-	ldrsb sb, [r11, #0x13]
+	ldrsb r9, [r11, #0x13]
 	add r10, r6, #0x14
 	mov r7, #0x2000
 	mov r5, #0
@@ -6204,7 +6204,7 @@ _020c8d94:
 _020c8e0c:
 	cmp r0, r7
 	ldrltsb r8, [r10]
-	ldrltsb sb, [r10, #1]
+	ldrltsb r9, [r10, #1]
 	movlt r7, r0
 _020c8e1c:
 	add r5, r5, #1
@@ -6212,9 +6212,9 @@ _020c8e1c:
 	add r10, r10, #4
 	blt _020c8d94
 	strb r8, [r11, #0x10]
-	strb sb, [r11, #0x11]
+	strb r9, [r11, #0x11]
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020c8d4c
 _020c8e3c: .word data_027e0ff0
@@ -6640,9 +6640,9 @@ _020c93bc: .word data_027e0764
 	.global func_ov00_020c93c0
 	arm_func_start func_ov00_020c93c0
 func_ov00_020c93c0: ; 0x020c93c0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	ldr r4, _020c948c ; =data_027e0ff0
-	mov sb, r0
+	mov r9, r0
 	mov r7, r2
 	mov r8, r1
 	ldr r0, [r4]
@@ -6691,10 +6691,10 @@ _020c9448:
 _020c9474:
 	add r1, r4, r5, lsl #2
 	ldrsb r0, [r1, #0x14]
-	strb r0, [sb]
+	strb r0, [r9]
 	ldrsb r0, [r1, #0x15]
-	strb r0, [sb, #1]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	strb r0, [r9, #1]
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020c93c0
 _020c948c: .word data_027e0ff0
@@ -6702,9 +6702,9 @@ _020c948c: .word data_027e0ff0
 	.global func_ov00_020c9490
 	arm_func_start func_ov00_020c9490
 func_ov00_020c9490: ; 0x020c9490
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	ldr r4, _020c9558 ; =data_027e0ff0
-	mov sb, r0
+	mov r9, r0
 	mov r7, r2
 	mov r8, r1
 	ldr r0, [r4]
@@ -6752,10 +6752,10 @@ _020c9518:
 _020c9540:
 	add r1, r4, r5, lsl #2
 	ldrsb r0, [r1, #0x14]
-	strb r0, [sb]
+	strb r0, [r9]
 	ldrsb r0, [r1, #0x15]
-	strb r0, [sb, #1]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	strb r0, [r9, #1]
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020c9490
 _020c9558: .word data_027e0ff0
@@ -6763,11 +6763,11 @@ _020c9558: .word data_027e0ff0
 	.global func_ov00_020c955c
 	arm_func_start func_ov00_020c955c
 func_ov00_020c955c: ; 0x020c955c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	ldr r3, _020c95fc ; =data_027e0ff0
 	mov r10, r0
 	ldr r0, [r3]
-	mov sb, r1
+	mov r9, r1
 	mov r1, r2
 	bl func_ov00_020c47cc
 	mov r4, r0
@@ -6784,7 +6784,7 @@ _020c958c:
 	cmp r0, #1
 	bhi _020c95c0
 	add r0, r4, #4
-	add r1, sb, #4
+	add r1, r9, #4
 	bl func_01ff9ec0
 	cmp r7, r0
 	movlt r7, r0
@@ -6798,13 +6798,13 @@ _020c95c0:
 	cmp r6, r0
 	streqb r0, [r10]
 	streqb r0, [r10, #1]
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	add r1, r4, r6, lsl #2
 	ldrsb r0, [r1, #0x14]
 	strb r0, [r10]
 	ldrsb r0, [r1, #0x15]
 	strb r0, [r10, #1]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020c955c
 _020c95fc: .word data_027e0ff0
@@ -6812,11 +6812,11 @@ _020c95fc: .word data_027e0ff0
 	.global func_ov00_020c9600
 	arm_func_start func_ov00_020c9600
 func_ov00_020c9600: ; 0x020c9600
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	ldr r3, _020c96a0 ; =data_027e0ff0
 	mov r10, r0
 	ldr r0, [r3]
-	mov sb, r1
+	mov r9, r1
 	mov r1, r2
 	bl func_ov00_020c47cc
 	mov r4, r0
@@ -6833,7 +6833,7 @@ _020c9630:
 	cmp r0, #1
 	bhi _020c9664
 	add r0, r4, #4
-	add r1, sb, #4
+	add r1, r9, #4
 	bl func_01ff9ec0
 	cmp r7, r0
 	movgt r7, r0
@@ -6847,13 +6847,13 @@ _020c9664:
 	cmp r6, r0
 	streqb r0, [r10]
 	streqb r0, [r10, #1]
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	add r1, r4, r6, lsl #2
 	ldrsb r0, [r1, #0x14]
 	strb r0, [r10]
 	ldrsb r0, [r1, #0x15]
 	strb r0, [r10, #1]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020c9600
 _020c96a0: .word data_027e0ff0
@@ -11529,7 +11529,7 @@ _020ccf74:
 	.global func_ov00_020ccf7c
 	arm_func_start func_ov00_020ccf7c
 func_ov00_020ccf7c: ; 0x020ccf7c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	mov r8, r0
 	ldr r0, [r8, #0xc]
 	mov r7, r1
@@ -11537,11 +11537,11 @@ func_ov00_020ccf7c: ; 0x020ccf7c
 	cmp r0, #0
 	mov r4, #0
 	ble _020cd004
-	ldr sb, _020cd00c ; =data_027e0fe4
+	ldr r9, _020cd00c ; =data_027e0fe4
 	mov r5, r4
 _020ccfa4:
 	ldr r1, [r8, #0x10]
-	ldr r0, [sb]
+	ldr r0, [r9]
 	add r1, r1, r5
 	bl _ZN12ActorManager8GetActorEP8ActorRef
 	cmp r0, #0
@@ -11559,7 +11559,7 @@ _020ccfa4:
 	str r0, [r6, #4]
 _020ccfe8:
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _020ccff0:
 	ldr r0, [r8, #0xc]
 	add r4, r4, #1
@@ -11568,7 +11568,7 @@ _020ccff0:
 	blt _020ccfa4
 _020cd004:
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020ccf7c
 _020cd00c: .word data_027e0fe4
@@ -12065,7 +12065,7 @@ _020cd628: .word data_02050f54
 	.global func_ov00_020cd62c
 	arm_func_start func_ov00_020cd62c
 func_ov00_020cd62c: ; 0x020cd62c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x24
 	mov r4, r0
 	ldrsh r0, [r4, #0x34]
@@ -12089,7 +12089,7 @@ func_ov00_020cd62c: ; 0x020cd62c
 	cmp r5, r0
 	moveq r0, #0
 	streqh r0, [r4, #0x34]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _020cd690:
 	mov r2, r5
 	mov r3, r6
@@ -12125,15 +12125,15 @@ _020cd690:
 	mov r0, r0, lsl #0x10
 	ldr r6, [r1]
 	ldmib r1, {r5, r8}
-	umull r10, sb, r8, r6
-	mla sb, r8, r5, sb
+	umull r10, r9, r8, r6
+	mla r9, r8, r5, r9
 	ldr r7, [r1, #0xc]
 	ldr ip, [r1, #0x10]
-	mla sb, r7, r6, sb
+	mla r9, r7, r6, r9
 	ldr r11, [r1, #0x14]
 	adds r7, ip, r10
 	ldr r5, _020cd8d8 ; =data_027e0764
-	adc r6, r11, sb
+	adc r6, r11, r9
 	str r7, [r5]
 	str r6, [r5, #4]
 	ldr r5, _020cd8dc ; =0x00001c73
@@ -12171,14 +12171,14 @@ _020cd690:
 	mov r0, #0x1e
 	add sp, sp, #0x24
 	strh r0, [r4, #0x34]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _020cd7d4:
 	add r1, r4, #0x18
 	bl _ZN5Actor12XzDistanceToEP5Vec3p
 	ldr r1, [r4, #0x30]
 	cmp r0, r1
 	addle sp, sp, #0x24
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r1, [r4]
 	add r2, sp, #0
 	add r0, r4, #0x18
@@ -12197,9 +12197,9 @@ _020cd7d4:
 	ldr r5, [r11, #0xc]
 	ldr r10, [r11, #0x10]
 	mla r7, r5, lr, r7
-	ldr sb, [r11, #0x14]
+	ldr r9, [r11, #0x14]
 	adds r5, r10, r8
-	adc r6, sb, r7
+	adc r6, r9, r7
 	stmia r11, {r5, r6}
 	ldr r5, _020cd8dc ; =0x00001c73
 	mov r1, #0
@@ -12237,7 +12237,7 @@ _020cd7d4:
 	mov r0, #0x1e
 	strh r0, [r4, #0x34]
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020cd62c
 _020cd8d8: .word data_027e0764
@@ -12421,7 +12421,7 @@ func_ov00_020cdb2c: ; 0x020cdb2c
 	.global func_ov00_020cdb34
 	arm_func_start func_ov00_020cdb34
 func_ov00_020cdb34: ; 0x020cdb34
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	mov r4, r0
 	ldr r0, [r4]
 	mov r5, r1
@@ -12459,7 +12459,7 @@ _020cdbbc:
 	ldr r0, [r4]
 	ldrb r0, [r0, #0x111]
 	cmp r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	ldr ip, _020cdca4 ; =data_027e0764
 	mov r3, #0xcd
 	ldr r1, [ip]
@@ -12488,14 +12488,14 @@ _020cdbbc:
 	ldrsh r7, [r5, r6]
 	mov r2, r2, lsl #0x1
 	ldrsh r2, [r5, r2]
-	umull sb, r8, r7, r3
+	umull r9, r8, r7, r3
 	mov r6, #0
 	umull r5, lr, r2, r3
 	str r0, [ip, #4]
 	mla r8, r7, r6, r8
 	mov r0, r7, asr #0x1f
 	mla r8, r0, r3, r8
-	adds r1, sb, #0x800
+	adds r1, r9, #0x800
 	adc r7, r8, #0
 	mov r8, r1, lsr #0xc
 	adds r1, r5, #0x800
@@ -12513,7 +12513,7 @@ _020cdbbc:
 	ldr r0, [r4]
 	rsb r1, r3, #0x400
 	str r1, [r0, #0x64]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020cdb34
 _020cdca4: .word data_027e0764
@@ -13001,7 +13001,7 @@ func_ov00_020ce2f0: ; 0x020ce2f0
 	.global func_ov00_020ce340
 	arm_func_start func_ov00_020ce340
 func_ov00_020ce340: ; 0x020ce340
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	mov r10, r0
 	ldr r4, [r10, #8]
 	ldr r0, [r2, #8]
@@ -13013,25 +13013,25 @@ func_ov00_020ce340: ; 0x020ce340
 	sub r7, r5, r6
 	smull r2, r6, r7, r7
 	adc r0, r0, #0
-	adds sb, r2, #0x800
+	adds r9, r2, #0x800
 	mov r2, r4, lsr #0xc
 	smull r5, r4, r1, r1
 	adc r6, r6, #0
 	adds r5, r5, #0x800
-	mov sb, sb, lsr #0xc
-	orr sb, sb, r6, lsl #20
+	mov r9, r9, lsr #0xc
+	orr r9, r9, r6, lsl #20
 	orr r2, r2, r0, lsl #20
-	add r0, sb, r2
+	add r0, r9, r2
 	adc r4, r4, #0
 	mov r5, r5, lsr #0xc
 	orr r5, r5, r4, lsl #20
 	cmp r0, r5
-	mov sb, r3
+	mov r9, r3
 	mov r6, r1
 	mov r5, r1, asr #0x1f
 	mov r1, #0
 	movle r0, r1
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	bl func_01ff9958
 	mov r4, r0
 	mov r0, r7
@@ -13056,15 +13056,15 @@ func_ov00_020ce340: ; 0x020ce340
 	adds r1, r3, #0x800
 	mla r2, r5, r0, r2
 	add r4, r7, r4
-	str r4, [sb]
+	str r4, [r9]
 	ldr r4, [r10, #8]
 	adc r0, r2, #0
 	mov r1, r1, lsr #0xc
 	orr r1, r1, r0, lsl #20
 	add r0, r4, r1
-	str r0, [sb, #8]
+	str r0, [r9, #8]
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	arm_func_end func_ov00_020ce340
 
 	.global func_ov00_020ce440
@@ -13347,7 +13347,7 @@ func_ov00_020ce704: ; 0x020ce704
 	.global func_ov00_020ce740
 	arm_func_start func_ov00_020ce740
 func_ov00_020ce740: ; 0x020ce740
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #4
 	ldr r1, _020ce8c4 ; =data_027e0618
 	mov r7, r0
@@ -13363,7 +13363,7 @@ func_ov00_020ce740: ; 0x020ce740
 	bne _020ce818
 	mov r6, #0
 	ldr r10, _020ce8c8 ; =data_ov00_020eec9c
-	mov sb, #1
+	mov r9, #1
 	mov r8, #0x3c
 	mov r4, r6
 _020ce78c:
@@ -13380,7 +13380,7 @@ _020ce78c:
 	cmp r0, #0
 	bne _020ce7cc
 	mov r0, r10
-	mov r1, sb
+	mov r1, r9
 	bl func_ov00_020d77e4
 	str r8, [r7]
 _020ce7cc:
@@ -13451,7 +13451,7 @@ _020ce8b4:
 	mov r0, #0
 	strb r0, [r7, #0x38]
 	add sp, sp, #4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020ce740
 _020ce8c4: .word data_027e0618
@@ -13911,7 +13911,7 @@ func_ov00_020cee10: ; 0x020cee10
 	.global func_ov00_020cee58
 	arm_func_start func_ov00_020cee58
 func_ov00_020cee58: ; 0x020cee58
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	mov r8, r0
 	ldr r0, [r8]
 	mov r7, r1
@@ -13920,10 +13920,10 @@ func_ov00_020cee58: ; 0x020cee58
 	cmp r0, #0
 	mov r4, #0
 	ble _020ceed8
-	add sb, r8, #4
+	add r9, r8, #4
 _020cee80:
 	mov r0, r7
-	mov r1, sb
+	mov r1, r9
 	bl func_01ff9ec0
 	cmp r0, r6
 	bgt _020ceec4
@@ -13939,16 +13939,16 @@ _020cee80:
 	str r0, [r5, #8]
 _020ceebc:
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _020ceec4:
 	ldr r0, [r8]
 	add r4, r4, #1
 	cmp r4, r0
-	add sb, sb, #0xc
+	add r9, r9, #0xc
 	blt _020cee80
 _020ceed8:
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	arm_func_end func_ov00_020cee58
 
 	.global func_ov00_020ceee0
@@ -14879,17 +14879,17 @@ _020cf860: .word data_027e0618
 	.global func_ov00_020cf864
 	arm_func_start func_ov00_020cf864
 func_ov00_020cf864: ; 0x020cf864
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	mov r6, #0
 	mov r10, r0
-	mov sb, r1
+	mov r9, r1
 	mov r7, r6
 	mov r8, r6
 	mov r11, #0x1000
 	mov r4, r6
 	mov r5, #1
 _020cf888:
-	tst sb, r5, lsl r7
+	tst r9, r5, lsl r7
 	beq _020cf8e4
 	ldr r0, [r10, #0x14]
 	add r1, r0, r8
@@ -14912,14 +14912,14 @@ _020cf8d0:
 	movle r0, r6
 	mov r6, r0
 	cmp r0, #0x1000
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _020cf8e4:
 	add r7, r7, #1
 	cmp r7, #0xc
 	add r8, r8, #6
 	blt _020cf888
 	mov r0, r6
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	arm_func_end func_ov00_020cf864
 
 	.global func_ov00_020cf8fc
@@ -16495,11 +16495,11 @@ _020d0b78: .word data_ov00_020df27c
 	.global func_ov00_020d0b7c
 	arm_func_start func_ov00_020d0b7c
 func_ov00_020d0b7c: ; 0x020d0b7c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x50
 	ldrsh r4, [sp, #0x7c]
 	mov r5, r0
-	mov sb, r1
+	mov r9, r1
 	mov r8, r2
 	mov r7, r3
 	cmp r4, #0
@@ -16509,13 +16509,13 @@ func_ov00_020d0b7c: ; 0x020d0b7c
 	str r1, [sp]
 	mov r5, #0
 	str r5, [sp, #4]
-	sub r1, sb, r7
+	sub r1, r9, r7
 	sub r2, r8, r4
-	add r3, sb, r7
+	add r3, r9, r7
 	str r5, [sp, #8]
 	bl func_ov00_020d0a80
 	add sp, sp, #0x50
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _020d0bd0:
 	ldr r1, _020d1034 ; =0x00007fff
 	bl func_ov00_020d0a54
@@ -16635,7 +16635,7 @@ _020d0d04:
 	str r1, [sp, #0x2c]
 	sub r0, r1, r0
 	add r0, r0, #0x800
-	add r0, sb, r0, asr #12
+	add r0, r9, r0, asr #12
 	bl func_ov05_0210e288
 	smull r2, r1, r10, r6
 	adds r2, r2, #0x800
@@ -16695,7 +16695,7 @@ _020d0d04:
 	ldr r0, [sp, #0x2c]
 	sub r0, r0, r4
 	add r0, r0, #0x800
-	add r0, sb, r0, asr #12
+	add r0, r9, r0, asr #12
 	bl func_ov05_0210e288
 	ldr r2, [sp, #0x38]
 	str r0, [sp, #0x40]
@@ -16746,7 +16746,7 @@ _020d0d04:
 	orr r5, r5, r0, lsl #20
 	sub r0, r5, r4
 	add r0, r0, #0x800
-	add r0, sb, r0, asr #12
+	add r0, r9, r0, asr #12
 	bl func_ov05_0210e288
 	str r0, [sp, #0x4c]
 	umull r2, r1, r10, r6
@@ -16778,7 +16778,7 @@ _020d0d04:
 	ldr r1, [sp, #0x4c]
 	mov r2, r2, lsl #0x10
 	mov r1, r1, lsl #0x10
-	add r0, sb, r3, asr #12
+	add r0, r9, r3, asr #12
 	str r7, [r6]
 	orr r1, r2, r1, lsr #16
 	str r1, [r6, #0xc]
@@ -16801,7 +16801,7 @@ _020d0d04:
 	mov r0, #0
 	str r0, [r2, #0x7c]
 	add sp, sp, #0x50
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020d0b7c
 _020d1034: .word 0x00007fff
@@ -17395,7 +17395,7 @@ _020d1630:
 	.global func_ov00_020d1650
 	arm_func_start func_ov00_020d1650
 func_ov00_020d1650: ; 0x020d1650
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	mov r5, r0
 	bl func_0204b068
 	mov r3, #0
@@ -17404,7 +17404,7 @@ func_ov00_020d1650: ; 0x020d1650
 	cmp r0, #0
 	ble _020d16e8
 	mov r2, #1
-	mov sb, r3
+	mov r9, r3
 	mov r8, #0xa
 _020d167c:
 	sub r6, r0, r4
@@ -17416,7 +17416,7 @@ _020d167c:
 	ble _020d16b8
 _020d1698:
 	umull r6, r7, lr, r8
-	mla r7, lr, sb, r7
+	mla r7, lr, r9, r7
 	mov lr, r6
 	mla r7, ip, r8, r7
 	mov ip, r7
@@ -17438,26 +17438,26 @@ _020d16b8:
 	blt _020d167c
 _020d16e8:
 	mov r0, r3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	arm_func_end func_ov00_020d1650
 
 	.global func_ov00_020d16f0
 	arm_func_start func_ov00_020d16f0
 func_ov00_020d16f0: ; 0x020d16f0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	mov r8, r2
-	mov sb, r1
+	mov r9, r1
 	cmp r8, #0
 	mov r10, r0
-	cmpeq sb, #0
+	cmpeq r9, #0
 	mov r0, #0
 	bne _020d1720
 	mov r1, #0x30
 	strh r1, [r10]
 	strh r0, [r10, #2]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _020d1720:
-	mov r0, sb
+	mov r0, r9
 	mov r1, r8
 	bl func_ov00_020d1558
 	mov r6, r0
@@ -17465,12 +17465,12 @@ _020d1720:
 	mov r7, #0
 	strh r7, [r10, r0]
 	cmp r6, #0
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	mov r5, #0xa
 	mov r11, r7
 	mov r4, #0x30
 _020d1750:
-	mov r0, sb
+	mov r0, r9
 	mov r1, r8
 	mov r2, r5
 	mov r3, r11
@@ -17479,17 +17479,17 @@ _020d1750:
 	sub r0, r6, r7
 	add r0, r10, r0, lsl #1
 	strh r1, [r0, #-2]
-	mov r0, sb
+	mov r0, r9
 	mov r1, r8
 	mov r2, #0xa
 	mov r3, #0
 	bl func_02002bac
 	add r7, r7, #1
-	mov sb, r0
+	mov r9, r0
 	mov r8, r1
 	cmp r7, r6
 	blt _020d1750
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	arm_func_end func_ov00_020d16f0
 
 	.global func_ov00_020d17a0
@@ -17978,16 +17978,16 @@ _020d1dd0: .word data_027e0fe4
 	.global func_ov00_020d1dd4
 	arm_func_start func_ov00_020d1dd4
 func_ov00_020d1dd4: ; 0x020d1dd4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x40
-	mov sb, r0
-	ldr r0, [sb, #0x4c]
+	mov r9, r0
+	ldr r0, [r9, #0x4c]
 	mov r8, r1
 	tst r0, #1
 	addeq sp, sp, #0x40
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
-	ldrb r0, [sb, #0x54]
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
+	ldrb r0, [r9, #0x54]
 	mov r6, #0
 	cmp r0, #0
 	beq _020d1e24
@@ -18008,11 +18008,11 @@ _020d1e24:
 	cmp r0, #0
 	addne sp, sp, #0x40
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _020d1e4c:
-	ldrb r1, [sb, #0x55]
+	ldrb r1, [r9, #0x55]
 	ldr r0, _020d2050 ; =data_027e0fe4
-	add r2, sb, #0x20
+	add r2, r9, #0x20
 	add r7, r2, r1, lsl #3
 	ldr r0, [r0]
 	mov r1, r7
@@ -18020,7 +18020,7 @@ _020d1e4c:
 	ldr r1, _020d2050 ; =data_027e0fe4
 	mov r4, r0
 	ldr r0, [r1]
-	add r1, sb, #0x20
+	add r1, r9, #0x20
 	bl _ZN12ActorManager8GetActorEP8ActorRef
 	ldr r2, [r0]
 	add r1, sp, #0x34
@@ -18032,25 +18032,25 @@ _020d1e4c:
 	beq _020d1fd8
 	ldr r0, _020d2054 ; =data_027e0c68
 	ldr r1, [r0, #0x20]
-	cmp r1, sb
+	cmp r1, r9
 	moveq r0, #1
 	beq _020d1edc
-	mov r1, sb
+	mov r1, r9
 	bl func_02036d30
 	cmp r0, #0
 	moveq r0, #0
 	beq _020d1edc
-	ldr r1, [sb, #0x4c]
+	ldr r1, [r9, #0x4c]
 	ldr r0, _020d2058 ; =data_ov00_020e8ae8
 	bic r1, r1, #2
-	str r1, [sb, #0x4c]
-	str sb, [r0, #0x20]
+	str r1, [r9, #0x4c]
+	str r9, [r0, #0x20]
 	mov r0, #1
 _020d1edc:
 	cmp r0, #0
 	addeq sp, sp, #0x40
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	cmp r6, #0
 	beq _020d1f54
 	ldr lr, [sp, #0x34]
@@ -18078,7 +18078,7 @@ _020d1edc:
 	mov r3, #1
 	bl func_ov00_020876bc
 _020d1f54:
-	ldr r0, [sb, #0x40]
+	ldr r0, [r9, #0x40]
 	cmp r0, #0
 	beq _020d1f74
 	add r1, r0, #0x100
@@ -18092,12 +18092,12 @@ _020d1f74:
 	bl func_020376c0
 	mov r3, #1
 	add r2, sp, #0x1c
-	mov r0, sb
+	mov r0, r9
 	mov r1, r8
 	str r3, [sp, #0x28]
 	bl func_020385d0
 	ldr r1, _020d205c ; =data_027e0fc8
-	str r0, [sb, #0x40]
+	str r0, [r9, #0x40]
 	ldr r0, [r1]
 	cmp r0, #0
 	ldrne r1, [r4, #4]
@@ -18117,10 +18117,10 @@ _020d1fd8:
 	ldrh r1, [r8, #2]
 	ldr r0, _020d2054 ; =data_027e0c68
 	add r2, sp, #0x34
-	mov r3, sb
+	mov r3, r9
 	orr r1, r1, r4, lsl #16
 	bl func_02036da8
-	str r0, [sb, #0x40]
+	str r0, [r9, #0x40]
 _020d1ff8:
 	ldr r0, _020d2054 ; =data_027e0c68
 	ldrb r3, [r8, #1]
@@ -18137,12 +18137,12 @@ _020d1ff8:
 	mov r1, r0
 	mov r0, r5
 	ldr r3, [r0]
-	ldr r2, [sb, #0x40]
+	ldr r2, [r9, #0x40]
 	ldr r3, [r3, #0x68]
 	blx r3
 	mov r0, #1
 	add sp, sp, #0x40
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020d1dd4
 _020d204c: .word data_027e0f64
@@ -18758,7 +18758,7 @@ _020d28b0: .word data_027e0fe4
 	.global func_ov00_020d28b4
 	arm_func_start func_ov00_020d28b4
 func_ov00_020d28b4: ; 0x020d28b4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #0x28
 	mov r8, r0
 	strb r1, [r8, #0x55]
@@ -18777,10 +18777,10 @@ func_ov00_020d28b4: ; 0x020d28b4
 	ldr r10, _020d29cc ; =data_027e0fe4
 	add r7, r8, #0x20
 	mov r5, #0
-	mvn sb, #0
+	mvn r9, #0
 _020d2904:
 	ldr r0, [r6]
-	cmp r0, sb
+	cmp r0, r9
 	beq _020d2934
 	ldr r0, [r10]
 	mov r1, r7
@@ -18830,7 +18830,7 @@ _020d2934:
 _020d29c0:
 	mov r0, #1
 	add sp, sp, #0x28
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020d28b4
 _020d29cc: .word data_027e0fe4
@@ -21250,7 +21250,7 @@ _020d461c:
 	.global func_ov00_020d4624
 	arm_func_start func_ov00_020d4624
 func_ov00_020d4624: ; 0x020d4624
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x70
 	movs r5, r1
 	mov r10, r0
@@ -21322,7 +21322,7 @@ _020d4660:
 	add sp, sp, #0x70
 	str r1, [r10, #0x160]
 	str r4, [r10, #0x15c]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _020d4740:
 	cmp r5, #0
 	beq _020d4764
@@ -21369,16 +21369,16 @@ _020d4790:
 	str r8, [sp, #0x18]
 	bl func_ov00_02083f44
 	ldr r1, [sp, #0xc]
-	subs sb, r0, r8
+	subs r9, r0, r8
 	str r0, [sp, #4]
 	ldr r2, _020d4858 ; =func_ov00_020b1940
 	add r0, r11, r5
 	add r1, r1, r4
-	rsbmi sb, sb, #0
+	rsbmi r9, r9, #0
 	bl func_ov00_020b199c
 	cmp r0, #0
 	beq _020d4834
-	cmp sb, #0x10
+	cmp r9, #0x10
 	bge _020d4834
 	ldr r0, [sp]
 	str r7, [r10, #0x158]
@@ -21387,14 +21387,14 @@ _020d4790:
 	add sp, sp, #0x70
 	str r0, [r10, #0x15c]
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _020d4834:
 	add r6, r6, #1
 	cmp r6, #4
 	blt _020d4790
 	mov r0, #0
 	add sp, sp, #0x70
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020d4624
 _020d484c: .word data_027e0e60
@@ -21631,7 +21631,7 @@ _020d4b50: .word 0x0000019a
 	.global func_ov00_020d4b54
 	arm_func_start func_ov00_020d4b54
 func_ov00_020d4b54: ; 0x020d4b54
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x64
 	ldr r1, _020d4ddc ; =data_ov00_020ee670
 	mov r7, #0
@@ -21660,7 +21660,7 @@ func_ov00_020d4b54: ; 0x020d4b54
 	add r0, sp, #0x40
 	bl func_01ff9cec
 	add r1, sp, #0x4c
-	mov sb, r0
+	mov r9, r0
 	add r11, sp, #4
 	ldmia r1, {r0, r1, r2}
 	stmia r11, {r0, r1, r2}
@@ -21678,29 +21678,29 @@ func_ov00_020d4b54: ; 0x020d4b54
 	bl func_01fffb4c
 	cmp r0, #0
 	beq _020d4d00
-	cmp sb, #0
+	cmp r9, #0
 	beq _020d4d08
 	ldr r4, _020d4ddc ; =data_ov00_020ee670
 	mov r11, r5
 	add r6, sp, #0x1c
 	mov r5, r7
 _020d4c28:
-	cmp sb, r8
+	cmp r9, r8
 	ble _020d4c4c
 	mov r0, r8
 	mov r1, r6
 	mov r2, r11
 	mov r3, r11
 	bl func_01ff9e64
-	sub sb, sb, r8
+	sub r9, r9, r8
 	b _020d4c64
 _020d4c4c:
-	mov r0, sb
+	mov r0, r9
 	mov r1, r6
 	mov r2, r11
 	mov r3, r11
 	bl func_01ff9e64
-	mov sb, #0
+	mov r9, #0
 _020d4c64:
 	ldr r1, [sp, #0x28]
 	mov r0, r10
@@ -21729,7 +21729,7 @@ _020d4c64:
 	bl func_ov00_020d454c
 	add sp, sp, #0x64
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _020d4cd4:
 	cmp r7, #0
 	bne _020d4d08
@@ -21739,7 +21739,7 @@ _020d4cd4:
 	str r2, [sp, #0x34]
 	str r1, [sp, #0x38]
 	str r0, [sp, #0x3c]
-	cmp sb, #0
+	cmp r9, #0
 	bne _020d4c28
 	b _020d4d08
 _020d4d00:
@@ -21801,7 +21801,7 @@ _020d4db8:
 	ldr r1, [r10, #0x50]
 	str r1, [r10, #0x5c]
 	add sp, sp, #0x64
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020d4b54
 _020d4ddc: .word data_ov00_020ee670
@@ -22555,7 +22555,7 @@ _020d5738: .word 0x0000019a
 	.global func_ov00_020d573c
 	arm_func_start func_ov00_020d573c
 func_ov00_020d573c: ; 0x020d573c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x10
 	mov r10, r0
 	str r1, [sp]
@@ -22596,12 +22596,12 @@ _020d57b0:
 	moveq r6, #1
 _020d57d4:
 	mov r7, #0
-	mov sb, r7
+	mov r9, r7
 	mov r5, r7
 	mov r4, #0x1000
 	mov r11, #1
 _020d57e8:
-	add r0, r10, sb, lsl #2
+	add r0, r10, r9, lsl #2
 	ldr r8, [r0, #0x464]
 	ldrb r0, [r8, #0x100]
 	cmp r0, #0
@@ -22634,8 +22634,8 @@ _020d583c:
 	movne r0, #0
 	strneb r0, [r8, #0x100]
 _020d5864:
-	add sb, sb, #1
-	cmp sb, #3
+	add r9, r9, #1
+	cmp r9, #3
 	blt _020d57e8
 	ldrb r0, [r10, #0x484]
 	cmp r0, #1
@@ -22651,7 +22651,7 @@ _020d5888:
 	mov r0, #1
 	strb r0, [r10, #0x484]
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020d573c
 _020d58a8: .word data_027e0e60
@@ -22814,16 +22814,16 @@ func_ov00_020d6194: ; 0x020d6194
 	.global func_ov00_020d61b0
 	arm_func_start func_ov00_020d61b0
 func_ov00_020d61b0: ; 0x020d61b0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x10
 	mov r10, r0
 	ldrb r5, [r10, #0x38]
-	mov sb, r1
+	mov r9, r1
 	mov r4, r2
 	cmp r5, #0
 	mov r11, r3
 	addeq sp, sp, #0x10
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldrb r1, [r10, #4]
 	cmp r1, #0
 	beq _020d632c
@@ -22833,7 +22833,7 @@ func_ov00_020d61b0: ; 0x020d61b0
 	ldr r1, [r10, #0x10]
 	mov r0, r10
 	add r3, r1, #1
-	mov r1, sb
+	mov r1, r9
 	mov r2, r4
 	str r3, [r10, #0x10]
 	bl func_ov00_020d6394
@@ -22863,7 +22863,7 @@ _020d6228:
 	blt _020d6228
 	cmp r7, #0
 	addeq sp, sp, #0x10
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r1, [r10, #8]
 	add r0, r1, #0x200
 	cmp r6, r0
@@ -22880,7 +22880,7 @@ _020d6228:
 	add r0, r2, r0, lsr #23
 	add r1, r3, r0, asr #9
 _020d62b0:
-	mov r0, sb, asr #0x2
+	mov r0, r9, asr #0x2
 	add r0, r0, r0, lsl #1
 	str r1, [sp]
 	mov r4, #0
@@ -22894,9 +22894,9 @@ _020d62b0:
 	str r4, [sp, #0xc]
 	bl func_ov00_020d80a4
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _020d62ec:
-	mov r0, sb, asr #0x2
+	mov r0, r9, asr #0x2
 	mov r1, #0x40
 	add r0, r0, r0, lsl #1
 	str r1, [sp]
@@ -22911,11 +22911,11 @@ _020d62ec:
 	str r4, [sp, #0xc]
 	bl func_ov00_020d80a4
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _020d632c:
 	bl func_ov00_020d6148
 	mov r0, r10
-	mov r1, sb
+	mov r1, r9
 	mov r2, r4
 	bl func_ov00_020d6394
 	mov r0, #0x40
@@ -22937,7 +22937,7 @@ _020d632c:
 	mov r0, r4
 	str r0, [r10, #0x10]
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020d61b0
 _020d6390: .word data_ov00_020eec9c
@@ -24844,9 +24844,9 @@ func_ov00_020d7880: ; 0x020d7880
 	.global func_ov00_020d78a0
 	arm_func_start func_ov00_020d78a0
 func_ov00_020d78a0: ; 0x020d78a0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	ldr r5, _020d7a78 ; =data_027e0764
-	mov sb, r1
+	mov r9, r1
 	ldr r7, [r5]
 	mov r8, r2
 	mov r10, r0
@@ -24854,10 +24854,10 @@ func_ov00_020d78a0: ; 0x020d78a0
 	umull r1, r0, r6, r7
 	mla r0, r6, r2, r0
 	mla r0, r11, r7, r0
-	cmp sb, #0x13
-	moveq sb, #0
+	cmp r9, #0x13
+	moveq r9, #0
 	ldr r2, [r5, #0x10]
-	mov r4, sb, lsl #0x2
+	mov r4, r9, lsl #0x2
 	add r4, r4, #0x29
 	ldr r7, [r5, #0x14]
 	adds r1, r2, r1
@@ -24911,7 +24911,7 @@ _020d7974:
 	mov r1, r1, lsr #0x10
 	mov r3, #0
 	bl func_ov00_020ceacc
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _020d79a4:
 	cmp r3, #0xf
 	movgt r3, #0xf
@@ -24947,7 +24947,7 @@ _020d79d8:
 	add r1, r2, r1, lsr #25
 	mov r8, r1, asr #0x7
 	mov r6, r0
-	cmp sb, #0x11
+	cmp r9, #0x11
 	moveq r0, r7, lsl #0x2
 	rsbeq r5, r0, #0
 	ldr r1, [r10, #0x20]
@@ -24967,7 +24967,7 @@ _020d79d8:
 	bl func_0201f88c
 	mov r0, r10
 	bl func_0201f710
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020d78a0
 _020d7a78: .word data_027e0764
@@ -25556,12 +25556,12 @@ _020d8168: .word 0x0000ffff
 	.global func_ov00_020d816c
 	arm_func_start func_ov00_020d816c
 func_ov00_020d816c: ; 0x020d816c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	mov r5, #0
 	mov r6, r0
 	add r4, r6, #0x28
 	mov r8, r5
-	mov sb, #1
+	mov r9, #1
 	mov r7, r5
 _020d8188:
 	ldr r0, [r4]
@@ -25572,7 +25572,7 @@ _020d8188:
 	bne _020d81b8
 	ldr r0, [r4, #8]
 	cmp r0, #0
-	movne r0, sb
+	movne r0, r9
 	moveq r0, r8
 	cmp r0, #0
 	bne _020d81d0
@@ -25590,7 +25590,7 @@ _020d81d4:
 	cmp r5, #8
 	add r4, r4, #0xc
 	blt _020d8188
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	arm_func_end func_ov00_020d816c
 
 	.global func_ov00_020d81e8

--- a/asm/ov00/ov00_020c3e54.s
+++ b/asm/ov00/ov00_020c3e54.s
@@ -208,9 +208,9 @@ _020c4040:
 	.global func_ov00_020c4048
 	arm_func_start func_ov00_020c4048
 func_ov00_020c4048: ; 0x020c4048
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	ldr r4, _020c42cc ; =data_027e0fe4
-	mov fp, r1
+	mov r11, r1
 	ldr r7, [r4]
 	mov sl, r2
 	ldrh r2, [r7]
@@ -225,7 +225,7 @@ _020c407c:
 	ldr r1, [r6]
 	cmp r1, #0
 	bne _020c429c
-	mov r1, fp
+	mov r1, r11
 	bl func_ov00_020c401c
 	str r0, [r6]
 	cmp r0, #0
@@ -235,9 +235,9 @@ _020c407c:
 	strne r0, [r8]
 	strne r0, [r8, #4]
 	mvn r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _020c40b4:
-	str fp, [r0, #4]
+	str r11, [r0, #4]
 	ldr r1, [r7, #0xc]
 	ldr r0, [r6]
 	str r1, [r0, #8]
@@ -358,7 +358,7 @@ _020c40b4:
 	strne r0, [r8]
 	strne r0, [r8, #4]
 	mvn r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _020c429c:
 	add r5, r5, #1
 	cmp r5, r2
@@ -373,7 +373,7 @@ _020c42ac:
 	strne r0, [r8, #4]
 _020c42c4:
 	mov r0, r4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020c4048
 _020c42cc: .word data_027e0fe4
@@ -1009,7 +1009,7 @@ _020c4ae4: .word data_027e0ff0
 	.global func_ov00_020c4ae8
 	arm_func_start func_ov00_020c4ae8
 func_ov00_020c4ae8: ; 0x020c4ae8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0xc
 	ldr r4, [r0, #4]
 	str r0, [sp]
@@ -1040,8 +1040,8 @@ _020c4b20:
 	beq _020c4bd8
 	ldr r0, [r7]
 	mov r6, #0
-	ldrb fp, [r0, #1]
-	cmp fp, #0
+	ldrb r11, [r0, #1]
+	cmp r11, #0
 	ble _020c4bd8
 	mov r8, r6
 _020c4b70:
@@ -1068,7 +1068,7 @@ _020c4b70:
 _020c4bc0:
 	add r0, r6, #1
 	mov r0, r0, lsl #0x18
-	cmp fp, r0, asr #24
+	cmp r11, r0, asr #24
 	add r8, r8, #0x24
 	mov r6, r0, asr #0x18
 	bgt _020c4b70
@@ -1083,13 +1083,13 @@ _020c4bd8:
 _020c4bf4:
 	ldr r0, [sp, #8]
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	arm_func_end func_ov00_020c4ae8
 
 	.global func_ov00_020c4c00
 	arm_func_start func_ov00_020c4c00
 func_ov00_020c4c00: ; 0x020c4c00
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x40
 	mov sl, r1
 	mov sb, r3
@@ -1119,7 +1119,7 @@ func_ov00_020c4c00: ; 0x020c4c00
 	add r8, r4, #0x14
 	mov r7, #0
 	str r0, [sp]
-	ldrsb fp, [sb, #1]
+	ldrsb r11, [sb, #1]
 	add r5, sp, #0x1c
 	add r4, sp, #0x10
 _020c4c84:
@@ -1156,7 +1156,7 @@ _020c4c84:
 	ldrsb r1, [r8]
 	mov r6, r0
 	str r1, [sp]
-	ldrsb fp, [r8, #1]
+	ldrsb r11, [r8, #1]
 _020c4d0c:
 	add r7, r7, #1
 	cmp r7, #4
@@ -1172,12 +1172,12 @@ _020c4d0c:
 	ldr r1, [sp]
 	add sp, sp, #0x40
 	strb r1, [sb, #2]
-	strb fp, [sb, #3]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	strb r11, [sb, #3]
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _020c4d4c:
 	mov r0, #0
 	add sp, sp, #0x40
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020c4c00
 _020c4d58: .word data_027e0ff0
@@ -1185,9 +1185,9 @@ _020c4d58: .word data_027e0ff0
 	.global func_ov00_020c4d5c
 	arm_func_start func_ov00_020c4d5c
 func_ov00_020c4d5c: ; 0x020c4d5c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x204
-	mov fp, r0
+	mov r11, r0
 	mov sl, r1
 	add r3, sp, #4
 	str r2, [sp]
@@ -1200,13 +1200,13 @@ _020c4d80:
 	add r3, r3, #2
 	cmp r3, r0
 	blo _020c4d80
-	ldr r0, [fp, #4]
+	ldr r0, [r11, #4]
 	mov r5, #0
 	cmp r0, #0
 	ble _020c4e4c
 	add r4, sp, #4
 _020c4da8:
-	ldr r2, [fp]
+	ldr r2, [r11]
 	and r1, r5, #0xff
 	ldr r0, [r2, r1, lsl #3]
 	add sb, r2, r1, lsl #3
@@ -1246,7 +1246,7 @@ _020c4e20:
 _020c4e34:
 	add r0, r5, #1
 	mov r0, r0, lsl #0x18
-	ldr r1, [fp, #4]
+	ldr r1, [r11, #4]
 	mov r5, r0, asr #0x18
 	cmp r1, r0, asr #24
 	bgt _020c4da8
@@ -1285,11 +1285,11 @@ _020c4ea8:
 	ldrsb r2, [r3, #1]
 	mov r0, #1
 	strb r2, [r1, #1]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _020c4ed4:
 	mov r0, #0
 	add sp, sp, #0x204
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020c4d5c
 _020c4ee0: .word data_027e0764
@@ -1403,19 +1403,19 @@ _020c500c:
 	.global func_ov00_020c5014
 	arm_func_start func_ov00_020c5014
 func_ov00_020c5014: ; 0x020c5014
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	mov sl, r0
 	ldr r0, [sl]
-	mov fp, #0
+	mov r11, #0
 	ldrb r4, [r0, #1]
 	mov sb, r1
 	str r2, [sp]
 	mov r8, r3
-	mov r5, fp
+	mov r5, r11
 	cmp r4, #0
-	sub r6, fp, #0x80000001
+	sub r6, r11, #0x80000001
 	ble _020c50c0
-	mov r7, fp
+	mov r7, r11
 _020c5048:
 	cmp r8, #0
 	beq _020c5090
@@ -1444,7 +1444,7 @@ _020c5090:
 	bl func_01ff9ec0
 	cmp r0, r6
 	movlt r6, r0
-	movlt fp, r5
+	movlt r11, r5
 _020c50b0:
 	add r5, r5, #1
 	cmp r5, r4
@@ -1454,8 +1454,8 @@ _020c50c0:
 	ldr r0, [sp]
 	cmp r0, #0
 	strne r6, [r0]
-	mov r0, fp
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	mov r0, r11
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	arm_func_end func_ov00_020c5014
 
 	.global func_ov00_020c50d4
@@ -3473,7 +3473,7 @@ _020c69e4: .word func_ov00_020c69a0
 	.global func_ov00_020c69e8
 	arm_func_start func_ov00_020c69e8
 func_ov00_020c69e8: ; 0x020c69e8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0xc
 	mov r7, r0
 	ldr r3, [r7, #4]
@@ -3502,7 +3502,7 @@ func_ov00_020c69e8: ; 0x020c69e8
 	mov r0, r7
 	bl func_ov00_020c69a0
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _020c6a60:
 	bl func_ov00_020c6d34
 	mov r4, r0
@@ -3521,9 +3521,9 @@ _020c6a60:
 	ldr r2, [sl, #0xc]
 	ldr r1, [r6, #8]
 	ldr r0, [r6]
-	sub fp, r2, r1
+	sub r11, r2, r1
 	ldr r2, [sl, #4]
-	mov r1, fp
+	mov r1, r11
 	sub r0, r2, r0
 	str r0, [sp, #4]
 	bl func_01ffa0f4
@@ -3546,7 +3546,7 @@ _020c6a60:
 	bl func_01ffa0f4
 	ldr r1, [sp, #4]
 	cmp r1, #0
-	cmpeq fp, #0
+	cmpeq r11, #0
 	ldreq r6, [sp]
 	mov r1, r0, lsl #0x10
 	cmp r4, r5
@@ -3555,7 +3555,7 @@ _020c6a60:
 	mov r1, #0
 	bl func_ov00_020c69a0
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _020c6b30:
 	ldr r0, [sp, #8]
 	cmp r5, r0
@@ -3564,7 +3564,7 @@ _020c6b30:
 	mov r1, #1
 	bl func_ov00_020c69a0
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _020c6b50:
 	sub r0, r6, r1, asr #16
 	mov r0, r0, lsl #0x10
@@ -3582,12 +3582,12 @@ _020c6b50:
 	mov r1, #1
 	bl func_ov00_020c69a0
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _020c6b94:
 	mov r1, #0
 	bl func_ov00_020c69a0
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020c69e8
 _020c6ba4: .word data_027e0764
@@ -6152,20 +6152,20 @@ func_ov00_020c8d28: ; 0x020c8d28
 	.global func_ov00_020c8d4c
 	arm_func_start func_ov00_020c8d4c
 func_ov00_020c8d4c: ; 0x020c8d4c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0xc
 	ldrsb r2, [r1]
-	mov fp, r0
+	mov r11, r0
 	ldr r0, _020c8e3c ; =data_027e0ff0
-	strb r2, [fp, #0x12]
+	strb r2, [r11, #0x12]
 	ldrsb r2, [r1, #1]
-	strb r2, [fp, #0x13]
+	strb r2, [r11, #0x13]
 	ldr r0, [r0]
 	bl func_ov00_020c47cc
 	mov r6, r0
 	ldr r0, _020c8e40 ; =0x00007fff
-	ldrsb r8, [fp, #0x12]
-	ldrsb sb, [fp, #0x13]
+	ldrsb r8, [r11, #0x12]
+	ldrsb sb, [r11, #0x13]
 	add sl, r6, #0x14
 	mov r7, #0x2000
 	mov r5, #0
@@ -6211,10 +6211,10 @@ _020c8e1c:
 	cmp r5, #4
 	add sl, sl, #4
 	blt _020c8d94
-	strb r8, [fp, #0x10]
-	strb sb, [fp, #0x11]
+	strb r8, [r11, #0x10]
+	strb sb, [r11, #0x11]
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020c8d4c
 _020c8e3c: .word data_027e0ff0
@@ -12065,7 +12065,7 @@ _020cd628: .word data_02050f54
 	.global func_ov00_020cd62c
 	arm_func_start func_ov00_020cd62c
 func_ov00_020cd62c: ; 0x020cd62c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x24
 	mov r4, r0
 	ldrsh r0, [r4, #0x34]
@@ -12089,7 +12089,7 @@ func_ov00_020cd62c: ; 0x020cd62c
 	cmp r5, r0
 	moveq r0, #0
 	streqh r0, [r4, #0x34]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _020cd690:
 	mov r2, r5
 	mov r3, r6
@@ -12130,10 +12130,10 @@ _020cd690:
 	ldr r7, [r1, #0xc]
 	ldr ip, [r1, #0x10]
 	mla sb, r7, r6, sb
-	ldr fp, [r1, #0x14]
+	ldr r11, [r1, #0x14]
 	adds r7, ip, sl
 	ldr r5, _020cd8d8 ; =data_027e0764
-	adc r6, fp, sb
+	adc r6, r11, sb
 	str r7, [r5]
 	str r6, [r5, #4]
 	ldr r5, _020cd8dc ; =0x00001c73
@@ -12171,14 +12171,14 @@ _020cd690:
 	mov r0, #0x1e
 	add sp, sp, #0x24
 	strh r0, [r4, #0x34]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _020cd7d4:
 	add r1, r4, #0x18
 	bl _ZN5Actor12XzDistanceToEP5Vec3p
 	ldr r1, [r4, #0x30]
 	cmp r0, r1
 	addle sp, sp, #0x24
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r1, [r4]
 	add r2, sp, #0
 	add r0, r4, #0x18
@@ -12187,20 +12187,20 @@ _020cd7d4:
 	ldr r0, [sp]
 	ldr r1, [sp, #8]
 	bl func_01ffa0f4
-	ldr fp, _020cd8d8 ; =data_027e0764
+	ldr r11, _020cd8d8 ; =data_027e0764
 	mov r0, r0, lsl #0x10
-	ldr r6, [fp, #8]
-	ldr lr, [fp]
-	ldr ip, [fp, #4]
+	ldr r6, [r11, #8]
+	ldr lr, [r11]
+	ldr ip, [r11, #4]
 	umull r8, r7, r6, lr
 	mla r7, r6, ip, r7
-	ldr r5, [fp, #0xc]
-	ldr sl, [fp, #0x10]
+	ldr r5, [r11, #0xc]
+	ldr sl, [r11, #0x10]
 	mla r7, r5, lr, r7
-	ldr sb, [fp, #0x14]
+	ldr sb, [r11, #0x14]
 	adds r5, sl, r8
 	adc r6, sb, r7
-	stmia fp, {r5, r6}
+	stmia r11, {r5, r6}
 	ldr r5, _020cd8dc ; =0x00001c73
 	mov r1, #0
 	umull r5, r7, r6, r5
@@ -12237,7 +12237,7 @@ _020cd7d4:
 	mov r0, #0x1e
 	strh r0, [r4, #0x34]
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020cd62c
 _020cd8d8: .word data_027e0764
@@ -14879,13 +14879,13 @@ _020cf860: .word data_027e0618
 	.global func_ov00_020cf864
 	arm_func_start func_ov00_020cf864
 func_ov00_020cf864: ; 0x020cf864
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	mov r6, #0
 	mov sl, r0
 	mov sb, r1
 	mov r7, r6
 	mov r8, r6
-	mov fp, #0x1000
+	mov r11, #0x1000
 	mov r4, r6
 	mov r5, #1
 _020cf888:
@@ -14900,7 +14900,7 @@ _020cf888:
 	beq _020cf8d0
 	ldrsh r1, [r1, #4]
 	cmp r0, r1
-	moveq r0, fp
+	moveq r0, r11
 	beq _020cf8d0
 	sub r0, r0, r2
 	sub r1, r1, r2
@@ -14912,14 +14912,14 @@ _020cf8d0:
 	movle r0, r6
 	mov r6, r0
 	cmp r0, #0x1000
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _020cf8e4:
 	add r7, r7, #1
 	cmp r7, #0xc
 	add r8, r8, #6
 	blt _020cf888
 	mov r0, r6
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	arm_func_end func_ov00_020cf864
 
 	.global func_ov00_020cf8fc
@@ -16495,7 +16495,7 @@ _020d0b78: .word data_ov00_020df27c
 	.global func_ov00_020d0b7c
 	arm_func_start func_ov00_020d0b7c
 func_ov00_020d0b7c: ; 0x020d0b7c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x50
 	ldrsh r4, [sp, #0x7c]
 	mov r5, r0
@@ -16515,7 +16515,7 @@ func_ov00_020d0b7c: ; 0x020d0b7c
 	str r5, [sp, #8]
 	bl func_ov00_020d0a80
 	add sp, sp, #0x50
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _020d0bd0:
 	ldr r1, _020d1034 ; =0x00007fff
 	bl func_ov00_020d0a54
@@ -16611,9 +16611,9 @@ _020d0d04:
 	mov r2, r0, asr #0x1
 	add r1, r7, r7, lsr #31
 	mov r0, r1, asr #0x1
-	mov fp, r2, lsl #0xc
+	mov r11, r2, lsl #0xc
 	mov sl, r0, lsl #0xc
-	smull r1, r0, fp, r6
+	smull r1, r0, r11, r6
 	adds r2, r1, #0x800
 	adc r1, r0, #0
 	mov r0, r2, lsr #0xc
@@ -16642,13 +16642,13 @@ _020d0d04:
 	adc r1, r1, #0
 	mov sl, r2, lsr #0xc
 	orr sl, sl, r1, lsl #20
-	smull r2, r1, fp, r5
+	smull r2, r1, r11, r5
 	adds r2, r2, #0x800
 	adc r1, r1, #0
-	mov fp, r2, lsr #0xc
-	orr fp, fp, r1, lsl #20
+	mov r11, r2, lsr #0xc
+	orr r11, r11, r1, lsl #20
 	str r0, [sp, #0x30]
-	add r0, fp, sl
+	add r0, r11, sl
 	add r0, r0, #0x800
 	add r0, r8, r0, asr #12
 	bl func_ov05_0210e2a4
@@ -16783,7 +16783,7 @@ _020d0d04:
 	orr r1, r2, r1, lsr #16
 	str r1, [r6, #0xc]
 	bl func_ov05_0210e288
-	add r1, fp, r4
+	add r1, r11, r4
 	add r1, r1, #0x800
 	mov r4, r0
 	add r0, r8, r1, asr #12
@@ -16801,7 +16801,7 @@ _020d0d04:
 	mov r0, #0
 	str r0, [r2, #0x7c]
 	add sp, sp, #0x50
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020d0b7c
 _020d1034: .word 0x00007fff
@@ -17395,7 +17395,7 @@ _020d1630:
 	.global func_ov00_020d1650
 	arm_func_start func_ov00_020d1650
 func_ov00_020d1650: ; 0x020d1650
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	mov r5, r0
 	bl func_0204b068
 	mov r3, #0
@@ -17408,11 +17408,11 @@ func_ov00_020d1650: ; 0x020d1650
 	mov r8, #0xa
 _020d167c:
 	sub r6, r0, r4
-	sub fp, r6, #1
+	sub r11, r6, #1
 	mov ip, #0
 	mov lr, r2
 	mov sl, ip
-	cmp fp, #0
+	cmp r11, #0
 	ble _020d16b8
 _020d1698:
 	umull r6, r7, lr, r8
@@ -17421,7 +17421,7 @@ _020d1698:
 	mla r7, ip, r8, r7
 	mov ip, r7
 	add sl, sl, #1
-	cmp sl, fp
+	cmp sl, r11
 	blt _020d1698
 _020d16b8:
 	mov r6, r4, lsl #0x1
@@ -17429,22 +17429,22 @@ _020d16b8:
 	add r4, r4, #1
 	sub r7, r6, #0x30
 	mov r6, r7, asr #0x1f
-	umull fp, sl, lr, r7
+	umull r11, sl, lr, r7
 	mla sl, lr, r6, sl
 	mla sl, ip, r7, sl
-	adds r3, r3, fp
+	adds r3, r3, r11
 	adc r1, r1, sl
 	cmp r4, r0
 	blt _020d167c
 _020d16e8:
 	mov r0, r3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	arm_func_end func_ov00_020d1650
 
 	.global func_ov00_020d16f0
 	arm_func_start func_ov00_020d16f0
 func_ov00_020d16f0: ; 0x020d16f0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	mov r8, r2
 	mov sb, r1
 	cmp r8, #0
@@ -17455,7 +17455,7 @@ func_ov00_020d16f0: ; 0x020d16f0
 	mov r1, #0x30
 	strh r1, [sl]
 	strh r0, [sl, #2]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _020d1720:
 	mov r0, sb
 	mov r1, r8
@@ -17465,15 +17465,15 @@ _020d1720:
 	mov r7, #0
 	strh r7, [sl, r0]
 	cmp r6, #0
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	mov r5, #0xa
-	mov fp, r7
+	mov r11, r7
 	mov r4, #0x30
 _020d1750:
 	mov r0, sb
 	mov r1, r8
 	mov r2, r5
-	mov r3, fp
+	mov r3, r11
 	bl func_02002bb8
 	adds r1, r0, r4
 	sub r0, r6, r7
@@ -17489,7 +17489,7 @@ _020d1750:
 	mov r8, r1
 	cmp r7, r6
 	blt _020d1750
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	arm_func_end func_ov00_020d16f0
 
 	.global func_ov00_020d17a0
@@ -21250,7 +21250,7 @@ _020d461c:
 	.global func_ov00_020d4624
 	arm_func_start func_ov00_020d4624
 func_ov00_020d4624: ; 0x020d4624
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x70
 	movs r5, r1
 	mov sl, r0
@@ -21322,7 +21322,7 @@ _020d4660:
 	add sp, sp, #0x70
 	str r1, [sl, #0x160]
 	str r4, [sl, #0x15c]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _020d4740:
 	cmp r5, #0
 	beq _020d4764
@@ -21348,7 +21348,7 @@ _020d4770:
 	mov r6, #0
 _020d4790:
 	ldr r0, [sp, #8]
-	ldrb fp, [sp, #0x10]
+	ldrb r11, [sp, #0x10]
 	add r1, r0, r6, lsl #3
 	ldr r5, [r0, r6, lsl #3]
 	ldr r0, [sp, #0x58]
@@ -21372,7 +21372,7 @@ _020d4790:
 	subs sb, r0, r8
 	str r0, [sp, #4]
 	ldr r2, _020d4858 ; =func_ov00_020b1940
-	add r0, fp, r5
+	add r0, r11, r5
 	add r1, r1, r4
 	rsbmi sb, sb, #0
 	bl func_ov00_020b199c
@@ -21387,14 +21387,14 @@ _020d4790:
 	add sp, sp, #0x70
 	str r0, [sl, #0x15c]
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _020d4834:
 	add r6, r6, #1
 	cmp r6, #4
 	blt _020d4790
 	mov r0, #0
 	add sp, sp, #0x70
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020d4624
 _020d484c: .word data_027e0e60
@@ -21631,7 +21631,7 @@ _020d4b50: .word 0x0000019a
 	.global func_ov00_020d4b54
 	arm_func_start func_ov00_020d4b54
 func_ov00_020d4b54: ; 0x020d4b54
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x64
 	ldr r1, _020d4ddc ; =data_ov00_020ee670
 	mov r7, #0
@@ -21661,14 +21661,14 @@ func_ov00_020d4b54: ; 0x020d4b54
 	bl func_01ff9cec
 	add r1, sp, #0x4c
 	mov sb, r0
-	add fp, sp, #4
+	add r11, sp, #4
 	ldmia r1, {r0, r1, r2}
-	stmia fp, {r0, r1, r2}
+	stmia r11, {r0, r1, r2}
 	add r6, sp, #0x34
-	ldmia fp, {r0, r1, r2}
+	ldmia r11, {r0, r1, r2}
 	stmia r6, {r0, r1, r2}
 	add r5, sp, #0x28
-	ldmia fp, {r0, r1, r2}
+	ldmia r11, {r0, r1, r2}
 	add r4, sp, #0x40
 	stmia r5, {r0, r1, r2}
 	add r3, sp, #0x1c
@@ -21681,7 +21681,7 @@ func_ov00_020d4b54: ; 0x020d4b54
 	cmp sb, #0
 	beq _020d4d08
 	ldr r4, _020d4ddc ; =data_ov00_020ee670
-	mov fp, r5
+	mov r11, r5
 	add r6, sp, #0x1c
 	mov r5, r7
 _020d4c28:
@@ -21689,16 +21689,16 @@ _020d4c28:
 	ble _020d4c4c
 	mov r0, r8
 	mov r1, r6
-	mov r2, fp
-	mov r3, fp
+	mov r2, r11
+	mov r3, r11
 	bl func_01ff9e64
 	sub sb, sb, r8
 	b _020d4c64
 _020d4c4c:
 	mov r0, sb
 	mov r1, r6
-	mov r2, fp
-	mov r3, fp
+	mov r2, r11
+	mov r3, r11
 	bl func_01ff9e64
 	mov sb, #0
 _020d4c64:
@@ -21729,7 +21729,7 @@ _020d4c64:
 	bl func_ov00_020d454c
 	add sp, sp, #0x64
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _020d4cd4:
 	cmp r7, #0
 	bne _020d4d08
@@ -21801,7 +21801,7 @@ _020d4db8:
 	ldr r1, [sl, #0x50]
 	str r1, [sl, #0x5c]
 	add sp, sp, #0x64
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020d4b54
 _020d4ddc: .word data_ov00_020ee670
@@ -22555,7 +22555,7 @@ _020d5738: .word 0x0000019a
 	.global func_ov00_020d573c
 	arm_func_start func_ov00_020d573c
 func_ov00_020d573c: ; 0x020d573c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x10
 	mov sl, r0
 	str r1, [sp]
@@ -22599,7 +22599,7 @@ _020d57d4:
 	mov sb, r7
 	mov r5, r7
 	mov r4, #0x1000
-	mov fp, #1
+	mov r11, #1
 _020d57e8:
 	add r0, sl, sb, lsl #2
 	ldr r8, [r0, #0x464]
@@ -22619,7 +22619,7 @@ _020d57e8:
 	add r0, r8, #0xc0
 	str r4, [r1, #0x10]
 	mov r1, #0
-	strb fp, [r8, #0x100]
+	strb r11, [r8, #0x100]
 	bl func_ov00_020c0e24
 	b _020d5864
 _020d583c:
@@ -22651,7 +22651,7 @@ _020d5888:
 	mov r0, #1
 	strb r0, [sl, #0x484]
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020d573c
 _020d58a8: .word data_027e0e60
@@ -22814,16 +22814,16 @@ func_ov00_020d6194: ; 0x020d6194
 	.global func_ov00_020d61b0
 	arm_func_start func_ov00_020d61b0
 func_ov00_020d61b0: ; 0x020d61b0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x10
 	mov sl, r0
 	ldrb r5, [sl, #0x38]
 	mov sb, r1
 	mov r4, r2
 	cmp r5, #0
-	mov fp, r3
+	mov r11, r3
 	addeq sp, sp, #0x10
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldrb r1, [sl, #4]
 	cmp r1, #0
 	beq _020d632c
@@ -22863,7 +22863,7 @@ _020d6228:
 	blt _020d6228
 	cmp r7, #0
 	addeq sp, sp, #0x10
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r1, [sl, #8]
 	add r0, r1, #0x200
 	cmp r6, r0
@@ -22888,13 +22888,13 @@ _020d62b0:
 	sub r0, r0, #0x60
 	str r0, [sp, #8]
 	ldr r0, _020d6390 ; =data_ov00_020eec9c
-	mov r2, fp
+	mov r2, r11
 	mov r1, #3
 	mov r3, #5
 	str r4, [sp, #0xc]
 	bl func_ov00_020d80a4
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _020d62ec:
 	mov r0, sb, asr #0x2
 	mov r1, #0x40
@@ -22905,13 +22905,13 @@ _020d62ec:
 	sub r0, r0, #0x60
 	str r0, [sp, #8]
 	ldr r0, _020d6390 ; =data_ov00_020eec9c
-	mov r2, fp
+	mov r2, r11
 	mov r1, #3
 	mov r3, #5
 	str r4, [sp, #0xc]
 	bl func_ov00_020d80a4
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _020d632c:
 	bl func_ov00_020d6148
 	mov r0, sl
@@ -22924,7 +22924,7 @@ _020d632c:
 	str r4, [sp, #4]
 	str r4, [sp, #8]
 	ldr r0, _020d6390 ; =data_ov00_020eec9c
-	mov r2, fp
+	mov r2, r11
 	mov r1, #3
 	mov r3, #1
 	str r4, [sp, #0xc]
@@ -22937,7 +22937,7 @@ _020d632c:
 	mov r0, r4
 	str r0, [sl, #0x10]
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020d61b0
 _020d6390: .word data_ov00_020eec9c
@@ -24844,16 +24844,16 @@ func_ov00_020d7880: ; 0x020d7880
 	.global func_ov00_020d78a0
 	arm_func_start func_ov00_020d78a0
 func_ov00_020d78a0: ; 0x020d78a0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	ldr r5, _020d7a78 ; =data_027e0764
 	mov sb, r1
 	ldr r7, [r5]
 	mov r8, r2
 	mov sl, r0
-	ldmib r5, {r2, r6, fp}
+	ldmib r5, {r2, r6, r11}
 	umull r1, r0, r6, r7
 	mla r0, r6, r2, r0
-	mla r0, fp, r7, r0
+	mla r0, r11, r7, r0
 	cmp sb, #0x13
 	moveq sb, #0
 	ldr r2, [r5, #0x10]
@@ -24911,7 +24911,7 @@ _020d7974:
 	mov r1, r1, lsr #0x10
 	mov r3, #0
 	bl func_ov00_020ceacc
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _020d79a4:
 	cmp r3, #0xf
 	movgt r3, #0xf
@@ -24938,11 +24938,11 @@ _020d79d8:
 	mov r1, r0
 	mov r0, sl
 	bl func_ov00_020d75c8
-	mov fp, r0
+	mov r11, r0
 	ldr r0, _020d7a7c ; =data_027e0ffc
 	mov r1, r8
 	bl func_ov00_020ce970
-	mul r2, fp, r6
+	mul r2, r11, r6
 	mov r1, r2, asr #0x6
 	add r1, r2, r1, lsr #25
 	mov r8, r1, asr #0x7
@@ -24967,7 +24967,7 @@ _020d79d8:
 	bl func_0201f88c
 	mov r0, sl
 	bl func_0201f710
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov00_020d78a0
 _020d7a78: .word data_027e0764

--- a/asm/ov00/ov00_020d59f0.inc
+++ b/asm/ov00/ov00_020d59f0.inc
@@ -273,14 +273,14 @@ func_ov00_020d5cd8: ; 0x020d5cd8
 	.global func_ov00_020d5dc4
 	arm_func_start func_ov00_020d5dc4
 func_ov00_020d5dc4: ; 0x020d5dc4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	ldr r4, [r0]
 	ldr r5, [r1]
-	ldmib r1, {r3, fp, lr}
+	ldmib r1, {r3, r11, lr}
 	ldmib r0, {r2, sl, ip}
 	mul sb, r4, lr
 	mul r1, ip, r5
-	mul r6, r2, fp
+	mul r6, r2, r11
 	add sb, sb, #0x800
 	mul r7, r2, lr
 	mul r8, ip, r3
@@ -303,12 +303,12 @@ func_ov00_020d5dc4: ; 0x020d5dc4
 	add sb, r7, sb, asr #12
 	mul r7, r4, r3
 	mul r3, r2, r3
-	mul r6, ip, fp
+	mul r6, ip, r11
 	mul lr, ip, lr
 	mul ip, r4, r5
-	mul r8, r4, fp
+	mul r8, r4, r11
 	mul r4, r2, r5
-	mul r2, sl, fp
+	mul r2, sl, r11
 	add sl, r1, #0x800
 	add r1, r8, #0x800
 	sub r1, sb, r1, asr #12
@@ -330,17 +330,17 @@ func_ov00_020d5dc4: ; 0x020d5dc4
 	str r5, [r0, #8]
 	sub r1, r3, r1, asr #12
 	str r1, [r0, #0xc]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	arm_func_end func_ov00_020d5dc4
 
 	.global func_ov00_020d5eac
 	arm_func_start func_ov00_020d5eac
 func_ov00_020d5eac: ; 0x020d5eac
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	ldr r5, [r1]
 	ldr r4, [r0, #0xc]
 	ldr r2, [r0, #8]
-	ldmib r1, {r3, fp, lr}
+	ldmib r1, {r3, r11, lr}
 	ldmia r0, {r6, ip}
 	mul sl, r5, r4
 	mul r1, lr, r6
@@ -354,11 +354,11 @@ func_ov00_020d5eac: ; 0x020d5eac
 	add sl, sl, r1, asr #12
 	add r7, r7, #0x800
 	add r7, sl, r7, asr #12
-	mul sl, fp, ip
+	mul sl, r11, ip
 	add sl, sl, #0x800
 	sub r7, r7, sl, asr #12
-	mul sl, fp, r6
-	mul r1, fp, r4
+	mul sl, r11, r6
+	mul r1, r11, r4
 	str r7, [r0]
 	mul r4, lr, r4
 	mul r7, lr, r2
@@ -372,12 +372,12 @@ func_ov00_020d5eac: ; 0x020d5eac
 	add sl, r8, sl, asr #12
 	mul r8, r5, ip
 	mul r5, r3, ip
-	mul r2, fp, r2
-	add fp, r1, #0x800
+	mul r2, r11, r2
+	add r11, r1, #0x800
 	add r1, sb, #0x800
 	add r3, lr, #0x800
 	add sb, r7, #0x800
-	mov r7, fp, asr #0xc
+	mov r7, r11, asr #0xc
 	sub r1, sl, r1, asr #12
 	str r1, [r0, #4]
 	add r8, r8, #0x800
@@ -394,7 +394,7 @@ func_ov00_020d5eac: ; 0x020d5eac
 	str r5, [r0, #8]
 	sub r1, r3, r1, asr #12
 	str r1, [r0, #0xc]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	arm_func_end func_ov00_020d5eac
 
 	.global func_ov00_020d5f98

--- a/asm/ov00/ov00_020d59f0.inc
+++ b/asm/ov00/ov00_020d59f0.inc
@@ -209,7 +209,7 @@ func_ov00_020d5c54: ; 0x020d5c54
 	.global func_ov00_020d5cd8
 	arm_func_start func_ov00_020d5cd8
 func_ov00_020d5cd8: ; 0x020d5cd8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	ldr r3, [r0, #4]
 	ldr r2, [r0, #8]
 	ldr r4, [r0, #0xc]
@@ -221,11 +221,11 @@ func_ov00_020d5cd8: ; 0x020d5cd8
 	mul sb, r4, r3
 	mul r6, lr, r2
 	mul r8, lr, lr
-	add sl, r0, #0x800
+	add r10, r0, #0x800
 	mul r0, r4, lr
 	add lr, r5, #0x800
 	mul r5, r2, r3
-	mov r4, sl, asr #0xc
+	mov r4, r10, asr #0xc
 	add r3, ip, #0x800
 	add r2, r4, lr, asr #12
 	add ip, sb, #0x800
@@ -267,17 +267,17 @@ func_ov00_020d5cd8: ; 0x020d5cd8
 	str r0, [r1, #0x1c]
 	rsb r0, r4, #0x1000
 	str r0, [r1, #0x20]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	arm_func_end func_ov00_020d5cd8
 
 	.global func_ov00_020d5dc4
 	arm_func_start func_ov00_020d5dc4
 func_ov00_020d5dc4: ; 0x020d5dc4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	ldr r4, [r0]
 	ldr r5, [r1]
 	ldmib r1, {r3, r11, lr}
-	ldmib r0, {r2, sl, ip}
+	ldmib r0, {r2, r10, ip}
 	mul sb, r4, lr
 	mul r1, ip, r5
 	mul r6, r2, r11
@@ -290,11 +290,11 @@ func_ov00_020d5dc4: ; 0x020d5dc4
 	add sb, sb, r1, asr #12
 	add r6, r6, #0x800
 	add r6, sb, r6, asr #12
-	mul sb, sl, r3
+	mul sb, r10, r3
 	add sb, sb, #0x800
 	sub r6, r6, sb, asr #12
-	mul sb, sl, r5
-	mul r1, sl, lr
+	mul sb, r10, r5
+	mul r1, r10, lr
 	str r6, [r0]
 	add r8, r8, #0x800
 	mov r7, r7, asr #0xc
@@ -308,14 +308,14 @@ func_ov00_020d5dc4: ; 0x020d5dc4
 	mul ip, r4, r5
 	mul r8, r4, r11
 	mul r4, r2, r5
-	mul r2, sl, r11
-	add sl, r1, #0x800
+	mul r2, r10, r11
+	add r10, r1, #0x800
 	add r1, r8, #0x800
 	sub r1, sb, r1, asr #12
 	add r5, ip, #0x800
 	add r8, r6, #0x800
 	str r1, [r0, #4]
-	mov r6, sl, asr #0xc
+	mov r6, r10, asr #0xc
 	add sb, r7, #0x800
 	add r7, r6, r8, asr #12
 	add r8, r7, sb, asr #12
@@ -330,34 +330,34 @@ func_ov00_020d5dc4: ; 0x020d5dc4
 	str r5, [r0, #8]
 	sub r1, r3, r1, asr #12
 	str r1, [r0, #0xc]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	arm_func_end func_ov00_020d5dc4
 
 	.global func_ov00_020d5eac
 	arm_func_start func_ov00_020d5eac
 func_ov00_020d5eac: ; 0x020d5eac
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	ldr r5, [r1]
 	ldr r4, [r0, #0xc]
 	ldr r2, [r0, #8]
 	ldmib r1, {r3, r11, lr}
 	ldmia r0, {r6, ip}
-	mul sl, r5, r4
+	mul r10, r5, r4
 	mul r1, lr, r6
 	mul r7, r3, r2
-	add sl, sl, #0x800
+	add r10, r10, #0x800
 	mul r8, r3, r4
 	mul sb, lr, ip
 	add r8, r8, #0x800
 	add r1, r1, #0x800
-	mov sl, sl, asr #0xc
-	add sl, sl, r1, asr #12
+	mov r10, r10, asr #0xc
+	add r10, r10, r1, asr #12
 	add r7, r7, #0x800
-	add r7, sl, r7, asr #12
-	mul sl, r11, ip
-	add sl, sl, #0x800
-	sub r7, r7, sl, asr #12
-	mul sl, r11, r6
+	add r7, r10, r7, asr #12
+	mul r10, r11, ip
+	add r10, r10, #0x800
+	sub r7, r7, r10, asr #12
+	mul r10, r11, r6
 	mul r1, r11, r4
 	str r7, [r0]
 	mul r4, lr, r4
@@ -367,9 +367,9 @@ func_ov00_020d5eac: ; 0x020d5eac
 	add sb, sb, #0x800
 	mov r8, r8, asr #0xc
 	add r8, r8, sb, asr #12
-	add sl, sl, #0x800
+	add r10, r10, #0x800
 	mul sb, r5, r2
-	add sl, r8, sl, asr #12
+	add r10, r8, r10, asr #12
 	mul r8, r5, ip
 	mul r5, r3, ip
 	mul r2, r11, r2
@@ -378,7 +378,7 @@ func_ov00_020d5eac: ; 0x020d5eac
 	add r3, lr, #0x800
 	add sb, r7, #0x800
 	mov r7, r11, asr #0xc
-	sub r1, sl, r1, asr #12
+	sub r1, r10, r1, asr #12
 	str r1, [r0, #4]
 	add r8, r8, #0x800
 	add r7, r7, sb, asr #12
@@ -394,7 +394,7 @@ func_ov00_020d5eac: ; 0x020d5eac
 	str r5, [r0, #8]
 	sub r1, r3, r1, asr #12
 	str r1, [r0, #0xc]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	arm_func_end func_ov00_020d5eac
 
 	.global func_ov00_020d5f98

--- a/asm/ov00/ov00_020d59f0.inc
+++ b/asm/ov00/ov00_020d59f0.inc
@@ -209,7 +209,7 @@ func_ov00_020d5c54: ; 0x020d5c54
 	.global func_ov00_020d5cd8
 	arm_func_start func_ov00_020d5cd8
 func_ov00_020d5cd8: ; 0x020d5cd8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	ldr r3, [r0, #4]
 	ldr r2, [r0, #8]
 	ldr r4, [r0, #0xc]
@@ -218,7 +218,7 @@ func_ov00_020d5cd8: ; 0x020d5cd8
 	mul r5, r2, r2
 	mul ip, r4, r2
 	mul r7, lr, r3
-	mul sb, r4, r3
+	mul r9, r4, r3
 	mul r6, lr, r2
 	mul r8, lr, lr
 	add r10, r0, #0x800
@@ -228,13 +228,13 @@ func_ov00_020d5cd8: ; 0x020d5cd8
 	mov r4, r10, asr #0xc
 	add r3, ip, #0x800
 	add r2, r4, lr, asr #12
-	add ip, sb, #0x800
+	add ip, r9, #0x800
 	mov r2, r2, lsl #0x1
 	rsb r2, r2, #0x1000
 	add r8, r8, #0x800
-	mov sb, lr, asr #0xc
+	mov r9, lr, asr #0xc
 	add lr, r0, #0x800
-	add r0, sb, r8, asr #12
+	add r0, r9, r8, asr #12
 	mov r0, r0, lsl #0x1
 	add r4, r4, r8, asr #12
 	mov r4, r4, lsl #0x1
@@ -242,10 +242,10 @@ func_ov00_020d5cd8: ; 0x020d5cd8
 	mov r3, r3, asr #0xc
 	add r8, r3, r7, asr #12
 	rsb r7, r3, r7, asr #12
-	add sb, r6, #0x800
+	add r9, r6, #0x800
 	mov r3, ip, asr #0xc
-	rsb r6, r3, sb, asr #12
-	add r3, r3, sb, asr #12
+	rsb r6, r3, r9, asr #12
+	add r3, r3, r9, asr #12
 	str r2, [r1]
 	mov r2, r8, lsl #0x1
 	str r2, [r1, #4]
@@ -267,40 +267,40 @@ func_ov00_020d5cd8: ; 0x020d5cd8
 	str r0, [r1, #0x1c]
 	rsb r0, r4, #0x1000
 	str r0, [r1, #0x20]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	arm_func_end func_ov00_020d5cd8
 
 	.global func_ov00_020d5dc4
 	arm_func_start func_ov00_020d5dc4
 func_ov00_020d5dc4: ; 0x020d5dc4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	ldr r4, [r0]
 	ldr r5, [r1]
 	ldmib r1, {r3, r11, lr}
 	ldmib r0, {r2, r10, ip}
-	mul sb, r4, lr
+	mul r9, r4, lr
 	mul r1, ip, r5
 	mul r6, r2, r11
-	add sb, sb, #0x800
+	add r9, r9, #0x800
 	mul r7, r2, lr
 	mul r8, ip, r3
 	add r7, r7, #0x800
 	add r1, r1, #0x800
-	mov sb, sb, asr #0xc
-	add sb, sb, r1, asr #12
+	mov r9, r9, asr #0xc
+	add r9, r9, r1, asr #12
 	add r6, r6, #0x800
-	add r6, sb, r6, asr #12
-	mul sb, r10, r3
-	add sb, sb, #0x800
-	sub r6, r6, sb, asr #12
-	mul sb, r10, r5
+	add r6, r9, r6, asr #12
+	mul r9, r10, r3
+	add r9, r9, #0x800
+	sub r6, r6, r9, asr #12
+	mul r9, r10, r5
 	mul r1, r10, lr
 	str r6, [r0]
 	add r8, r8, #0x800
 	mov r7, r7, asr #0xc
 	add r7, r7, r8, asr #12
-	add sb, sb, #0x800
-	add sb, r7, sb, asr #12
+	add r9, r9, #0x800
+	add r9, r7, r9, asr #12
 	mul r7, r4, r3
 	mul r3, r2, r3
 	mul r6, ip, r11
@@ -311,14 +311,14 @@ func_ov00_020d5dc4: ; 0x020d5dc4
 	mul r2, r10, r11
 	add r10, r1, #0x800
 	add r1, r8, #0x800
-	sub r1, sb, r1, asr #12
+	sub r1, r9, r1, asr #12
 	add r5, ip, #0x800
 	add r8, r6, #0x800
 	str r1, [r0, #4]
 	mov r6, r10, asr #0xc
-	add sb, r7, #0x800
+	add r9, r7, #0x800
 	add r7, r6, r8, asr #12
-	add r8, r7, sb, asr #12
+	add r8, r7, r9, asr #12
 	add r6, lr, #0x800
 	mov r5, r5, asr #0xc
 	add r7, r4, #0x800
@@ -330,13 +330,13 @@ func_ov00_020d5dc4: ; 0x020d5dc4
 	str r5, [r0, #8]
 	sub r1, r3, r1, asr #12
 	str r1, [r0, #0xc]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	arm_func_end func_ov00_020d5dc4
 
 	.global func_ov00_020d5eac
 	arm_func_start func_ov00_020d5eac
 func_ov00_020d5eac: ; 0x020d5eac
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	ldr r5, [r1]
 	ldr r4, [r0, #0xc]
 	ldr r2, [r0, #8]
@@ -347,7 +347,7 @@ func_ov00_020d5eac: ; 0x020d5eac
 	mul r7, r3, r2
 	add r10, r10, #0x800
 	mul r8, r3, r4
-	mul sb, lr, ip
+	mul r9, lr, ip
 	add r8, r8, #0x800
 	add r1, r1, #0x800
 	mov r10, r10, asr #0xc
@@ -364,24 +364,24 @@ func_ov00_020d5eac: ; 0x020d5eac
 	mul r7, lr, r2
 	mul lr, r5, r6
 	mul r6, r3, r6
-	add sb, sb, #0x800
+	add r9, r9, #0x800
 	mov r8, r8, asr #0xc
-	add r8, r8, sb, asr #12
+	add r8, r8, r9, asr #12
 	add r10, r10, #0x800
-	mul sb, r5, r2
+	mul r9, r5, r2
 	add r10, r8, r10, asr #12
 	mul r8, r5, ip
 	mul r5, r3, ip
 	mul r2, r11, r2
 	add r11, r1, #0x800
-	add r1, sb, #0x800
+	add r1, r9, #0x800
 	add r3, lr, #0x800
-	add sb, r7, #0x800
+	add r9, r7, #0x800
 	mov r7, r11, asr #0xc
 	sub r1, r10, r1, asr #12
 	str r1, [r0, #4]
 	add r8, r8, #0x800
-	add r7, r7, sb, asr #12
+	add r7, r7, r9, asr #12
 	add r4, r4, #0x800
 	mov r3, r3, asr #0xc
 	rsb r4, r3, r4, asr #12
@@ -394,7 +394,7 @@ func_ov00_020d5eac: ; 0x020d5eac
 	str r5, [r0, #8]
 	sub r1, r3, r1, asr #12
 	str r1, [r0, #0xc]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	arm_func_end func_ov00_020d5eac
 
 	.global func_ov00_020d5f98

--- a/asm/ov01.s
+++ b/asm/ov01.s
@@ -23,7 +23,7 @@ _020eed68: .word data_ov01_020f8b60
 	.global func_ov01_020eed6c
 	arm_func_start func_ov01_020eed6c
 func_ov01_020eed6c: ; 0x020eed6c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	mov r6, r0
 	mov r4, r1
 	mov r7, r2
@@ -35,25 +35,25 @@ func_ov01_020eed6c: ; 0x020eed6c
 	beq _020eeda0
 	bl func_0200ee60
 	mov r0, #3
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _020eeda0:
 	cmp r6, #0
 	bne _020eedb4
 	bl func_0200ee60
 	mov r0, #6
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _020eedb4:
 	cmp r4, #3
 	bls _020eedc8
 	bl func_0200ee60
 	mov r0, #6
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _020eedc8:
 	tst r6, #0x1f
 	beq _020eeddc
 	bl func_0200ee60
 	mov r0, #6
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _020eeddc:
 	blx func_02008a50
 	mov r0, #0xa
@@ -64,7 +64,7 @@ _020eeddc:
 	mov r0, r5
 	bl func_0200ee60
 	mov r0, #4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _020eee04:
 	mov r0, r6
 	mov r1, r7
@@ -120,13 +120,13 @@ _020eeeb0:
 	mov r6, #0
 	mov r4, #0x8000
 	ldr r10, _020eef48 ; =data_ov01_020f8c00
-	mov sb, #2
+	mov r9, #2
 	ldr r8, _020eef40 ; =data_ov01_020f8b68
 	mov r7, #1
 	b _020eef0c
 _020eeee4:
 	mov r2, r6, lsl #0x8
-	mov r1, sb
+	mov r1, r9
 	add r0, r10, r6, lsl #8
 	strh r4, [r10, r2]
 	bl func_0200e2a4
@@ -147,7 +147,7 @@ _020eef0c:
 	strh r2, [r1]
 	bl func_0200ee60
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov01_020eed6c
 _020eef3c: .word data_ov01_020f8b60
@@ -410,14 +410,14 @@ _020ef250: .word data_ov01_020f8b60
 	.global func_ov01_020ef254
 	arm_func_start func_ov01_020ef254
 func_ov01_020ef254: ; 0x020ef254
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #8
 	ldr r0, _020ef5ec ; =data_ov01_020f8b60
 	cmp r2, #0
 	ldr r4, [r0, #4]
 	mov r10, r1
 	addne sp, sp, #8
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, [r4, #0x10]
 	mov r1, #0x100
 	bl func_0200e288
@@ -512,11 +512,11 @@ _020ef3a8:
 	bl func_ov01_020eef50
 	cmp r4, #0
 	addeq sp, sp, #8
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	mov r0, r10
 	blx r4
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _020ef3e4:
 	ldr r1, [r0, #0x18]
 	cmp r1, #0
@@ -527,7 +527,7 @@ _020ef3e4:
 	ldrh r0, [r0]
 	cmp r0, #0
 	addeq sp, sp, #8
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _020ef40c:
 	ldrh r0, [r10]
 	cmp r0, #8
@@ -544,7 +544,7 @@ _020ef40c:
 	mov r7, #0
 	str r0, [sp, #4]
 	ldrh r8, [r10, #0x2c]
-	ldrh sb, [r10, #0x2e]
+	ldrh r9, [r10, #0x2e]
 	b _020ef480
 _020ef450:
 	cmp r0, #0xc
@@ -557,7 +557,7 @@ _020ef450:
 	str r0, [sp, #4]
 	add r0, r10, #0x10
 	ldrh r8, [r10, #0x16]
-	ldrh sb, [r10, #0x18]
+	ldrh r9, [r10, #0x18]
 	str r0, [sp]
 _020ef480:
 	cmp r5, #7
@@ -613,15 +613,15 @@ _020ef538:
 _020ef544:
 	cmp r7, #0
 	moveq r1, r8
-	movne r1, sb
+	movne r1, r9
 	cmp r7, #0
 	ldr r0, _020ef5ec ; =data_ov01_020f8b60
 	ldr r7, _020ef5ec ; =data_ov01_020f8b60
 	strh r1, [r0, #0x90]
-	movne sb, r8
+	movne r9, r8
 	ldr r5, _020ef5f0 ; =data_ov01_020f8bb0
 	mov r6, #0
-	strh sb, [r7, #0x92]
+	strh r9, [r7, #0x92]
 _020ef570:
 	strh r6, [r7, #0x56]
 	add r2, r4, r6, lsl #2
@@ -647,7 +647,7 @@ _020ef5ac:
 	ldr r0, [r4, #0x10]
 	cmp r10, r0
 	addeq sp, sp, #8
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldrh r2, [r10]
 	mov r0, r10
 	mov r1, #0x100
@@ -655,7 +655,7 @@ _020ef5ac:
 	strh r2, [r10]
 	bl func_0200e2a4
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov01_020ef254
 _020ef5ec: .word data_ov01_020f8b60
@@ -1925,7 +1925,7 @@ _020f05f0:
 	.global func_ov01_020f061c
 	arm_func_start func_ov01_020f061c
 func_ov01_020f061c: ; 0x020f061c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x30
 	mov r8, r0
 	mov r7, r1
@@ -1939,7 +1939,7 @@ func_ov01_020f061c: ; 0x020f061c
 	bl func_ov01_020ef1c0
 	cmp r0, #0
 	addne sp, sp, #0x30
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	add r0, r4, #0x188
 	mov r1, #2
 	bl func_0200e288
@@ -1953,7 +1953,7 @@ func_ov01_020f061c: ; 0x020f061c
 	cmpne r0, #1
 	addne sp, sp, #0x30
 	movne r0, #3
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	add r0, r4, #0xc
 	mov r1, #4
 	bl func_0200e288
@@ -1961,16 +1961,16 @@ func_ov01_020f061c: ; 0x020f061c
 	cmp r0, #1
 	addeq sp, sp, #0x30
 	moveq r0, #3
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	tst r6, #0x3f
 	addne sp, sp, #0x30
 	movne r0, #6
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
-	ldrh sb, [sp, #0x50]
-	tst sb, #0x1f
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
+	ldrh r9, [sp, #0x50]
+	tst r9, #0x1f
 	addne sp, sp, #0x30
 	movne r0, #6
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	add r0, r4, #0x9c
 	mov r1, #2
 	bl func_0200e288
@@ -1981,12 +1981,12 @@ func_ov01_020f061c: ; 0x020f061c
 	cmp r6, r0
 	addlt sp, sp, #0x30
 	movlt r0, #6
-	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmltia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	bl func_ov01_020ef850
-	cmp sb, r0
+	cmp r9, r0
 	addlt sp, sp, #0x30
 	movlt r0, #6
-	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmltia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _020f0714:
 	mov r1, r8
 	mov r0, #0xe
@@ -2013,7 +2013,7 @@ _020f0714:
 	cmp r0, #0
 	moveq r0, #2
 	add sp, sp, #0x30
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	arm_func_end func_ov01_020f061c
 
 	.global func_ov01_020f077c
@@ -2152,9 +2152,9 @@ func_ov01_020f08f8: ; 0x020f08f8
 	.global func_ov01_020f093c
 	arm_func_start func_ov01_020f093c
 func_ov01_020f093c: ; 0x020f093c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x14
-	mov sb, r0
+	mov r9, r0
 	mov r8, r1
 	mov r7, r2
 	mov r6, r3
@@ -2167,7 +2167,7 @@ func_ov01_020f093c: ; 0x020f093c
 	bl func_ov01_020ef1c0
 	cmp r0, #0
 	addne sp, sp, #0x14
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	add r0, r5, #0x3c
 	mov r1, #2
 	bl func_0200e288
@@ -2191,11 +2191,11 @@ _020f09c8:
 	cmp r7, #0
 	addeq sp, sp, #0x14
 	moveq r0, #6
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	cmp r4, #0
 	addeq sp, sp, #0x14
 	moveq r0, #7
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	add r0, r5, #0x7c
 	mov r1, #2
 	bl func_0200e288
@@ -2203,15 +2203,15 @@ _020f09c8:
 	cmp r7, r0
 	addeq sp, sp, #0x14
 	moveq r0, #6
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	cmp r6, #0x200
 	addhi sp, sp, #0x14
 	movhi r0, #6
-	ldmhiia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmhiia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	cmp r6, #0
 	addeq sp, sp, #0x14
 	moveq r0, #6
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	mov r0, r7
 	mov r1, r6
 	bl func_0200e2a4
@@ -2221,7 +2221,7 @@ _020f09c8:
 	str r2, [sp]
 	str r1, [sp, #4]
 	str r0, [sp, #8]
-	str sb, [sp, #0xc]
+	str r9, [sp, #0xc]
 	mov r2, r7
 	mov r3, r6
 	mov r0, #0xf
@@ -2231,7 +2231,7 @@ _020f09c8:
 	cmp r0, #0
 	moveq r0, #2
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	arm_func_end func_ov01_020f093c
 
 	.global func_ov01_020f0a78
@@ -2404,7 +2404,7 @@ func_ov01_020f0c54: ; 0x020f0c54
 	.global func_ov01_020f0cc0
 	arm_func_start func_ov01_020f0cc0
 func_ov01_020f0cc0: ; 0x020f0cc0
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0xc
 	mov r10, r0
 	mov r7, r1
@@ -2417,19 +2417,19 @@ func_ov01_020f0cc0: ; 0x020f0cc0
 	bl func_ov01_020ef1c0
 	cmp r0, #0
 	addne sp, sp, #0xc
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	cmp r10, #0
 	addeq sp, sp, #0xc
 	moveq r0, #6
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	cmp r7, #0x10
 	addhs sp, sp, #0xc
 	movhs r0, #6
-	ldmhsia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmhsia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	cmp r6, #0
 	addeq sp, sp, #0xc
 	moveq r0, #6
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	bl func_ov01_020ef640
 	movs r4, r0
 	bne _020f0d3c
@@ -2470,7 +2470,7 @@ _020f0d3c:
 	strh r0, [r3, #0xe]
 	add sp, sp, #0xc
 	mov r0, #6
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _020f0dc8:
 	add r0, r0, #4
 	strh r0, [r3, #0x14]
@@ -2493,7 +2493,7 @@ _020f0de8:
 	mov r2, r10
 	bl func_ov01_020ef72c
 	mov r7, r10
-	mov sb, #0
+	mov r9, #0
 	add r4, r10, #0x800
 	mov r6, #1
 	ldr r11, _020f0f08 ; =func_ov01_020f12a4
@@ -2518,7 +2518,7 @@ _020f0e30:
 	bl func_ov01_020f093c
 	cmp r0, #7
 	bne _020f0e98
-	add r0, r10, sb, lsl #1
+	add r0, r10, r9, lsl #1
 	add r0, r0, #0x800
 	strh r5, [r0]
 	ldrh r0, [r4, #0xa]
@@ -2535,16 +2535,16 @@ _020f0e98:
 	strh r1, [r0, #0x1c]
 	add sp, sp, #0xc
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _020f0ebc:
 	add r7, r7, #0x200
-	add sb, sb, #1
+	add r9, r9, #1
 _020f0ec4:
 	ldrh r0, [r4, #0x18]
 	cmp r0, #1
 	movne r0, #1
 	moveq r0, #2
-	cmp sb, r0
+	cmp r9, r0
 	blt _020f0e30
 	b _020f0ef8
 _020f0ee0:
@@ -2557,7 +2557,7 @@ _020f0ee0:
 _020f0ef8:
 	mov r0, #0
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov01_020f0cc0
 _020f0f04: .word func_ov01_020f137c
@@ -2591,10 +2591,10 @@ func_ov01_020f0f14: ; 0x020f0f14
 	.global func_ov01_020f0f5c
 	arm_func_start func_ov01_020f0f5c
 func_ov01_020f0f5c: ; 0x020f0f5c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0xc
 	mov r10, r0
-	mov sb, r1
+	mov r9, r1
 	mov r8, r2
 	mov r0, #2
 	mov r1, #9
@@ -2602,19 +2602,19 @@ func_ov01_020f0f5c: ; 0x020f0f5c
 	bl func_ov01_020ef1c0
 	cmp r0, #0
 	addne sp, sp, #0xc
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	cmp r10, #0
 	addeq sp, sp, #0xc
 	moveq r0, #6
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
-	cmp sb, #0
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
+	cmp r9, #0
 	addeq sp, sp, #0xc
 	moveq r0, #6
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	cmp r8, #0
 	addeq sp, sp, #0xc
 	moveq r0, #6
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	bl func_ov01_020ef640
 	movs r5, r0
 	bne _020f0fd0
@@ -2626,12 +2626,12 @@ _020f0fd0:
 	cmp r0, #5
 	addeq sp, sp, #0xc
 	moveq r0, #1
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	cmp r0, #1
 	cmpne r0, #4
 	addne sp, sp, #0xc
 	movne r0, #3
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	cmp r5, #0
 	mov r7, #5
 	bne _020f1194
@@ -2679,7 +2679,7 @@ _020f1094:
 	strh r1, [r0, #0x1c]
 	add sp, sp, #0xc
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _020f10b8:
 	add r0, r10, #0x800
 	ldrh r2, [r0, #0xc]
@@ -2727,7 +2727,7 @@ _020f1150:
 	cmp r5, #0
 	beq _020f1290
 	mov r0, r10
-	mov r2, sb
+	mov r2, r9
 	mov r1, #0
 	bl func_ov01_020f159c
 	add r0, r10, #0x800
@@ -2777,7 +2777,7 @@ _020f1214:
 	add r0, r10, #0x800
 	ldrh r1, [r0, #0xa]
 	ldrh r2, [r0, #0x10]
-	mov r0, sb
+	mov r0, r9
 	add r6, r10, r1, lsl #9
 	add r1, r6, #0x20
 	bl func_020078d8
@@ -2806,7 +2806,7 @@ _020f1214:
 _020f1290:
 	mov r0, r7
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov01_020f0f5c
 _020f129c: .word func_ov01_020f12a4
@@ -3093,10 +3093,10 @@ _020f1638:
 	.global func_ov01_020f1668
 	arm_func_start func_ov01_020f1668
 func_ov01_020f1668: ; 0x020f1668
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #0xc
 	mov r10, r0
-	mov sb, r1
+	mov r9, r1
 	bl func_0200ee4c
 	add r1, r10, #0x800
 	ldrh r1, [r1, #8]
@@ -3129,7 +3129,7 @@ func_ov01_020f1668: ; 0x020f1668
 	strh r5, [r0, #8]
 	ldrh r0, [r0, #0xe]
 	mov r1, r6, lsl #0x9
-	cmp sb, #1
+	cmp r9, #1
 	strh r0, [r10, r1]
 	ldreqh r0, [r10, r1]
 	biceq r0, r0, #1
@@ -3163,21 +3163,21 @@ func_ov01_020f1668: ; 0x020f1668
 	add r1, r1, #1
 	and r1, r1, #3
 	strh r1, [r0, #0xa]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 _020f1784:
 	cmp r0, #0
 	cmpne r0, #2
 	addeq sp, sp, #0xc
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	add r0, r10, #0x800
 	mov r1, #5
 	strh r1, [r0, #0x1c]
 	add sp, sp, #0xc
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 _020f17a8:
 	bl func_0200ee60
 	add sp, sp, #0xc
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov01_020f1668
 _020f17b4: .word func_ov01_020f12a4
@@ -10753,20 +10753,20 @@ _020f5254: .word 0x00300010
 	.global func_ov01_020f5258
 	arm_func_start func_ov01_020f5258
 func_ov01_020f5258: ; 0x020f5258
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
-	mov sb, r1
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
+	mov r9, r1
 	mov r10, r0
-	cmp sb, #0x1f
+	cmp r9, #0x1f
 	bge _020f52c4
 	mov r1, #0x16
 	add r4, r10, #0x1c0
 	add r5, r10, #0x40
 	mov r0, #0xc
-	mla r6, sb, r0, r5
-	mla r7, sb, r1, r4
+	mla r6, r9, r0, r5
+	mla r7, r9, r1, r4
 	mov r11, r1
 _020f5288:
-	add r8, sb, #1
+	add r8, r9, #1
 	mov r0, #0xc
 	mla r0, r8, r0, r5
 	mov r1, r6
@@ -10776,8 +10776,8 @@ _020f5288:
 	mov r1, r7
 	mov r2, #0x16
 	bl func_020078d8
-	add sb, sb, #1
-	cmp sb, #0x1f
+	add r9, r9, #1
+	cmp r9, #0x1f
 	add r6, r6, #0xc
 	add r7, r7, #0x16
 	blt _020f5288
@@ -10795,18 +10795,18 @@ _020f52c4:
 	mov r1, #0x500
 	blx func_0202f134
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	arm_func_end func_ov01_020f5258
 
 	.global func_ov01_020f52fc
 	arm_func_start func_ov01_020f52fc
 func_ov01_020f52fc: ; 0x020f52fc
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	mov r10, r0
 	mov r0, #0
 	cmp r1, #0
 	str r0, [sp]
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r8, [sp]
 	add r6, r10, #0x40
 	mov r4, r0
@@ -10814,20 +10814,20 @@ func_ov01_020f52fc: ; 0x020f52fc
 	mvn r11, #0
 _020f5328:
 	mov r0, #0xc
-	mla sb, r8, r0, r6
+	mla r9, r8, r0, r6
 	mov r7, r11
 _020f5334:
 	cmp r8, #0x20
 	blt _020f5358
 	ldr r0, [sp]
 	cmp r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, _020f53ac ; =data_027e0d54
 	add r1, r10, #0x40
 	bl func_ov10_021188c8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _020f5358:
-	mov r0, sb
+	mov r0, r9
 	blx func_ov00_020777d0
 	cmp r0, #0
 	movne r0, r5
@@ -10845,11 +10845,11 @@ _020f5358:
 	str r0, [sp]
 	b _020f5328
 _020f539c:
-	add sb, sb, #0xc
+	add r9, r9, #0xc
 	add r8, r8, #1
 	b _020f5334
 _020f53a8:
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	arm_func_end func_ov01_020f52fc
 _020f53ac: .word data_027e0d54
 
@@ -11182,7 +11182,7 @@ _020f57a8: .word data_ov00_020e899c
 	.global func_ov01_020f57ac
 	arm_func_start func_ov01_020f57ac
 func_ov01_020f57ac: ; 0x020f57ac
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #0x14
 	mov r6, r0
 	ldrb r0, [r6, #0x4c]
@@ -11235,15 +11235,15 @@ _020f585c:
 	movne r0, #0
 	strneb r0, [r6, #0x4c]
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 _020f587c:
-	mov sb, #0
+	mov r9, #0
 	mov r4, r6
 	add r5, r6, #4
-	mov r7, sb
-	mov r8, sb
+	mov r7, r9
+	mov r8, r9
 _020f5890:
-	cmp sb, #2
+	cmp r9, #2
 	bne _020f58e4
 	mov r0, r6
 	ldrh r10, [r4, #0xe]
@@ -11263,7 +11263,7 @@ _020f5890:
 	beq _020f5924
 	add sp, sp, #0x14
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 _020f58e4:
 	mov r0, r5
 	ldr ip, [r0]
@@ -11280,16 +11280,16 @@ _020f58e4:
 	cmp r0, #0
 	addne sp, sp, #0x14
 	movne r0, #1
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 _020f5924:
-	add sb, sb, #1
-	cmp sb, #3
+	add r9, r9, #1
+	cmp r9, #3
 	add r4, r4, #0x18
 	add r5, r5, #0x18
 	blt _020f5890
 	mov r0, #0
 	add sp, sp, #0x14
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov01_020f57ac
 _020f5944: .word data_027e0d78
@@ -11363,18 +11363,18 @@ _020f5a1c: .word data_ov00_020eec9c
 	.global func_ov01_020f5a20
 	arm_func_start func_ov01_020f5a20
 func_ov01_020f5a20: ; 0x020f5a20
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x30
 	mov r10, r0
 	add r0, sp, #0x10
-	mov sb, r1
+	mov r9, r1
 	mov r8, r2
 	bl func_01ffbe34
 	mov r0, #1
 	strb r0, [sp, #0x1a]
 	add r1, sp, #0x10
 	str r1, [sp]
-	mov r2, sb
+	mov r2, r9
 	mov r3, r8
 	mov r0, #0x10c
 	mov r1, #0xc
@@ -11400,7 +11400,7 @@ _020f5a90:
 	mov r0, r11
 	mov r1, #0x1c
 	mov r2, #0xf
-	mov r3, sb
+	mov r3, r9
 	str r5, [sp, #4]
 	bl func_020349cc
 	b _020f5b00
@@ -11412,14 +11412,14 @@ _020f5abc:
 	mov r0, #0x10c
 	mov r1, #0x1d
 	mov r2, #0x10
-	mov r3, sb
+	mov r3, r9
 	str r5, [sp, #4]
 	bl func_020349cc
 	b _020f5b00
 _020f5ae8:
 	mov r0, r7
 	str r4, [sp]
-	mov r1, sb
+	mov r1, r9
 	mov r2, r8
 	mov r3, r5
 	bl func_ov00_020d00c4
@@ -11445,7 +11445,7 @@ _020f5b00:
 	bne _020f5b6c
 	bl func_ov01_020f5bb0
 	add r3, r8, r0
-	mov r2, sb
+	mov r2, r9
 	mov r0, #0x10c
 	mov r1, #0xd
 	str r4, [sp]
@@ -11455,7 +11455,7 @@ _020f5b6c:
 	bl func_ov01_020f5bb0
 	add r0, r8, r0
 	str r0, [sp]
-	mov r3, sb
+	mov r3, r9
 	mov r0, #0x10c
 	mov r1, #0xe
 	mov r2, #0xd
@@ -11469,7 +11469,7 @@ _020f5b90:
 	str r2, [sp]
 	bl func_0203493c
 	add sp, sp, #0x30
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	arm_func_end func_ov01_020f5a20
 
 	.global func_ov01_020f5bb0
@@ -11596,7 +11596,7 @@ _020f5d34: .word func_ov01_020f576c
 	.global func_ov01_020f5d38
 	arm_func_start func_ov01_020f5d38
 func_ov01_020f5d38: ; 0x020f5d38
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x18
 	mov r10, r0
 	str r2, [sp, #0x10]
@@ -11648,40 +11648,40 @@ func_ov01_020f5d38: ; 0x020f5d38
 	mov r2, #0xa
 	mov r3, #0xb
 	bl func_ov00_020cfed0
-	mov sb, #0
+	mov r9, #0
 	mov r0, #0x16
 	mov r8, #1
 	strb r0, [r10, #0x57]
 	add r6, r10, #0x14
-	mov r7, sb
+	mov r7, r9
 	mvn r5, #0
 	mov r4, r8
-	mov r11, sb
+	mov r11, r9
 _020f5e2c:
-	add r0, sb, #0x71
+	add r0, r9, #0x71
 	stmia sp, {r0, r8}
-	add r1, sb, #3
+	add r1, r9, #3
 	mov r0, #0x18
 	mla r0, r1, r0, r6
-	add r3, sb, #5
+	add r3, r9, #5
 	str r7, [sp, #8]
 	mov r1, #0x10c
 	mov r2, r5
 	and r3, r3, #0xff
 	str r7, [sp, #0xc]
 	bl func_ov00_020cfed0
-	add r0, sb, #0x75
+	add r0, r9, #0x75
 	stmia sp, {r0, r4, r11}
-	add r1, sb, #8
+	add r1, r9, #8
 	mov r0, #0x18
 	mla r0, r1, r0, r6
 	mov r1, #0x10c
 	mov r2, r5
-	and r3, sb, #0xff
+	and r3, r9, #0xff
 	str r11, [sp, #0xc]
 	bl func_ov00_020cfed0
-	add sb, sb, #1
-	cmp sb, #5
+	add r9, r9, #1
+	cmp r9, #5
 	blt _020f5e2c
 	ldr r1, [r10, #0x14c]
 	mov r0, r10
@@ -11699,7 +11699,7 @@ _020f5e2c:
 	mov r1, #0x10c
 	bl func_02032bd8
 	mov r6, #1
-	ldr sb, _020f5f80 ; =data_02068e7c
+	ldr r9, _020f5f80 ; =data_02068e7c
 	mov r8, #0
 	mov r7, #0x10
 	mov r4, r6
@@ -11721,7 +11721,7 @@ _020f5ee4:
 	mov r1, #1
 	mov r3, r2
 	bl func_02032714
-	str sb, [r5, #0x2c]
+	str r9, [r5, #0x2c]
 	strb r4, [r5, #0x4e]
 	mov r0, r10
 	mov r1, r8
@@ -11741,7 +11741,7 @@ _020f5ee4:
 	strb r2, [r10, #0x1c7]
 	bl func_ov01_020f5fd0
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov01_020f5d38
 _020f5f78: .word data_027e0cbc
@@ -12085,21 +12085,21 @@ _020f63d4: .word data_027e0d54
 	.global func_ov01_020f63d8
 	arm_func_start func_ov01_020f63d8
 func_ov01_020f63d8: ; 0x020f63d8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	mov r4, r0
 	ldr r0, [r4, #0xc]
 	cmp r0, #3
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	mov r6, #0
 	mov r8, r4
-	add sb, r4, #0x14
+	add r9, r4, #0x14
 	mov r5, r6
 _020f6400:
 	cmp r6, #7
 	cmpne r6, #0xc
 	beq _020f6448
-	mov r0, sb
+	mov r0, r9
 	ldr ip, [r0]
 	ldrh r7, [r8, #0x1e]
 	ldr ip, [ip]
@@ -12113,16 +12113,16 @@ _020f6400:
 	bl func_ov01_020f6468
 	cmp r0, #0
 	movne r0, #1
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _020f6448:
 	add r6, r6, #1
 	cmp r6, #0xd
 	add r8, r8, #0x18
-	add sb, sb, #0x18
+	add r9, r9, #0x18
 	blt _020f6400
 	add r0, r4, #0x14c
 	bl func_ov01_020f57ac
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	arm_func_end func_ov01_020f63d8
 
 	.global func_ov01_020f6468
@@ -12316,18 +12316,18 @@ func_ov01_020f66d0: ; 0x020f66d0
 	.global func_ov01_020f66e8
 	arm_func_start func_ov01_020f66e8
 func_ov01_020f66e8: ; 0x020f66e8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	mov r6, #0
 	mov r10, r0
 	mov r8, r6
-	mov sb, r6
+	mov r9, r6
 	sub r7, r6, #1
 	mov r4, r6
 	mov r5, #1
 _020f6708:
 	ldr r0, [r10, #8]
 	add r0, r0, #0x40
-	add r0, r0, sb
+	add r0, r0, r9
 	blx func_ov00_020777d0
 	cmp r0, #0
 	movne r0, r5
@@ -12343,29 +12343,29 @@ _020f673c:
 	mov r0, r0, lsl #0x18
 	mov r8, r0, asr #0x18
 	cmp r8, #0x20
-	add sb, sb, #0xc
+	add r9, r9, #0xc
 	blt _020f6708
 	cmp r6, #0x20
-	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmgeia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _020f675c:
 	add r0, r10, r6
 	add r6, r6, #1
 	strb r7, [r0, #0x1a6]
 	cmp r6, #0x20
 	blt _020f675c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	arm_func_end func_ov01_020f66e8
 
 	.global func_ov01_020f6774
 	arm_func_start func_ov01_020f6774
 func_ov01_020f6774: ; 0x020f6774
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x2c
 	mov r8, r0
 	ldr r0, [r8, #0xc]
 	cmp r0, #0
 	addeq sp, sp, #0x2c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, [r8, #0x10]
 	mov r1, #0xf000
 	mov r0, r0, lsl #0xc
@@ -12384,7 +12384,7 @@ func_ov01_020f6774: ; 0x020f6774
 	str r0, [sp, #4]
 	sub r11, r7, #0x400
 	add r10, r8, #0x100
-	add sb, sp, #0xc
+	add r9, sp, #0xc
 _020f67dc:
 	ldr r0, _020f6aa4 ; =data_027e0c68
 	bl func_020367ec
@@ -12536,7 +12536,7 @@ _020f69b8:
 	add r0, r8, #0x2c
 	mov r1, #0
 	mov r2, r2, asr #0xc
-	mov r3, sb
+	mov r3, r9
 	bl func_ov00_020d00c4
 	b _020f6a8c
 _020f69f0:
@@ -12551,7 +12551,7 @@ _020f69f0:
 	add r0, r8, #0x44
 	mov r1, #0
 	mov r2, r2, asr #0xc
-	mov r3, sb
+	mov r3, r9
 	bl func_ov00_020d00c4
 	b _020f6a8c
 _020f6a28:
@@ -12564,7 +12564,7 @@ _020f6a28:
 	add r0, r8, #0x14
 	mov r1, r1, asr #0xc
 	mov r2, #0
-	mov r3, sb
+	mov r3, r9
 	bl func_ov00_020d00c4
 	b _020f6a8c
 _020f6a58:
@@ -12580,7 +12580,7 @@ _020f6a78:
 	mov r1, #0
 	mov r0, #0x10c
 	mov r2, r1
-	str sb, [sp]
+	str r9, [sp]
 	bl func_0203493c
 _020f6a8c:
 	add r6, r6, #0x400
@@ -12588,7 +12588,7 @@ _020f6a8c:
 	cmp r5, #0xa
 	blt _020f67dc
 	add sp, sp, #0x2c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov01_020f6774
 _020f6aa4: .word data_027e0c68
@@ -13215,7 +13215,7 @@ _020f7328: .word 0x04001000
 	.global func_ov01_020f732c
 	arm_func_start func_ov01_020f732c
 func_ov01_020f732c: ; 0x020f732c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #0x28
 	mov r5, r0
 	ldrb r0, [r5, #0xc]
@@ -13225,7 +13225,7 @@ func_ov01_020f732c: ; 0x020f732c
 	cmpne r0, #0
 	addeq sp, sp, #0x28
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	add r0, sp, #8
 	bl func_01ffbe34
 	mov r1, #1
@@ -13334,9 +13334,9 @@ func_ov01_020f732c: ; 0x020f732c
 	mov r0, r6
 	mov r1, #0x64
 	bl func_01ff9b4c
-	mov sb, r0
+	mov r9, r0
 	mov r0, #0x64
-	mul r0, sb, r0
+	mul r0, r9, r0
 	sub r10, r6, r0
 	mov r0, r10
 	mov r1, #0xa
@@ -13369,10 +13369,10 @@ _020f755c:
 _020f7584:
 	cmp r7, #0
 	cmple r8, #0
-	cmple sb, #0
+	cmple r9, #0
 	ble _020f75b0
 	add ip, sp, #8
-	add r1, sb, #0x24
+	add r1, r9, #0x24
 	mov r0, #0x9c
 	mov r2, #7
 	mov r3, #0
@@ -13381,7 +13381,7 @@ _020f7584:
 _020f75b0:
 	cmp r7, #0
 	cmple r8, #0
-	cmple sb, #0
+	cmple r9, #0
 	cmple r6, #0
 	ble _020f75e0
 	add r7, sp, #8
@@ -13415,15 +13415,15 @@ _020f75e0:
 	mov r8, r0
 	mov r0, #0x64
 	mul r0, r8, r0
-	sub sb, r6, r0
-	mov r0, sb
+	sub r9, r6, r0
+	mov r0, r9
 	mov r1, #0xa
 	bl func_01ff9b4c
 	mov r6, r0
-	mov r0, sb
+	mov r0, r9
 	mov r1, #0xa
 	bl func_01ff9b88
-	mov sb, r0
+	mov r9, r0
 	cmp r7, #0
 	ble _020f7684
 	add r10, sp, #8
@@ -13460,7 +13460,7 @@ _020f76d8:
 	add r0, sp, #8
 	str r4, [sp]
 	str r0, [sp, #4]
-	add r1, sb, #0x24
+	add r1, r9, #0x24
 	mov r0, #0x9c
 	mov r2, #0x11
 	mov r3, #0
@@ -13480,15 +13480,15 @@ _020f76d8:
 	mov r8, r0
 	mov r0, #0x64
 	mul r0, r8, r0
-	sub sb, r6, r0
-	mov r0, sb
+	sub r9, r6, r0
+	mov r0, r9
 	mov r1, #0xa
 	bl func_01ff9b4c
 	mov r6, r0
-	mov r0, sb
+	mov r0, r9
 	mov r1, #0xa
 	bl func_01ff9b88
-	mov sb, r0
+	mov r9, r0
 	cmp r7, #0
 	ble _020f777c
 	add r10, sp, #8
@@ -13525,7 +13525,7 @@ _020f77d0:
 	add r0, sp, #8
 	str r4, [sp]
 	str r0, [sp, #4]
-	add r1, sb, #0x24
+	add r1, r9, #0x24
 	mov r0, #0x9c
 	mov r2, #0x15
 	mov r3, #0
@@ -13545,15 +13545,15 @@ _020f77d0:
 	mov r8, r0
 	mov r0, #0x64
 	mul r0, r8, r0
-	sub sb, r6, r0
-	mov r0, sb
+	sub r9, r6, r0
+	mov r0, r9
 	mov r1, #0xa
 	bl func_01ff9b4c
 	mov r6, r0
-	mov r0, sb
+	mov r0, r9
 	mov r1, #0xa
 	bl func_01ff9b88
-	mov sb, r0
+	mov r9, r0
 	cmp r7, #0
 	ble _020f7874
 	add r10, sp, #8
@@ -13590,7 +13590,7 @@ _020f78c8:
 	add r0, sp, #8
 	str r4, [sp]
 	str r0, [sp, #4]
-	add r1, sb, #0x24
+	add r1, r9, #0x24
 	mov r0, #0x9c
 	mov r2, #0x19
 	mov r3, #0
@@ -13648,7 +13648,7 @@ _020f7990:
 	bl func_020349cc
 	mov r0, #1
 	add sp, sp, #0x28
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov01_020f732c
 _020f79b8: .word 0x00002710
@@ -13656,7 +13656,7 @@ _020f79b8: .word 0x00002710
 	.global func_ov01_020f79bc
 	arm_func_start func_ov01_020f79bc
 func_ov01_020f79bc: ; 0x020f79bc
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x9c
 	ldr r5, _020f7b74 ; =data_027e0d54
 	mov r10, r0
@@ -13722,7 +13722,7 @@ _020f7aa4:
 	cmp r0, #0
 	bne _020f7b30
 	mov r6, #0
-	ldr sb, _020f7b80 ; =data_ov00_020ec218
+	ldr r9, _020f7b80 ; =data_ov00_020ec218
 	mov r8, r6
 _020f7abc:
 	tst r10, r4, lsl r6
@@ -13736,7 +13736,7 @@ _020f7abc:
 	str r0, [sp, #0x10]
 	ldrh ip, [r5, #0x16]
 	ldr r1, _020f7b84 ; =0x0003f500
-	mov r0, sb
+	mov r0, r9
 	mul r1, ip, r1
 	add r1, r1, #0x3e800
 	add r1, r1, r7
@@ -13751,7 +13751,7 @@ _020f7abc:
 	b _020f7b30
 _020f7b1c:
 	add r8, r8, #0x100
-	add sb, sb, #0x100
+	add r9, r9, #0x100
 	add r6, r6, #1
 	cmp r6, #5
 	blo _020f7abc
@@ -13773,7 +13773,7 @@ _020f7b48:
 	strb r0, [r5, #0xd]
 	strb r0, [r5, #0xe]
 	add sp, sp, #0x9c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov01_020f79bc
 _020f7b74: .word data_027e0d54
@@ -13823,13 +13823,13 @@ _020f7c04: .word 0x0003f500
 	.global func_ov01_020f7c08
 	arm_func_start func_ov01_020f7c08
 func_ov01_020f7c08: ; 0x020f7c08
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	mov r10, #0
 	mov r8, #0x100
 	mov r7, r0
 	mov r6, r1
 	mov r5, r10
-	mov sb, #1
+	mov r9, #1
 	mov r4, r8
 _020f7c28:
 	mov r0, r7
@@ -13838,7 +13838,7 @@ _020f7c28:
 	bl func_0204366c
 	cmp r0, #0
 	beq _020f7c5c
-	orr r0, r10, sb, lsl r5
+	orr r0, r10, r9, lsl r5
 	mov r3, r0, lsl #0x10
 	mov r0, r7
 	mov r1, r6
@@ -13852,7 +13852,7 @@ _020f7c5c:
 	add r6, r6, #0x100
 	blt _020f7c28
 	mov r0, r10
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	arm_func_end func_ov01_020f7c08
 
 	.global func_ov01_020f7c78
@@ -14671,21 +14671,21 @@ func_ov01_020f84c8: ; 0x020f84c8
 	.global func_ov01_020f8500
 	arm_func_start func_ov01_020f8500
 func_ov01_020f8500: ; 0x020f8500
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
-	mov sb, r1
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
+	mov r9, r1
 	mov r10, r0
-	mov r0, sb
+	mov r0, r9
 	bl func_ov01_020f84b8
 	cmp r0, #0
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
-	mov r0, sb
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
+	mov r0, r9
 	bl func_ov01_020f84c8
 	cmp r0, #0
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	mov r7, #0
-	mov r6, sb
+	mov r6, r9
 	mov r5, r7
 	mov r4, #0x14
 _020f8544:
@@ -14705,7 +14705,7 @@ _020f8560:
 	mov r5, r4
 	mov r6, r4
 	mov r7, r10
-	mov r8, sb
+	mov r8, r9
 	mov r11, #8
 	b _020f85ac
 _020f858c:
@@ -14745,7 +14745,7 @@ _020f85e4:
 	mov r0, r7
 	mov r2, r11
 	strb r1, [r7, #0x13]
-	add r1, sb, #0x3c
+	add r1, r9, #0x3c
 	strb r3, [r8, #0x13]
 	bl func_020320c0
 	mov r0, r8
@@ -14763,11 +14763,11 @@ _020f8638:
 	ble _020f8650
 	mov r0, r10
 	bl func_ov01_020f84a8
-	mov r0, sb
+	mov r0, r9
 	bl func_ov01_020f84a8
 _020f8650:
 	mov r0, r4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	arm_func_end func_ov01_020f8500
 
 	.global func_ov01_020f8658

--- a/asm/ov01.s
+++ b/asm/ov01.s
@@ -23,7 +23,7 @@ _020eed68: .word data_ov01_020f8b60
 	.global func_ov01_020eed6c
 	arm_func_start func_ov01_020eed6c
 func_ov01_020eed6c: ; 0x020eed6c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	mov r6, r0
 	mov r4, r1
 	mov r7, r2
@@ -35,25 +35,25 @@ func_ov01_020eed6c: ; 0x020eed6c
 	beq _020eeda0
 	bl func_0200ee60
 	mov r0, #3
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _020eeda0:
 	cmp r6, #0
 	bne _020eedb4
 	bl func_0200ee60
 	mov r0, #6
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _020eedb4:
 	cmp r4, #3
 	bls _020eedc8
 	bl func_0200ee60
 	mov r0, #6
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _020eedc8:
 	tst r6, #0x1f
 	beq _020eeddc
 	bl func_0200ee60
 	mov r0, #6
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _020eeddc:
 	blx func_02008a50
 	mov r0, #0xa
@@ -64,7 +64,7 @@ _020eeddc:
 	mov r0, r5
 	bl func_0200ee60
 	mov r0, #4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _020eee04:
 	mov r0, r6
 	mov r1, r7
@@ -119,7 +119,7 @@ _020eeeb0:
 	bl func_0200ddb4
 	mov r6, #0
 	mov r4, #0x8000
-	ldr sl, _020eef48 ; =data_ov01_020f8c00
+	ldr r10, _020eef48 ; =data_ov01_020f8c00
 	mov sb, #2
 	ldr r8, _020eef40 ; =data_ov01_020f8b68
 	mov r7, #1
@@ -127,12 +127,12 @@ _020eeeb0:
 _020eeee4:
 	mov r2, r6, lsl #0x8
 	mov r1, sb
-	add r0, sl, r6, lsl #8
-	strh r4, [sl, r2]
+	add r0, r10, r6, lsl #8
+	strh r4, [r10, r2]
 	bl func_0200e2a4
 	mov r0, r8
 	mov r2, r7
-	add r1, sl, r6, lsl #8
+	add r1, r10, r6, lsl #8
 	bl func_0200dddc
 	add r6, r6, #1
 _020eef0c:
@@ -147,7 +147,7 @@ _020eef0c:
 	strh r2, [r1]
 	bl func_0200ee60
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov01_020eed6c
 _020eef3c: .word data_ov01_020f8b60
@@ -410,14 +410,14 @@ _020ef250: .word data_ov01_020f8b60
 	.global func_ov01_020ef254
 	arm_func_start func_ov01_020ef254
 func_ov01_020ef254: ; 0x020ef254
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #8
 	ldr r0, _020ef5ec ; =data_ov01_020f8b60
 	cmp r2, #0
 	ldr r4, [r0, #4]
-	mov sl, r1
+	mov r10, r1
 	addne sp, sp, #8
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, [r4, #0x10]
 	mov r1, #0x100
 	bl func_0200e288
@@ -429,18 +429,18 @@ func_ov01_020ef254: ; 0x020ef254
 	bl func_0200e288
 _020ef298:
 	ldr r0, [r4, #0x10]
-	cmp sl, r0
+	cmp r10, r0
 	beq _020ef2b0
-	mov r0, sl
+	mov r0, r10
 	mov r1, #0x100
 	bl func_0200e288
 _020ef2b0:
-	ldrh r0, [sl]
+	ldrh r0, [r10]
 	cmp r0, #0x2c
 	blo _020ef368
 	cmp r0, #0x80
 	bne _020ef2ec
-	ldrh r0, [sl, #2]
+	ldrh r0, [r10, #2]
 	cmp r0, #0x13
 	bne _020ef2d4
 	bl func_0200f248
@@ -448,27 +448,27 @@ _020ef2d4:
 	ldr r1, [r4, #0xc8]
 	cmp r1, #0
 	beq _020ef5ac
-	mov r0, sl
+	mov r0, r10
 	blx r1
 	b _020ef5ac
 _020ef2ec:
 	cmp r0, #0x82
 	bne _020ef340
-	ldrh r0, [sl, #6]
+	ldrh r0, [r10, #6]
 	add r1, r4, r0, lsl #2
 	ldr r0, [r1, #0xcc]
 	cmp r0, #0
 	beq _020ef5ac
 	ldr r0, [r1, #0x10c]
-	str r0, [sl, #0x1c]
+	str r0, [r10, #0x1c]
 	ldr r0, [r4, #0x14c]
-	strh r0, [sl, #0x22]
+	strh r0, [r10, #0x22]
 	ldr r1, [r4, #4]
-	ldr r0, [sl, #8]
+	ldr r0, [r10, #8]
 	ldrh r1, [r1, #0x72]
 	bl func_0200e288
-	ldrh r1, [sl, #6]
-	mov r0, sl
+	ldrh r1, [r10, #6]
+	mov r0, r10
 	add r1, r4, r1, lsl #2
 	ldr r1, [r1, #0xcc]
 	blx r1
@@ -477,34 +477,34 @@ _020ef340:
 	cmp r0, #0x81
 	bne _020ef5ac
 	mov r0, #0xf
-	strh r0, [sl]
-	ldr r1, [sl, #0x1c]
+	strh r0, [r10]
+	ldr r1, [r10, #0x1c]
 	cmp r1, #0
 	beq _020ef5ac
-	mov r0, sl
+	mov r0, r10
 	blx r1
 	b _020ef5ac
 _020ef368:
 	cmp r0, #0xe
 	bne _020ef3a8
-	ldrh r0, [sl, #4]
+	ldrh r0, [r10, #4]
 	add r0, r0, #0xf5
 	add r0, r0, #0xff00
 	mov r0, r0, lsl #0x10
 	mov r0, r0, lsr #0x10
 	cmp r0, #1
 	bhi _020ef3a8
-	ldrh r0, [sl, #2]
+	ldrh r0, [r10, #2]
 	cmp r0, #0
 	bne _020ef3a8
 	ldr r1, [r4, #4]
-	ldr r0, [sl, #8]
+	ldr r0, [r10, #8]
 	ldrh r1, [r1, #0x72]
 	bl func_0200e288
 _020ef3a8:
-	ldrh r1, [sl]
+	ldrh r1, [r10]
 	cmp r1, #2
-	ldreqh r0, [sl, #2]
+	ldreqh r0, [r10, #2]
 	cmpeq r0, #0
 	add r0, r4, r1, lsl #2
 	bne _020ef3e4
@@ -512,52 +512,52 @@ _020ef3a8:
 	bl func_ov01_020eef50
 	cmp r4, #0
 	addeq sp, sp, #8
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
-	mov r0, sl
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	mov r0, r10
 	blx r4
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _020ef3e4:
 	ldr r1, [r0, #0x18]
 	cmp r1, #0
 	beq _020ef40c
-	mov r0, sl
+	mov r0, r10
 	blx r1
 	ldr r0, _020ef5ec ; =data_ov01_020f8b60
 	ldrh r0, [r0]
 	cmp r0, #0
 	addeq sp, sp, #8
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _020ef40c:
-	ldrh r0, [sl]
+	ldrh r0, [r10]
 	cmp r0, #8
 	cmpne r0, #0xc
 	bne _020ef5ac
 	cmp r0, #8
 	bne _020ef450
-	add r0, sl, #0xa
+	add r0, r10, #0xa
 	str r0, [sp]
-	ldrh r5, [sl, #8]
-	ldrh r6, [sl, #0x10]
-	ldrh r0, [sl, #0x12]
-	add r11, sl, #0x14
+	ldrh r5, [r10, #8]
+	ldrh r6, [r10, #0x10]
+	ldrh r0, [r10, #0x12]
+	add r11, r10, #0x14
 	mov r7, #0
 	str r0, [sp, #4]
-	ldrh r8, [sl, #0x2c]
-	ldrh sb, [sl, #0x2e]
+	ldrh r8, [r10, #0x2c]
+	ldrh sb, [r10, #0x2e]
 	b _020ef480
 _020ef450:
 	cmp r0, #0xc
 	bne _020ef480
-	ldrh r5, [sl, #8]
-	ldrh r7, [sl, #0xa]
-	ldrh r0, [sl, #0xc]
+	ldrh r5, [r10, #8]
+	ldrh r7, [r10, #0xa]
+	ldrh r0, [r10, #0xc]
 	mov r6, #0
 	mov r11, r6
 	str r0, [sp, #4]
-	add r0, sl, #0x10
-	ldrh r8, [sl, #0x16]
-	ldrh sb, [sl, #0x18]
+	add r0, r10, #0x10
+	ldrh r8, [r10, #0x16]
+	ldrh sb, [r10, #0x18]
 	str r0, [sp]
 _020ef480:
 	cmp r5, #7
@@ -645,17 +645,17 @@ _020ef5ac:
 	bl func_0200e288
 	bl func_ov01_020ef600
 	ldr r0, [r4, #0x10]
-	cmp sl, r0
+	cmp r10, r0
 	addeq sp, sp, #8
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
-	ldrh r2, [sl]
-	mov r0, sl
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldrh r2, [r10]
+	mov r0, r10
 	mov r1, #0x100
 	orr r2, r2, #0x8000
-	strh r2, [sl]
+	strh r2, [r10]
 	bl func_0200e2a4
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov01_020ef254
 _020ef5ec: .word data_ov01_020f8b60
@@ -2404,9 +2404,9 @@ func_ov01_020f0c54: ; 0x020f0c54
 	.global func_ov01_020f0cc0
 	arm_func_start func_ov01_020f0cc0
 func_ov01_020f0cc0: ; 0x020f0cc0
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0xc
-	mov sl, r0
+	mov r10, r0
 	mov r7, r1
 	mov r6, r2
 	mov r0, #2
@@ -2417,30 +2417,30 @@ func_ov01_020f0cc0: ; 0x020f0cc0
 	bl func_ov01_020ef1c0
 	cmp r0, #0
 	addne sp, sp, #0xc
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
-	cmp sl, #0
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	cmp r10, #0
 	addeq sp, sp, #0xc
 	moveq r0, #6
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	cmp r7, #0x10
 	addhs sp, sp, #0xc
 	movhs r0, #6
-	ldmhsia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmhsia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	cmp r6, #0
 	addeq sp, sp, #0xc
 	moveq r0, #6
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	bl func_ov01_020ef640
 	movs r4, r0
 	bne _020f0d3c
 	bl func_ov01_020ef6a0
 	mov r8, r0
 _020f0d3c:
-	mov r1, sl
+	mov r1, r10
 	mov r0, #0
 	mov r2, #0x820
 	bl func_02007938
-	add r0, sl, #0x800
+	add r0, r10, #0x800
 	mov r2, #0
 	strh r2, [r0, #8]
 	strh r2, [r0, #0xa]
@@ -2454,12 +2454,12 @@ _020f0d3c:
 	cmp r1, #0
 	mov r0, r0, lsl #0x10
 	movne r2, #1
-	add r1, sl, #0x800
+	add r1, r10, #0x800
 	strh r2, [r1, #0x18]
 	mov r0, r0, lsr #0x10
 	strh r0, [r1, #0xe]
 	bl func_0200b984
-	add r3, sl, #0x800
+	add r3, r10, #0x800
 	mul r1, r5, r0
 	strh r0, [r3, #0x12]
 	strh r1, [r3, #0x14]
@@ -2470,7 +2470,7 @@ _020f0d3c:
 	strh r0, [r3, #0xe]
 	add sp, sp, #0xc
 	mov r0, #6
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _020f0dc8:
 	add r0, r0, #4
 	strh r0, [r3, #0x14]
@@ -2485,16 +2485,16 @@ _020f0de8:
 	mov r0, r2, lsl #0x9
 	add r2, r2, #1
 	and r1, r1, r4
-	strh r1, [sl, r0]
+	strh r1, [r10, r0]
 	cmp r2, #4
 	blt _020f0de8
 	ldr r1, _020f0f04 ; =func_ov01_020f137c
 	mov r0, r7
-	mov r2, sl
+	mov r2, r10
 	bl func_ov01_020ef72c
-	mov r7, sl
+	mov r7, r10
 	mov sb, #0
-	add r4, sl, #0x800
+	add r4, r10, #0x800
 	mov r6, #1
 	ldr r11, _020f0f08 ; =func_ov01_020f12a4
 	ldr r5, _020f0f0c ; =0x0000ffff
@@ -2502,7 +2502,7 @@ _020f0de8:
 _020f0e30:
 	ldrh r2, [r4, #8]
 	mov r0, r11
-	mov r1, sl
+	mov r1, r10
 	add r2, r2, #1
 	and r2, r2, #3
 	strh r2, [r4, #8]
@@ -2518,7 +2518,7 @@ _020f0e30:
 	bl func_ov01_020f093c
 	cmp r0, #7
 	bne _020f0e98
-	add r0, sl, sb, lsl #1
+	add r0, r10, sb, lsl #1
 	add r0, r0, #0x800
 	strh r5, [r0]
 	ldrh r0, [r4, #0xa]
@@ -2530,12 +2530,12 @@ _020f0e98:
 	cmp r0, #0
 	cmpne r0, #2
 	beq _020f0ebc
-	add r0, sl, #0x800
+	add r0, r10, #0x800
 	mov r1, #5
 	strh r1, [r0, #0x1c]
 	add sp, sp, #0xc
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _020f0ebc:
 	add r7, r7, #0x200
 	add sb, sb, #1
@@ -2551,13 +2551,13 @@ _020f0ee0:
 	ldr r1, _020f0f10 ; =func_ov01_020f14a8
 	mov r4, #3
 	mov r0, r7
-	mov r2, sl
+	mov r2, r10
 	strh r4, [r3, #0xa]
 	bl func_ov01_020ef72c
 _020f0ef8:
 	mov r0, #0
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov01_020f0cc0
 _020f0f04: .word func_ov01_020f137c
@@ -2591,9 +2591,9 @@ func_ov01_020f0f14: ; 0x020f0f14
 	.global func_ov01_020f0f5c
 	arm_func_start func_ov01_020f0f5c
 func_ov01_020f0f5c: ; 0x020f0f5c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0xc
-	mov sl, r0
+	mov r10, r0
 	mov sb, r1
 	mov r8, r2
 	mov r0, #2
@@ -2602,36 +2602,36 @@ func_ov01_020f0f5c: ; 0x020f0f5c
 	bl func_ov01_020ef1c0
 	cmp r0, #0
 	addne sp, sp, #0xc
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
-	cmp sl, #0
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	cmp r10, #0
 	addeq sp, sp, #0xc
 	moveq r0, #6
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	cmp sb, #0
 	addeq sp, sp, #0xc
 	moveq r0, #6
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	cmp r8, #0
 	addeq sp, sp, #0xc
 	moveq r0, #6
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	bl func_ov01_020ef640
 	movs r5, r0
 	bne _020f0fd0
 	bl func_ov01_020ef6a0
 	mov r4, r0
 _020f0fd0:
-	add r0, sl, #0x800
+	add r0, r10, #0x800
 	ldrh r0, [r0, #0x1c]
 	cmp r0, #5
 	addeq sp, sp, #0xc
 	moveq r0, #1
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	cmp r0, #1
 	cmpne r0, #4
 	addne sp, sp, #0xc
 	movne r0, #3
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	cmp r5, #0
 	mov r7, #5
 	bne _020f1194
@@ -2639,7 +2639,7 @@ _020f0fd0:
 	mov r11, r5
 	cmp r0, #4
 	bne _020f10b8
-	add ip, sl, #0x800
+	add ip, r10, #0x800
 	mov r2, #1
 	strh r2, [ip, #0x1c]
 	ldrh r3, [ip, #0xe]
@@ -2655,16 +2655,16 @@ _020f0fd0:
 	str r3, [sp, #4]
 	str r2, [sp, #8]
 	ldrh r3, [ip, #0x14]
-	mov r1, sl
-	add r2, sl, r6, lsl #9
+	mov r1, r10
+	add r2, r10, r6, lsl #9
 	bl func_ov01_020f093c
 	cmp r0, #7
 	bne _020f1094
-	add r0, sl, r6, lsl #1
+	add r0, r10, r6, lsl #1
 	ldr r1, _020f12a0 ; =0x0000ffff
 	add r0, r0, #0x800
 	strh r1, [r0]
-	add r0, sl, #0x800
+	add r0, r10, #0x800
 	ldrh r1, [r0, #0xa]
 	add r1, r1, #1
 	and r1, r1, #3
@@ -2674,32 +2674,32 @@ _020f1094:
 	cmp r0, #0
 	cmpne r0, #2
 	beq _020f10b8
-	add r0, sl, #0x800
+	add r0, r10, #0x800
 	mov r1, r7
 	strh r1, [r0, #0x1c]
 	add sp, sp, #0xc
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _020f10b8:
-	add r0, sl, #0x800
+	add r0, r10, #0x800
 	ldrh r2, [r0, #0xc]
 	ldrh r1, [r0, #0xa]
 	cmp r2, r1
 	beq _020f1150
 	mov r5, r2, lsl #0x9
-	ldrh r3, [sl, r5]
+	ldrh r3, [r10, r5]
 	mov r1, r8
 	mov r2, #0x200
 	orr r3, r3, #1
-	strh r3, [sl, r5]
+	strh r3, [r10, r5]
 	ldrh r0, [r0, #0xc]
-	add r0, sl, r0, lsl #9
+	add r0, r10, r0, lsl #9
 	bl func_020078d8
-	add r1, sl, #0x800
+	add r1, r10, #0x800
 	ldrh r0, [r1, #0xc]
 	mov r5, #1
 	mov r7, #0
-	add r0, sl, r0, lsl #1
+	add r0, r10, r0, lsl #1
 	add r0, r0, #0x800
 	ldrh r0, [r0]
 	strh r0, [r1, #0x1a]
@@ -2714,34 +2714,34 @@ _020f10b8:
 	beq _020f114c
 	ldrh r0, [r1, #8]
 	mov r0, r0, lsl #0x9
-	ldrh r0, [sl, r0]
+	ldrh r0, [r10, r0]
 	cmp r0, #1
 	moveq r11, r5
 	beq _020f1150
 _020f114c:
 	mov r11, #0
 _020f1150:
-	mov r0, sl
+	mov r0, r10
 	mov r1, #0
 	bl func_ov01_020f1668
 	cmp r5, #0
 	beq _020f1290
-	mov r0, sl
+	mov r0, r10
 	mov r2, sb
 	mov r1, #0
 	bl func_ov01_020f159c
-	add r0, sl, #0x800
+	add r0, r10, #0x800
 	ldrh r0, [r0, #0x18]
 	cmp r0, #0
 	bne _020f1290
-	mov r0, sl
+	mov r0, r10
 	mov r1, r11
 	bl func_ov01_020f1668
 	b _020f1290
 _020f1194:
 	cmp r0, #4
 	mov r0, #0
-	add r1, sl, #0x800
+	add r1, r10, #0x800
 	moveq r0, #1
 	streqh r0, [r1, #0x1c]
 	beq _020f1214
@@ -2750,20 +2750,20 @@ _020f1194:
 	cmp r2, r1
 	beq _020f1214
 	mov r2, r2, lsl #0x9
-	ldrh r1, [sl, r2]
+	ldrh r1, [r10, r2]
 	tst r1, #1
 	orreq r1, r1, #1
-	streqh r1, [sl, r2]
+	streqh r1, [r10, r2]
 	beq _020f1214
 	mov r1, r8
-	add r0, sl, r2
+	add r0, r10, r2
 	mov r2, #0x200
 	bl func_020078d8
-	add r2, sl, #0x800
+	add r2, r10, #0x800
 	ldrh r1, [r2, #0xc]
 	mov r0, #1
 	mov r7, #0
-	add r1, sl, r1, lsl #1
+	add r1, r10, r1, lsl #1
 	add r1, r1, #0x800
 	ldrh r1, [r1]
 	strh r1, [r2, #0x1a]
@@ -2774,26 +2774,26 @@ _020f1194:
 _020f1214:
 	cmp r0, #0
 	beq _020f1290
-	add r0, sl, #0x800
+	add r0, r10, #0x800
 	ldrh r1, [r0, #0xa]
 	ldrh r2, [r0, #0x10]
 	mov r0, sb
-	add r6, sl, r1, lsl #9
+	add r6, r10, r1, lsl #9
 	add r1, r6, #0x20
 	bl func_020078d8
-	add r3, sl, #0x800
+	add r3, r10, #0x800
 	ldrh r1, [r3, #0xe]
 	mov r4, #1
 	ldr r0, _020f129c ; =func_ov01_020f12a4
 	str r1, [sp]
 	ldrh r5, [r3, #0x16]
-	mov r1, sl
+	mov r1, r10
 	add r2, r6, #0x20
 	str r5, [sp, #4]
 	str r4, [sp, #8]
 	ldrh r3, [r3, #0x10]
 	bl func_ov01_020f093c
-	add r1, sl, #0x800
+	add r1, r10, #0x800
 	ldrh r2, [r1, #0xa]
 	cmp r0, #2
 	cmpne r0, #0
@@ -2806,7 +2806,7 @@ _020f1214:
 _020f1290:
 	mov r0, r7
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov01_020f0f5c
 _020f129c: .word func_ov01_020f12a4
@@ -3093,20 +3093,20 @@ _020f1638:
 	.global func_ov01_020f1668
 	arm_func_start func_ov01_020f1668
 func_ov01_020f1668: ; 0x020f1668
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #0xc
-	mov sl, r0
+	mov r10, r0
 	mov sb, r1
 	bl func_0200ee4c
-	add r1, sl, #0x800
+	add r1, r10, #0x800
 	ldrh r1, [r1, #8]
 	mov r4, r0
 	mov r1, r1, lsl #0x9
-	ldrh r1, [sl, r1]
+	ldrh r1, [r10, r1]
 	cmp r1, #0
 	bne _020f17a8
 	bl func_ov01_020ef6a0
-	add r1, sl, #0x800
+	add r1, r10, #0x800
 	ldrh r6, [r1, #8]
 	ldrh r1, [r1, #0x18]
 	mov r7, r0
@@ -3116,27 +3116,27 @@ func_ov01_020f1668: ; 0x020f1668
 	addeq r0, r5, #1
 	andeq r8, r0, #3
 	movne r8, r5
-	add r1, sl, r8, lsl #9
+	add r1, r10, r8, lsl #9
 	mov r0, #0
 	mov r2, #0x200
 	bl func_020078c0
-	add r0, sl, #0x800
+	add r0, r10, #0x800
 	ldrh r3, [r0, #0xe]
 	orr r2, r7, #1
 	mov r1, r8, lsl #0x9
 	and r2, r3, r2
-	strh r2, [sl, r1]
+	strh r2, [r10, r1]
 	strh r5, [r0, #8]
 	ldrh r0, [r0, #0xe]
 	mov r1, r6, lsl #0x9
 	cmp sb, #1
-	strh r0, [sl, r1]
-	ldreqh r0, [sl, r1]
+	strh r0, [r10, r1]
+	ldreqh r0, [r10, r1]
 	biceq r0, r0, #1
-	streqh r0, [sl, r1]
+	streqh r0, [r10, r1]
 	mov r0, r4
 	bl func_0200ee60
-	add r3, sl, #0x800
+	add r3, r10, #0x800
 	ldrh r1, [r3, #0xe]
 	mov r4, #1
 	ldr r0, _020f17b4 ; =func_ov01_020f12a4
@@ -3145,39 +3145,39 @@ func_ov01_020f1668: ; 0x020f1668
 	mov r1, r1, lsr #0x10
 	str r1, [sp]
 	ldrh r5, [r3, #0x16]
-	mov r1, sl
-	add r2, sl, r6, lsl #9
+	mov r1, r10
+	add r2, r10, r6, lsl #9
 	str r5, [sp, #4]
 	str r4, [sp, #8]
 	ldrh r3, [r3, #0x14]
 	bl func_ov01_020f093c
 	cmp r0, #7
 	bne _020f1784
-	add r0, sl, r6, lsl #1
+	add r0, r10, r6, lsl #1
 	ldr r1, _020f17b8 ; =0x0000ffff
 	add r0, r0, #0x800
 	strh r1, [r0]
-	add r0, sl, #0x800
+	add r0, r10, #0x800
 	ldrh r1, [r0, #0xa]
 	add sp, sp, #0xc
 	add r1, r1, #1
 	and r1, r1, #3
 	strh r1, [r0, #0xa]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 _020f1784:
 	cmp r0, #0
 	cmpne r0, #2
 	addeq sp, sp, #0xc
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
-	add r0, sl, #0x800
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	add r0, r10, #0x800
 	mov r1, #5
 	strh r1, [r0, #0x1c]
 	add sp, sp, #0xc
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 _020f17a8:
 	bl func_0200ee60
 	add sp, sp, #0xc
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov01_020f1668
 _020f17b4: .word func_ov01_020f12a4
@@ -10753,14 +10753,14 @@ _020f5254: .word 0x00300010
 	.global func_ov01_020f5258
 	arm_func_start func_ov01_020f5258
 func_ov01_020f5258: ; 0x020f5258
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	mov sb, r1
-	mov sl, r0
+	mov r10, r0
 	cmp sb, #0x1f
 	bge _020f52c4
 	mov r1, #0x16
-	add r4, sl, #0x1c0
-	add r5, sl, #0x40
+	add r4, r10, #0x1c0
+	add r5, r10, #0x40
 	mov r0, #0xc
 	mla r6, sb, r0, r5
 	mla r7, sb, r1, r4
@@ -10782,33 +10782,33 @@ _020f5288:
 	add r7, r7, #0x16
 	blt _020f5288
 _020f52c4:
-	add r1, sl, #0x1b4
+	add r1, r10, #0x1b4
 	mov r0, #0
 	mov r2, #0xc
 	bl func_020078f4
-	add r0, sl, #0x6a
+	add r0, r10, #0x6a
 	add r1, r0, #0x400
 	mov r0, #0
 	mov r2, #0x16
 	bl func_020078c0
-	add r0, sl, #0x40
+	add r0, r10, #0x40
 	mov r1, #0x500
 	blx func_0202f134
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	arm_func_end func_ov01_020f5258
 
 	.global func_ov01_020f52fc
 	arm_func_start func_ov01_020f52fc
 func_ov01_020f52fc: ; 0x020f52fc
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
-	mov sl, r0
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	mov r10, r0
 	mov r0, #0
 	cmp r1, #0
 	str r0, [sp]
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r8, [sp]
-	add r6, sl, #0x40
+	add r6, r10, #0x40
 	mov r4, r0
 	mov r5, #1
 	mvn r11, #0
@@ -10821,11 +10821,11 @@ _020f5334:
 	blt _020f5358
 	ldr r0, [sp]
 	cmp r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, _020f53ac ; =data_027e0d54
-	add r1, sl, #0x40
+	add r1, r10, #0x40
 	bl func_ov10_021188c8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _020f5358:
 	mov r0, sb
 	blx func_ov00_020777d0
@@ -10837,7 +10837,7 @@ _020f5358:
 	beq _020f539c
 	cmp r7, #0
 	blt _020f539c
-	mov r0, sl
+	mov r0, r10
 	mov r1, r7
 	bl func_ov01_020f5258
 	mov r0, #1
@@ -10849,7 +10849,7 @@ _020f539c:
 	add r8, r8, #1
 	b _020f5334
 _020f53a8:
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	arm_func_end func_ov01_020f52fc
 _020f53ac: .word data_027e0d54
 
@@ -11182,7 +11182,7 @@ _020f57a8: .word data_ov00_020e899c
 	.global func_ov01_020f57ac
 	arm_func_start func_ov01_020f57ac
 func_ov01_020f57ac: ; 0x020f57ac
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #0x14
 	mov r6, r0
 	ldrb r0, [r6, #0x4c]
@@ -11235,7 +11235,7 @@ _020f585c:
 	movne r0, #0
 	strneb r0, [r6, #0x4c]
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 _020f587c:
 	mov sb, #0
 	mov r4, r6
@@ -11246,7 +11246,7 @@ _020f5890:
 	cmp sb, #2
 	bne _020f58e4
 	mov r0, r6
-	ldrh sl, [r4, #0xe]
+	ldrh r10, [r4, #0xe]
 	bl func_ov01_020f5bb0
 	mov r2, r0
 	mov r0, r5
@@ -11255,7 +11255,7 @@ _020f5890:
 	mov r3, r8
 	ldr ip, [ip]
 	blx ip
-	mov r1, sl
+	mov r1, r10
 	mov r2, r0
 	mov r0, r6
 	bl func_ov01_020f594c
@@ -11263,11 +11263,11 @@ _020f5890:
 	beq _020f5924
 	add sp, sp, #0x14
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 _020f58e4:
 	mov r0, r5
 	ldr ip, [r0]
-	ldrh sl, [r4, #0xe]
+	ldrh r10, [r4, #0xe]
 	ldr ip, [ip]
 	mov r1, r7
 	mov r2, r7
@@ -11275,12 +11275,12 @@ _020f58e4:
 	blx ip
 	mov r2, r0
 	mov r0, r6
-	mov r1, sl
+	mov r1, r10
 	bl func_ov01_020f594c
 	cmp r0, #0
 	addne sp, sp, #0x14
 	movne r0, #1
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 _020f5924:
 	add sb, sb, #1
 	cmp sb, #3
@@ -11289,7 +11289,7 @@ _020f5924:
 	blt _020f5890
 	mov r0, #0
 	add sp, sp, #0x14
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov01_020f57ac
 _020f5944: .word data_027e0d78
@@ -11363,9 +11363,9 @@ _020f5a1c: .word data_ov00_020eec9c
 	.global func_ov01_020f5a20
 	arm_func_start func_ov01_020f5a20
 func_ov01_020f5a20: ; 0x020f5a20
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x30
-	mov sl, r0
+	mov r10, r0
 	add r0, sp, #0x10
 	mov sb, r1
 	mov r8, r2
@@ -11380,7 +11380,7 @@ func_ov01_020f5a20: ; 0x020f5a20
 	mov r1, #0xc
 	bl func_0203493c
 	mov r6, #0
-	add r7, sl, #4
+	add r7, r10, #4
 	mov r4, r6
 	add r5, sp, #0x10
 	mov r11, #0x10c
@@ -11393,7 +11393,7 @@ _020f5a74:
 	beq _020f5b00
 	b _020f5ae8
 _020f5a90:
-	ldr r0, [sl]
+	ldr r0, [r10]
 	cmp r0, #0
 	bne _020f5ae8
 	str r8, [sp]
@@ -11405,7 +11405,7 @@ _020f5a90:
 	bl func_020349cc
 	b _020f5b00
 _020f5abc:
-	ldr r0, [sl]
+	ldr r0, [r10]
 	cmp r0, #0x1c
 	bne _020f5ae8
 	str r8, [sp]
@@ -11438,10 +11438,10 @@ _020f5b00:
 	mov r1, #0xd
 	mov r2, #0xe
 	bl func_02034710
-	ldrb r0, [sl, #0x4c]
+	ldrb r0, [r10, #0x4c]
 	add r4, sp, #0x10
 	cmp r0, #0
-	mov r0, sl
+	mov r0, r10
 	bne _020f5b6c
 	bl func_ov01_020f5bb0
 	add r3, r8, r0
@@ -11469,7 +11469,7 @@ _020f5b90:
 	str r2, [sp]
 	bl func_0203493c
 	add sp, sp, #0x30
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	arm_func_end func_ov01_020f5a20
 
 	.global func_ov01_020f5bb0
@@ -11596,12 +11596,12 @@ _020f5d34: .word func_ov01_020f576c
 	.global func_ov01_020f5d38
 	arm_func_start func_ov01_020f5d38
 func_ov01_020f5d38: ; 0x020f5d38
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x18
-	mov sl, r0
+	mov r10, r0
 	str r2, [sp, #0x10]
 	mov r0, r1
-	str r1, [sl, #8]
+	str r1, [r10, #8]
 	ldr r1, [sp, #0x10]
 	str r3, [sp, #0x14]
 	bl func_ov01_020f52fc
@@ -11618,7 +11618,7 @@ func_ov01_020f5d38: ; 0x020f5d38
 	str r0, [sp, #8]
 	mov r2, #0x11
 	str r0, [sp, #0xc]
-	add r0, sl, #0x14
+	add r0, r10, #0x14
 	mov r1, #0x10c
 	mov r3, r2
 	bl func_ov00_020cfed0
@@ -11629,13 +11629,13 @@ func_ov01_020f5d38: ; 0x020f5d38
 	mov r0, #0
 	str r0, [sp, #8]
 	str r0, [sp, #0xc]
-	add r0, sl, #0x2c
+	add r0, r10, #0x2c
 	mov r1, #0x10c
 	mov r2, #9
 	mov r3, #0xa
 	bl func_ov00_020cfed0
 	mov r0, #0x15
-	strb r0, [sl, #0x3f]
+	strb r0, [r10, #0x3f]
 	mov r0, #0x6d
 	str r0, [sp]
 	mov r0, #1
@@ -11643,7 +11643,7 @@ func_ov01_020f5d38: ; 0x020f5d38
 	mov r0, #0
 	str r0, [sp, #8]
 	str r0, [sp, #0xc]
-	add r0, sl, #0x44
+	add r0, r10, #0x44
 	mov r1, #0x10c
 	mov r2, #0xa
 	mov r3, #0xb
@@ -11651,8 +11651,8 @@ func_ov01_020f5d38: ; 0x020f5d38
 	mov sb, #0
 	mov r0, #0x16
 	mov r8, #1
-	strb r0, [sl, #0x57]
-	add r6, sl, #0x14
+	strb r0, [r10, #0x57]
+	add r6, r10, #0x14
 	mov r7, sb
 	mvn r5, #0
 	mov r4, r8
@@ -11683,13 +11683,13 @@ _020f5e2c:
 	add sb, sb, #1
 	cmp sb, #5
 	blt _020f5e2c
-	ldr r1, [sl, #0x14c]
-	mov r0, sl
+	ldr r1, [r10, #0x14c]
+	mov r0, r10
 	mov r1, r1, lsl #0x10
 	mov r2, r1, asr #0x10
 	mov r1, r2, lsl #0xc
-	str r1, [sl, #0x19c]
-	add r1, sl, #0x100
+	str r1, [r10, #0x19c]
+	add r1, r10, #0x100
 	strh r2, [r1, #0xa0]
 	bl func_ov01_020f66e8
 	ldr r0, _020f5f7c ; =data_ov01_020ff198
@@ -11723,25 +11723,25 @@ _020f5ee4:
 	bl func_02032714
 	str sb, [r5, #0x2c]
 	strb r4, [r5, #0x4e]
-	mov r0, sl
+	mov r0, r10
 	mov r1, r8
 	strb r11, [r5, #0x4f]
 	bl func_ov01_020f6ab0
 	add r8, r8, #1
 	cmp r8, #5
 	blt _020f5ee4
-	add r0, sl, #0x100
+	add r0, r10, #0x100
 	mvn r1, #0
 	strh r1, [r0, #0xa4]
 	ldr r2, [sp, #0x10]
 	ldr r1, [sp, #0x14]
-	strb r2, [sl, #0x1c6]
+	strb r2, [r10, #0x1c6]
 	mov r2, #1
-	mov r0, sl
-	strb r2, [sl, #0x1c7]
+	mov r0, r10
+	strb r2, [r10, #0x1c7]
 	bl func_ov01_020f5fd0
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov01_020f5d38
 _020f5f78: .word data_027e0cbc
@@ -12316,16 +12316,16 @@ func_ov01_020f66d0: ; 0x020f66d0
 	.global func_ov01_020f66e8
 	arm_func_start func_ov01_020f66e8
 func_ov01_020f66e8: ; 0x020f66e8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	mov r6, #0
-	mov sl, r0
+	mov r10, r0
 	mov r8, r6
 	mov sb, r6
 	sub r7, r6, #1
 	mov r4, r6
 	mov r5, #1
 _020f6708:
-	ldr r0, [sl, #8]
+	ldr r0, [r10, #8]
 	add r0, r0, #0x40
 	add r0, r0, sb
 	blx func_ov00_020777d0
@@ -12335,7 +12335,7 @@ _020f6708:
 	cmp r0, #0
 	moveq r7, r8
 	beq _020f673c
-	add r0, sl, r6
+	add r0, r10, r6
 	strb r8, [r0, #0x1a6]
 	add r6, r6, #1
 _020f673c:
@@ -12346,26 +12346,26 @@ _020f673c:
 	add sb, sb, #0xc
 	blt _020f6708
 	cmp r6, #0x20
-	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _020f675c:
-	add r0, sl, r6
+	add r0, r10, r6
 	add r6, r6, #1
 	strb r7, [r0, #0x1a6]
 	cmp r6, #0x20
 	blt _020f675c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	arm_func_end func_ov01_020f66e8
 
 	.global func_ov01_020f6774
 	arm_func_start func_ov01_020f6774
 func_ov01_020f6774: ; 0x020f6774
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x2c
 	mov r8, r0
 	ldr r0, [r8, #0xc]
 	cmp r0, #0
 	addeq sp, sp, #0x2c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, [r8, #0x10]
 	mov r1, #0xf000
 	mov r0, r0, lsl #0xc
@@ -12383,7 +12383,7 @@ func_ov01_020f6774: ; 0x020f6774
 	mov r6, r5
 	str r0, [sp, #4]
 	sub r11, r7, #0x400
-	add sl, r8, #0x100
+	add r10, r8, #0x100
 	add sb, sp, #0xc
 _020f67dc:
 	ldr r0, _020f6aa4 ; =data_027e0c68
@@ -12502,7 +12502,7 @@ _020f6940: ; jump table
 	b _020f6a28 ; case 8
 	b _020f6a58 ; case 9
 _020f6968:
-	ldrsh r0, [sl, #0xa2]
+	ldrsh r0, [r10, #0xa2]
 	cmp r0, #4
 	beq _020f6a8c
 _020f6974:
@@ -12588,7 +12588,7 @@ _020f6a8c:
 	cmp r5, #0xa
 	blt _020f67dc
 	add sp, sp, #0x2c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov01_020f6774
 _020f6aa4: .word data_027e0c68
@@ -13215,7 +13215,7 @@ _020f7328: .word 0x04001000
 	.global func_ov01_020f732c
 	arm_func_start func_ov01_020f732c
 func_ov01_020f732c: ; 0x020f732c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #0x28
 	mov r5, r0
 	ldrb r0, [r5, #0xc]
@@ -13225,7 +13225,7 @@ func_ov01_020f732c: ; 0x020f732c
 	cmpne r0, #0
 	addeq sp, sp, #0x28
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	add r0, sp, #8
 	bl func_01ffbe34
 	mov r1, #1
@@ -13337,15 +13337,15 @@ func_ov01_020f732c: ; 0x020f732c
 	mov sb, r0
 	mov r0, #0x64
 	mul r0, sb, r0
-	sub sl, r6, r0
-	mov r0, sl
+	sub r10, r6, r0
+	mov r0, r10
 	mov r1, #0xa
 	bl func_01ff9b4c
 	mov r6, r0
-	mov r0, sl
+	mov r0, r10
 	mov r1, #0xa
 	bl func_01ff9b88
-	mov sl, r0
+	mov r10, r0
 	cmp r7, #0
 	ble _020f755c
 	add ip, sp, #8
@@ -13395,7 +13395,7 @@ _020f75e0:
 	add r0, sp, #8
 	str r4, [sp]
 	str r0, [sp, #4]
-	add r1, sl, #0x24
+	add r1, r10, #0x24
 	mov r0, #0x9c
 	mov r2, #9
 	mov r3, #0
@@ -13426,23 +13426,23 @@ _020f75e0:
 	mov sb, r0
 	cmp r7, #0
 	ble _020f7684
-	add sl, sp, #8
+	add r10, sp, #8
 	add r1, r7, #0x24
 	mov r0, #0x9c
 	mov r2, #0xe
 	mov r3, #0
-	stmia sp, {r4, sl}
+	stmia sp, {r4, r10}
 	bl func_020349cc
 _020f7684:
 	cmp r7, #0
 	cmple r8, #0
 	ble _020f76ac
-	add sl, sp, #8
+	add r10, sp, #8
 	add r1, r8, #0x24
 	mov r0, #0x9c
 	mov r2, #0xf
 	mov r3, #0
-	stmia sp, {r4, sl}
+	stmia sp, {r4, r10}
 	bl func_020349cc
 _020f76ac:
 	cmp r7, #0
@@ -13491,23 +13491,23 @@ _020f76d8:
 	mov sb, r0
 	cmp r7, #0
 	ble _020f777c
-	add sl, sp, #8
+	add r10, sp, #8
 	add r1, r7, #0x24
 	mov r0, #0x9c
 	mov r2, #0x12
 	mov r3, #0
-	stmia sp, {r4, sl}
+	stmia sp, {r4, r10}
 	bl func_020349cc
 _020f777c:
 	cmp r7, #0
 	cmple r8, #0
 	ble _020f77a4
-	add sl, sp, #8
+	add r10, sp, #8
 	add r1, r8, #0x24
 	mov r0, #0x9c
 	mov r2, #0x13
 	mov r3, #0
-	stmia sp, {r4, sl}
+	stmia sp, {r4, r10}
 	bl func_020349cc
 _020f77a4:
 	cmp r7, #0
@@ -13556,23 +13556,23 @@ _020f77d0:
 	mov sb, r0
 	cmp r7, #0
 	ble _020f7874
-	add sl, sp, #8
+	add r10, sp, #8
 	add r1, r7, #0x24
 	mov r0, #0x9c
 	mov r2, #0x16
 	mov r3, #0
-	stmia sp, {r4, sl}
+	stmia sp, {r4, r10}
 	bl func_020349cc
 _020f7874:
 	cmp r7, #0
 	cmple r8, #0
 	ble _020f789c
-	add sl, sp, #8
+	add r10, sp, #8
 	add r1, r8, #0x24
 	mov r0, #0x9c
 	mov r2, #0x17
 	mov r3, #0
-	stmia sp, {r4, sl}
+	stmia sp, {r4, r10}
 	bl func_020349cc
 _020f789c:
 	cmp r7, #0
@@ -13648,7 +13648,7 @@ _020f7990:
 	bl func_020349cc
 	mov r0, #1
 	add sp, sp, #0x28
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov01_020f732c
 _020f79b8: .word 0x00002710
@@ -13656,10 +13656,10 @@ _020f79b8: .word 0x00002710
 	.global func_ov01_020f79bc
 	arm_func_start func_ov01_020f79bc
 func_ov01_020f79bc: ; 0x020f79bc
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x9c
 	ldr r5, _020f7b74 ; =data_027e0d54
-	mov sl, r0
+	mov r10, r0
 	ldrh r0, [r5, #0x14]
 	mov r6, r1
 	mov r4, r2
@@ -13710,7 +13710,7 @@ _020f7a7c:
 	ldr r0, [r5, #0x10]
 	cmp r0, #0
 	bne _020f7b48
-	cmp sl, #0
+	cmp r10, #0
 	beq _020f7b48
 	mov r0, #0
 	str r0, [sp, #0x14]
@@ -13725,7 +13725,7 @@ _020f7aa4:
 	ldr sb, _020f7b80 ; =data_ov00_020ec218
 	mov r8, r6
 _020f7abc:
-	tst sl, r4, lsl r6
+	tst r10, r4, lsl r6
 	beq _020f7b1c
 	mov r0, #0
 	str r0, [sp]
@@ -13773,7 +13773,7 @@ _020f7b48:
 	strb r0, [r5, #0xd]
 	strb r0, [r5, #0xe]
 	add sp, sp, #0x9c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov01_020f79bc
 _020f7b74: .word data_027e0d54
@@ -13823,12 +13823,12 @@ _020f7c04: .word 0x0003f500
 	.global func_ov01_020f7c08
 	arm_func_start func_ov01_020f7c08
 func_ov01_020f7c08: ; 0x020f7c08
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
-	mov sl, #0
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	mov r10, #0
 	mov r8, #0x100
 	mov r7, r0
 	mov r6, r1
-	mov r5, sl
+	mov r5, r10
 	mov sb, #1
 	mov r4, r8
 _020f7c28:
@@ -13838,12 +13838,12 @@ _020f7c28:
 	bl func_0204366c
 	cmp r0, #0
 	beq _020f7c5c
-	orr r0, sl, sb, lsl r5
+	orr r0, r10, sb, lsl r5
 	mov r3, r0, lsl #0x10
 	mov r0, r7
 	mov r1, r6
 	mov r2, r8
-	mov sl, r3, lsr #0x10
+	mov r10, r3, lsr #0x10
 	bl func_02007984
 _020f7c5c:
 	add r5, r5, #1
@@ -13851,8 +13851,8 @@ _020f7c5c:
 	add r7, r7, #0x100
 	add r6, r6, #0x100
 	blt _020f7c28
-	mov r0, sl
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	mov r0, r10
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	arm_func_end func_ov01_020f7c08
 
 	.global func_ov01_020f7c78
@@ -14671,19 +14671,19 @@ func_ov01_020f84c8: ; 0x020f84c8
 	.global func_ov01_020f8500
 	arm_func_start func_ov01_020f8500
 func_ov01_020f8500: ; 0x020f8500
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	mov sb, r1
-	mov sl, r0
+	mov r10, r0
 	mov r0, sb
 	bl func_ov01_020f84b8
 	cmp r0, #0
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	mov r0, sb
 	bl func_ov01_020f84c8
 	cmp r0, #0
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	mov r7, #0
 	mov r6, sb
 	mov r5, r7
@@ -14704,7 +14704,7 @@ _020f8560:
 	mov r4, #0
 	mov r5, r4
 	mov r6, r4
-	mov r7, sl
+	mov r7, r10
 	mov r8, sb
 	mov r11, #8
 	b _020f85ac
@@ -14750,7 +14750,7 @@ _020f85e4:
 	bl func_020320c0
 	mov r0, r8
 	mov r2, #8
-	add r1, sl, #0x3c
+	add r1, r10, #0x3c
 	bl func_020320c0
 	add r4, r4, #1
 	add r5, r5, #1
@@ -14761,13 +14761,13 @@ _020f85e4:
 _020f8638:
 	cmp r4, #0
 	ble _020f8650
-	mov r0, sl
+	mov r0, r10
 	bl func_ov01_020f84a8
 	mov r0, sb
 	bl func_ov01_020f84a8
 _020f8650:
 	mov r0, r4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	arm_func_end func_ov01_020f8500
 
 	.global func_ov01_020f8658

--- a/asm/ov01.s
+++ b/asm/ov01.s
@@ -410,14 +410,14 @@ _020ef250: .word data_ov01_020f8b60
 	.global func_ov01_020ef254
 	arm_func_start func_ov01_020ef254
 func_ov01_020ef254: ; 0x020ef254
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #8
 	ldr r0, _020ef5ec ; =data_ov01_020f8b60
 	cmp r2, #0
 	ldr r4, [r0, #4]
 	mov sl, r1
 	addne sp, sp, #8
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, [r4, #0x10]
 	mov r1, #0x100
 	bl func_0200e288
@@ -512,11 +512,11 @@ _020ef3a8:
 	bl func_ov01_020eef50
 	cmp r4, #0
 	addeq sp, sp, #8
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	mov r0, sl
 	blx r4
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _020ef3e4:
 	ldr r1, [r0, #0x18]
 	cmp r1, #0
@@ -527,7 +527,7 @@ _020ef3e4:
 	ldrh r0, [r0]
 	cmp r0, #0
 	addeq sp, sp, #8
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _020ef40c:
 	ldrh r0, [sl]
 	cmp r0, #8
@@ -540,7 +540,7 @@ _020ef40c:
 	ldrh r5, [sl, #8]
 	ldrh r6, [sl, #0x10]
 	ldrh r0, [sl, #0x12]
-	add fp, sl, #0x14
+	add r11, sl, #0x14
 	mov r7, #0
 	str r0, [sp, #4]
 	ldrh r8, [sl, #0x2c]
@@ -553,7 +553,7 @@ _020ef450:
 	ldrh r7, [sl, #0xa]
 	ldrh r0, [sl, #0xc]
 	mov r6, #0
-	mov fp, r6
+	mov r11, r6
 	str r0, [sp, #4]
 	add r0, sl, #0x10
 	ldrh r8, [sl, #0x16]
@@ -599,11 +599,11 @@ _020ef480:
 	mov r2, #6
 	strh r3, [ip, #0x8c]
 	bl func_02007ad8
-	cmp fp, #0
+	cmp r11, #0
 	mov r2, #0x18
 	beq _020ef538
 	ldr r1, _020ef5fc ; =data_ov01_020f8bd4
-	mov r0, fp
+	mov r0, r11
 	bl func_020078d8
 	b _020ef544
 _020ef538:
@@ -647,7 +647,7 @@ _020ef5ac:
 	ldr r0, [r4, #0x10]
 	cmp sl, r0
 	addeq sp, sp, #8
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldrh r2, [sl]
 	mov r0, sl
 	mov r1, #0x100
@@ -655,7 +655,7 @@ _020ef5ac:
 	strh r2, [sl]
 	bl func_0200e2a4
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov01_020ef254
 _020ef5ec: .word data_ov01_020f8b60
@@ -2404,7 +2404,7 @@ func_ov01_020f0c54: ; 0x020f0c54
 	.global func_ov01_020f0cc0
 	arm_func_start func_ov01_020f0cc0
 func_ov01_020f0cc0: ; 0x020f0cc0
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0xc
 	mov sl, r0
 	mov r7, r1
@@ -2417,19 +2417,19 @@ func_ov01_020f0cc0: ; 0x020f0cc0
 	bl func_ov01_020ef1c0
 	cmp r0, #0
 	addne sp, sp, #0xc
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	cmp sl, #0
 	addeq sp, sp, #0xc
 	moveq r0, #6
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	cmp r7, #0x10
 	addhs sp, sp, #0xc
 	movhs r0, #6
-	ldmhsia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmhsia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	cmp r6, #0
 	addeq sp, sp, #0xc
 	moveq r0, #6
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	bl func_ov01_020ef640
 	movs r4, r0
 	bne _020f0d3c
@@ -2470,7 +2470,7 @@ _020f0d3c:
 	strh r0, [r3, #0xe]
 	add sp, sp, #0xc
 	mov r0, #6
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _020f0dc8:
 	add r0, r0, #4
 	strh r0, [r3, #0x14]
@@ -2496,12 +2496,12 @@ _020f0de8:
 	mov sb, #0
 	add r4, sl, #0x800
 	mov r6, #1
-	ldr fp, _020f0f08 ; =func_ov01_020f12a4
+	ldr r11, _020f0f08 ; =func_ov01_020f12a4
 	ldr r5, _020f0f0c ; =0x0000ffff
 	b _020f0ec4
 _020f0e30:
 	ldrh r2, [r4, #8]
-	mov r0, fp
+	mov r0, r11
 	mov r1, sl
 	add r2, r2, #1
 	and r2, r2, #3
@@ -2535,7 +2535,7 @@ _020f0e98:
 	strh r1, [r0, #0x1c]
 	add sp, sp, #0xc
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _020f0ebc:
 	add r7, r7, #0x200
 	add sb, sb, #1
@@ -2557,7 +2557,7 @@ _020f0ee0:
 _020f0ef8:
 	mov r0, #0
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov01_020f0cc0
 _020f0f04: .word func_ov01_020f137c
@@ -2591,7 +2591,7 @@ func_ov01_020f0f14: ; 0x020f0f14
 	.global func_ov01_020f0f5c
 	arm_func_start func_ov01_020f0f5c
 func_ov01_020f0f5c: ; 0x020f0f5c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0xc
 	mov sl, r0
 	mov sb, r1
@@ -2602,19 +2602,19 @@ func_ov01_020f0f5c: ; 0x020f0f5c
 	bl func_ov01_020ef1c0
 	cmp r0, #0
 	addne sp, sp, #0xc
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	cmp sl, #0
 	addeq sp, sp, #0xc
 	moveq r0, #6
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	cmp sb, #0
 	addeq sp, sp, #0xc
 	moveq r0, #6
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	cmp r8, #0
 	addeq sp, sp, #0xc
 	moveq r0, #6
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	bl func_ov01_020ef640
 	movs r5, r0
 	bne _020f0fd0
@@ -2626,17 +2626,17 @@ _020f0fd0:
 	cmp r0, #5
 	addeq sp, sp, #0xc
 	moveq r0, #1
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	cmp r0, #1
 	cmpne r0, #4
 	addne sp, sp, #0xc
 	movne r0, #3
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	cmp r5, #0
 	mov r7, #5
 	bne _020f1194
 	mov r5, #0
-	mov fp, r5
+	mov r11, r5
 	cmp r0, #4
 	bne _020f10b8
 	add ip, sl, #0x800
@@ -2679,7 +2679,7 @@ _020f1094:
 	strh r1, [r0, #0x1c]
 	add sp, sp, #0xc
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _020f10b8:
 	add r0, sl, #0x800
 	ldrh r2, [r0, #0xc]
@@ -2716,10 +2716,10 @@ _020f10b8:
 	mov r0, r0, lsl #0x9
 	ldrh r0, [sl, r0]
 	cmp r0, #1
-	moveq fp, r5
+	moveq r11, r5
 	beq _020f1150
 _020f114c:
-	mov fp, #0
+	mov r11, #0
 _020f1150:
 	mov r0, sl
 	mov r1, #0
@@ -2735,7 +2735,7 @@ _020f1150:
 	cmp r0, #0
 	bne _020f1290
 	mov r0, sl
-	mov r1, fp
+	mov r1, r11
 	bl func_ov01_020f1668
 	b _020f1290
 _020f1194:
@@ -2806,7 +2806,7 @@ _020f1214:
 _020f1290:
 	mov r0, r7
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov01_020f0f5c
 _020f129c: .word func_ov01_020f12a4
@@ -10753,7 +10753,7 @@ _020f5254: .word 0x00300010
 	.global func_ov01_020f5258
 	arm_func_start func_ov01_020f5258
 func_ov01_020f5258: ; 0x020f5258
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	mov sb, r1
 	mov sl, r0
 	cmp sb, #0x1f
@@ -10764,7 +10764,7 @@ func_ov01_020f5258: ; 0x020f5258
 	mov r0, #0xc
 	mla r6, sb, r0, r5
 	mla r7, sb, r1, r4
-	mov fp, r1
+	mov r11, r1
 _020f5288:
 	add r8, sb, #1
 	mov r0, #0xc
@@ -10772,7 +10772,7 @@ _020f5288:
 	mov r1, r6
 	mov r2, #0xc
 	bl func_02007908
-	mla r0, r8, fp, r4
+	mla r0, r8, r11, r4
 	mov r1, r7
 	mov r2, #0x16
 	bl func_020078d8
@@ -10795,37 +10795,37 @@ _020f52c4:
 	mov r1, #0x500
 	blx func_0202f134
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	arm_func_end func_ov01_020f5258
 
 	.global func_ov01_020f52fc
 	arm_func_start func_ov01_020f52fc
 func_ov01_020f52fc: ; 0x020f52fc
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	mov sl, r0
 	mov r0, #0
 	cmp r1, #0
 	str r0, [sp]
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r8, [sp]
 	add r6, sl, #0x40
 	mov r4, r0
 	mov r5, #1
-	mvn fp, #0
+	mvn r11, #0
 _020f5328:
 	mov r0, #0xc
 	mla sb, r8, r0, r6
-	mov r7, fp
+	mov r7, r11
 _020f5334:
 	cmp r8, #0x20
 	blt _020f5358
 	ldr r0, [sp]
 	cmp r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, _020f53ac ; =data_027e0d54
 	add r1, sl, #0x40
 	bl func_ov10_021188c8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _020f5358:
 	mov r0, sb
 	blx func_ov00_020777d0
@@ -10849,7 +10849,7 @@ _020f539c:
 	add r8, r8, #1
 	b _020f5334
 _020f53a8:
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	arm_func_end func_ov01_020f52fc
 _020f53ac: .word data_027e0d54
 
@@ -11363,7 +11363,7 @@ _020f5a1c: .word data_ov00_020eec9c
 	.global func_ov01_020f5a20
 	arm_func_start func_ov01_020f5a20
 func_ov01_020f5a20: ; 0x020f5a20
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x30
 	mov sl, r0
 	add r0, sp, #0x10
@@ -11383,7 +11383,7 @@ func_ov01_020f5a20: ; 0x020f5a20
 	add r7, sl, #4
 	mov r4, r6
 	add r5, sp, #0x10
-	mov fp, #0x10c
+	mov r11, #0x10c
 _020f5a74:
 	cmp r6, #0
 	beq _020f5a90
@@ -11397,7 +11397,7 @@ _020f5a90:
 	cmp r0, #0
 	bne _020f5ae8
 	str r8, [sp]
-	mov r0, fp
+	mov r0, r11
 	mov r1, #0x1c
 	mov r2, #0xf
 	mov r3, sb
@@ -11469,7 +11469,7 @@ _020f5b90:
 	str r2, [sp]
 	bl func_0203493c
 	add sp, sp, #0x30
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	arm_func_end func_ov01_020f5a20
 
 	.global func_ov01_020f5bb0
@@ -11596,7 +11596,7 @@ _020f5d34: .word func_ov01_020f576c
 	.global func_ov01_020f5d38
 	arm_func_start func_ov01_020f5d38
 func_ov01_020f5d38: ; 0x020f5d38
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x18
 	mov sl, r0
 	str r2, [sp, #0x10]
@@ -11656,7 +11656,7 @@ func_ov01_020f5d38: ; 0x020f5d38
 	mov r7, sb
 	mvn r5, #0
 	mov r4, r8
-	mov fp, sb
+	mov r11, sb
 _020f5e2c:
 	add r0, sb, #0x71
 	stmia sp, {r0, r8}
@@ -11671,14 +11671,14 @@ _020f5e2c:
 	str r7, [sp, #0xc]
 	bl func_ov00_020cfed0
 	add r0, sb, #0x75
-	stmia sp, {r0, r4, fp}
+	stmia sp, {r0, r4, r11}
 	add r1, sb, #8
 	mov r0, #0x18
 	mla r0, r1, r0, r6
 	mov r1, #0x10c
 	mov r2, r5
 	and r3, sb, #0xff
-	str fp, [sp, #0xc]
+	str r11, [sp, #0xc]
 	bl func_ov00_020cfed0
 	add sb, sb, #1
 	cmp sb, #5
@@ -11703,7 +11703,7 @@ _020f5e2c:
 	mov r8, #0
 	mov r7, #0x10
 	mov r4, r6
-	mov fp, #0x14
+	mov r11, #0x14
 _020f5ee4:
 	bl func_020329b0
 	str r7, [sp]
@@ -11725,7 +11725,7 @@ _020f5ee4:
 	strb r4, [r5, #0x4e]
 	mov r0, sl
 	mov r1, r8
-	strb fp, [r5, #0x4f]
+	strb r11, [r5, #0x4f]
 	bl func_ov01_020f6ab0
 	add r8, r8, #1
 	cmp r8, #5
@@ -11741,7 +11741,7 @@ _020f5ee4:
 	strb r2, [sl, #0x1c7]
 	bl func_ov01_020f5fd0
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov01_020f5d38
 _020f5f78: .word data_027e0cbc
@@ -12359,13 +12359,13 @@ _020f675c:
 	.global func_ov01_020f6774
 	arm_func_start func_ov01_020f6774
 func_ov01_020f6774: ; 0x020f6774
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x2c
 	mov r8, r0
 	ldr r0, [r8, #0xc]
 	cmp r0, #0
 	addeq sp, sp, #0x2c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, [r8, #0x10]
 	mov r1, #0xf000
 	mov r0, r0, lsl #0xc
@@ -12382,7 +12382,7 @@ func_ov01_020f6774: ; 0x020f6774
 	sub r0, r7, #0x600
 	mov r6, r5
 	str r0, [sp, #4]
-	sub fp, r7, #0x400
+	sub r11, r7, #0x400
 	add sl, r8, #0x100
 	add sb, sp, #0xc
 _020f67dc:
@@ -12423,7 +12423,7 @@ _020f684c:
 	sub r2, r7, r0, lsl #10
 	b _020f686c
 _020f6858:
-	mov r2, fp
+	mov r2, r11
 	b _020f686c
 _020f6860:
 	ldr r2, [sp, #4]
@@ -12588,7 +12588,7 @@ _020f6a8c:
 	cmp r5, #0xa
 	blt _020f67dc
 	add sp, sp, #0x2c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov01_020f6774
 _020f6aa4: .word data_027e0c68
@@ -13656,7 +13656,7 @@ _020f79b8: .word 0x00002710
 	.global func_ov01_020f79bc
 	arm_func_start func_ov01_020f79bc
 func_ov01_020f79bc: ; 0x020f79bc
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x9c
 	ldr r5, _020f7b74 ; =data_027e0d54
 	mov sl, r0
@@ -13715,7 +13715,7 @@ _020f7a7c:
 	mov r0, #0
 	str r0, [sp, #0x14]
 	mov r7, r0
-	mov fp, #7
+	mov r11, #7
 	mov r4, #1
 _020f7aa4:
 	ldr r0, [r5, #0x10]
@@ -13729,7 +13729,7 @@ _020f7abc:
 	beq _020f7b1c
 	mov r0, #0
 	str r0, [sp]
-	stmib sp, {r0, fp}
+	stmib sp, {r0, r11}
 	mov r0, #0xa
 	str r0, [sp, #0xc]
 	mov r0, #2
@@ -13773,7 +13773,7 @@ _020f7b48:
 	strb r0, [r5, #0xd]
 	strb r0, [r5, #0xe]
 	add sp, sp, #0x9c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov01_020f79bc
 _020f7b74: .word data_027e0d54
@@ -14671,19 +14671,19 @@ func_ov01_020f84c8: ; 0x020f84c8
 	.global func_ov01_020f8500
 	arm_func_start func_ov01_020f8500
 func_ov01_020f8500: ; 0x020f8500
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	mov sb, r1
 	mov sl, r0
 	mov r0, sb
 	bl func_ov01_020f84b8
 	cmp r0, #0
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	mov r0, sb
 	bl func_ov01_020f84c8
 	cmp r0, #0
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	mov r7, #0
 	mov r6, sb
 	mov r5, r7
@@ -14706,7 +14706,7 @@ _020f8560:
 	mov r6, r4
 	mov r7, sl
 	mov r8, sb
-	mov fp, #8
+	mov r11, #8
 	b _020f85ac
 _020f858c:
 	ldrb r0, [r7, #0x12]
@@ -14743,7 +14743,7 @@ _020f85e4:
 	ldrb r3, [r7, #0x13]
 	ldrb r1, [r8, #0x13]
 	mov r0, r7
-	mov r2, fp
+	mov r2, r11
 	strb r1, [r7, #0x13]
 	add r1, sb, #0x3c
 	strb r3, [r8, #0x13]
@@ -14767,7 +14767,7 @@ _020f8638:
 	bl func_ov01_020f84a8
 _020f8650:
 	mov r0, r4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	arm_func_end func_ov01_020f8500
 
 	.global func_ov01_020f8658

--- a/asm/ov02.s
+++ b/asm/ov02.s
@@ -6049,7 +6049,7 @@ func_ov02_020f3ae0: ; 0x020f3ae0
 	.global func_ov02_020f3ae4
 	arm_func_start func_ov02_020f3ae4
 func_ov02_020f3ae4: ; 0x020f3ae4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x6c
 	str r0, [sp, #8]
 	add r0, sp, #0x4c
@@ -6083,7 +6083,7 @@ func_ov02_020f3ae4: ; 0x020f3ae4
 	str r3, [sp, #0x38]
 	str r2, [sp, #0x2c]
 	str r1, [sp, #0x30]
-	mov fp, #5
+	mov r11, #5
 	mov r6, #0x30
 	mov r7, #0x3b
 	mov r8, #0x1c
@@ -6129,7 +6129,7 @@ _020f3b80:
 	mov r1, sb
 	add r0, sp, #0x28
 	mov r2, sl
-	str fp, [sp, #0x34]
+	str r11, [sp, #0x34]
 	bl func_ov02_020f5f98
 	mov r0, #0x4d
 	add r1, r4, #0x10
@@ -6233,7 +6233,7 @@ _020f3d9c:
 	add r4, r4, #1
 	add r0, r0, #3
 	str r0, [sp, #0x1c]
-	add fp, fp, #3
+	add r11, r11, #3
 	add r6, r6, #3
 	add r7, r7, #2
 	add r8, r8, #2
@@ -6248,7 +6248,7 @@ _020f3d9c:
 	str r1, [sp, #0x2c]
 	mov r7, #0
 	str r0, [sp, #0x20]
-	mov fp, #9
+	mov r11, #9
 	mov r8, #0x3b
 	mov sb, #0x42
 	mov sl, #0x19
@@ -6296,7 +6296,7 @@ _020f3dfc:
 	mov r1, r4
 	add r0, sp, #0x28
 	mov r2, r6
-	str fp, [sp, #0x34]
+	str r11, [sp, #0x34]
 	bl func_ov02_020f5f98
 _020f3eac:
 	mov r0, #0xec
@@ -6401,7 +6401,7 @@ _020f4020:
 	add r7, r7, #1
 	add r0, r0, #3
 	str r0, [sp, #0x20]
-	add fp, fp, #3
+	add r11, r11, #3
 	add r8, r8, #3
 	add sb, sb, #2
 	add sl, sl, #2
@@ -6499,7 +6499,7 @@ _020f40fc:
 	bl _ZNK11ItemManager7HasItemEi
 	cmp r0, #0
 	addeq sp, sp, #0x6c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	mov r2, r5
 	mov r0, #0xec
 	mov r1, #6
@@ -6513,7 +6513,7 @@ _020f40fc:
 	str r4, [sp]
 	bl func_0203493c
 	add sp, sp, #0x6c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov02_020f3ae4
 _020f41ec: .word gItemManager

--- a/asm/ov02.s
+++ b/asm/ov02.s
@@ -6049,7 +6049,7 @@ func_ov02_020f3ae0: ; 0x020f3ae0
 	.global func_ov02_020f3ae4
 	arm_func_start func_ov02_020f3ae4
 func_ov02_020f3ae4: ; 0x020f3ae4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x6c
 	str r0, [sp, #8]
 	add r0, sp, #0x4c
@@ -6087,13 +6087,13 @@ func_ov02_020f3ae4: ; 0x020f3ae4
 	mov r6, #0x30
 	mov r7, #0x3b
 	mov r8, #0x1c
-	add sl, sp, #0x4c
+	add r10, sp, #0x4c
 _020f3b80:
 	mov r0, #0x4d
 	add r1, r4, #1
 	mov r2, r5
 	mov r3, #0
-	str sl, [sp]
+	str r10, [sp]
 	bl func_0203493c
 	ldr r0, _020f41ec ; =gItemManager
 	mov r1, r4
@@ -6109,33 +6109,33 @@ _020f3b80:
 	mov r0, #0x4d
 	mov r2, r5
 	mov r3, #0
-	str sl, [sp]
+	str r10, [sp]
 	bl func_0203493c
 	ldr r0, [sp, #8]
 	mov r1, r5
 	add r0, r0, r4, lsl #2
 	ldr r0, [r0, #0x10]
 	mov r2, #0
-	mov r3, sl
+	mov r3, r10
 	bl func_02032788
 	ldr r1, [sp, #0x1c]
 	mov r0, #0x4d
 	mov r2, r5
 	mov r3, #0
-	str sl, [sp]
+	str r10, [sp]
 	bl func_0203493c
 	mov r0, #1
 	str r0, [sp, #0x28]
 	mov r1, sb
 	add r0, sp, #0x28
-	mov r2, sl
+	mov r2, r10
 	str r11, [sp, #0x34]
 	bl func_ov02_020f5f98
 	mov r0, #0x4d
 	add r1, r4, #0x10
 	mov r2, r5
 	mov r3, #0
-	str sl, [sp]
+	str r10, [sp]
 	bl func_0203493c
 	blx func_0202ab48
 	cmp r0, #1
@@ -6164,11 +6164,11 @@ _020f3c58:
 	add r1, r4, #0x2c
 	mov r2, r5
 	mov r3, #0
-	str sl, [sp]
+	str r10, [sp]
 	bl func_0203493c
 	add r0, sp, #0x28
 	mov r1, sb
-	mov r2, sl
+	mov r2, r10
 	str r6, [sp, #0x34]
 	bl func_ov02_020f5f98
 _020f3cc4:
@@ -6176,12 +6176,12 @@ _020f3cc4:
 	add r1, r4, #0x38
 	mov r2, r5
 	mov r3, #0
-	str sl, [sp]
+	str r10, [sp]
 	bl func_0203493c
 	mov r0, #0xc
 	mul r1, sb, r0
 	ldr r0, [sp, #0xc]
-	mov r2, sl
+	mov r2, r10
 	sub r1, r0, r1
 	add r0, sp, #0x28
 	str r7, [sp, #0x34]
@@ -6202,10 +6202,10 @@ _020f3d00:
 	add r1, r4, #0x13
 	mov r2, r5
 	mov r3, #0
-	str sl, [sp]
+	str r10, [sp]
 	bl func_0203493c
 	mov r0, #0
-	stmia sp, {r0, sl}
+	stmia sp, {r0, r10}
 	mov r0, #0x4d
 	add r1, sb, #0x22
 	add r2, r4, #0x19
@@ -6216,12 +6216,12 @@ _020f3d5c:
 	add r1, r4, #0x16
 	mov r2, r5
 	mov r3, #0
-	str sl, [sp]
+	str r10, [sp]
 	bl func_0203493c
 	mov r0, #0x64
 	mul r1, sb, r0
 	ldr r0, [sp, #0x10]
-	mov r2, sl
+	mov r2, r10
 	sub r1, r0, r1
 	mov r0, #0
 	str r0, [sp, #0x28]
@@ -6251,7 +6251,7 @@ _020f3d9c:
 	mov r11, #9
 	mov r8, #0x3b
 	mov sb, #0x42
-	mov sl, #0x19
+	mov r10, #0x19
 	add r6, sp, #0x4c
 _020f3dfc:
 	mov r0, #0xec
@@ -6394,7 +6394,7 @@ _020f3fe0:
 	mov r0, #0
 	str r0, [sp, #0x28]
 	add r0, sp, #0x28
-	str sl, [sp, #0x34]
+	str r10, [sp, #0x34]
 	bl func_ov02_020f5f98
 _020f4020:
 	ldr r0, [sp, #0x20]
@@ -6404,7 +6404,7 @@ _020f4020:
 	add r11, r11, #3
 	add r8, r8, #3
 	add sb, sb, #2
-	add sl, sl, #2
+	add r10, r10, #2
 	cmp r7, #2
 	blt _020f3dfc
 	ldr r0, _020f41ec ; =gItemManager
@@ -6499,7 +6499,7 @@ _020f40fc:
 	bl _ZNK11ItemManager7HasItemEi
 	cmp r0, #0
 	addeq sp, sp, #0x6c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	mov r2, r5
 	mov r0, #0xec
 	mov r1, #6
@@ -6513,7 +6513,7 @@ _020f40fc:
 	str r4, [sp]
 	bl func_0203493c
 	add sp, sp, #0x6c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov02_020f3ae4
 _020f41ec: .word gItemManager
@@ -8663,7 +8663,7 @@ _020f5f94: .word data_ov00_020eec9c
 	.global func_ov02_020f5f98
 	arm_func_start func_ov02_020f5f98
 func_ov02_020f5f98: ; 0x020f5f98
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #8
 	mov r6, r0
 	ldr r0, [r6, #0x10]
@@ -8685,8 +8685,8 @@ _020f5fdc:
 	mov r0, r5
 	mov r1, #0x3e8
 	bl func_01ff9b4c
-	mov sl, r0
-	cmp sl, #0
+	mov r10, r0
+	cmp r10, #0
 	bgt _020f5ffc
 	cmp sb, #0
 	beq _020f6020
@@ -8696,7 +8696,7 @@ _020f5ffc:
 	stmia sp, {r0, r4}
 	ldmib r6, {r0, r1}
 	mov r3, r8
-	add r1, r1, sl
+	add r1, r1, r10
 	bl func_020349cc
 	mov sb, #1
 	b _020f6030
@@ -8707,15 +8707,15 @@ _020f6020:
 	subeq r8, r8, r0
 _020f6030:
 	mov r0, #0x3e8
-	mul r0, sl, r0
+	mul r0, r10, r0
 	add r7, r7, #1
 	sub r5, r5, r0
 _020f6040:
 	mov r0, r5
 	mov r1, #0x64
 	bl func_01ff9b4c
-	mov sl, r0
-	cmp sl, #0
+	mov r10, r0
+	cmp r10, #0
 	bgt _020f6060
 	cmp sb, #0
 	beq _020f6084
@@ -8725,7 +8725,7 @@ _020f6060:
 	stmia sp, {r0, r4}
 	ldmib r6, {r0, r1}
 	mov r3, r8
-	add r1, r1, sl
+	add r1, r1, r10
 	bl func_020349cc
 	mov sb, #1
 	b _020f6094
@@ -8736,15 +8736,15 @@ _020f6084:
 	subeq r8, r8, r0
 _020f6094:
 	mov r0, #0x64
-	mul r0, sl, r0
+	mul r0, r10, r0
 	add r7, r7, #1
 	sub r5, r5, r0
 _020f60a4:
 	mov r0, r5
 	mov r1, #0xa
 	bl func_01ff9b4c
-	mov sl, r0
-	cmp sl, #0
+	mov r10, r0
+	cmp r10, #0
 	bgt _020f60c4
 	cmp sb, #0
 	beq _020f60e4
@@ -8754,7 +8754,7 @@ _020f60c4:
 	stmia sp, {r0, r4}
 	ldmib r6, {r0, r1}
 	mov r3, r8
-	add r1, r1, sl
+	add r1, r1, r10
 	bl func_020349cc
 	b _020f60f4
 _020f60e4:
@@ -8778,7 +8778,7 @@ _020f60f8:
 	bl func_020349cc
 _020f6124:
 	add sp, sp, #8
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	arm_func_end func_ov02_020f5f98
 
 	.global func_ov02_020f612c

--- a/asm/ov02.s
+++ b/asm/ov02.s
@@ -263,7 +263,7 @@ _020ef080: .word gItemManager
 	.global func_ov02_020ef084
 	arm_func_start func_ov02_020ef084
 func_ov02_020ef084: ; 0x020ef084
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0xc
 	ldr r2, _020ef998 ; =gItemManager
 	ldr r1, _020ef99c ; =0x91a2b3c5
@@ -295,7 +295,7 @@ _020ef0d0:
 	cmp r7, #0x80
 	blt _020ef0d0
 	mov r7, #0
-	mov sb, r5
+	mov r9, r5
 	add r8, r5, #0x10
 	mov r6, r7
 _020ef108:
@@ -306,11 +306,11 @@ _020ef108:
 	mov r1, r7
 	bl func_ov02_020f0a54
 	cmp r0, #0
-	streqb r6, [sb, #0x6c]
+	streqb r6, [r9, #0x6c]
 	add r7, r7, #1
 	cmp r7, #3
 	add r8, r8, #0xf0
-	add sb, sb, #0xf0
+	add r9, r9, #0xf0
 	blt _020ef108
 	mov r2, #0x13
 	str r2, [sp]
@@ -871,7 +871,7 @@ _020ef96c:
 	str r1, [r5, #0xd14]
 	blx func_ov09_021144d0
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov02_020ef084
 _020ef998: .word gItemManager
@@ -1323,7 +1323,7 @@ _020eff6c: .word 0x04000304
 	.global func_ov02_020eff70
 	arm_func_start func_ov02_020eff70
 func_ov02_020eff70: ; 0x020eff70
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x48
 	mov r7, r0
 	add r0, sp, #0x28
@@ -1633,7 +1633,7 @@ _020f0414:
 	blx func_ov09_02113868
 	ldrb r0, [r7, #0xd0e]
 	mov r2, #2
-	mov sb, #0
+	mov r9, #0
 	cmp r0, #0
 	ldrne r0, _020f071c ; =data_ov09_0211f528
 	movne r1, #0x14000
@@ -1654,13 +1654,13 @@ _020f0414:
 	mov r6, r1
 _020f0474:
 	mov r0, r6
-	mov r1, sb
+	mov r1, r9
 	mov r2, r4
 	mov r3, r5
 	str r8, [sp]
 	bl func_0203493c
-	add sb, sb, #1
-	cmp sb, #6
+	add r9, r9, #1
+	cmp r9, #6
 	ble _020f0474
 	ldr r0, _020f0724 ; =data_027e0f74
 	mov r1, #0xd4
@@ -1722,18 +1722,18 @@ _020f0560:
 	str r6, [sp]
 	bl func_0203493c
 _020f0570:
-	mov sb, #0xd
+	mov r9, #0xd
 	add r8, sp, #0x28
 	mov r6, #0xef
 _020f057c:
 	mov r0, r6
-	mov r1, sb
+	mov r1, r9
 	mov r2, r4
 	mov r3, r5
 	str r8, [sp]
 	bl func_0203493c
-	add sb, sb, #1
-	cmp sb, #0xe
+	add r9, r9, #1
+	cmp r9, #0xe
 	ble _020f057c
 	ldrb r0, [r7, #0xd0e]
 	cmp r0, #0
@@ -1828,13 +1828,13 @@ _020f06e0:
 	ldrb r0, [r7, #0xd0e]
 	cmp r0, #0
 	addeq sp, sp, #0x48
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	mov r1, #0x14000
 	ldr r0, _020f071c ; =data_ov09_0211f528
 	rsb r1, r1, #0
 	str r1, [r0]
 	add sp, sp, #0x48
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov02_020eff70
 _020f071c: .word data_ov09_0211f528
@@ -6049,7 +6049,7 @@ func_ov02_020f3ae0: ; 0x020f3ae0
 	.global func_ov02_020f3ae4
 	arm_func_start func_ov02_020f3ae4
 func_ov02_020f3ae4: ; 0x020f3ae4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x6c
 	str r0, [sp, #8]
 	add r0, sp, #0x4c
@@ -6099,12 +6099,12 @@ _020f3b80:
 	mov r1, r4
 	ldr r0, [r0]
 	blx _ZNK11ItemManager10GetUnk_098Ej
-	mov sb, r0
-	cmp sb, #0
+	mov r9, r0
+	cmp r9, #0
 	ble _020f3d9c
 	ldr r0, [sp, #0x24]
 	add r1, r4, #0xd
-	add r0, r0, sb
+	add r0, r0, r9
 	str r0, [sp, #0x24]
 	mov r0, #0x4d
 	mov r2, r5
@@ -6126,7 +6126,7 @@ _020f3b80:
 	bl func_0203493c
 	mov r0, #1
 	str r0, [sp, #0x28]
-	mov r1, sb
+	mov r1, r9
 	add r0, sp, #0x28
 	mov r2, r10
 	str r11, [sp, #0x34]
@@ -6157,8 +6157,8 @@ _020f3c58:
 	mov r1, #0xc
 	str r0, [sp, #0xc]
 	bl func_01ff9b4c
-	mov sb, r0
-	cmp sb, #0
+	mov r9, r0
+	cmp r9, #0
 	ble _020f3cc4
 	mov r0, #0x4d
 	add r1, r4, #0x2c
@@ -6167,7 +6167,7 @@ _020f3c58:
 	str r10, [sp]
 	bl func_0203493c
 	add r0, sp, #0x28
-	mov r1, sb
+	mov r1, r9
 	mov r2, r10
 	str r6, [sp, #0x34]
 	bl func_ov02_020f5f98
@@ -6179,7 +6179,7 @@ _020f3cc4:
 	str r10, [sp]
 	bl func_0203493c
 	mov r0, #0xc
-	mul r1, sb, r0
+	mul r1, r9, r0
 	ldr r0, [sp, #0xc]
 	mov r2, r10
 	sub r1, r0, r1
@@ -6195,8 +6195,8 @@ _020f3d00:
 	mov r1, #0x64
 	str r0, [sp, #0x10]
 	bl func_01ff9b4c
-	mov sb, r0
-	cmp sb, #0
+	mov r9, r0
+	cmp r9, #0
 	ble _020f3d5c
 	mov r0, #0x4d
 	add r1, r4, #0x13
@@ -6207,7 +6207,7 @@ _020f3d00:
 	mov r0, #0
 	stmia sp, {r0, r10}
 	mov r0, #0x4d
-	add r1, sb, #0x22
+	add r1, r9, #0x22
 	add r2, r4, #0x19
 	mov r3, r5
 	bl func_020349cc
@@ -6219,7 +6219,7 @@ _020f3d5c:
 	str r10, [sp]
 	bl func_0203493c
 	mov r0, #0x64
-	mul r1, sb, r0
+	mul r1, r9, r0
 	ldr r0, [sp, #0x10]
 	mov r2, r10
 	sub r1, r0, r1
@@ -6250,7 +6250,7 @@ _020f3d9c:
 	str r0, [sp, #0x20]
 	mov r11, #9
 	mov r8, #0x3b
-	mov sb, #0x42
+	mov r9, #0x42
 	mov r10, #0x19
 	add r6, sp, #0x4c
 _020f3dfc:
@@ -6352,7 +6352,7 @@ _020f3f48:
 	mov r2, r6
 	sub r1, r0, r1
 	add r0, sp, #0x28
-	str sb, [sp, #0x34]
+	str r9, [sp, #0x34]
 	bl func_ov02_020f5f98
 	b _020f4020
 _020f3f84:
@@ -6403,7 +6403,7 @@ _020f4020:
 	str r0, [sp, #0x20]
 	add r11, r11, #3
 	add r8, r8, #3
-	add sb, sb, #2
+	add r9, r9, #2
 	add r10, r10, #2
 	cmp r7, #2
 	blt _020f3dfc
@@ -6499,7 +6499,7 @@ _020f40fc:
 	bl _ZNK11ItemManager7HasItemEi
 	cmp r0, #0
 	addeq sp, sp, #0x6c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	mov r2, r5
 	mov r0, #0xec
 	mov r1, #6
@@ -6513,7 +6513,7 @@ _020f40fc:
 	str r4, [sp]
 	bl func_0203493c
 	add sp, sp, #0x6c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov02_020f3ae4
 _020f41ec: .word gItemManager
@@ -8663,11 +8663,11 @@ _020f5f94: .word data_ov00_020eec9c
 	.global func_ov02_020f5f98
 	arm_func_start func_ov02_020f5f98
 func_ov02_020f5f98: ; 0x020f5f98
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #8
 	mov r6, r0
 	ldr r0, [r6, #0x10]
-	ldrb sb, [r6, #0x20]
+	ldrb r9, [r6, #0x20]
 	ldr r7, [r6, #0xc]
 	ldr r8, [r6, #0x14]
 	mov r5, r1
@@ -8688,7 +8688,7 @@ _020f5fdc:
 	mov r10, r0
 	cmp r10, #0
 	bgt _020f5ffc
-	cmp sb, #0
+	cmp r9, #0
 	beq _020f6020
 _020f5ffc:
 	ldr r0, [r6, #0x18]
@@ -8698,7 +8698,7 @@ _020f5ffc:
 	mov r3, r8
 	add r1, r1, r10
 	bl func_020349cc
-	mov sb, #1
+	mov r9, #1
 	b _020f6030
 _020f6020:
 	ldr r0, [r6]
@@ -8717,7 +8717,7 @@ _020f6040:
 	mov r10, r0
 	cmp r10, #0
 	bgt _020f6060
-	cmp sb, #0
+	cmp r9, #0
 	beq _020f6084
 _020f6060:
 	ldr r0, [r6, #0x18]
@@ -8727,7 +8727,7 @@ _020f6060:
 	mov r3, r8
 	add r1, r1, r10
 	bl func_020349cc
-	mov sb, #1
+	mov r9, #1
 	b _020f6094
 _020f6084:
 	ldr r0, [r6]
@@ -8746,7 +8746,7 @@ _020f60a4:
 	mov r10, r0
 	cmp r10, #0
 	bgt _020f60c4
-	cmp sb, #0
+	cmp r9, #0
 	beq _020f60e4
 _020f60c4:
 	ldr r0, [r6, #0x18]
@@ -8778,7 +8778,7 @@ _020f60f8:
 	bl func_020349cc
 _020f6124:
 	add sp, sp, #8
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	arm_func_end func_ov02_020f5f98
 
 	.global func_ov02_020f612c

--- a/asm/ov03.s
+++ b/asm/ov03.s
@@ -3482,9 +3482,9 @@ _020f06a8: .word data_027e0184
 	.global func_ov03_020f06ac
 	arm_func_start func_ov03_020f06ac
 func_ov03_020f06ac: ; 0x020f06ac
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	ldr r7, [sp, #0x28]
-	mov sb, r0
+	mov r9, r0
 	mov r8, r1
 	cmp r7, #0
 	ldr r6, [sp, #0x2c]
@@ -3493,11 +3493,11 @@ func_ov03_020f06ac: ; 0x020f06ac
 	mov r0, r2
 	mov r1, r3
 	bl func_01ff9b24
-	ldr r0, [sb, #0xc]
+	ldr r0, [r9, #0xc]
 	add r0, r0, #0x800
 	mov r5, r0, asr #0xc
 	bl func_01ff9a18
-	ldr ip, [sb, #8]
+	ldr ip, [r9, #8]
 	rsb r2, r5, #0
 	rsb r1, r5, #0x100
 	mul r3, r2, ip
@@ -3533,11 +3533,11 @@ _020f075c:
 	ldr r0, [sp, #0x20]
 	ldr r1, [sp, #0x24]
 	bl func_01ff9b24
-	ldr r0, [sb, #0x10]
+	ldr r0, [r9, #0x10]
 	add r0, r0, #0x800
 	mov r7, r0, asr #0xc
 	bl func_01ff9a18
-	ldr r5, [sb, #8]
+	ldr r5, [r9, #8]
 	rsb r2, r7, #0
 	mul r3, r2, r5
 	rsb r1, r7, #0xc0
@@ -3587,7 +3587,7 @@ _020f0818:
 	str r0, [r6]
 _020f0834:
 	mov r0, r4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov03_020f06ac
 _020f083c: .word data_027e0c38
@@ -3596,9 +3596,9 @@ _020f0840: .word data_027e080c
 	.global func_ov03_020f0844
 	arm_func_start func_ov03_020f0844
 func_ov03_020f0844: ; 0x020f0844
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #8
-	movs sb, r1
+	movs r9, r1
 	mov r10, r0
 	mov r8, r2
 	mov r7, r3
@@ -3657,7 +3657,7 @@ _020f08a4:
 	stmib r6, {r0, r1}
 	ldr r0, [r10, #8]
 	bl func_01ff991c
-	cmp sb, #0
+	cmp r9, #0
 	beq _020f097c
 	sub r1, r8, #0x80
 	mul r1, r5, r1
@@ -3701,7 +3701,7 @@ _020f097c:
 	str r1, [r6]
 	mov r3, r0, asr #0x1f
 _020f09d8:
-	cmp sb, #0
+	cmp r9, #0
 	beq _020f0a30
 	sub r1, r7, #0x60
 	mul r1, r4, r1
@@ -3722,7 +3722,7 @@ _020f09d8:
 	add sp, sp, #8
 	add r0, r1, r0
 	str r0, [r6, #8]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _020f0a30:
 	ldr r2, [r10, #0x10]
 	sub r1, r7, #0x60000
@@ -3750,7 +3750,7 @@ _020f0a30:
 	add r0, r1, r0
 	str r0, [r6, #8]
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov03_020f0844
 _020f0a9c: .word data_027e0c38
@@ -3825,7 +3825,7 @@ _020f0b88: .word data_027e0d3c
 	.global func_ov03_020f0b8c
 	arm_func_start func_ov03_020f0b8c
 func_ov03_020f0b8c: ; 0x020f0b8c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0xe4
 	ldr r3, _020f0e2c ; =data_027e0c54
 	mov r8, r0
@@ -3836,7 +3836,7 @@ func_ov03_020f0b8c: ; 0x020f0b8c
 	beq _020f0bbc
 	cmp r7, #2
 	addeq sp, sp, #0xe4
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _020f0bbc:
 	cmp r6, #1
 	movls r0, #1
@@ -3846,14 +3846,14 @@ _020f0bbc:
 	cmp r0, r7
 	bne _020f0bfc
 	addne sp, sp, #0xe4
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	ldrh r0, [r8, #0x6a]
 	cmp r0, #0
 	addeq sp, sp, #0xe4
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	cmp r6, #1
 	addhi sp, sp, #0xe4
-	ldmhiia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmhiia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _020f0bfc:
 	cmp r7, #4
 	addls pc, pc, r7, lsl #2
@@ -3932,12 +3932,12 @@ _020f0ca4:
 	add r1, r0, #0x10
 	mov r0, #0xc0000
 	bl func_01ff9b4c
-	mov sb, r0
+	mov r9, r0
 	add r1, r5, #0x10
 	mov r0, #0x100000
 	bl func_01ff9b4c
-	cmp r0, sb
-	movge r0, sb
+	cmp r0, r9
+	movge r0, r9
 	cmp r0, #0x2000
 	movgt r0, #0x2000
 	cmp r0, #0x1000
@@ -4004,7 +4004,7 @@ _020f0e08:
 _020f0e20:
 	str r7, [r8, #4]
 	add sp, sp, #0xe4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov03_020f0b8c
 _020f0e2c: .word data_027e0c54
@@ -4714,12 +4714,12 @@ _020f1668: .word data_027e05f8
 	.global func_ov03_020f166c
 	arm_func_start func_ov03_020f166c
 func_ov03_020f166c: ; 0x020f166c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	mov r10, r0
 	ldr r0, [r10, #4]
 	cmp r0, #2
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r1, _020f182c ; =data_027e0c54
 	ldr r0, _020f1830 ; =data_ov09_0211f5b4
 	ldrb r5, [r1]
@@ -4731,10 +4731,10 @@ func_ov03_020f166c: ; 0x020f166c
 	cmp r4, #0
 	cmpeq r0, #0
 	ldr r0, _020f1838 ; =data_027e077c
-	moveq sb, #0x1e
+	moveq r9, #0x1e
 	ldr r1, _020f183c ; =data_02056be4
 	ldr r0, [r0]
-	movne sb, #0
+	movne r9, #0
 	ldrb r0, [r1, r0]
 	tst r0, #1
 	beq _020f1780
@@ -4746,7 +4746,7 @@ func_ov03_020f166c: ; 0x020f166c
 	and r0, r1, r0
 	cmp r0, #0x1000000
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	mov r5, #0
 	mov r7, r10
 	add r8, r10, #0x8c
@@ -4765,7 +4765,7 @@ _020f1710:
 	ldrh r6, [r7, #0x96]
 	ldr ip, [ip]
 	mov r1, r11
-	mov r2, sb
+	mov r2, r9
 	mov r3, r11
 	blx ip
 	mov r2, r0
@@ -4778,7 +4778,7 @@ _020f1710:
 	mov r1, #3
 	bl func_ov03_020f13b0
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _020f1768:
 	add r5, r5, #1
 	cmp r5, #3
@@ -4797,7 +4797,7 @@ _020f1794:
 	and r0, r0, r11
 	cmp r0, #0x1000000
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	cmp r5, #1
 	bne _020f17b8
 	cmp r4, #0
@@ -4811,7 +4811,7 @@ _020f17b8:
 	ldrh r6, [r7, #0x4e]
 	mov r1, #0
 	ldr ip, [ip]
-	mov r2, sb
+	mov r2, r9
 	mov r3, r1
 	blx ip
 	mov r2, r0
@@ -4824,7 +4824,7 @@ _020f17b8:
 	mov r1, #3
 	bl func_ov03_020f13b0
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _020f1810:
 	add r5, r5, #1
 	cmp r5, #3
@@ -4833,7 +4833,7 @@ _020f1810:
 	blt _020f1794
 _020f1824:
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov03_020f166c
 _020f182c: .word data_027e0c54
@@ -5433,7 +5433,7 @@ func_ov03_020f1f38: ; 0x020f1f38
 	.global func_ov03_020f1f4c
 	arm_func_start func_ov03_020f1f4c
 func_ov03_020f1f4c: ; 0x020f1f4c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	ldr r3, _020f2130 ; =data_027e0d78
 	ldr r2, _020f2134 ; =data_ov03_02100100
 	ldr r5, [r3, #0x2c]
@@ -5468,7 +5468,7 @@ _020f1fa4:
 _020f1fc4:
 	cmp r1, #0
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	ldrsb r0, [r7, #0x14]
 	mov r1, #1
 	cmp r0, #1
@@ -5476,12 +5476,12 @@ _020f1fc4:
 	movne r1, #0
 	cmp r1, #0
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	mov r0, r7
 	bl func_ov03_020f26bc
 	cmp r0, #0
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	ldr r0, _020f2138 ; =data_027e103c
 	ldr r0, [r0]
 	bl func_ov00_020cf4f4
@@ -5493,7 +5493,7 @@ _020f1fc4:
 	ldrsb r0, [r0, #0x14]
 	cmp r0, #0
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _020f2034:
 	ldr r0, _020f2138 ; =data_027e103c
 	ldr r1, _020f213c ; =0x0000019f
@@ -5501,14 +5501,14 @@ _020f2034:
 	bl func_ov00_020cf8fc
 	cmp r0, #0
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	ldr r0, _020f2140 ; =data_027e077c
 	ldr r1, [r0]
 	mov r0, r1
 	cmp r1, #1
 	cmpne r0, #0x37
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	ldrsb r0, [r7, #0x14]
 	cmp r0, #0
 	beq _020f20e8
@@ -5523,18 +5523,18 @@ _020f2094:
 	ldr r0, [r7, #0x20]
 	mov r1, r6
 	ldr ip, [r0, r5]!
-	ldrh sb, [r0, #0xa]
+	ldrh r9, [r0, #0xa]
 	ldr ip, [ip]
 	mov r2, r8
 	mov r3, r8
 	blx ip
 	mov r2, r0
 	mov r0, r7
-	mov r1, sb
+	mov r1, r9
 	bl func_ov03_020f2188
 	cmp r0, #0
 	movne r0, #1
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	ldrb r0, [r7, #0x1d]
 	add r4, r4, #1
 	add r5, r5, #0x18
@@ -5557,10 +5557,10 @@ _020f20e8:
 	bl func_ov03_020f2188
 	cmp r0, #0
 	movne r0, #1
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _020f2128:
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov03_020f1f4c
 _020f2130: .word data_027e0d78
@@ -6753,13 +6753,13 @@ _020f2d9c: .word func_ov03_020f2da0 - 1
 	.global func_ov03_020f2da0
 	arm_func_start func_ov03_020f2da0
 func_ov03_020f2da0: ; 0x020f2da0
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x34
 	mov r10, r0
 	ldrb r0, [r10, #0xa]
 	cmp r0, #0
 	addeq sp, sp, #0x34
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	bl func_01ffa8d4
 	ldr r2, _020f2f8c ; =0x04000444
 	mov r3, #0
@@ -6777,9 +6777,9 @@ func_ov03_020f2da0: ; 0x020f2da0
 	orr r0, r0, #0xc0
 	str r0, [r2, #0x60]
 	ldr r0, [r10, #4]
-	ldrh sb, [r10, #8]
+	ldrh r9, [r10, #8]
 	sub r0, r0, #1
-	cmp sb, r0
+	cmp r9, r0
 	bhs _020f2f78
 _020f2e10:
 	ldr r0, _020f2f98 ; =0x04000500
@@ -6791,7 +6791,7 @@ _020f2e10:
 _020f2e28:
 	mov r0, r10
 	ldr r2, [r0]
-	mov r1, sb
+	mov r1, r9
 	ldr r2, [r2, #0x20]
 	blx r2
 	ldr ip, [r0, #4]
@@ -6853,12 +6853,12 @@ _020f2e28:
 	str r0, [r4]
 	str r11, [r4]
 	ldr r0, [r10, #4]
-	add sb, sb, #1
-	cmp sb, r0
+	add r9, r9, #1
+	cmp r9, r0
 	bhs _020f2f5c
 	mov r0, r10
 	ldr r2, [r0]
-	sub r1, sb, #1
+	sub r1, r9, #1
 	ldr r2, [r2, #0x20]
 	blx r2
 	ldr r1, [r0, #0xc]
@@ -6872,14 +6872,14 @@ _020f2f5c:
 	str r1, [r0]
 	ldr r0, [r10, #4]
 	sub r0, r0, #1
-	cmp sb, r0
+	cmp r9, r0
 	blo _020f2e10
 _020f2f78:
 	ldr r0, _020f2fa0 ; =0x04000448
 	mov r1, #1
 	str r1, [r0]
 	add sp, sp, #0x34
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov03_020f2da0
 _020f2f8c: .word 0x04000444
@@ -6960,7 +6960,7 @@ func_ov03_020f301c: ; 0x020f301c
 	.global func_ov03_020f3064
 	arm_func_start func_ov03_020f3064
 func_ov03_020f3064: ; 0x020f3064
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x10
 	movs r5, r3
 	mov r7, r0
@@ -6980,7 +6980,7 @@ func_ov03_020f3064: ; 0x020f3064
 	cmpeq r0, #0
 	addeq sp, sp, #0x10
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _020f30b8:
 	mov r0, r7
 	ldr r2, [r0]
@@ -7038,7 +7038,7 @@ _020f316c:
 	cmp r0, r1, asr #1
 	addgt sp, sp, #0x10
 	movgt r0, #0
-	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _020f3198:
 	cmp r5, #0
 	beq _020f31b0
@@ -7087,19 +7087,19 @@ _020f3218:
 	ldr r8, [r4, #0xc]
 	ldr r0, _020f3510 ; =0x04000280
 	smlal r1, r10, r8, r8
-	mov sb, #2
-	strh sb, [r0]
-	mov sb, #0
-	str sb, [r0, #0x10]
-	mov sb, #0x1000000
-	str sb, [r0, #0x14]
+	mov r9, #2
+	strh r9, [r0]
+	mov r9, #0
+	str r9, [r0, #0x10]
+	mov r9, #0x1000000
+	str r9, [r0, #0x14]
 	str r1, [r0, #0x18]
 	mov r8, r10, lsl #0x2
 	str r10, [r0, #0x1c]
-	mov sb, #1
-	strh sb, [r0, #0x30]
-	mov sb, r1, lsl #0x2
-	str sb, [r0, #0x38]
+	mov r9, #1
+	strh r9, [r0, #0x30]
+	mov r9, r1, lsl #0x2
+	str r9, [r0, #0x38]
 	orr r8, r8, r1, lsr #30
 	str r3, [sp, #8]
 	str r2, [sp, #0xc]
@@ -7117,15 +7117,15 @@ _020f32a4:
 	bne _020f32a4
 	ldr r11, _020f3514 ; =0x040002a0
 	ldr r1, [r4, #0xc]
-	ldr sb, [r11]
+	ldr r9, [r11]
 	mov ip, r10, asr #0x1f
-	umull r8, lr, sb, r10
+	umull r8, lr, r9, r10
 	umull r3, r2, r8, r1
 	mov r0, r1, asr #0x1f
-	mla lr, sb, ip, lr
-	ldr sb, [r11, #4]
+	mla lr, r9, ip, lr
+	ldr r9, [r11, #4]
 	mla r2, r8, r0, r2
-	mla lr, sb, r10, lr
+	mla lr, r9, r10, lr
 	mla r2, lr, r1, r2
 	adds r0, r3, #0
 	adc r0, r2, #0x1000
@@ -7222,14 +7222,14 @@ _020f3430:
 	ldr r11, [ip]
 	mov r10, r2, asr #0x1f
 	umull r1, r0, r11, r2
-	umull sb, r8, r1, r4
+	umull r9, r8, r1, r4
 	mov r3, r4, asr #0x1f
 	mla r0, r11, r10, r0
 	ldr r10, [ip, #4]
 	mla r8, r1, r3, r8
 	mla r0, r10, r2, r0
 	mla r8, r0, r4, r8
-	adds r2, sb, #0
+	adds r2, r9, #0
 	adc r2, r8, #0x1000
 	mov r2, r2, asr #0xd
 	str r2, [r5, #0xc]
@@ -7268,7 +7268,7 @@ _020f34e0:
 	add r1, r1, #1
 	str r1, [r7, #4]
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov03_020f3064
 _020f3508: .word 0x040002b0
@@ -11926,7 +11926,7 @@ _020f5af0: .word data_027e0c38
 	.global func_ov03_020f5af4
 	arm_func_start func_ov03_020f5af4
 func_ov03_020f5af4: ; 0x020f5af4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x2c
 	mov r4, #6
 	mul r4, r2, r4
@@ -11940,7 +11940,7 @@ func_ov03_020f5af4: ; 0x020f5af4
 	ldr r5, [sp, #0x5c]
 	add r2, sp, #0x28
 	add r3, sp, #0x24
-	ldr sb, [sp, #0x50]
+	ldr r9, [sp, #0x50]
 	ldr r8, [sp, #0x54]
 	ldr r11, [sp, #0x58]
 	str r5, [sp, #0x5c]
@@ -12016,7 +12016,7 @@ _020f5c34:
 	beq _020f5c60
 	cmp r4, #0
 	addgt r0, r10, #0x9c
-	add r1, r2, sb
+	add r1, r2, r9
 	add r2, r3, r8
 	addle r0, r10, #0x124
 	mov r3, r11
@@ -12025,7 +12025,7 @@ _020f5c34:
 _020f5c60:
 	cmp r4, #0
 	ldrgtb r1, [r7, #4]
-	add r2, r2, sb
+	add r2, r2, r9
 	add r3, r3, r8
 	ldrleb r1, [r7, #3]
 	str r11, [sp]
@@ -12039,7 +12039,7 @@ _020f5c8c:
 	ldr r0, [sp, #0x18]
 	cmp r0, #0
 	addlt sp, sp, #0x2c
-	ldmltia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmltia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, [sp, #0x5c]
 	cmp r0, #0
 	beq _020f5cc4
@@ -12047,7 +12047,7 @@ _020f5c8c:
 	ldr r2, [sp, #0x10]
 	mov r3, r11
 	add r0, r10, #0x124
-	add r1, r1, sb
+	add r1, r1, r9
 	add r2, r2, r8
 	bl func_02034a1c
 _020f5cc4:
@@ -12055,11 +12055,11 @@ _020f5cc4:
 	ldr r2, [sp, #0x10]
 	mov r3, r11
 	add r0, r10, #0x14
-	add r1, r1, sb
+	add r1, r1, r9
 	add r2, r2, r8
 	bl func_02034a1c
 	add sp, sp, #0x2c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov03_020f5af4
 _020f5ce8: .word data_ov03_020ff614
@@ -13218,7 +13218,7 @@ _020f6b14: .word 0x00007530
 	.global func_ov03_020f6b18
 	arm_func_start func_ov03_020f6b18
 func_ov03_020f6b18: ; 0x020f6b18
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #0x34
 	ldr r1, _020f6d28 ; =data_027e0d38
 	mov r6, r0
@@ -13226,7 +13226,7 @@ func_ov03_020f6b18: ; 0x020f6b18
 	bl func_ov00_02078b40
 	cmp r0, #2
 	addeq sp, sp, #0x34
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	add r0, r6, #0x100
 	ldrsh r1, [r0, #0xdc]
 	ldrsh r0, [r0, #0xe0]
@@ -13242,14 +13242,14 @@ _020f6b64:
 	mov r10, #0
 	ble _020f6bb0
 	sub r7, r4, #1
-	mov sb, r10
+	mov r9, r10
 	mov r8, #0xbe
 _020f6b7c:
 	mov r0, r8
-	mov r2, sb
-	mov r3, sb
+	mov r2, r9
+	mov r3, r9
 	add r1, r10, #1
-	str sb, [sp]
+	str r9, [sp]
 	bl func_0203493c
 	cmp r10, r7
 	bne _020f6ba4
@@ -13357,7 +13357,7 @@ _020f6cfc:
 	moveq r0, #0
 	streq r0, [r6, #0x1e8]
 	add sp, sp, #0x34
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov03_020f6b18
 _020f6d28: .word data_027e0d38
@@ -13640,7 +13640,7 @@ _020f70c4: .word data_027e05f8
 	.global func_ov03_020f70c8
 	arm_func_start func_ov03_020f70c8
 func_ov03_020f70c8: ; 0x020f70c8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x4c
 	ldr r3, _020f72a8 ; =data_027e0c38
 	mov r8, r0
@@ -13671,16 +13671,16 @@ _020f7128:
 	cmp r4, #0
 	beq _020f7174
 	cmp r5, #0
-	mvnne sb, #0xd3
+	mvnne r9, #0xd3
 	add r0, sp, #0x2c
-	moveq sb, #0
+	moveq r9, #0
 	bl func_01ffbe34
 	mov r0, #1
 	str r0, [sp, #0x30]
 	add r3, sp, #0x2c
 	mov r2, r6
 	add r0, r8, #0x208
-	add r1, r7, sb
+	add r1, r7, r9
 	str r8, [sp]
 	bl func_ov00_020d00c4
 	b _020f71a4
@@ -13727,7 +13727,7 @@ _020f71a4:
 	add r1, r1, #0xa
 	bl func_ov14_02153a48
 	add sp, sp, #0x4c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _020f721c:
 	ldr r0, _020f72b0 ; =data_027e103c
 	ldr r0, [r0]
@@ -13754,7 +13754,7 @@ _020f7240:
 	bl _ZN11ItemManager18func_ov00_020ad790Ei
 	cmp r0, #0
 	addne sp, sp, #0x4c
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	mov r0, #0
 	str r0, [sp]
 	ldr r1, [sp, #8]
@@ -13765,7 +13765,7 @@ _020f7240:
 	mov r1, #4
 	bl func_02034984
 	add sp, sp, #0x4c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov03_020f70c8
 _020f72a8: .word data_027e0c38
@@ -14211,16 +14211,16 @@ _020f772c: .word data_027e077c
 	.global func_ov03_020f7730
 	arm_func_start func_ov03_020f7730
 func_ov03_020f7730: ; 0x020f7730
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x6c
 	ldr r1, _020f7bac ; =data_027e1054
-	mov sb, r0
+	mov r9, r0
 	ldr r0, [r1]
 	ldr r0, [r0, #4]
 	ldrb r1, [r0, #0x95]
 	cmp r1, #0
 	beq _020f7760
-	ldr r0, [sb, #0x24]
+	ldr r0, [r9, #0x24]
 	bl func_ov03_020f9468
 	b _020f79e0
 _020f7760:
@@ -14393,10 +14393,10 @@ _020f79d4:
 	cmp r7, #6
 	blt _020f7964
 _020f79e0:
-	ldrsb r0, [sb, #0x14]
+	ldrsb r0, [r9, #0x14]
 	cmp r0, #0
 	addeq sp, sp, #0x6c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, _020f7bc8 ; =data_027e077c
 	ldr r0, [r0]
 	cmp r0, #0xa
@@ -14419,40 +14419,40 @@ _020f7a0c: ; jump table
 _020f7a38:
 	cmp r0, #0x2e
 	addne sp, sp, #0x6c
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _020f7a44:
-	ldr r0, [sb, #0x34]
+	ldr r0, [r9, #0x34]
 	cmp r0, #0
 	beq _020f7a60
 	cmp r0, #1
 	beq _020f7a74
 	add sp, sp, #0x6c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _020f7a60:
-	ldrsh r1, [sb, #0xe]
-	ldr r0, [sb, #0x28]
+	ldrsh r1, [r9, #0xe]
+	ldr r0, [r9, #0x28]
 	bl func_ov03_020f8790
 	add sp, sp, #0x6c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _020f7a74:
-	ldrsh r1, [sb, #0xe]
-	ldr r0, [sb, #0x2c]
+	ldrsh r1, [r9, #0xe]
+	ldr r0, [r9, #0x2c]
 	bl func_ov17_0215ff30
 	add sp, sp, #0x6c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _020f7a88:
-	ldrsh r1, [sb, #0xe]
-	ldr r0, [sb, #0x2c]
+	ldrsh r1, [r9, #0xe]
+	ldr r0, [r9, #0x2c]
 	bl func_ov17_0215ff30
 	add sp, sp, #0x6c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _020f7a9c:
-	ldrsh r0, [sb, #0x1c]
-	ldrsh r2, [sb, #0x1e]
+	ldrsh r0, [r9, #0x1c]
+	ldrsh r2, [r9, #0x1e]
 	cmp r0, r2
 	moveq r2, #0
 	beq _020f7ad8
-	ldrsh r1, [sb, #0x20]
+	ldrsh r1, [r9, #0x20]
 	cmp r0, r1
 	moveq r2, #0x1000
 	beq _020f7ad8
@@ -14469,26 +14469,26 @@ _020f7ad8:
 	mov r1, r1, lsl #0xc
 	bl func_ov00_020d03f8
 	add r4, r0, #0x800
-	ldrsh r1, [sb, #0xe]
-	ldr r0, [sb, #0x28]
+	ldrsh r1, [r9, #0xe]
+	ldr r0, [r9, #0x28]
 	sub r1, r1, r4, asr #12
 	bl func_ov03_020f8790
-	ldrsh r2, [sb, #0xe]
+	ldrsh r2, [r9, #0xe]
 	ldr r1, _020f7bcc ; =data_ov03_02100750
-	ldr r0, [sb, #0x2c]
+	ldr r0, [r9, #0x2c]
 	ldr r1, [r1, #8]
 	add r2, r2, r4, asr #12
 	sub r1, r2, r1
 	bl func_ov17_0215ff30
 	add sp, sp, #0x6c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _020f7b24:
-	ldrsh r0, [sb, #0x1c]
-	ldrsh r2, [sb, #0x1e]
+	ldrsh r0, [r9, #0x1c]
+	ldrsh r2, [r9, #0x1e]
 	cmp r0, r2
 	moveq r2, #0
 	beq _020f7b60
-	ldrsh r1, [sb, #0x20]
+	ldrsh r1, [r9, #0x20]
 	cmp r0, r1
 	moveq r2, #0x1000
 	beq _020f7b60
@@ -14506,19 +14506,19 @@ _020f7b60:
 	bl func_ov00_020d03f8
 	ldr r1, _020f7bcc ; =data_ov03_02100750
 	add r4, r0, #0x800
-	ldrsh r2, [sb, #0xe]
+	ldrsh r2, [r9, #0xe]
 	ldr r1, [r1, #8]
-	ldr r0, [sb, #0x28]
+	ldr r0, [r9, #0x28]
 	add r2, r2, r4, asr #12
 	sub r1, r2, r1
 	bl func_ov03_020f8790
-	ldrsh r1, [sb, #0xe]
-	ldr r0, [sb, #0x2c]
+	ldrsh r1, [r9, #0xe]
+	ldr r0, [r9, #0x2c]
 	sub r1, r1, r4, asr #12
 	bl func_ov17_0215ff30
 _020f7ba4:
 	add sp, sp, #0x6c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov03_020f7730
 _020f7bac: .word data_027e1054
@@ -15218,7 +15218,7 @@ _020f82a0:
 	.global func_ov03_020f82ac
 	arm_func_start func_ov03_020f82ac
 func_ov03_020f82ac: ; 0x020f82ac
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #8
 	mov r4, r0
 	ldrsh r1, [r4, #0x66]
@@ -15235,7 +15235,7 @@ func_ov03_020f82ac: ; 0x020f82ac
 	movne r0, #0
 	addne sp, sp, #8
 	strneb r0, [r4, #0x17e]
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _020f82f4:
 	mov r0, r4
 	bl func_ov03_020f8620
@@ -15285,7 +15285,7 @@ _020f8378:
 	mov r8, #0
 	ldr r5, _020f84d4 ; =data_027e0d78
 	strb r8, [r4, #0x17e]
-	add sb, r4, #4
+	add r9, r4, #4
 	mov r7, r8
 	mov r6, #2
 _020f83b0:
@@ -15306,7 +15306,7 @@ _020f83dc:
 	str r6, [sp, #4]
 	ldr r1, [r5, #0x10]
 	ldr r2, [r5, #0x14]
-	mov r0, sb
+	mov r0, r9
 	mov r3, r7
 	bl func_ov00_020d0804
 	cmp r0, #0
@@ -15321,7 +15321,7 @@ _020f83dc:
 _020f841c:
 	add r8, r8, #1
 	cmp r8, #4
-	add sb, sb, #0x18
+	add r9, r9, #0x18
 	blt _020f83b0
 	b _020f8438
 _020f8430:
@@ -15329,7 +15329,7 @@ _020f8430:
 	strb r0, [r4, #0x17f]
 _020f8438:
 	mov r7, #0
-	mov sb, r4
+	mov r9, r4
 	add r10, r4, #4
 	mov r6, r7
 _020f8448:
@@ -15348,7 +15348,7 @@ _020f845c:
 _020f8474:
 	mov r0, r10
 	ldr r5, [r0]
-	ldrh r8, [sb, #0xe]
+	ldrh r8, [r9, #0xe]
 	ldr r5, [r5]
 	mov r1, r6
 	mov r2, r6
@@ -15361,16 +15361,16 @@ _020f8474:
 	cmp r0, #0
 	addne sp, sp, #8
 	movne r0, #1
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _020f84b4:
 	add r7, r7, #1
 	cmp r7, #4
-	add sb, sb, #0x18
+	add r9, r9, #0x18
 	add r10, r10, #0x18
 	blt _020f8448
 	mov r0, #0
 	add sp, sp, #8
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov03_020f82ac
 _020f84d4: .word data_027e0d78
@@ -15596,7 +15596,7 @@ _020f878c: .word data_027e0c68
 	.global func_ov03_020f8790
 	arm_func_start func_ov03_020f8790
 func_ov03_020f8790: ; 0x020f8790
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x2c
 	mov r5, r0
 	mov r4, r1
@@ -15643,7 +15643,7 @@ func_ov03_020f8790: ; 0x020f8790
 	bl func_02034984
 _020f8844:
 	mov r8, #0
-	add sb, r5, #4
+	add r9, r5, #4
 	mov r7, r8
 	add r6, sp, #0xc
 _020f8854:
@@ -15653,7 +15653,7 @@ _020f8854:
 	cmp r0, #0
 	beq _020f8880
 _020f8868:
-	mov r0, sb
+	mov r0, r9
 	mov r1, r4
 	mov r2, r7
 	mov r3, r6
@@ -15662,10 +15662,10 @@ _020f8868:
 _020f8880:
 	add r8, r8, #1
 	cmp r8, #4
-	add sb, sb, #0x18
+	add r9, r9, #0x18
 	blt _020f8854
 	add sp, sp, #0x2c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov03_020f8790
 _020f8898: .word data_027e0618
@@ -16201,7 +16201,7 @@ _020f8e44: .word data_027e077c
 	.global func_ov03_020f8e48
 	arm_func_start func_ov03_020f8e48
 func_ov03_020f8e48: ; 0x020f8e48
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0xc
 	mov r7, r0
 	mov r2, #0
@@ -16241,7 +16241,7 @@ _020f8ec4:
 	cmp r1, r0
 	addne sp, sp, #0xc
 	movne r0, #0
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldrb r2, [r7, #0x24d]
 	add r3, r7, #0x218
 	mov r0, #0x18
@@ -16260,7 +16260,7 @@ _020f8ec4:
 	cmp r0, #0
 	addne sp, sp, #0xc
 	movne r0, #1
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldrb r1, [r7, #0x24d]
 	add r2, r7, #0x218
 	mov r0, #0x18
@@ -16269,7 +16269,7 @@ _020f8ec4:
 	tst r1, #6
 	addne sp, sp, #0xc
 	movne r0, #0
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldrb r1, [r7, #0x24c]
 	cmp r1, #0
 	bne _020f8f80
@@ -16295,9 +16295,9 @@ _020f8f9c:
 	sub r1, r8, #4
 	ldr r0, [r0]
 	bl func_ov00_0209d8d8
-	movs sb, r0
+	movs r9, r0
 	beq _020f91c0
-	ldrb r1, [sb, #0x14]
+	ldrb r1, [r9, #0x14]
 	cmp r1, #0
 	beq _020f8fd0
 	bl func_ov00_020a3fc0
@@ -16309,7 +16309,7 @@ _020f8fd0:
 _020f8fd4:
 	cmp r6, #0
 	beq _020f91c0
-	ldrb r0, [sb, #0x10]
+	ldrb r0, [r9, #0x10]
 	cmp r0, #3
 	addls pc, pc, r0, lsl #2
 	b _020f9058
@@ -16346,7 +16346,7 @@ _020f9044:
 	cmp r0, #0
 	beq _020f91c0
 _020f9058:
-	mov r0, sb
+	mov r0, r9
 	add r1, sp, #4
 	bl func_ov00_020a3fe4
 	ldrb r0, [r7, #0x24c]
@@ -16357,18 +16357,18 @@ _020f9058:
 	str r1, [sp]
 	ldr r1, _020f92e8 ; =data_027e0d78
 	ldr r2, _020f92e8 ; =data_027e0d78
-	ldr sb, [r0]
+	ldr r9, [r0]
 	ldr r1, [r1, #0x10]
 	ldr r2, [r2, #0x14]
 	ldr r3, [sp, #4]
-	ldr sb, [sb, #0xc]
+	ldr r9, [r9, #0xc]
 	blx sb
 	cmp r0, #0
 	beq _020f9160
 	ldrh r1, [r5, #0x2a]
 	ldr r0, [r7, #0x248]
-	sub sb, r1, #0x18
-	cmp sb, r0
+	sub r9, r1, #0x18
+	cmp r9, r0
 	beq _020f9158
 	ldrb r0, [r7, #0x24f]
 	cmp r0, #3
@@ -16404,7 +16404,7 @@ _020f9118:
 	mov r1, #0x10
 	bl func_ov00_020d77e4
 	ldr r0, _020f92f0 ; =data_027e0f7c
-	mov r1, sb
+	mov r1, r9
 	ldr r0, [r0]
 	bl func_ov00_0209d748
 	cmp r0, r11
@@ -16414,27 +16414,27 @@ _020f9118:
 	add r2, sp, #4
 	bl func_ov03_020fc348
 _020f9154:
-	str sb, [r7, #0x248]
+	str r9, [r7, #0x248]
 _020f9158:
 	mov r0, #1
 	strb r0, [r7, #0x24c]
 _020f9160:
 	mov r0, r4
 	ldr ip, [r0]
-	ldrh sb, [r5, #0x2a]
+	ldrh r9, [r5, #0x2a]
 	ldr r1, [sp, #4]
 	ldr r2, [sp, #8]
 	ldr ip, [ip, #4]
 	mov r3, #0
 	blx ip
 	mov r2, r0
-	mov r1, sb
+	mov r1, r9
 	mov r0, r7
 	bl func_ov03_020f9344
 	cmp r0, #0
 	addne sp, sp, #0xc
 	movne r0, #1
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldrb r0, [r5, #0x2d]
 	tst r0, #6
 	beq _020f91c0
@@ -16442,7 +16442,7 @@ _020f9160:
 	beq _020f91d4
 	add sp, sp, #0xc
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _020f91c0:
 	add r4, r4, #0x18
 	add r5, r5, #0x18
@@ -16453,7 +16453,7 @@ _020f91d4:
 	ldr r4, _020f92ec ; =gItemManager
 	ldr r10, _020f92fc ; =data_027e0f74
 	mov r8, r7
-	add sb, r7, #0x20
+	add r9, r7, #0x20
 	mov r5, #0
 _020f91e8:
 	cmp r5, #3
@@ -16502,7 +16502,7 @@ _020f9274:
 	cmp r0, #0
 	beq _020f92c8
 _020f9288:
-	mov r0, sb
+	mov r0, r9
 	ldr r11, [r0]
 	ldrh r6, [r8, #0x2a]
 	mov r1, #0
@@ -16517,16 +16517,16 @@ _020f9288:
 	cmp r0, #0
 	addne sp, sp, #0xc
 	movne r0, #1
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _020f92c8:
 	add r5, r5, #1
 	cmp r5, #4
 	add r8, r8, #0x18
-	add sb, sb, #0x18
+	add r9, r9, #0x18
 	blt _020f91e8
 	mov r0, #0
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov03_020f8e48
 _020f92e8: .word data_027e0d78
@@ -16658,14 +16658,14 @@ _020f9460:
 	.global func_ov03_020f9468
 	arm_func_start func_ov03_020f9468
 func_ov03_020f9468: ; 0x020f9468
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0xe0
 	ldr r1, _020f9a5c ; =data_027e0618
 	str r0, [sp, #0x10]
 	ldrb r0, [r1, #0x101]
 	cmp r0, #0
 	addne sp, sp, #0xe0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, _020f9a60 ; =data_027e0d38
 	ldr r0, [r0]
 	add r0, r0, #0xc
@@ -16684,7 +16684,7 @@ func_ov03_020f9468: ; 0x020f9468
 	str r1, [sp, #0x5c]
 	str r0, [sp, #0x54]
 	mov r10, #0
-	mvn sb, #0
+	mvn r9, #0
 	add r8, sp, #0x1c
 	add r11, sp, #0x24
 	add r7, sp, #0x50
@@ -16698,9 +16698,9 @@ _020f94e0:
 	ldr r0, [r5]
 	mov r1, r10
 	bl func_ov00_0209d928
-	str sb, [sp, #0x20]
+	str r9, [sp, #0x20]
 	mov r1, r8
-	str sb, [sp, #0x1c]
+	str r9, [sp, #0x1c]
 	bl func_ov00_020a40b0
 	ldr r0, [sp, #0x20]
 	ldr r1, [sp, #0x1c]
@@ -16855,7 +16855,7 @@ _020f9740:
 	orr r0, r0, #0x1000
 	str r0, [sp, #0xac]
 	mov r0, r8
-	add sb, r0, #0x20
+	add r9, r0, #0x20
 	mov r7, #0
 	add r4, r0, #0x200
 	add r6, sp, #0x70
@@ -16877,7 +16877,7 @@ _020f9798:
 	mov r2, #0
 	mov r3, r2
 	str r3, [sp]
-	mov r0, sb
+	mov r0, r9
 	mov r1, r10
 	mov r3, r6
 	bl func_ov00_020d00c4
@@ -16885,7 +16885,7 @@ _020f97b4:
 	add r7, r7, #1
 	cmp r7, #4
 	add r8, r8, #0x18
-	add sb, sb, #0x18
+	add r9, r9, #0x18
 	blt _020f976c
 	ldr r0, _020f9a74 ; =gItemManager
 	mov r1, #0x21
@@ -16910,7 +16910,7 @@ _020f97b4:
 	ldr r0, [sp, #0x10]
 	mov r5, #4
 	add r8, r0, #0x60
-	add sb, r0, #0x80
+	add r9, r0, #0x80
 	add r4, r0, #0x200
 	add r11, sp, #0xa0
 _020f9830:
@@ -16965,13 +16965,13 @@ _020f98e4:
 	str r0, [sp]
 	ldr r1, [sp, #0x40]
 	ldr r2, [sp, #0x3c]
-	mov r0, sb
+	mov r0, r9
 	add r1, r1, r10
 	mov r3, r11
 	bl func_ov00_020d0210
 _020f9904:
 	add r8, r8, #0x18
-	add sb, sb, #0x18
+	add r9, r9, #0x18
 	add r5, r5, #1
 	cmp r5, #0x14
 	blt _020f9830
@@ -17000,9 +17000,9 @@ _020f9944:
 	cmp r0, r1
 	beq _020f99c4
 _020f9974:
-	mov sb, #0
+	mov r9, #0
 _020f9978:
-	ldrb r1, [r10, sb]
+	ldrb r1, [r10, r9]
 	mov r0, r8
 	mov r2, r7
 	mov r3, r6
@@ -17013,13 +17013,13 @@ _020f9978:
 	mov r3, r11
 	bl func_ov00_02079680
 	str r5, [sp]
-	ldrb r1, [r10, sb]
+	ldrb r1, [r10, r9]
 	ldr r2, [sp, #0x38]
 	ldr r3, [sp, #0x34]
 	mov r0, #0xde
 	bl func_02034984
-	add sb, sb, #1
-	cmp sb, #3
+	add r9, r9, #1
+	cmp r9, #3
 	blt _020f9978
 _020f99c4:
 	ldr r0, [sp, #0x18]
@@ -17031,16 +17031,16 @@ _020f99c4:
 	add r0, r0, #1
 	str r0, [sp, #0x14]
 	blt _020f9944
-	mov sb, #0xda
+	mov r9, #0xda
 	ldr r4, _020f9a68 ; =data_027e0d3c
 	mov r10, #4
 	add r8, sp, #0x30
 	add r7, sp, #0x2c
 	mov r6, #1
 	add r5, sp, #0xa0
-	mov r11, sb
+	mov r11, r9
 _020f9a08:
-	mov r0, sb
+	mov r0, r9
 	mov r1, r10
 	mov r2, r8
 	mov r3, r7
@@ -17060,7 +17060,7 @@ _020f9a08:
 	cmp r10, #7
 	ble _020f9a08
 	add sp, sp, #0xe0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov03_020f9468
 _020f9a5c: .word data_027e0618
@@ -18283,7 +18283,7 @@ _020fa8d4: .word data_ov03_020ff870
 	.global func_ov03_020fa8d8
 	arm_func_start func_ov03_020fa8d8
 func_ov03_020fa8d8: ; 0x020fa8d8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x14
 	ldr r2, _020fa9e4 ; =data_027e0c54
 	mov r6, r0
@@ -18297,15 +18297,15 @@ func_ov03_020fa8d8: ; 0x020fa8d8
 	movne r7, #0
 	bl func_020078f4
 	ldr r0, _020fa9e8 ; =data_ov03_020ff870
-	mov sb, #0
+	mov r9, #0
 	ldr r8, [r0, r4, lsl #2]
 	ldrb r0, [r8]
 	cmp r0, #0xff
 	addeq sp, sp, #0x14
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	mov r11, #1
 _020fa92c:
-	ldrb r5, [r8, sb]
+	ldrb r5, [r8, r9]
 	ldr r0, [r6, #4]
 	ldr r10, [r0, r5, lsl #2]
 	ldrsb r0, [r10, #0x17]
@@ -18349,12 +18349,12 @@ _020fa9b0:
 	mov r3, #0
 	bl func_020340d0
 _020fa9cc:
-	add sb, sb, #1
-	ldrb r0, [r8, sb]
+	add r9, r9, #1
+	ldrb r0, [r8, r9]
 	cmp r0, #0xff
 	bne _020fa92c
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov03_020fa8d8
 _020fa9e4: .word data_027e0c54
@@ -20057,15 +20057,15 @@ _020fb6fc: .word func_ov03_020fb700 - 1
 	.global func_ov03_020fb700
 	arm_func_start func_ov03_020fb700
 func_ov03_020fb700: ; 0x020fb700
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
-	mov sb, r0
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
+	mov r9, r0
 	mov r6, #0
 	mov r8, #0x1000
 	bl func_ov03_020fb44c
 	cmp r0, #0
 	ldrne r8, [r0, #0x1c4]
-	cmp sb, #4
-	addls pc, pc, sb, lsl #2
+	cmp r9, #4
+	addls pc, pc, r9, lsl #2
 	b _020fb7b0
 _020fb728: ; jump table
 	b _020fb79c ; case 0
@@ -20141,9 +20141,9 @@ _020fb7b0:
 	mov r7, r3, asr #0xc
 	str r2, [r1, #0x40]
 	bl func_ov05_0210e288
-	rsb sb, r7, #0x60
+	rsb r9, r7, #0x60
 	mov r5, r0
-	mov r0, sb
+	mov r0, r9
 	bl func_ov05_0210e2a4
 	mov r0, r0, lsl #0x10
 	mov r3, r0, lsr #0x10
@@ -20194,7 +20194,7 @@ _020fb7b0:
 	str r1, [r2, #0xc]
 	bl func_ov05_0210e288
 	mov r4, r0
-	mov r0, sb
+	mov r0, r9
 	bl func_ov05_0210e2a4
 	mov r0, r0, lsl #0x10
 	mov r1, r0, lsr #0x10
@@ -20206,7 +20206,7 @@ _020fb7b0:
 	str r0, [r2, #0xc]
 	mov r0, #0
 	str r0, [r2, #0x7c]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov03_020fb700
 _020fb93c: .word 0x0000ffff
@@ -21061,17 +21061,17 @@ func_ov03_020fc1e8: ; 0x020fc1e8
 	.global func_ov03_020fc200
 	arm_func_start func_ov03_020fc200
 func_ov03_020fc200: ; 0x020fc200
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #0x3c
 	mov r10, r0
 	ldr r0, [r10]
-	mov sb, r1
+	mov r9, r1
 	ldrb r0, [r0, #0x12c]
 	mov r8, r2
 	mov r7, r3
 	cmp r0, #0
 	addeq sp, sp, #0x3c
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	add r0, sp, #0x1c
 	bl func_01ffbe34
 	mov r4, #0
@@ -21134,19 +21134,19 @@ _020fc2a4:
 	str r0, [sp, #0xc]
 	str r5, [sp, #0x10]
 	str r6, [sp, #0x14]
-	mov r0, sb
+	mov r0, r9
 	str ip, [sp, #0x18]
 	bl func_02034d68
 	cmp r4, #0
 	addne sp, sp, #0x3c
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	mov r1, #0
 	ldr r0, [r10]
 	mov r2, r1
 	mov r3, r1
 	bl func_02032788
 	add sp, sp, #0x3c
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	arm_func_end func_ov03_020fc200
 
 	.global func_ov03_020fc348

--- a/asm/ov03.s
+++ b/asm/ov03.s
@@ -3596,10 +3596,10 @@ _020f0840: .word data_027e080c
 	.global func_ov03_020f0844
 	arm_func_start func_ov03_020f0844
 func_ov03_020f0844: ; 0x020f0844
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #8
 	movs sb, r1
-	mov sl, r0
+	mov r10, r0
 	mov r8, r2
 	mov r7, r3
 	ldr r6, [sp, #0x30]
@@ -3655,7 +3655,7 @@ _020f08a4:
 	add r1, r2, r1, asr #1
 	mov r0, #0
 	stmib r6, {r0, r1}
-	ldr r0, [sl, #8]
+	ldr r0, [r10, #8]
 	bl func_01ff991c
 	cmp sb, #0
 	beq _020f097c
@@ -3663,7 +3663,7 @@ _020f08a4:
 	mul r1, r5, r1
 	smull r3, r2, r1, r0
 	adds r3, r3, #0x800
-	ldr r1, [sl, #0xc]
+	ldr r1, [r10, #0xc]
 	adc r2, r2, #0
 	add r1, r1, #0x800
 	mov r3, r3, lsr #0xc
@@ -3677,7 +3677,7 @@ _020f08a4:
 	str r1, [r6]
 	b _020f09d8
 _020f097c:
-	ldr r2, [sl, #0xc]
+	ldr r2, [r10, #0xc]
 	sub r1, r8, #0x80000
 	sub r2, r2, #0x80000
 	smull r3, r8, r2, r5
@@ -3709,7 +3709,7 @@ _020f09d8:
 	mla r5, r1, r3, r5
 	mov r2, r1, asr #0x1f
 	mla r5, r2, r0, r5
-	ldr r1, [sl, #0x10]
+	ldr r1, [r10, #0x10]
 	adds r3, r7, #0x800
 	add r0, r1, #0x800
 	mov r0, r0, asr #0xc
@@ -3722,9 +3722,9 @@ _020f09d8:
 	add sp, sp, #8
 	add r0, r1, r0
 	str r0, [r6, #8]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _020f0a30:
-	ldr r2, [sl, #0x10]
+	ldr r2, [r10, #0x10]
 	sub r1, r7, #0x60000
 	sub r2, r2, #0x60000
 	smull r5, r7, r2, r4
@@ -3750,7 +3750,7 @@ _020f0a30:
 	add r0, r1, r0
 	str r0, [r6, #8]
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov03_020f0844
 _020f0a9c: .word data_027e0c38
@@ -4714,12 +4714,12 @@ _020f1668: .word data_027e05f8
 	.global func_ov03_020f166c
 	arm_func_start func_ov03_020f166c
 func_ov03_020f166c: ; 0x020f166c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
-	mov sl, r0
-	ldr r0, [sl, #4]
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	mov r10, r0
+	ldr r0, [r10, #4]
 	cmp r0, #2
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r1, _020f182c ; =data_027e0c54
 	ldr r0, _020f1830 ; =data_ov09_0211f5b4
 	ldrb r5, [r1]
@@ -4741,15 +4741,15 @@ func_ov03_020f166c: ; 0x020f166c
 	cmp r5, #0
 	bne _020f1780
 	mov r0, #0x10000
-	ldr r1, [sl, #0x20]
+	ldr r1, [r10, #0x20]
 	rsb r0, r0, #0
 	and r0, r1, r0
 	cmp r0, #0x1000000
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	mov r5, #0
-	mov r7, sl
-	add r8, sl, #0x8c
+	mov r7, r10
+	add r8, r10, #0x8c
 	mov r11, r5
 _020f1700:
 	cmp r5, #1
@@ -4769,16 +4769,16 @@ _020f1710:
 	mov r3, r11
 	blx ip
 	mov r2, r0
-	mov r0, sl
+	mov r0, r10
 	mov r1, r6
 	bl func_ov03_020f1840
 	cmp r0, #0
 	beq _020f1768
-	mov r0, sl
+	mov r0, r10
 	mov r1, #3
 	bl func_ov03_020f13b0
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _020f1768:
 	add r5, r5, #1
 	cmp r5, #3
@@ -4788,16 +4788,16 @@ _020f1768:
 	b _020f1824
 _020f1780:
 	mov r11, #0x10000
-	mov r7, sl
-	add r8, sl, #0x44
+	mov r7, r10
+	add r8, r10, #0x44
 	mov r5, #0
 	rsb r11, r11, #0
 _020f1794:
-	ldr r0, [sl, #0x20]
+	ldr r0, [r10, #0x20]
 	and r0, r0, r11
 	cmp r0, #0x1000000
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	cmp r5, #1
 	bne _020f17b8
 	cmp r4, #0
@@ -4816,15 +4816,15 @@ _020f17b8:
 	blx ip
 	mov r2, r0
 	mov r1, r6
-	mov r0, sl
+	mov r0, r10
 	bl func_ov03_020f1840
 	cmp r0, #0
 	beq _020f1810
-	mov r0, sl
+	mov r0, r10
 	mov r1, #3
 	bl func_ov03_020f13b0
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _020f1810:
 	add r5, r5, #1
 	cmp r5, #3
@@ -4833,7 +4833,7 @@ _020f1810:
 	blt _020f1794
 _020f1824:
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov03_020f166c
 _020f182c: .word data_027e0c54
@@ -6753,31 +6753,31 @@ _020f2d9c: .word func_ov03_020f2da0 - 1
 	.global func_ov03_020f2da0
 	arm_func_start func_ov03_020f2da0
 func_ov03_020f2da0: ; 0x020f2da0
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x34
-	mov sl, r0
-	ldrb r0, [sl, #0xa]
+	mov r10, r0
+	ldrb r0, [r10, #0xa]
 	cmp r0, #0
 	addeq sp, sp, #0x34
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	bl func_01ffa8d4
 	ldr r2, _020f2f8c ; =0x04000444
 	mov r3, #0
 	ldr r0, _020f2f90 ; =0x21230000
 	str r3, [r2]
 	str r0, [r2, #0x64]
-	ldrh r1, [sl, #0xc]
+	ldrh r1, [r10, #0xc]
 	ldr r0, _020f2f94 ; =data_ov03_02100688
 	orr r1, r1, #0x8000
 	str r1, [r2, #0x7c]
 	str r3, [r2, #0x80]
-	ldrb r1, [sl, #0xa]
+	ldrb r1, [r10, #0xa]
 	str r0, [sp, #8]
 	mov r0, r1, lsl #0x10
 	orr r0, r0, #0xc0
 	str r0, [r2, #0x60]
-	ldr r0, [sl, #4]
-	ldrh sb, [sl, #8]
+	ldr r0, [r10, #4]
+	ldrh sb, [r10, #8]
 	sub r0, r0, #1
 	cmp sb, r0
 	bhs _020f2f78
@@ -6789,7 +6789,7 @@ _020f2e10:
 	sub r4, r0, #0x74
 	mov r11, r8
 _020f2e28:
-	mov r0, sl
+	mov r0, r10
 	ldr r2, [r0]
 	mov r1, sb
 	ldr r2, [r2, #0x20]
@@ -6798,10 +6798,10 @@ _020f2e28:
 	ldr r6, [r0, #0xc]
 	ldr r7, [r0, #8]
 	ldr r5, [r0, #0x10]
-	ldr r3, [sl, #0x10]
+	ldr r3, [r10, #0x10]
 	add r0, ip, r6
 	add r1, r3, r0
-	ldr r2, [sl, #0x14]
+	ldr r2, [r10, #0x14]
 	sub r0, ip, r6
 	str r6, [sp, #0x14]
 	add r6, r7, r5
@@ -6852,11 +6852,11 @@ _020f2e28:
 	orr r0, r1, r0, lsr #16
 	str r0, [r4]
 	str r11, [r4]
-	ldr r0, [sl, #4]
+	ldr r0, [r10, #4]
 	add sb, sb, #1
 	cmp sb, r0
 	bhs _020f2f5c
-	mov r0, sl
+	mov r0, r10
 	ldr r2, [r0]
 	sub r1, sb, #1
 	ldr r2, [r2, #0x20]
@@ -6870,7 +6870,7 @@ _020f2f5c:
 	ldr r0, _020f2f9c ; =0x04000504
 	mov r1, #0
 	str r1, [r0]
-	ldr r0, [sl, #4]
+	ldr r0, [r10, #4]
 	sub r0, r0, #1
 	cmp sb, r0
 	blo _020f2e10
@@ -6879,7 +6879,7 @@ _020f2f78:
 	mov r1, #1
 	str r1, [r0]
 	add sp, sp, #0x34
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov03_020f2da0
 _020f2f8c: .word 0x04000444
@@ -6960,7 +6960,7 @@ func_ov03_020f301c: ; 0x020f301c
 	.global func_ov03_020f3064
 	arm_func_start func_ov03_020f3064
 func_ov03_020f3064: ; 0x020f3064
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x10
 	movs r5, r3
 	mov r7, r0
@@ -6980,7 +6980,7 @@ func_ov03_020f3064: ; 0x020f3064
 	cmpeq r0, #0
 	addeq sp, sp, #0x10
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _020f30b8:
 	mov r0, r7
 	ldr r2, [r0]
@@ -7038,7 +7038,7 @@ _020f316c:
 	cmp r0, r1, asr #1
 	addgt sp, sp, #0x10
 	movgt r0, #0
-	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _020f3198:
 	cmp r5, #0
 	beq _020f31b0
@@ -7080,13 +7080,13 @@ _020f3218:
 	sub r3, r1, r0
 	rsb r0, r3, #0
 	ldr r2, [r5, #8]
-	smull r1, sl, r0, r0
+	smull r1, r10, r0, r0
 	sub r2, r8, r2
 	str r2, [r4, #0xc]
 	str r0, [r4, #0x10]
 	ldr r8, [r4, #0xc]
 	ldr r0, _020f3510 ; =0x04000280
-	smlal r1, sl, r8, r8
+	smlal r1, r10, r8, r8
 	mov sb, #2
 	strh sb, [r0]
 	mov sb, #0
@@ -7094,8 +7094,8 @@ _020f3218:
 	mov sb, #0x1000000
 	str sb, [r0, #0x14]
 	str r1, [r0, #0x18]
-	mov r8, sl, lsl #0x2
-	str sl, [r0, #0x1c]
+	mov r8, r10, lsl #0x2
+	str r10, [r0, #0x1c]
 	mov sb, #1
 	strh sb, [r0, #0x30]
 	mov sb, r1, lsl #0x2
@@ -7109,7 +7109,7 @@ _020f328c:
 	tst r1, #0x8000
 	bne _020f328c
 	ldr r0, _020f350c ; =0x040002b4
-	ldr sl, [r0]
+	ldr r10, [r0]
 	sub r1, r0, #0x34
 _020f32a4:
 	ldrh r0, [r1]
@@ -7118,14 +7118,14 @@ _020f32a4:
 	ldr r11, _020f3514 ; =0x040002a0
 	ldr r1, [r4, #0xc]
 	ldr sb, [r11]
-	mov ip, sl, asr #0x1f
-	umull r8, lr, sb, sl
+	mov ip, r10, asr #0x1f
+	umull r8, lr, sb, r10
 	umull r3, r2, r8, r1
 	mov r0, r1, asr #0x1f
 	mla lr, sb, ip, lr
 	ldr sb, [r11, #4]
 	mla r2, r8, r0, r2
-	mla lr, sb, sl, lr
+	mla lr, sb, r10, lr
 	mla r2, lr, r1, r2
 	adds r0, r3, #0
 	adc r0, r2, #0x1000
@@ -7220,14 +7220,14 @@ _020f3430:
 	ldr ip, _020f3514 ; =0x040002a0
 	ldr r4, [r5, #0xc]
 	ldr r11, [ip]
-	mov sl, r2, asr #0x1f
+	mov r10, r2, asr #0x1f
 	umull r1, r0, r11, r2
 	umull sb, r8, r1, r4
 	mov r3, r4, asr #0x1f
-	mla r0, r11, sl, r0
-	ldr sl, [ip, #4]
+	mla r0, r11, r10, r0
+	ldr r10, [ip, #4]
 	mla r8, r1, r3, r8
-	mla r0, sl, r2, r0
+	mla r0, r10, r2, r0
 	mla r8, r0, r4, r8
 	adds r2, sb, #0
 	adc r2, r8, #0x1000
@@ -7268,7 +7268,7 @@ _020f34e0:
 	add r1, r1, #1
 	str r1, [r7, #4]
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov03_020f3064
 _020f3508: .word 0x040002b0
@@ -11926,13 +11926,13 @@ _020f5af0: .word data_027e0c38
 	.global func_ov03_020f5af4
 	arm_func_start func_ov03_020f5af4
 func_ov03_020f5af4: ; 0x020f5af4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x2c
 	mov r4, #6
 	mul r4, r2, r4
 	str r3, [sp, #8]
 	ldr r5, _020f5ce8 ; =data_ov03_020ff614
-	mov sl, r0
+	mov r10, r0
 	ldrsh r0, [r5, r4]
 	ldr r2, _020f5cec ; =data_ov03_020ff616
 	str r1, [sp, #4]
@@ -11949,7 +11949,7 @@ func_ov03_020f5af4: ; 0x020f5af4
 	str r0, [sp, #0x1c]
 	mov r0, #0
 	str r0, [sp, #0x14]
-	ldrsh r0, [sl, #0xe]
+	ldrsh r0, [r10, #0xe]
 	str r0, [sp, #0x20]
 	ldr r0, [sp, #0x1c]
 	sub r0, r0, #2
@@ -11989,7 +11989,7 @@ _020f5bd0:
 	mov r1, #8
 	bl func_01ff9b88
 	ldr r1, [sp, #0xc]
-	ldrsh r3, [sl, #0x10]
+	ldrsh r3, [r10, #0x10]
 	add r2, r1, r0
 	ldr r0, [sp, #0x1c]
 	ldr ip, [sp, #0x28]
@@ -12015,10 +12015,10 @@ _020f5c34:
 	cmp r0, #0
 	beq _020f5c60
 	cmp r4, #0
-	addgt r0, sl, #0x9c
+	addgt r0, r10, #0x9c
 	add r1, r2, sb
 	add r2, r3, r8
-	addle r0, sl, #0x124
+	addle r0, r10, #0x124
 	mov r3, r11
 	bl func_02034a1c
 	b _020f5c80
@@ -12039,14 +12039,14 @@ _020f5c8c:
 	ldr r0, [sp, #0x18]
 	cmp r0, #0
 	addlt sp, sp, #0x2c
-	ldmltia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmltia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, [sp, #0x5c]
 	cmp r0, #0
 	beq _020f5cc4
 	ldr r1, [sp, #0x14]
 	ldr r2, [sp, #0x10]
 	mov r3, r11
-	add r0, sl, #0x124
+	add r0, r10, #0x124
 	add r1, r1, sb
 	add r2, r2, r8
 	bl func_02034a1c
@@ -12054,12 +12054,12 @@ _020f5cc4:
 	ldr r1, [sp, #0x14]
 	ldr r2, [sp, #0x10]
 	mov r3, r11
-	add r0, sl, #0x14
+	add r0, r10, #0x14
 	add r1, r1, sb
 	add r2, r2, r8
 	bl func_02034a1c
 	add sp, sp, #0x2c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov03_020f5af4
 _020f5ce8: .word data_ov03_020ff614
@@ -13218,7 +13218,7 @@ _020f6b14: .word 0x00007530
 	.global func_ov03_020f6b18
 	arm_func_start func_ov03_020f6b18
 func_ov03_020f6b18: ; 0x020f6b18
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #0x34
 	ldr r1, _020f6d28 ; =data_027e0d38
 	mov r6, r0
@@ -13226,7 +13226,7 @@ func_ov03_020f6b18: ; 0x020f6b18
 	bl func_ov00_02078b40
 	cmp r0, #2
 	addeq sp, sp, #0x34
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	add r0, r6, #0x100
 	ldrsh r1, [r0, #0xdc]
 	ldrsh r0, [r0, #0xe0]
@@ -13239,25 +13239,25 @@ func_ov03_020f6b18: ; 0x020f6b18
 	moveq r5, #1
 _020f6b64:
 	cmp r4, #0
-	mov sl, #0
+	mov r10, #0
 	ble _020f6bb0
 	sub r7, r4, #1
-	mov sb, sl
+	mov sb, r10
 	mov r8, #0xbe
 _020f6b7c:
 	mov r0, r8
 	mov r2, sb
 	mov r3, sb
-	add r1, sl, #1
+	add r1, r10, #1
 	str sb, [sp]
 	bl func_0203493c
-	cmp sl, r7
+	cmp r10, r7
 	bne _020f6ba4
 	cmp r5, #0
 	bne _020f6bb0
 _020f6ba4:
-	add sl, sl, #1
-	cmp sl, r4
+	add r10, r10, #1
+	cmp r10, r4
 	blt _020f6b7c
 _020f6bb0:
 	ldr r0, [r6, #0x1e8]
@@ -13357,7 +13357,7 @@ _020f6cfc:
 	moveq r0, #0
 	streq r0, [r6, #0x1e8]
 	add sp, sp, #0x34
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov03_020f6b18
 _020f6d28: .word data_027e0d38
@@ -14211,7 +14211,7 @@ _020f772c: .word data_027e077c
 	.global func_ov03_020f7730
 	arm_func_start func_ov03_020f7730
 func_ov03_020f7730: ; 0x020f7730
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x6c
 	ldr r1, _020f7bac ; =data_027e1054
 	mov sb, r0
@@ -14265,7 +14265,7 @@ _020f77e8:
 	ldr r5, _020f7bb8 ; =data_027e0f7c
 	mov r7, #0xa
 	str r0, [sp, #0x3c]
-	add sl, sp, #0xc
+	add r10, sp, #0xc
 	add r11, sp, #0x10
 	add r6, sp, #0x3c
 _020f7808:
@@ -14280,7 +14280,7 @@ _020f7808:
 	cmp r8, r1
 	bne _020f786c
 	ldr r2, [r0, #8]
-	mov r1, sl
+	mov r1, r10
 	str r2, [sp, #0xc]
 	ldr r2, [r0, #0xc]
 	ldr r0, [r4]
@@ -14353,7 +14353,7 @@ _020f7908:
 	mov r0, #1
 	orr r1, r1, #0x1000
 	ldr r11, _020f7bb0 ; =data_027e0d3c
-	ldr sl, _020f7bbc ; =data_027e0f74
+	ldr r10, _020f7bbc ; =data_027e0f74
 	ldr r4, _020f7bb8 ; =data_027e0f7c
 	str r1, [sp, #0x28]
 	str r0, [sp, #0x20]
@@ -14369,7 +14369,7 @@ _020f7964:
 	bne _020f79d4
 	add r0, r7, #0x37
 	add r1, r0, #0x100
-	ldr r0, [sl]
+	ldr r0, [r10]
 	bl func_ov00_02097760
 	cmp r0, #0
 	beq _020f79d4
@@ -14396,7 +14396,7 @@ _020f79e0:
 	ldrsb r0, [sb, #0x14]
 	cmp r0, #0
 	addeq sp, sp, #0x6c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, _020f7bc8 ; =data_027e077c
 	ldr r0, [r0]
 	cmp r0, #0xa
@@ -14419,7 +14419,7 @@ _020f7a0c: ; jump table
 _020f7a38:
 	cmp r0, #0x2e
 	addne sp, sp, #0x6c
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _020f7a44:
 	ldr r0, [sb, #0x34]
 	cmp r0, #0
@@ -14427,25 +14427,25 @@ _020f7a44:
 	cmp r0, #1
 	beq _020f7a74
 	add sp, sp, #0x6c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _020f7a60:
 	ldrsh r1, [sb, #0xe]
 	ldr r0, [sb, #0x28]
 	bl func_ov03_020f8790
 	add sp, sp, #0x6c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _020f7a74:
 	ldrsh r1, [sb, #0xe]
 	ldr r0, [sb, #0x2c]
 	bl func_ov17_0215ff30
 	add sp, sp, #0x6c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _020f7a88:
 	ldrsh r1, [sb, #0xe]
 	ldr r0, [sb, #0x2c]
 	bl func_ov17_0215ff30
 	add sp, sp, #0x6c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _020f7a9c:
 	ldrsh r0, [sb, #0x1c]
 	ldrsh r2, [sb, #0x1e]
@@ -14481,7 +14481,7 @@ _020f7ad8:
 	sub r1, r2, r1
 	bl func_ov17_0215ff30
 	add sp, sp, #0x6c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _020f7b24:
 	ldrsh r0, [sb, #0x1c]
 	ldrsh r2, [sb, #0x1e]
@@ -14518,7 +14518,7 @@ _020f7b60:
 	bl func_ov17_0215ff30
 _020f7ba4:
 	add sp, sp, #0x6c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov03_020f7730
 _020f7bac: .word data_027e1054
@@ -15218,7 +15218,7 @@ _020f82a0:
 	.global func_ov03_020f82ac
 	arm_func_start func_ov03_020f82ac
 func_ov03_020f82ac: ; 0x020f82ac
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #8
 	mov r4, r0
 	ldrsh r1, [r4, #0x66]
@@ -15235,7 +15235,7 @@ func_ov03_020f82ac: ; 0x020f82ac
 	movne r0, #0
 	addne sp, sp, #8
 	strneb r0, [r4, #0x17e]
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _020f82f4:
 	mov r0, r4
 	bl func_ov03_020f8620
@@ -15330,7 +15330,7 @@ _020f8430:
 _020f8438:
 	mov r7, #0
 	mov sb, r4
-	add sl, r4, #4
+	add r10, r4, #4
 	mov r6, r7
 _020f8448:
 	cmp r7, #2
@@ -15346,7 +15346,7 @@ _020f845c:
 	cmp r0, #0
 	bne _020f84b4
 _020f8474:
-	mov r0, sl
+	mov r0, r10
 	ldr r5, [r0]
 	ldrh r8, [sb, #0xe]
 	ldr r5, [r5]
@@ -15361,16 +15361,16 @@ _020f8474:
 	cmp r0, #0
 	addne sp, sp, #8
 	movne r0, #1
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _020f84b4:
 	add r7, r7, #1
 	cmp r7, #4
 	add sb, sb, #0x18
-	add sl, sl, #0x18
+	add r10, r10, #0x18
 	blt _020f8448
 	mov r0, #0
 	add sp, sp, #8
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov03_020f82ac
 _020f84d4: .word data_027e0d78
@@ -16201,7 +16201,7 @@ _020f8e44: .word data_027e077c
 	.global func_ov03_020f8e48
 	arm_func_start func_ov03_020f8e48
 func_ov03_020f8e48: ; 0x020f8e48
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0xc
 	mov r7, r0
 	mov r2, #0
@@ -16241,7 +16241,7 @@ _020f8ec4:
 	cmp r1, r0
 	addne sp, sp, #0xc
 	movne r0, #0
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldrb r2, [r7, #0x24d]
 	add r3, r7, #0x218
 	mov r0, #0x18
@@ -16260,7 +16260,7 @@ _020f8ec4:
 	cmp r0, #0
 	addne sp, sp, #0xc
 	movne r0, #1
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldrb r1, [r7, #0x24d]
 	add r2, r7, #0x218
 	mov r0, #0x18
@@ -16269,7 +16269,7 @@ _020f8ec4:
 	tst r1, #6
 	addne sp, sp, #0xc
 	movne r0, #0
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldrb r1, [r7, #0x24c]
 	cmp r1, #0
 	bne _020f8f80
@@ -16284,7 +16284,7 @@ _020f8ec4:
 	strb r0, [r7, #0x24c]
 _020f8f80:
 	mvn r11, #0
-	ldr sl, _020f92ec ; =gItemManager
+	ldr r10, _020f92ec ; =gItemManager
 	str r11, [sp, #4]
 	str r11, [sp, #8]
 	add r4, r7, #0x80
@@ -16319,28 +16319,28 @@ _020f8fec: ; jump table
 	b _020f9014 ; case 2
 	b _020f9044 ; case 3
 _020f8ffc:
-	ldr r0, [sl]
+	ldr r0, [r10]
 	mov r1, #0x21
 	bl _ZNK11ItemManager7HasItemEi
 	cmp r0, #0
 	bne _020f9058
 	b _020f91c0
 _020f9014:
-	ldr r0, [sl]
+	ldr r0, [r10]
 	mov r1, #0x23
 	bl _ZNK11ItemManager7HasItemEi
 	cmp r0, #0
 	bne _020f9058
 	b _020f91c0
 _020f902c:
-	ldr r0, [sl]
+	ldr r0, [r10]
 	mov r1, #0x22
 	bl _ZNK11ItemManager7HasItemEi
 	cmp r0, #0
 	bne _020f9058
 	b _020f91c0
 _020f9044:
-	ldr r0, [sl]
+	ldr r0, [r10]
 	mov r1, #0x24
 	bl _ZNK11ItemManager7HasItemEi
 	cmp r0, #0
@@ -16434,7 +16434,7 @@ _020f9160:
 	cmp r0, #0
 	addne sp, sp, #0xc
 	movne r0, #1
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldrb r0, [r5, #0x2d]
 	tst r0, #6
 	beq _020f91c0
@@ -16442,7 +16442,7 @@ _020f9160:
 	beq _020f91d4
 	add sp, sp, #0xc
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _020f91c0:
 	add r4, r4, #0x18
 	add r5, r5, #0x18
@@ -16451,7 +16451,7 @@ _020f91c0:
 	blt _020f8f9c
 _020f91d4:
 	ldr r4, _020f92ec ; =gItemManager
-	ldr sl, _020f92fc ; =data_027e0f74
+	ldr r10, _020f92fc ; =data_027e0f74
 	mov r8, r7
 	add sb, r7, #0x20
 	mov r5, #0
@@ -16470,12 +16470,12 @@ _020f9204:
 	bl _ZNK11ItemManager7HasItemEi
 	cmp r0, #0
 	beq _020f92c8
-	ldr r0, [sl]
+	ldr r0, [r10]
 	mov r1, #6
 	bl func_ov00_02097760
 	cmp r0, #0
 	beq _020f9288
-	ldr r0, [sl]
+	ldr r0, [r10]
 	ldr r1, _020f9300 ; =0x0000015f
 	bl func_ov00_02097760
 	cmp r0, #0
@@ -16517,7 +16517,7 @@ _020f9288:
 	cmp r0, #0
 	addne sp, sp, #0xc
 	movne r0, #1
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _020f92c8:
 	add r5, r5, #1
 	cmp r5, #4
@@ -16526,7 +16526,7 @@ _020f92c8:
 	blt _020f91e8
 	mov r0, #0
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov03_020f8e48
 _020f92e8: .word data_027e0d78
@@ -16658,14 +16658,14 @@ _020f9460:
 	.global func_ov03_020f9468
 	arm_func_start func_ov03_020f9468
 func_ov03_020f9468: ; 0x020f9468
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0xe0
 	ldr r1, _020f9a5c ; =data_027e0618
 	str r0, [sp, #0x10]
 	ldrb r0, [r1, #0x101]
 	cmp r0, #0
 	addne sp, sp, #0xe0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, _020f9a60 ; =data_027e0d38
 	ldr r0, [r0]
 	add r0, r0, #0xc
@@ -16683,20 +16683,20 @@ func_ov03_020f9468: ; 0x020f9468
 	ldr r6, _020f9a6c ; =data_027e0f74
 	str r1, [sp, #0x5c]
 	str r0, [sp, #0x54]
-	mov sl, #0
+	mov r10, #0
 	mvn sb, #0
 	add r8, sp, #0x1c
 	add r11, sp, #0x24
 	add r7, sp, #0x50
 _020f94e0:
-	add r0, sl, #0x37
+	add r0, r10, #0x37
 	add r1, r0, #0x100
 	ldr r0, [r6]
 	bl func_ov00_02097760
 	cmp r0, #0
 	beq _020f9550
 	ldr r0, [r5]
-	mov r1, sl
+	mov r1, r10
 	bl func_ov00_0209d928
 	str sb, [sp, #0x20]
 	mov r1, r8
@@ -16718,8 +16718,8 @@ _020f94e0:
 	mov r1, #8
 	bl func_02034984
 _020f9550:
-	add sl, sl, #1
-	cmp sl, #6
+	add r10, r10, #1
+	cmp r10, #6
 	blt _020f94e0
 _020f955c:
 	mov r0, #0xa
@@ -16746,7 +16746,7 @@ _020f95a4:
 	ldrb r0, [r0, #0x101]
 	ldr r1, [r1, #0x14]
 	cmp r0, #0
-	rsb sl, r1, #0
+	rsb r10, r1, #0
 	bne _020f96e8
 	add r0, sp, #0xc0
 	bl func_01ffbe34
@@ -16757,7 +16757,7 @@ _020f95a4:
 	cmp r0, #0
 	moveq r0, #1
 	movne r0, #0
-	adds r0, sl, r0
+	adds r0, r10, r0
 	beq _020f9658
 	ldr r0, [sp, #0x10]
 	add r0, r0, #0x200
@@ -16878,7 +16878,7 @@ _020f9798:
 	mov r3, r2
 	str r3, [sp]
 	mov r0, sb
-	mov r1, sl
+	mov r1, r10
 	mov r3, r6
 	bl func_ov00_020d00c4
 _020f97b4:
@@ -16957,7 +16957,7 @@ _020f9884:
 	ldrsb r1, [r8, #0x33]
 	ldr r3, [sp, #0x3c]
 	mov r0, #0xdb
-	add r2, r2, sl
+	add r2, r2, r10
 	bl func_02034984
 	b _020f9904
 _020f98e4:
@@ -16966,7 +16966,7 @@ _020f98e4:
 	ldr r1, [sp, #0x40]
 	ldr r2, [sp, #0x3c]
 	mov r0, sb
-	add r1, r1, sl
+	add r1, r1, r10
 	mov r3, r11
 	bl func_ov00_020d0210
 _020f9904:
@@ -16978,7 +16978,7 @@ _020f9904:
 	add r0, sp, #0x44
 	str r0, [sp, #0x14]
 	mov r0, #0
-	ldr sl, _020f9a78 ; =data_ov03_020ff634
+	ldr r10, _020f9a78 ; =data_ov03_020ff634
 	ldr r4, _020f9a68 ; =data_027e0d3c
 	str r0, [sp, #0x18]
 	mov r8, #0xde
@@ -17002,7 +17002,7 @@ _020f9944:
 _020f9974:
 	mov sb, #0
 _020f9978:
-	ldrb r1, [sl, sb]
+	ldrb r1, [r10, sb]
 	mov r0, r8
 	mov r2, r7
 	mov r3, r6
@@ -17013,7 +17013,7 @@ _020f9978:
 	mov r3, r11
 	bl func_ov00_02079680
 	str r5, [sp]
-	ldrb r1, [sl, sb]
+	ldrb r1, [r10, sb]
 	ldr r2, [sp, #0x38]
 	ldr r3, [sp, #0x34]
 	mov r0, #0xde
@@ -17023,7 +17023,7 @@ _020f9978:
 	blt _020f9978
 _020f99c4:
 	ldr r0, [sp, #0x18]
-	add sl, sl, #3
+	add r10, r10, #3
 	add r0, r0, #1
 	str r0, [sp, #0x18]
 	cmp r0, #4
@@ -17033,7 +17033,7 @@ _020f99c4:
 	blt _020f9944
 	mov sb, #0xda
 	ldr r4, _020f9a68 ; =data_027e0d3c
-	mov sl, #4
+	mov r10, #4
 	add r8, sp, #0x30
 	add r7, sp, #0x2c
 	mov r6, #1
@@ -17041,7 +17041,7 @@ _020f99c4:
 	mov r11, sb
 _020f9a08:
 	mov r0, sb
-	mov r1, sl
+	mov r1, r10
 	mov r2, r8
 	mov r3, r7
 	bl func_02034698
@@ -17052,15 +17052,15 @@ _020f9a08:
 	bl func_ov00_02079680
 	str r5, [sp]
 	mov r0, r11
-	mov r1, sl
+	mov r1, r10
 	ldr r2, [sp, #0x30]
 	ldr r3, [sp, #0x2c]
 	bl func_02034984
-	add sl, sl, #1
-	cmp sl, #7
+	add r10, r10, #1
+	cmp r10, #7
 	ble _020f9a08
 	add sp, sp, #0xe0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov03_020f9468
 _020f9a5c: .word data_027e0618
@@ -18283,7 +18283,7 @@ _020fa8d4: .word data_ov03_020ff870
 	.global func_ov03_020fa8d8
 	arm_func_start func_ov03_020fa8d8
 func_ov03_020fa8d8: ; 0x020fa8d8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x14
 	ldr r2, _020fa9e4 ; =data_027e0c54
 	mov r6, r0
@@ -18302,24 +18302,24 @@ func_ov03_020fa8d8: ; 0x020fa8d8
 	ldrb r0, [r8]
 	cmp r0, #0xff
 	addeq sp, sp, #0x14
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	mov r11, #1
 _020fa92c:
 	ldrb r5, [r8, sb]
 	ldr r0, [r6, #4]
-	ldr sl, [r0, r5, lsl #2]
-	ldrsb r0, [sl, #0x17]
-	ldrb r4, [sl, #0x16]
+	ldr r10, [r0, r5, lsl #2]
+	ldrsb r0, [r10, #0x17]
+	ldrb r4, [r10, #0x16]
 	bl func_0203eadc
 	add r2, sp, #4
 	add r3, r2, r0, lsl #3
 	ldr r2, [r3, r4, lsl #2]
-	mov r1, sl
-	add sl, r2, #1
+	mov r1, r10
+	add r10, r2, #1
 	ldr r0, _020fa9ec ; =data_02075dac
-	str sl, [r3, r4, lsl #2]
+	str r10, [r3, r4, lsl #2]
 	bl func_0203fa54
-	add r0, r0, sl, lsl #3
+	add r0, r0, r10, lsl #3
 	ldr r0, [r0, #0x10]
 	mov r1, #0
 	cmp r0, #0
@@ -18341,7 +18341,7 @@ _020fa99c:
 	cmpeq r7, #1
 	bne _020fa9cc
 _020fa9b0:
-	str sl, [sp]
+	str r10, [sp]
 	ldr r0, [r6, #4]
 	mov r1, r11
 	ldr r0, [r0, r5, lsl #2]
@@ -18354,7 +18354,7 @@ _020fa9cc:
 	cmp r0, #0xff
 	bne _020fa92c
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov03_020fa8d8
 _020fa9e4: .word data_027e0c54
@@ -20057,7 +20057,7 @@ _020fb6fc: .word func_ov03_020fb700 - 1
 	.global func_ov03_020fb700
 	arm_func_start func_ov03_020fb700
 func_ov03_020fb700: ; 0x020fb700
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	mov sb, r0
 	mov r6, #0
 	mov r8, #0x1000
@@ -20075,35 +20075,35 @@ _020fb728: ; jump table
 	b _020fb73c ; case 4
 _020fb73c:
 	mov r6, #0x100
-	mov sl, #0x100000
+	mov r10, #0x100000
 	mov r4, #0x40000
 	mov r5, #0x4d
 	mov r7, #5
 	b _020fb7b0
 _020fb754:
-	mov sl, #0x40000
-	mov r4, sl
+	mov r10, #0x40000
+	mov r4, r10
 	mov r6, #0x40
 	mov r5, #0x4c
 	mov r7, #3
 	b _020fb7b0
 _020fb76c:
-	mov sl, #0x40000
-	mov r4, sl
+	mov r10, #0x40000
+	mov r4, r10
 	mov r6, #0x40
 	mov r5, #0x4b
 	mov r7, #3
 	b _020fb7b0
 _020fb784:
-	mov sl, #0x40000
-	mov r4, sl
+	mov r10, #0x40000
+	mov r4, r10
 	mov r6, #0x40
 	mov r5, #0x4a
 	mov r7, #3
 	b _020fb7b0
 _020fb79c:
 	mov r6, #0x100
-	mov sl, #0x100000
+	mov r10, #0x100000
 	mov r4, #0x40000
 	mov r5, #0x4e
 	mov r7, #5
@@ -20178,7 +20178,7 @@ _020fb7b0:
 	mov r4, r0
 	add r0, r7, #0x60
 	bl func_ov05_0210e2a4
-	mov r1, sl, lsl #0x8
+	mov r1, r10, lsl #0x8
 	mov r1, r1, asr #0x10
 	mov r1, r1, lsl #0x10
 	mov r5, r1, lsr #0x10
@@ -20206,7 +20206,7 @@ _020fb7b0:
 	str r0, [r2, #0xc]
 	mov r0, #0
 	str r0, [r2, #0x7c]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov03_020fb700
 _020fb93c: .word 0x0000ffff
@@ -21061,32 +21061,32 @@ func_ov03_020fc1e8: ; 0x020fc1e8
 	.global func_ov03_020fc200
 	arm_func_start func_ov03_020fc200
 func_ov03_020fc200: ; 0x020fc200
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #0x3c
-	mov sl, r0
-	ldr r0, [sl]
+	mov r10, r0
+	ldr r0, [r10]
 	mov sb, r1
 	ldrb r0, [r0, #0x12c]
 	mov r8, r2
 	mov r7, r3
 	cmp r0, #0
 	addeq sp, sp, #0x3c
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	add r0, sp, #0x1c
 	bl func_01ffbe34
 	mov r4, #0
 	str r4, [sp, #0x20]
-	ldrh r0, [sl, #4]
+	ldrh r0, [r10, #4]
 	cmp r0, #0
 	movne r4, #1
 	cmp r4, #0
 	beq _020fc260
-	ldr r1, [sl, #8]
+	ldr r1, [r10, #8]
 	add r1, r1, #0x800
 	mov r5, r1, asr #0xc
 	b _020fc274
 _020fc260:
-	ldr r1, [sl]
+	ldr r1, [r10]
 	ldr r1, [r1, #0x124]
 	ldrsh r1, [r1]
 	mov r1, r1, lsl #0x14
@@ -21094,12 +21094,12 @@ _020fc260:
 _020fc274:
 	cmp r4, #0
 	beq _020fc28c
-	ldr r1, [sl, #0xc]
+	ldr r1, [r10, #0xc]
 	add r1, r1, #0x800
 	mov r6, r1, asr #0xc
 	b _020fc2a4
 _020fc28c:
-	ldr r1, [sl]
+	ldr r1, [r10]
 	ldr r1, [r1, #0x124]
 	ldrsh r1, [r1, #2]
 	mov r1, r1, lsl #0x14
@@ -21118,7 +21118,7 @@ _020fc2a4:
 	ldr r1, [sp, #0x6c]
 	mov r2, r7
 	str r1, [sp, #8]
-	ldrb r1, [sl, #0x18]
+	ldrb r1, [r10, #0x18]
 	ldr r3, [sp, #0x60]
 	add ip, sp, #0x1c
 	add r1, r1, #0x1e
@@ -21139,14 +21139,14 @@ _020fc2a4:
 	bl func_02034d68
 	cmp r4, #0
 	addne sp, sp, #0x3c
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	mov r1, #0
-	ldr r0, [sl]
+	ldr r0, [r10]
 	mov r2, r1
 	mov r3, r1
 	bl func_02032788
 	add sp, sp, #0x3c
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	arm_func_end func_ov03_020fc200
 
 	.global func_ov03_020fc348

--- a/asm/ov03.s
+++ b/asm/ov03.s
@@ -3596,7 +3596,7 @@ _020f0840: .word data_027e080c
 	.global func_ov03_020f0844
 	arm_func_start func_ov03_020f0844
 func_ov03_020f0844: ; 0x020f0844
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #8
 	movs sb, r1
 	mov sl, r0
@@ -3626,13 +3626,13 @@ _020f08a4:
 	ldr r5, [r0]
 	mov r0, r5
 	bl func_ov00_02083394
-	mov fp, r0
+	mov r11, r0
 	mov r0, r5
 	bl func_ov00_020833a0
 	str r0, [sp]
 	mov r0, r5
 	bl func_ov00_020833ac
-	sub r0, r0, fp
+	sub r0, r0, r11
 	add r4, r0, r0, lsr #31
 	mov r0, r5
 	mov r5, r4, asr #0x1
@@ -3647,7 +3647,7 @@ _020f08a4:
 	mov r0, r0, asr #0x1
 	mov r1, #0x60
 	bl func_01ff9b4c
-	add r3, fp, r4, asr #1
+	add r3, r11, r4, asr #1
 	mov r4, r0
 	ldr r2, [sp]
 	ldr r1, [sp, #4]
@@ -3722,7 +3722,7 @@ _020f09d8:
 	add sp, sp, #8
 	add r0, r1, r0
 	str r0, [r6, #8]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _020f0a30:
 	ldr r2, [sl, #0x10]
 	sub r1, r7, #0x60000
@@ -3750,7 +3750,7 @@ _020f0a30:
 	add r0, r1, r0
 	str r0, [r6, #8]
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov03_020f0844
 _020f0a9c: .word data_027e0c38
@@ -4714,12 +4714,12 @@ _020f1668: .word data_027e05f8
 	.global func_ov03_020f166c
 	arm_func_start func_ov03_020f166c
 func_ov03_020f166c: ; 0x020f166c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	mov sl, r0
 	ldr r0, [sl, #4]
 	cmp r0, #2
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r1, _020f182c ; =data_027e0c54
 	ldr r0, _020f1830 ; =data_ov09_0211f5b4
 	ldrb r5, [r1]
@@ -4746,11 +4746,11 @@ func_ov03_020f166c: ; 0x020f166c
 	and r0, r1, r0
 	cmp r0, #0x1000000
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	mov r5, #0
 	mov r7, sl
 	add r8, sl, #0x8c
-	mov fp, r5
+	mov r11, r5
 _020f1700:
 	cmp r5, #1
 	bne _020f1710
@@ -4764,9 +4764,9 @@ _020f1710:
 	ldr ip, [r0]
 	ldrh r6, [r7, #0x96]
 	ldr ip, [ip]
-	mov r1, fp
+	mov r1, r11
 	mov r2, sb
-	mov r3, fp
+	mov r3, r11
 	blx ip
 	mov r2, r0
 	mov r0, sl
@@ -4778,7 +4778,7 @@ _020f1710:
 	mov r1, #3
 	bl func_ov03_020f13b0
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _020f1768:
 	add r5, r5, #1
 	cmp r5, #3
@@ -4787,17 +4787,17 @@ _020f1768:
 	blt _020f1700
 	b _020f1824
 _020f1780:
-	mov fp, #0x10000
+	mov r11, #0x10000
 	mov r7, sl
 	add r8, sl, #0x44
 	mov r5, #0
-	rsb fp, fp, #0
+	rsb r11, r11, #0
 _020f1794:
 	ldr r0, [sl, #0x20]
-	and r0, r0, fp
+	and r0, r0, r11
 	cmp r0, #0x1000000
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	cmp r5, #1
 	bne _020f17b8
 	cmp r4, #0
@@ -4824,7 +4824,7 @@ _020f17b8:
 	mov r1, #3
 	bl func_ov03_020f13b0
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _020f1810:
 	add r5, r5, #1
 	cmp r5, #3
@@ -4833,7 +4833,7 @@ _020f1810:
 	blt _020f1794
 _020f1824:
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov03_020f166c
 _020f182c: .word data_027e0c54
@@ -6753,13 +6753,13 @@ _020f2d9c: .word func_ov03_020f2da0 - 1
 	.global func_ov03_020f2da0
 	arm_func_start func_ov03_020f2da0
 func_ov03_020f2da0: ; 0x020f2da0
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x34
 	mov sl, r0
 	ldrb r0, [sl, #0xa]
 	cmp r0, #0
 	addeq sp, sp, #0x34
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	bl func_01ffa8d4
 	ldr r2, _020f2f8c ; =0x04000444
 	mov r3, #0
@@ -6787,7 +6787,7 @@ _020f2e10:
 	str r1, [r0]
 	mov r8, #0
 	sub r4, r0, #0x74
-	mov fp, r8
+	mov r11, r8
 _020f2e28:
 	mov r0, sl
 	ldr r2, [r0]
@@ -6848,10 +6848,10 @@ _020f2e28:
 	str r2, [r4]
 	mov r0, r5, lsl #0x10
 	mov r1, r1, lsl #0x10
-	str fp, [r4]
+	str r11, [r4]
 	orr r0, r1, r0, lsr #16
 	str r0, [r4]
-	str fp, [r4]
+	str r11, [r4]
 	ldr r0, [sl, #4]
 	add sb, sb, #1
 	cmp sb, r0
@@ -6879,7 +6879,7 @@ _020f2f78:
 	mov r1, #1
 	str r1, [r0]
 	add sp, sp, #0x34
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov03_020f2da0
 _020f2f8c: .word 0x04000444
@@ -6960,7 +6960,7 @@ func_ov03_020f301c: ; 0x020f301c
 	.global func_ov03_020f3064
 	arm_func_start func_ov03_020f3064
 func_ov03_020f3064: ; 0x020f3064
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x10
 	movs r5, r3
 	mov r7, r0
@@ -6980,7 +6980,7 @@ func_ov03_020f3064: ; 0x020f3064
 	cmpeq r0, #0
 	addeq sp, sp, #0x10
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _020f30b8:
 	mov r0, r7
 	ldr r2, [r0]
@@ -7038,7 +7038,7 @@ _020f316c:
 	cmp r0, r1, asr #1
 	addgt sp, sp, #0x10
 	movgt r0, #0
-	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _020f3198:
 	cmp r5, #0
 	beq _020f31b0
@@ -7115,15 +7115,15 @@ _020f32a4:
 	ldrh r0, [r1]
 	tst r0, #0x8000
 	bne _020f32a4
-	ldr fp, _020f3514 ; =0x040002a0
+	ldr r11, _020f3514 ; =0x040002a0
 	ldr r1, [r4, #0xc]
-	ldr sb, [fp]
+	ldr sb, [r11]
 	mov ip, sl, asr #0x1f
 	umull r8, lr, sb, sl
 	umull r3, r2, r8, r1
 	mov r0, r1, asr #0x1f
 	mla lr, sb, ip, lr
-	ldr sb, [fp, #4]
+	ldr sb, [r11, #4]
 	mla r2, r8, r0, r2
 	mla lr, sb, sl, lr
 	mla r2, lr, r1, r2
@@ -7219,12 +7219,12 @@ _020f3430:
 	bne _020f3430
 	ldr ip, _020f3514 ; =0x040002a0
 	ldr r4, [r5, #0xc]
-	ldr fp, [ip]
+	ldr r11, [ip]
 	mov sl, r2, asr #0x1f
-	umull r1, r0, fp, r2
+	umull r1, r0, r11, r2
 	umull sb, r8, r1, r4
 	mov r3, r4, asr #0x1f
-	mla r0, fp, sl, r0
+	mla r0, r11, sl, r0
 	ldr sl, [ip, #4]
 	mla r8, r1, r3, r8
 	mla r0, sl, r2, r0
@@ -7268,7 +7268,7 @@ _020f34e0:
 	add r1, r1, #1
 	str r1, [r7, #4]
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov03_020f3064
 _020f3508: .word 0x040002b0
@@ -11926,7 +11926,7 @@ _020f5af0: .word data_027e0c38
 	.global func_ov03_020f5af4
 	arm_func_start func_ov03_020f5af4
 func_ov03_020f5af4: ; 0x020f5af4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x2c
 	mov r4, #6
 	mul r4, r2, r4
@@ -11942,7 +11942,7 @@ func_ov03_020f5af4: ; 0x020f5af4
 	add r3, sp, #0x24
 	ldr sb, [sp, #0x50]
 	ldr r8, [sp, #0x54]
-	ldr fp, [sp, #0x58]
+	ldr r11, [sp, #0x58]
 	str r5, [sp, #0x5c]
 	bl func_02034698
 	mov r0, #1
@@ -12019,7 +12019,7 @@ _020f5c34:
 	add r1, r2, sb
 	add r2, r3, r8
 	addle r0, sl, #0x124
-	mov r3, fp
+	mov r3, r11
 	bl func_02034a1c
 	b _020f5c80
 _020f5c60:
@@ -12028,7 +12028,7 @@ _020f5c60:
 	add r2, r2, sb
 	add r3, r3, r8
 	ldrleb r1, [r7, #3]
-	str fp, [sp]
+	str r11, [sp]
 	ldrsh r0, [r7]
 	bl func_02034984
 _020f5c80:
@@ -12039,13 +12039,13 @@ _020f5c8c:
 	ldr r0, [sp, #0x18]
 	cmp r0, #0
 	addlt sp, sp, #0x2c
-	ldmltia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmltia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, [sp, #0x5c]
 	cmp r0, #0
 	beq _020f5cc4
 	ldr r1, [sp, #0x14]
 	ldr r2, [sp, #0x10]
-	mov r3, fp
+	mov r3, r11
 	add r0, sl, #0x124
 	add r1, r1, sb
 	add r2, r2, r8
@@ -12053,13 +12053,13 @@ _020f5c8c:
 _020f5cc4:
 	ldr r1, [sp, #0x14]
 	ldr r2, [sp, #0x10]
-	mov r3, fp
+	mov r3, r11
 	add r0, sl, #0x14
 	add r1, r1, sb
 	add r2, r2, r8
 	bl func_02034a1c
 	add sp, sp, #0x2c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov03_020f5af4
 _020f5ce8: .word data_ov03_020ff614
@@ -14211,7 +14211,7 @@ _020f772c: .word data_027e077c
 	.global func_ov03_020f7730
 	arm_func_start func_ov03_020f7730
 func_ov03_020f7730: ; 0x020f7730
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x6c
 	ldr r1, _020f7bac ; =data_027e1054
 	mov sb, r0
@@ -14266,7 +14266,7 @@ _020f77e8:
 	mov r7, #0xa
 	str r0, [sp, #0x3c]
 	add sl, sp, #0xc
-	add fp, sp, #0x10
+	add r11, sp, #0x10
 	add r6, sp, #0x3c
 _020f7808:
 	ldr r0, [r5]
@@ -14285,7 +14285,7 @@ _020f7808:
 	ldr r2, [r0, #0xc]
 	ldr r0, [r4]
 	str r2, [sp, #0x10]
-	mov r2, fp
+	mov r2, r11
 	mov r3, #1
 	bl func_ov00_02079680
 	str r6, [sp]
@@ -14352,7 +14352,7 @@ _020f7908:
 	ldr r1, [sp, #0x28]
 	mov r0, #1
 	orr r1, r1, #0x1000
-	ldr fp, _020f7bb0 ; =data_027e0d3c
+	ldr r11, _020f7bb0 ; =data_027e0d3c
 	ldr sl, _020f7bbc ; =data_027e0f74
 	ldr r4, _020f7bb8 ; =data_027e0f7c
 	str r1, [sp, #0x28]
@@ -14374,7 +14374,7 @@ _020f7964:
 	cmp r0, #0
 	beq _020f79d4
 	ldr r1, [r6, #8]
-	ldr r0, [fp]
+	ldr r0, [r11]
 	str r1, [sp, #4]
 	ldr r2, [r6, #0xc]
 	add r1, sp, #4
@@ -14396,7 +14396,7 @@ _020f79e0:
 	ldrsb r0, [sb, #0x14]
 	cmp r0, #0
 	addeq sp, sp, #0x6c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, _020f7bc8 ; =data_027e077c
 	ldr r0, [r0]
 	cmp r0, #0xa
@@ -14419,7 +14419,7 @@ _020f7a0c: ; jump table
 _020f7a38:
 	cmp r0, #0x2e
 	addne sp, sp, #0x6c
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _020f7a44:
 	ldr r0, [sb, #0x34]
 	cmp r0, #0
@@ -14427,25 +14427,25 @@ _020f7a44:
 	cmp r0, #1
 	beq _020f7a74
 	add sp, sp, #0x6c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _020f7a60:
 	ldrsh r1, [sb, #0xe]
 	ldr r0, [sb, #0x28]
 	bl func_ov03_020f8790
 	add sp, sp, #0x6c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _020f7a74:
 	ldrsh r1, [sb, #0xe]
 	ldr r0, [sb, #0x2c]
 	bl func_ov17_0215ff30
 	add sp, sp, #0x6c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _020f7a88:
 	ldrsh r1, [sb, #0xe]
 	ldr r0, [sb, #0x2c]
 	bl func_ov17_0215ff30
 	add sp, sp, #0x6c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _020f7a9c:
 	ldrsh r0, [sb, #0x1c]
 	ldrsh r2, [sb, #0x1e]
@@ -14481,7 +14481,7 @@ _020f7ad8:
 	sub r1, r2, r1
 	bl func_ov17_0215ff30
 	add sp, sp, #0x6c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _020f7b24:
 	ldrsh r0, [sb, #0x1c]
 	ldrsh r2, [sb, #0x1e]
@@ -14518,7 +14518,7 @@ _020f7b60:
 	bl func_ov17_0215ff30
 _020f7ba4:
 	add sp, sp, #0x6c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov03_020f7730
 _020f7bac: .word data_027e1054
@@ -16201,7 +16201,7 @@ _020f8e44: .word data_027e077c
 	.global func_ov03_020f8e48
 	arm_func_start func_ov03_020f8e48
 func_ov03_020f8e48: ; 0x020f8e48
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0xc
 	mov r7, r0
 	mov r2, #0
@@ -16241,7 +16241,7 @@ _020f8ec4:
 	cmp r1, r0
 	addne sp, sp, #0xc
 	movne r0, #0
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldrb r2, [r7, #0x24d]
 	add r3, r7, #0x218
 	mov r0, #0x18
@@ -16260,7 +16260,7 @@ _020f8ec4:
 	cmp r0, #0
 	addne sp, sp, #0xc
 	movne r0, #1
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldrb r1, [r7, #0x24d]
 	add r2, r7, #0x218
 	mov r0, #0x18
@@ -16269,7 +16269,7 @@ _020f8ec4:
 	tst r1, #6
 	addne sp, sp, #0xc
 	movne r0, #0
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldrb r1, [r7, #0x24c]
 	cmp r1, #0
 	bne _020f8f80
@@ -16283,10 +16283,10 @@ _020f8ec4:
 	blx r4
 	strb r0, [r7, #0x24c]
 _020f8f80:
-	mvn fp, #0
+	mvn r11, #0
 	ldr sl, _020f92ec ; =gItemManager
-	str fp, [sp, #4]
-	str fp, [sp, #8]
+	str r11, [sp, #4]
+	str r11, [sp, #8]
 	add r4, r7, #0x80
 	add r5, r7, #0x60
 	mov r8, #4
@@ -16407,7 +16407,7 @@ _020f9118:
 	mov r1, sb
 	ldr r0, [r0]
 	bl func_ov00_0209d748
-	cmp r0, fp
+	cmp r0, r11
 	beq _020f9154
 	add r1, r0, #0xb7
 	add r0, r7, #4
@@ -16434,7 +16434,7 @@ _020f9160:
 	cmp r0, #0
 	addne sp, sp, #0xc
 	movne r0, #1
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldrb r0, [r5, #0x2d]
 	tst r0, #6
 	beq _020f91c0
@@ -16442,7 +16442,7 @@ _020f9160:
 	beq _020f91d4
 	add sp, sp, #0xc
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _020f91c0:
 	add r4, r4, #0x18
 	add r5, r5, #0x18
@@ -16503,13 +16503,13 @@ _020f9274:
 	beq _020f92c8
 _020f9288:
 	mov r0, sb
-	ldr fp, [r0]
+	ldr r11, [r0]
 	ldrh r6, [r8, #0x2a]
 	mov r1, #0
-	ldr fp, [fp]
+	ldr r11, [r11]
 	mov r2, r1
 	mov r3, r7
-	blx fp
+	blx r11
 	mov r2, r0
 	mov r1, r6
 	mov r0, r7
@@ -16517,7 +16517,7 @@ _020f9288:
 	cmp r0, #0
 	addne sp, sp, #0xc
 	movne r0, #1
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _020f92c8:
 	add r5, r5, #1
 	cmp r5, #4
@@ -16526,7 +16526,7 @@ _020f92c8:
 	blt _020f91e8
 	mov r0, #0
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov03_020f8e48
 _020f92e8: .word data_027e0d78
@@ -16658,14 +16658,14 @@ _020f9460:
 	.global func_ov03_020f9468
 	arm_func_start func_ov03_020f9468
 func_ov03_020f9468: ; 0x020f9468
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0xe0
 	ldr r1, _020f9a5c ; =data_027e0618
 	str r0, [sp, #0x10]
 	ldrb r0, [r1, #0x101]
 	cmp r0, #0
 	addne sp, sp, #0xe0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, _020f9a60 ; =data_027e0d38
 	ldr r0, [r0]
 	add r0, r0, #0xc
@@ -16686,7 +16686,7 @@ func_ov03_020f9468: ; 0x020f9468
 	mov sl, #0
 	mvn sb, #0
 	add r8, sp, #0x1c
-	add fp, sp, #0x24
+	add r11, sp, #0x24
 	add r7, sp, #0x50
 _020f94e0:
 	add r0, sl, #0x37
@@ -16707,7 +16707,7 @@ _020f94e0:
 	str r0, [sp, #0x28]
 	str r1, [sp, #0x24]
 	ldr r0, [r4]
-	mov r1, fp
+	mov r1, r11
 	add r2, sp, #0x28
 	mov r3, #1
 	bl func_ov00_02079680
@@ -16859,10 +16859,10 @@ _020f9740:
 	mov r7, #0
 	add r4, r0, #0x200
 	add r6, sp, #0x70
-	add fp, sp, #0xa0
+	add r11, sp, #0xa0
 	mov r5, #2
 _020f976c:
-	mov r0, fp
+	mov r0, r11
 	mov r1, r6
 	mov r2, #0x20
 	bl func_02007984
@@ -16912,7 +16912,7 @@ _020f97b4:
 	add r8, r0, #0x60
 	add sb, r0, #0x80
 	add r4, r0, #0x200
-	add fp, sp, #0xa0
+	add r11, sp, #0xa0
 _020f9830:
 	ldr r0, _020f9a64 ; =data_027e0f7c
 	sub r1, r5, #4
@@ -16952,7 +16952,7 @@ _020f9884:
 	bne _020f98e4
 	cmp r7, #0
 	beq _020f98e4
-	str fp, [sp]
+	str r11, [sp]
 	ldr r2, [sp, #0x40]
 	ldrsb r1, [r8, #0x33]
 	ldr r3, [sp, #0x3c]
@@ -16967,7 +16967,7 @@ _020f98e4:
 	ldr r2, [sp, #0x3c]
 	mov r0, sb
 	add r1, r1, sl
-	mov r3, fp
+	mov r3, r11
 	bl func_ov00_020d0210
 _020f9904:
 	add r8, r8, #0x18
@@ -16984,7 +16984,7 @@ _020f9904:
 	mov r8, #0xde
 	add r7, sp, #0x38
 	add r6, sp, #0x34
-	mov fp, #1
+	mov r11, #1
 	add r5, sp, #0xa0
 _020f9944:
 	ldr r0, [sp, #0x14]
@@ -17010,7 +17010,7 @@ _020f9978:
 	ldr r0, [r4]
 	mov r1, r7
 	mov r2, r6
-	mov r3, fp
+	mov r3, r11
 	bl func_ov00_02079680
 	str r5, [sp]
 	ldrb r1, [sl, sb]
@@ -17038,7 +17038,7 @@ _020f99c4:
 	add r7, sp, #0x2c
 	mov r6, #1
 	add r5, sp, #0xa0
-	mov fp, sb
+	mov r11, sb
 _020f9a08:
 	mov r0, sb
 	mov r1, sl
@@ -17051,7 +17051,7 @@ _020f9a08:
 	mov r3, r6
 	bl func_ov00_02079680
 	str r5, [sp]
-	mov r0, fp
+	mov r0, r11
 	mov r1, sl
 	ldr r2, [sp, #0x30]
 	ldr r3, [sp, #0x2c]
@@ -17060,7 +17060,7 @@ _020f9a08:
 	cmp sl, #7
 	ble _020f9a08
 	add sp, sp, #0xe0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov03_020f9468
 _020f9a5c: .word data_027e0618
@@ -18283,7 +18283,7 @@ _020fa8d4: .word data_ov03_020ff870
 	.global func_ov03_020fa8d8
 	arm_func_start func_ov03_020fa8d8
 func_ov03_020fa8d8: ; 0x020fa8d8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x14
 	ldr r2, _020fa9e4 ; =data_027e0c54
 	mov r6, r0
@@ -18302,8 +18302,8 @@ func_ov03_020fa8d8: ; 0x020fa8d8
 	ldrb r0, [r8]
 	cmp r0, #0xff
 	addeq sp, sp, #0x14
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
-	mov fp, #1
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	mov r11, #1
 _020fa92c:
 	ldrb r5, [r8, sb]
 	ldr r0, [r6, #4]
@@ -18343,9 +18343,9 @@ _020fa99c:
 _020fa9b0:
 	str sl, [sp]
 	ldr r0, [r6, #4]
-	mov r1, fp
+	mov r1, r11
 	ldr r0, [r0, r5, lsl #2]
-	mov r2, fp
+	mov r2, r11
 	mov r3, #0
 	bl func_020340d0
 _020fa9cc:
@@ -18354,7 +18354,7 @@ _020fa9cc:
 	cmp r0, #0xff
 	bne _020fa92c
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov03_020fa8d8
 _020fa9e4: .word data_027e0c54

--- a/asm/ov05.s
+++ b/asm/ov05.s
@@ -574,7 +574,7 @@ func_ov05_021011fc: ; 0x021011fc
 	.global func_ov05_02101230
 	arm_func_start func_ov05_02101230
 func_ov05_02101230: ; 0x02101230
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x40
 	ldr r2, _0210141c ; =data_027e077c
 	mov sl, r0
@@ -582,7 +582,7 @@ func_ov05_02101230: ; 0x02101230
 	mov sb, r1
 	cmp r0, #0x22
 	addeq sp, sp, #0x40
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r2, [sl, #0xc]
 	ldr r0, [sl, #0x10]
 	mov r8, r2
@@ -593,7 +593,7 @@ func_ov05_02101230: ; 0x02101230
 	sub r6, sp, #4
 	add r5, sp, #1
 	mov r4, r7
-	mov fp, r7
+	mov r11, r7
 _02101280:
 	ldr r0, [r8]
 	mov r1, sb
@@ -641,7 +641,7 @@ _02101280:
 	blx r1
 _02101330:
 	mov r7, #1
-	str fp, [r8]
+	str r11, [r8]
 _02101338:
 	ldr r2, [sl, #0xc]
 	ldr r0, [sl, #0x10]
@@ -698,14 +698,14 @@ _021013bc:
 _021013f4:
 	cmp sb, #0
 	addne sp, sp, #0x40
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, [sl, #4]
 	cmp r0, #0
 	addeq sp, sp, #0x40
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	bl func_ov18_0216ad3c
 	add sp, sp, #0x40
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov05_02101230
 _0210141c: .word data_027e077c
@@ -2546,7 +2546,7 @@ func_ov05_02102cfc: ; 0x02102cfc
 	.global func_ov05_02102d1c
 	arm_func_start func_ov05_02102d1c
 func_ov05_02102d1c: ; 0x02102d1c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x90
 	str r0, [sp, #0x28]
 	ldr r0, [r0, #0x904]
@@ -2557,7 +2557,7 @@ func_ov05_02102d1c: ; 0x02102d1c
 	ldrsh r0, [r0, #8]
 	cmp r0, #0
 	addle sp, sp, #0x90
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02102d4c:
 	cmp r1, #0
 	beq _02102d6c
@@ -2566,7 +2566,7 @@ _02102d4c:
 	ldrh r0, [r0, #0xa]
 	tst r0, #0x10
 	addne sp, sp, #0x90
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02102d6c:
 	ldr r8, _02103558 ; =data_020691a0
 	bl func_ov05_02103ba0
@@ -2574,7 +2574,7 @@ _02102d6c:
 	ldr r0, [sp, #0x28]
 	mov r1, #0x20
 	bl func_ov05_02103b88
-	mov fp, r0
+	mov r11, r0
 	mov r2, #0
 	ldr r0, [sp, #0x28]
 	mov r1, #1
@@ -2706,7 +2706,7 @@ _02102ee8:
 	ldr r1, [sp, #0x34]
 	mov r0, sb
 	add r2, r6, #8
-	mov r3, fp
+	mov r3, r11
 	bl func_ov05_02102b0c
 	str r0, [r6, #4]
 	ldr r0, [r7, #0xc]
@@ -2785,7 +2785,7 @@ _02103048:
 	str r2, [sp, #0x18]
 	str r5, [sp, #0x1c]
 	str r0, [sp, #0x20]
-	str fp, [sp, #0x24]
+	str r11, [sp, #0x24]
 	ldr r2, [r6, #4]
 	mov r0, r8
 	bl func_ov05_021038c8
@@ -2813,7 +2813,7 @@ _02103048:
 	str r2, [sp, #0x18]
 	str r5, [sp, #0x1c]
 	str r0, [sp, #0x20]
-	str fp, [sp, #0x24]
+	str r11, [sp, #0x24]
 	ldr r2, [r6, #4]
 	mov r0, r8
 	bl func_ov05_0210373c
@@ -2958,7 +2958,7 @@ _021032d4:
 	ldr r6, _0210356c ; =data_ov05_021122a0
 	rsb r4, r4, #0
 	mov r7, sb
-	mov fp, sb
+	mov r11, sb
 _02103338:
 	mov r0, #3
 	str r0, [sp]
@@ -2978,10 +2978,10 @@ _02103338:
 	mov r1, #6
 	bl func_ov05_021036a0
 	ldr r1, [r8, #0x28]
-	mov r0, fp
+	mov r0, r11
 	str r1, [sp]
 	ldr r2, [r8]
-	mov r1, fp
+	mov r1, r11
 	str r2, [sp, #4]
 	ldrb r3, [r8, #0x2c]
 	mov r2, #2
@@ -3097,11 +3097,11 @@ _02103530:
 	ldrsh r0, [r0, #8]
 	cmp r0, #0
 	addle sp, sp, #0x90
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, [sp, #0x28]
 	bl func_ov18_0216945c
 	add sp, sp, #0x90
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov05_02102d1c
 _02103558: .word data_020691a0
@@ -3317,7 +3317,7 @@ _02103738: .word data_027e0d44
 	.global func_ov05_0210373c
 	arm_func_start func_ov05_0210373c
 func_ov05_0210373c: ; 0x0210373c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x10
 	ldr r7, [sp, #0x44]
 	ldr r4, _021038c0 ; =data_027e0e60
@@ -3330,7 +3330,7 @@ func_ov05_0210373c: ; 0x0210373c
 	mov r0, r4
 	mov r1, r6
 	mov r8, r2
-	mov fp, r3
+	mov r11, r3
 	bl func_ov00_020839f8
 	ldr r1, [sp, #0x38]
 	str r0, [sp]
@@ -3343,7 +3343,7 @@ func_ov05_0210373c: ; 0x0210373c
 	add r5, sl, ip
 	str r2, [sl, ip]
 	ldr r1, [sp]
-	mov r0, fp
+	mov r0, r11
 	add r2, r5, #8
 	bl func_ov05_02102b0c
 	str r0, [r5, #4]
@@ -3389,7 +3389,7 @@ _02103838:
 	mov r0, r4
 	str r1, [r5, #0x10]
 	ldr r2, [r7, #4]
-	mov r1, fp
+	mov r1, r11
 	str r2, [r5, #0x14]
 	ldr r3, [r7, #8]
 	ldr r2, [sp]
@@ -3416,7 +3416,7 @@ _02103878:
 _021038b4:
 	mov r0, sb
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov05_0210373c
 _021038c0: .word data_027e0e60
@@ -3425,7 +3425,7 @@ _021038c4: .word data_ov05_021122a8
 	.global func_ov05_021038c8
 	arm_func_start func_ov05_021038c8
 func_ov05_021038c8: ; 0x021038c8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x18
 	ldr r7, [sp, #0x4c]
 	ldr r4, _02103a9c ; =data_027e0e60
@@ -3440,8 +3440,8 @@ func_ov05_021038c8: ; 0x021038c8
 	mov r8, r2
 	mov r5, r3
 	bl func_ov00_020839d4
-	mov fp, r0
-	cmp r5, fp
+	mov r11, r0
+	cmp r5, r11
 	beq _02103a90
 	mov r1, #0x30
 	mul lr, sb, r1
@@ -3521,7 +3521,7 @@ _02103a10:
 	mov r0, r4
 	str r1, [r5, #0x14]
 	ldr r3, [r7, #8]
-	mov r1, fp
+	mov r1, r11
 	str r3, [r5, #0x18]
 	bl func_ov00_02083e34
 	str r0, [r5, #0x14]
@@ -3545,7 +3545,7 @@ _02103a54:
 _02103a90:
 	mov r0, sb
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov05_021038c8
 _02103a9c: .word data_027e0e60
@@ -4559,7 +4559,7 @@ _02104570: .word data_027e0d3c
 	.global func_ov05_02104574
 	arm_func_start func_ov05_02104574
 func_ov05_02104574: ; 0x02104574
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x2c
 	ldr r2, _02104730 ; =data_027e1054
 	mov r4, r0
@@ -4568,7 +4568,7 @@ func_ov05_02104574: ; 0x02104574
 	ldrb r0, [r0, #0x95]
 	cmp r0, #0
 	addne sp, sp, #0x2c
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldrh r0, [r1]
 	tst r0, #4
 	movne r1, #1
@@ -4580,7 +4580,7 @@ func_ov05_02104574: ; 0x02104574
 	moveq r0, #0
 	cmp r0, #0
 	addeq sp, sp, #0x2c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _021045cc:
 	ldr r0, _02104734 ; =data_027e0d38
 	ldr r0, [r0]
@@ -4589,7 +4589,7 @@ _021045cc:
 	cmp r0, #1
 	cmpne r0, #0x32
 	addeq sp, sp, #0x2c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r0, sp, #0xc
 	bl func_01ffbe34
 	ldr r0, [sp, #0x18]
@@ -4619,7 +4619,7 @@ _021045cc:
 	mov r2, r5
 	bl func_ov05_02104a48
 	add sp, sp, #0x2c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02104664:
 	ldr r7, _0210473c ; =data_027e0d3c
 	sub r0, sb, #2
@@ -4627,11 +4627,11 @@ _02104664:
 	ldr sl, [r1, #0x48]
 	cmp sl, r0
 	addeq sp, sp, #0x2c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r5, _02104738 ; =data_027e0f7c
 	ldr r6, _02104740 ; =gItemManager
 	add r4, r4, #0x200
-	add fp, sp, #8
+	add r11, sp, #8
 	add r8, sp, #0xc
 _02104694:
 	ldrsb r0, [r4, #0x4f]
@@ -4654,7 +4654,7 @@ _02104694:
 	cmp sl, r1
 	bne _0210471c
 	ldr r2, [r0, #4]
-	mov r1, fp
+	mov r1, r11
 	str r2, [sp, #8]
 	ldr r2, [r0, #8]
 	ldr r0, [r7]
@@ -4673,7 +4673,7 @@ _0210471c:
 	cmp sb, #0x20
 	blt _02104694
 	add sp, sp, #0x2c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov05_02104574
 _02104730: .word data_027e1054
@@ -4724,7 +4724,7 @@ _021047c4: .word data_027e0d3c
 	.global func_ov05_021047c8
 	arm_func_start func_ov05_021047c8
 func_ov05_021047c8: ; 0x021047c8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x34
 	ldr r0, _02104a28 ; =data_027e1054
 	ldr r0, [r0]
@@ -4732,7 +4732,7 @@ func_ov05_021047c8: ; 0x021047c8
 	ldrb r0, [r0, #0x95]
 	cmp r0, #0
 	addne sp, sp, #0x34
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldrh r0, [r1]
 	tst r0, #4
 	movne r1, #1
@@ -4744,7 +4744,7 @@ func_ov05_021047c8: ; 0x021047c8
 	moveq r0, #0
 	cmp r0, #0
 	addeq sp, sp, #0x34
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0210481c:
 	add r0, sp, #0x14
 	bl func_01ffbe34
@@ -4761,7 +4761,7 @@ _0210481c:
 	cmp r0, #1
 	beq _0210493c
 	add sp, sp, #0x34
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0210485c:
 	ldr r0, _02104a30 ; =data_027e0f74
 	ldr r1, _02104a34 ; =0x0000015f
@@ -4789,14 +4789,14 @@ _021048a8:
 	bl func_ov00_02097760
 	cmp r0, #0
 	addeq sp, sp, #0x34
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, _02104a38 ; =gItemManager
 	mov r1, #0
 	ldr r0, [r0]
 	bl _ZNK11ItemManager18IsTreasureSalvagedEj
 	cmp r0, #0
 	addne sp, sp, #0x34
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, _02104a3c ; =data_027e0f7c
 	mov r1, #0
 	ldr r0, [r0]
@@ -4819,7 +4819,7 @@ _021048a8:
 	mov r1, #0x12
 	bl func_02034984
 	add sp, sp, #0x34
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0210493c:
 	ldr r0, _02104a40 ; =data_027e077c
 	mov r1, #1
@@ -4828,14 +4828,14 @@ _0210493c:
 	moveq r1, r2
 	cmp r1, #0
 	addeq sp, sp, #0x34
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, _02104a38 ; =gItemManager
 	mov r1, #0x16
 	ldr r0, [r0]
 	bl _ZNK11ItemManager7HasItemEi
 	cmp r0, #0
 	addne sp, sp, #0x34
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, _02104a30 ; =data_027e0f74
 	ldr r1, _02104a44 ; =0x00000125
 	ldr r0, [r0]
@@ -4847,7 +4847,7 @@ _0210493c:
 	mov r8, #0xd0
 	add r7, sp, #8
 	add r6, sp, #4
-	mov fp, #1
+	mov r11, #1
 	add r5, sp, #0x14
 _021049ac:
 	and sl, sb, #0xff
@@ -4859,7 +4859,7 @@ _021049ac:
 	ldr r0, [r4]
 	mov r1, r7
 	mov r2, r6
-	mov r3, fp
+	mov r3, r11
 	bl func_ov00_02079680
 	str r5, [sp]
 	ldr r2, [sp, #8]
@@ -4871,7 +4871,7 @@ _021049ac:
 	cmp sb, #0x2a
 	blt _021049ac
 	add sp, sp, #0x34
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02104a04:
 	mov r2, #0
 	add r4, sp, #0x14
@@ -4881,7 +4881,7 @@ _02104a04:
 	str r4, [sp]
 	bl func_ov05_02104744
 	add sp, sp, #0x34
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov05_021047c8
 _02104a28: .word data_027e1054
@@ -8488,10 +8488,10 @@ func_ov05_02107b74: ; 0x02107b74
 	.global func_ov05_02107bd4
 	arm_func_start func_ov05_02107bd4
 func_ov05_02107bd4: ; 0x02107bd4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	mov sl, r0
 	ldr r4, _02107c80 ; =0x47454c4c
-	ldr fp, _02107c84 ; =0x57544352
+	ldr r11, _02107c84 ; =0x57544352
 	ldr r6, _02107c88 ; =data_027e0fe4
 	add sb, sl, #0x44
 	mov r8, #0
@@ -8509,7 +8509,7 @@ _02107bf4:
 	ldr r1, [r7, #4]
 	cmp r1, r4
 	beq _02107c30
-	cmp r1, fp
+	cmp r1, r11
 	beq _02107c4c
 	b _02107c68
 _02107c30:
@@ -8519,7 +8519,7 @@ _02107c30:
 	mov r0, r7
 	bl func_ov32_0217fd7c
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02107c4c:
 	bl func_ov26_02170150
 	cmp r0, #0
@@ -8527,14 +8527,14 @@ _02107c4c:
 	mov r0, r7
 	bl func_ov26_02170164
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02107c68:
 	add r8, r8, #1
 	cmp r8, #8
 	add sb, sb, #8
 	blt _02107bf4
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov05_02107bd4
 _02107c80: .word 0x47454c4c
@@ -8779,14 +8779,14 @@ _02107fb8:
 	.global func_ov05_02107fc0
 	arm_func_start func_ov05_02107fc0
 func_ov05_02107fc0: ; 0x02107fc0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	mov r1, #2
 	mov sl, r0
 	bl _ZN13LinkStateBase29HasFlags_PlayerLinkBase_Unk48Et
 	cmp r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	mov r6, #0
-	ldr fp, _02108088 ; =0x47454c4c
+	ldr r11, _02108088 ; =0x47454c4c
 	ldr r4, _0210808c ; =data_027e0fe4
 	mov sb, r6
 	add r8, sl, #0x44
@@ -8802,7 +8802,7 @@ _02107ff0:
 	movs r7, r0
 	beq _02108054
 	ldr r1, [r7, #4]
-	cmp r1, fp
+	cmp r1, r11
 	bne _0210802c
 	bl func_ov32_0217fd68
 	cmp r0, #0
@@ -8829,11 +8829,11 @@ _02108060:
 	add r8, r8, #8
 	blt _02107ff0
 	cmp r6, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	mov r0, sl
 	mov r1, #2
 	bl _ZN13LinkStateBase26Clear_PlayerLinkBase_Unk48Et
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov05_02107fc0
 _02108088: .word 0x47454c4c
@@ -9105,7 +9105,7 @@ _02108340:
 	.global func_ov05_021083e0
 	arm_func_start func_ov05_021083e0
 func_ov05_021083e0: ; 0x021083e0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	mov sl, r0
 	ldrb r0, [sl]
 	mov r1, #0
@@ -9142,10 +9142,10 @@ _0210843c:
 	add r6, r6, #0x38
 	blt _0210843c
 _0210846c:
-	sub fp, r5, #1
+	sub r11, r5, #1
 	mov r8, #0
-	cmp fp, #0
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	cmp r11, #0
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0210847c:
 	mov r0, r7
 	mov r1, r8
@@ -9177,9 +9177,9 @@ _021084d8:
 	blt _021084a8
 _021084e4:
 	add r8, r8, #1
-	cmp r8, fp
+	cmp r8, r11
 	blt _0210847c
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	arm_func_end func_ov05_021083e0
 
 	.global func_ov05_021084f4
@@ -12179,7 +12179,7 @@ _0210ad84: .word 0x000004cd
 	.global func_ov05_0210ad88
 	arm_func_start func_ov05_0210ad88
 func_ov05_0210ad88: ; 0x0210ad88
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x100
 	mov r5, r0
 	bl _ZN13LinkStateBase18func_ov00_020a8d40Ev
@@ -12209,7 +12209,7 @@ _0210ade0:
 	mov r0, r5
 	bl _ZN13LinkStateBase15ChangeLinkStateEi
 	add sp, sp, #0x100
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0210ae00:
 	ldr r0, [r5, #0xc]
 	cmp r0, #0
@@ -12346,9 +12346,9 @@ _0210ae98:
 	mov r3, lr, lsl #0xc
 	umull sb, r8, r7, r3
 	mla r8, r7, lr, r8
-	mov fp, r7, asr #0x1f
+	mov r11, r7, asr #0x1f
 	adds r7, sb, #0x800
-	mla r8, fp, r3, r8
+	mla r8, r11, r3, r8
 	ldr sl, [sp, #0x28]
 	adc r3, r8, #0
 	mov r7, r7, lsr #0xc
@@ -12454,7 +12454,7 @@ _0210ae98:
 	str r2, [r5, #4]
 	bl _ZN13LinkStateBase15ChangeLinkStateEi
 	add sp, sp, #0x100
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0210b1c0:
 	mov r0, #0x1000
 	rsb r0, r0, #0
@@ -12476,7 +12476,7 @@ _0210b1c0:
 	str r2, [r5, #4]
 	bl _ZN13LinkStateBase15ChangeLinkStateEi
 	add sp, sp, #0x100
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0210b214:
 	ldr r1, _0210b2a0 ; =data_ov05_02112894
 	mov r0, r5
@@ -12499,7 +12499,7 @@ _0210b244:
 	mov r0, r5
 	bl _ZN13LinkStateBase15ChangeLinkStateEi
 	add sp, sp, #0x100
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0210b264:
 	mov r0, r5
 	mov r1, r4
@@ -12507,7 +12507,7 @@ _0210b264:
 	add r0, r5, #0x24
 	bl func_0203516c
 	add sp, sp, #0x100
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov05_0210ad88
 _0210b280: .word data_027e0fe4
@@ -14560,7 +14560,7 @@ _0210cea8: .word data_027e0c38
 	.global func_ov05_0210ceac
 	arm_func_start func_ov05_0210ceac
 func_ov05_0210ceac: ; 0x0210ceac
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x10
 	ldr r8, [sp, #0x40]
 	mov r7, r1
@@ -14572,7 +14572,7 @@ func_ov05_0210ceac: ; 0x0210ceac
 	cmp r8, #0
 	str r1, [sp, #0x38]
 	addeq sp, sp, #0x10
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	mov r1, r3
 	subs r6, r1, r7
 	ldr r1, [sp, #0x38]
@@ -14585,18 +14585,18 @@ func_ov05_0210ceac: ; 0x0210ceac
 	str r8, [sp]
 	bl func_ov05_0210cd58
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0210cf14:
 	cmp r6, #0
 	strge r6, [sp, #8]
 	rsblt r0, r6, #0
 	strlt r0, [sp, #8]
 	cmp r5, #0
-	movge fp, r5
+	movge r11, r5
 	ldr r1, [sp, #8]
-	rsblt fp, r5, #0
+	rsblt r11, r5, #0
 	mov r1, r1, lsl #0xc
-	mov r0, fp, lsl #0xc
+	mov r0, r11, lsl #0xc
 	smull ip, r3, r1, r1
 	smull r2, r1, r0, r0
 	adds r0, ip, #0x800
@@ -14610,7 +14610,7 @@ _0210cf14:
 	add r0, r0, r2
 	bl func_01ff9a80
 	ldr r0, [sp, #8]
-	cmp r0, fp
+	cmp r0, r11
 	blt _0210d02c
 	mov r0, r5, lsl #0xc
 	mov r1, r6, lsl #0xc
@@ -14618,8 +14618,8 @@ _0210cf14:
 	ldr r0, [sp, #4]
 	mov r5, sl, lsl #0xc
 	cmp r7, r0
-	movle fp, #1
-	mvngt fp, #0
+	movle r11, #1
+	mvngt r11, #0
 	bl func_01ff9a18
 	mov r6, r0
 	ldr r0, [sp, #0x38]
@@ -14636,7 +14636,7 @@ _0210cfc0:
 	mov sl, #0
 	cmp r0, #0
 	addlt sp, sp, #0x10
-	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0210cfd4:
 	ldr r0, [r4, #0x20]
 	cmp r0, #0
@@ -14656,11 +14656,11 @@ _0210cff0:
 	ldr r0, [sp, #8]
 	add sl, sl, #1
 	cmp sl, r0
-	add r7, r7, fp
+	add r7, r7, r11
 	add r5, r5, r6
 	ble _0210cfd4
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0210d02c:
 	mov r0, r6, lsl #0xc
 	mov r1, r5, lsl #0xc
@@ -14684,10 +14684,10 @@ _0210d074:
 	cmp r6, #0
 	rsbgt r6, r6, #0
 _0210d07c:
-	cmp fp, #0
+	cmp r11, #0
 	mov r7, #0
 	addlt sp, sp, #0x10
-	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0210d08c:
 	ldr r0, [r4, #0x20]
 	cmp r0, #0
@@ -14706,12 +14706,12 @@ _0210d0a8:
 	bl func_ov05_0210cd58
 	ldr r0, [sp, #0xc]
 	add r7, r7, #1
-	cmp r7, fp
+	cmp r7, r11
 	add r5, r5, r6
 	add sl, sl, r0
 	ble _0210d08c
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	arm_func_end func_ov05_0210ceac
 
 	.global func_ov05_0210d0e4
@@ -14984,7 +14984,7 @@ func_ov05_0210d3d8: ; 0x0210d3d8
 	.global func_ov05_0210d474
 	arm_func_start func_ov05_0210d474
 func_ov05_0210d474: ; 0x0210d474
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x20
 	mov r8, r0
 	ldr r0, [r8]
@@ -15046,9 +15046,9 @@ _0210d4e8:
 	str r0, [sp, #0x18]
 	ldr r0, _0210d6d4 ; =data_027e0764
 	umull lr, ip, r3, r1
-	ldr fp, [r0, #4]
+	ldr r11, [r0, #4]
 	ldr r0, [sp, #4]
-	mla ip, r3, fp, ip
+	mla ip, r3, r11, ip
 	mla ip, r2, r1, ip
 	adds r3, sl, lr
 	ldr r1, _0210d6d4 ; =data_027e0764
@@ -15143,7 +15143,7 @@ _0210d6c4:
 	mov r0, #0
 	str r0, [r8]
 	add sp, sp, #0x20
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov05_0210d474
 _0210d6d4: .word data_027e0764
@@ -16071,7 +16071,7 @@ func_ov05_0210e2a4: ; 0x0210e2a4
 	.global func_ov05_0210e2c4
 	arm_func_start func_ov05_0210e2c4
 func_ov05_0210e2c4: ; 0x0210e2c4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x14
 	mov sl, r0
 	ldmia sl, {r5, r6}
@@ -16081,7 +16081,7 @@ func_ov05_0210e2c4: ; 0x0210e2c4
 	mov r8, r2
 	mov r7, r3
 	bl func_ov05_0210e288
-	mov fp, r0
+	mov r11, r0
 	mov r0, r6
 	bl func_ov05_0210e2a4
 	str r0, [sp, #0x10]
@@ -16098,11 +16098,11 @@ func_ov05_0210e2c4: ; 0x0210e2c4
 	ldr r1, [sp, #0x10]
 	ldr r4, [sp, #0x38]
 	str r7, [sp, #8]
-	mov r0, fp
+	mov r0, r11
 	str r4, [sp, #0xc]
 	bl func_ov05_0210e404
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	arm_func_end func_ov05_0210e2c4
 
 	.global func_ov05_0210e344
@@ -17611,7 +17611,7 @@ _0210f804: .word data_027e0f94
 	.global func_ov05_0210f808
 	arm_func_start func_ov05_0210f808
 func_ov05_0210f808: ; 0x0210f808
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x84
 	mov sl, r0
 	str r3, [sp, #8]
@@ -17884,7 +17884,7 @@ _0210fc04:
 	bl _ZN13LinkStateBase18func_ov00_020a8294Eij
 	add sp, sp, #0x84
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0210fc30:
 	ldr r0, _021101d8 ; =data_027e0fb8
 	ldr r0, [r0]
@@ -17991,7 +17991,7 @@ _0210fda4:
 	bl func_ov05_0210b96c
 	str r0, [sp, #0x10]
 	add r0, r0, #0x18
-	mov fp, sb, asr #0x1f
+	mov r11, sb, asr #0x1f
 	mov r6, #0
 	str r0, [sp, #0x18]
 _0210fdcc:
@@ -18009,7 +18009,7 @@ _0210fdcc:
 	mov r0, r1, asr #0x1f
 	umull r3, r2, sb, r1
 	mla r2, sb, r0, r2
-	mla r2, fp, r1, r2
+	mla r2, r11, r1, r2
 	mov r0, #0x800
 	adds r1, r3, r0
 	mov r0, #0
@@ -18061,7 +18061,7 @@ _0210fe90:
 	bl _ZN13LinkStateBase15ChangeLinkStateEi
 	add sp, sp, #0x84
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0210fed4:
 	add r6, r6, #1
 	cmp r6, #2
@@ -18273,7 +18273,7 @@ _021101bc:
 _021101cc:
 	mov r0, r4
 	add sp, sp, #0x84
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov05_0210f808
 _021101d8: .word data_027e0fb8
@@ -20230,7 +20230,7 @@ func_ov05_02111c6c: ; 0x02111c6c
 	.global func_ov05_02111c70
 	arm_func_start func_ov05_02111c70
 func_ov05_02111c70: ; 0x02111c70
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x10
 	mov sl, r0
 	ldrb r0, [sl, #5]
@@ -20244,7 +20244,7 @@ func_ov05_02111c70: ; 0x02111c70
 	bne _02111cac
 	cmp sb, #0
 	addne sp, sp, #0x10
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02111cac:
 	ldr r0, _02111e14 ; =data_027e0d38
 	ldr r0, [r0]
@@ -20256,7 +20256,7 @@ _02111cac:
 	ldr r0, [r0]
 	bl func_ov05_0210157c
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02111cd8:
 	ldr r1, _02111e1c ; =data_027e0f64
 	add r0, sp, #0xc
@@ -20274,13 +20274,13 @@ _02111cd8:
 	ldrb r3, [sp, #0xc]
 	ldrb r1, [sp, #0xb]
 	add r0, r0, #1
-	sub fp, r3, #1
+	sub r11, r3, #1
 	add r8, r1, #1
 	ldrh r1, [sl, #0x28]
-	cmp fp, #0
+	cmp r11, #0
 	ldrb r2, [sp, #0xa]
 	str r0, [sp, #4]
-	movle fp, #0
+	movle r11, #0
 	sub r0, r2, #1
 	str r0, [sp]
 	ldr r0, [sp]
@@ -20296,7 +20296,7 @@ _02111cd8:
 	cmp r8, r0
 	movge r8, r0
 	ldr r0, [sp, #4]
-	cmp fp, r0
+	cmp r11, r0
 	bgt _02111df8
 	add r5, sp, #8
 _02111d7c:
@@ -20304,7 +20304,7 @@ _02111d7c:
 	mov r0, r7
 	cmp r0, r8
 	bgt _02111de8
-	and r6, fp, #0xff
+	and r6, r11, #0xff
 _02111d90:
 	mov r0, sl
 	strb r6, [sp, #8]
@@ -20331,8 +20331,8 @@ _02111ddc:
 	ble _02111d90
 _02111de8:
 	ldr r0, [sp, #4]
-	add fp, fp, #1
-	cmp fp, r0
+	add r11, r11, #1
+	cmp r11, r0
 	ble _02111d7c
 _02111df8:
 	ldr r0, _02111e18 ; =data_027e0f68
@@ -20340,7 +20340,7 @@ _02111df8:
 	ldr r0, [r0]
 	bl func_ov05_02101530
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov05_02111c70
 _02111e10: .word data_027e0f74

--- a/asm/ov05.s
+++ b/asm/ov05.s
@@ -244,7 +244,7 @@ func_ov05_02100dc0: ; 0x02100dc0
 	.global func_ov05_02100e0c
 	arm_func_start func_ov05_02100e0c
 func_ov05_02100e0c: ; 0x02100e0c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	mov r5, r1
 	ldr r7, [r5, #8]
 	mov r6, r0
@@ -259,7 +259,7 @@ func_ov05_02100e0c: ; 0x02100e0c
 	mov r0, r6
 	mov r3, #1
 	bl func_ov05_02100dc0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _02100e4c:
 	blx func_ov00_0207bfc4
 	ldr r0, _0210105c ; =data_027e0d38
@@ -269,11 +269,11 @@ _02100e4c:
 	mov r4, r0
 	mov r0, r5
 	bl func_ov00_020a5e9c
-	mov sl, r0
+	mov r10, r0
 	ldr r0, _0210105c ; =data_027e0d38
 	mov sb, #0
 	ldr r0, [r0]
-	cmp r4, sl
+	cmp r4, r10
 	ldr r8, [r0, #0x14]
 	cmpeq r8, r7
 	movne sb, #1
@@ -290,7 +290,7 @@ _02100ea0:
 	moveq r7, #1
 	beq _02101044
 	ldr r0, _02101060 ; =data_027e0f7c
-	cmp r4, sl
+	cmp r4, r10
 	ldr r8, [r0]
 	beq _02100f08
 	mov r0, r8
@@ -299,7 +299,7 @@ _02100ea0:
 	cmp r0, #9
 	beq _02100ef0
 	mov r0, r8
-	mov r1, sl
+	mov r1, r10
 	bl func_ov00_0209d758
 	cmp r0, #9
 	bne _02100f08
@@ -405,7 +405,7 @@ _02101044:
 	mov r1, sb
 	mov r2, r7
 	bl func_ov05_02100cb0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov05_02100e0c
 _02101058: .word data_ov00_020d88ae
@@ -574,17 +574,17 @@ func_ov05_021011fc: ; 0x021011fc
 	.global func_ov05_02101230
 	arm_func_start func_ov05_02101230
 func_ov05_02101230: ; 0x02101230
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x40
 	ldr r2, _0210141c ; =data_027e077c
-	mov sl, r0
+	mov r10, r0
 	ldr r0, [r2]
 	mov sb, r1
 	cmp r0, #0x22
 	addeq sp, sp, #0x40
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
-	ldr r2, [sl, #0xc]
-	ldr r0, [sl, #0x10]
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldr r2, [r10, #0xc]
+	ldr r0, [r10, #0x10]
 	mov r8, r2
 	add r1, r2, r0, lsl #2
 	cmp r2, r1
@@ -608,10 +608,10 @@ _02101280:
 	ldr r0, [r0]
 	bl func_ov00_020828e0
 	ldr r3, [r8]
-	ldr r1, [sl, #0x18]
+	ldr r1, [r10, #0x18]
 	ldrb r7, [r3, #0x14]
 	ldrb r3, [r3, #0x15]
-	ldr r0, [sl, #0x1c]
+	ldr r0, [r10, #0x1c]
 	str r1, [sp, #0x38]
 	add r2, r1, r0, lsl #2
 	strb r7, [r6]
@@ -630,7 +630,7 @@ _02101280:
 	strb r3, [r6]
 	ldr r2, [sp, #0x18]
 	ldr r3, [r6]
-	add r0, sl, #0x18
+	add r0, r10, #0x18
 	str r1, [sp, #0x1c]
 	bl func_ov05_021015c8
 	ldr r0, [r8]
@@ -643,8 +643,8 @@ _02101330:
 	mov r7, #1
 	str r11, [r8]
 _02101338:
-	ldr r2, [sl, #0xc]
-	ldr r0, [sl, #0x10]
+	ldr r2, [r10, #0xc]
+	ldr r0, [r10, #0x10]
 	add r8, r8, #4
 	add r1, r2, r0, lsl #2
 	cmp r8, r1
@@ -681,15 +681,15 @@ _021013a4:
 	cmp r3, r2
 	bne _021013a4
 _021013bc:
-	ldr r2, [sl, #0xc]
-	ldr r0, [sl, #0x10]
+	ldr r2, [r10, #0xc]
+	ldr r0, [r10, #0x10]
 	mov r3, #0
 	add r2, r2, r0, lsl #2
 	strb r3, [sp]
 	sub r0, sp, #4
 	strb r3, [r0]
 	ldr r3, [r0]
-	add r0, sl, #0xc
+	add r0, r10, #0xc
 	str r1, [sp, #0x2c]
 	str r2, [sp, #0x20]
 	str r2, [sp, #0x10]
@@ -698,14 +698,14 @@ _021013bc:
 _021013f4:
 	cmp sb, #0
 	addne sp, sp, #0x40
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
-	ldr r0, [sl, #4]
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldr r0, [r10, #4]
 	cmp r0, #0
 	addeq sp, sp, #0x40
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	bl func_ov18_0216ad3c
 	add sp, sp, #0x40
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov05_02101230
 _0210141c: .word data_027e077c
@@ -1859,9 +1859,9 @@ _021023a8: .word 0xb60b60b7
 	.global func_ov05_021023ac
 	arm_func_start func_ov05_021023ac
 func_ov05_021023ac: ; 0x021023ac
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	ldr r3, _021026a4 ; =data_027e0618
-	mov sl, r0
+	mov r10, r0
 	ldr r0, [r3, #0xcc]
 	mov sb, r1
 	mov r8, r2
@@ -1944,7 +1944,7 @@ _02102498:
 	bne _02102544
 	cmp r5, #1
 	beq _02102544
-	ldrb r0, [sl, #3]
+	ldrb r0, [r10, #3]
 	cmp r8, #0
 	moveq r1, #1
 	movne r1, #0
@@ -2063,7 +2063,7 @@ _02102678:
 	bl func_ov05_02101af8
 _0210269c:
 	mov r0, r4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov05_021023ac
 _021026a4: .word data_027e0618
@@ -2546,7 +2546,7 @@ func_ov05_02102cfc: ; 0x02102cfc
 	.global func_ov05_02102d1c
 	arm_func_start func_ov05_02102d1c
 func_ov05_02102d1c: ; 0x02102d1c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x90
 	str r0, [sp, #0x28]
 	ldr r0, [r0, #0x904]
@@ -2557,7 +2557,7 @@ func_ov05_02102d1c: ; 0x02102d1c
 	ldrsh r0, [r0, #8]
 	cmp r0, #0
 	addle sp, sp, #0x90
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02102d4c:
 	cmp r1, #0
 	beq _02102d6c
@@ -2566,7 +2566,7 @@ _02102d4c:
 	ldrh r0, [r0, #0xa]
 	tst r0, #0x10
 	addne sp, sp, #0x90
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02102d6c:
 	ldr r8, _02103558 ; =data_020691a0
 	bl func_ov05_02103ba0
@@ -2601,10 +2601,10 @@ _02102dd8:
 _02102de0:
 	ldr r0, [sp, #0x28]
 	mov r1, #2
-	mov sl, #0
+	mov r10, #0
 	bl func_ov05_02103b88
 	cmp r0, #0
-	moveq r0, sl
+	moveq r0, r10
 	streq r0, [sp, #0x30]
 	beq _02102e0c
 	ldr r0, [sp, #0x44]
@@ -2619,7 +2619,7 @@ _02102e0c:
 	ble _02103224
 _02102e24:
 	mov r0, #0x30
-	mla r6, sl, r0, r8
+	mla r6, r10, r0, r8
 	mov r1, r7
 	add r0, r6, #0x10
 	bl func_ov05_02103b6c
@@ -2687,7 +2687,7 @@ _02102ee8:
 	bl func_ov05_02103b0c
 	str r0, [r6, #0x28]
 	ldr r0, [sp, #0x40]
-	add sl, sl, #1
+	add r10, r10, #1
 	cmp r0, #0
 	beq _0210314c
 	mov r0, r7
@@ -2769,7 +2769,7 @@ _02103048:
 	mov r0, r7
 	bl func_ov05_02103b0c
 	ldr r2, [sp, #0x34]
-	mov r1, sl
+	mov r1, r10
 	str r2, [sp]
 	ldr r2, [sp, #0x2c]
 	mov r3, sb
@@ -2790,17 +2790,17 @@ _02103048:
 	mov r0, r8
 	bl func_ov05_021038c8
 	cmp r4, #0
-	ldrne sl, [sp, #0x38]
+	ldrne r10, [sp, #0x38]
 	str r0, [sp, #0x48]
 	mov r0, r7
-	ldreq sl, [sp, #0x50]
+	ldreq r10, [sp, #0x50]
 	bl func_ov05_02103b18
 	str r0, [sp, #0x60]
 	mov r0, r7
 	bl func_ov05_02103b0c
 	ldr r2, [sp, #0x34]
 	ldr r1, [sp, #0x48]
-	stmia sp, {r2, sl}
+	stmia sp, {r2, r10}
 	ldr r2, [sp, #0x60]
 	mov r3, sb
 	str r2, [sp, #8]
@@ -2817,7 +2817,7 @@ _02103048:
 	ldr r2, [r6, #4]
 	mov r0, r8
 	bl func_ov05_0210373c
-	mov sl, r0
+	mov r10, r0
 	add r0, r4, #1
 	mov r0, r0, lsl #0x10
 	mov r4, r0, lsr #0x10
@@ -2884,7 +2884,7 @@ _02103204:
 	cmp r0, r1, lsr #16
 	bgt _02102e24
 _02103224:
-	cmp sl, #0
+	cmp r10, #0
 	bgt _02103240
 	ldr r0, [sp, #0x28]
 	add r0, r0, #0x900
@@ -2897,15 +2897,15 @@ _02103240:
 	ldr r0, _02103560 ; =0x040004c0
 	str r1, [r0]
 _02103250:
-	cmp sl, #0
+	cmp r10, #0
 	ble _02103530
-	cmp sl, #1
+	cmp r10, #1
 	ble _0210327c
 	mov r2, #0x30
-	mla r4, sl, r2, r8
+	mla r4, r10, r2, r8
 	ldr r3, _02103564 ; =func_ov05_02102cfc
 	mov r0, r8
-	mov r1, sl
+	mov r1, r10
 	str r4, [sp]
 	bl func_0200be04
 _0210327c:
@@ -2914,7 +2914,7 @@ _0210327c:
 	mov r6, r8
 	ldrh r5, [r8, #0x26]
 	bl func_ov00_02079e68
-	cmp sl, #0
+	cmp r10, #0
 	mov r4, #0
 	ble _021032d4
 	ldr sb, _02103568 ; =data_ov00_020e9360
@@ -2930,7 +2930,7 @@ _021032a4:
 _021032c0:
 	add r4, r4, #1
 	strb r0, [r6, #0x2c]
-	cmp r4, sl
+	cmp r4, r10
 	add r6, r6, #0x30
 	blt _021032a4
 _021032d4:
@@ -2951,7 +2951,7 @@ _021032d4:
 	mov r1, #0x10
 	bl func_ov05_02103704
 	str r0, [sp, #0x70]
-	cmp sl, #0
+	cmp r10, #0
 	mov sb, #0
 	ble _02103530
 	mov r4, #0x1000
@@ -3088,7 +3088,7 @@ _02103498:
 	mov r0, #1
 	bl func_ov05_02103570
 	add sb, sb, #1
-	cmp sb, sl
+	cmp sb, r10
 	add r8, r8, #0x30
 	blt _02103338
 _02103530:
@@ -3097,11 +3097,11 @@ _02103530:
 	ldrsh r0, [r0, #8]
 	cmp r0, #0
 	addle sp, sp, #0x90
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, [sp, #0x28]
 	bl func_ov18_0216945c
 	add sp, sp, #0x90
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov05_02102d1c
 _02103558: .word data_020691a0
@@ -3317,14 +3317,14 @@ _02103738: .word data_027e0d44
 	.global func_ov05_0210373c
 	arm_func_start func_ov05_0210373c
 func_ov05_0210373c: ; 0x0210373c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x10
 	ldr r7, [sp, #0x44]
 	ldr r4, _021038c0 ; =data_027e0e60
 	ldr r6, [r7, #8]
 	ldr r5, [sp, #0x3c]
 	ldr r4, [r4]
-	mov sl, r0
+	mov r10, r0
 	add r6, r6, r5
 	mov sb, r1
 	mov r0, r4
@@ -3340,8 +3340,8 @@ func_ov05_0210373c: ; 0x0210373c
 	mul ip, sb, r0
 	mov r2, #0x4000
 	ldrb r3, [sp, #0x5c]
-	add r5, sl, ip
-	str r2, [sl, ip]
+	add r5, r10, ip
+	str r2, [r10, ip]
 	ldr r1, [sp]
 	mov r0, r11
 	add r2, r5, #8
@@ -3416,7 +3416,7 @@ _02103878:
 _021038b4:
 	mov r0, sb
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov05_0210373c
 _021038c0: .word data_027e0e60
@@ -3425,14 +3425,14 @@ _021038c4: .word data_ov05_021122a8
 	.global func_ov05_021038c8
 	arm_func_start func_ov05_021038c8
 func_ov05_021038c8: ; 0x021038c8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x18
 	ldr r7, [sp, #0x4c]
 	ldr r4, _02103a9c ; =data_027e0e60
 	ldr r6, [r7]
 	ldr r5, [sp, #0x44]
 	ldr r4, [r4]
-	mov sl, r0
+	mov r10, r0
 	add r6, r6, r5
 	mov sb, r1
 	mov r0, r4
@@ -3445,12 +3445,12 @@ func_ov05_021038c8: ; 0x021038c8
 	beq _02103a90
 	mov r1, #0x30
 	mul lr, sb, r1
-	add r5, sl, lr
+	add r5, r10, lr
 	mov ip, #0x4000
 	ldrb r3, [sp, #0x64]
 	ldr r1, [sp, #0x40]
 	add r2, r5, #8
-	str ip, [sl, lr]
+	str ip, [r10, lr]
 	bl func_ov05_02102b0c
 	str r0, [r5, #4]
 	cmp r8, r0
@@ -3545,7 +3545,7 @@ _02103a54:
 _02103a90:
 	mov r0, sb
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov05_021038c8
 _02103a9c: .word data_027e0e60
@@ -4559,7 +4559,7 @@ _02104570: .word data_027e0d3c
 	.global func_ov05_02104574
 	arm_func_start func_ov05_02104574
 func_ov05_02104574: ; 0x02104574
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x2c
 	ldr r2, _02104730 ; =data_027e1054
 	mov r4, r0
@@ -4568,7 +4568,7 @@ func_ov05_02104574: ; 0x02104574
 	ldrb r0, [r0, #0x95]
 	cmp r0, #0
 	addne sp, sp, #0x2c
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldrh r0, [r1]
 	tst r0, #4
 	movne r1, #1
@@ -4580,7 +4580,7 @@ func_ov05_02104574: ; 0x02104574
 	moveq r0, #0
 	cmp r0, #0
 	addeq sp, sp, #0x2c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _021045cc:
 	ldr r0, _02104734 ; =data_027e0d38
 	ldr r0, [r0]
@@ -4589,7 +4589,7 @@ _021045cc:
 	cmp r0, #1
 	cmpne r0, #0x32
 	addeq sp, sp, #0x2c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	add r0, sp, #0xc
 	bl func_01ffbe34
 	ldr r0, [sp, #0x18]
@@ -4619,15 +4619,15 @@ _021045cc:
 	mov r2, r5
 	bl func_ov05_02104a48
 	add sp, sp, #0x2c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02104664:
 	ldr r7, _0210473c ; =data_027e0d3c
 	sub r0, sb, #2
 	ldr r1, [r7]
-	ldr sl, [r1, #0x48]
-	cmp sl, r0
+	ldr r10, [r1, #0x48]
+	cmp r10, r0
 	addeq sp, sp, #0x2c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r5, _02104738 ; =data_027e0f7c
 	ldr r6, _02104740 ; =gItemManager
 	add r4, r4, #0x200
@@ -4651,7 +4651,7 @@ _02104694:
 	and r1, sb, #0xff
 	bl func_ov00_0209d90c
 	ldrb r1, [r0, #1]
-	cmp sl, r1
+	cmp r10, r1
 	bne _0210471c
 	ldr r2, [r0, #4]
 	mov r1, r11
@@ -4673,7 +4673,7 @@ _0210471c:
 	cmp sb, #0x20
 	blt _02104694
 	add sp, sp, #0x2c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov05_02104574
 _02104730: .word data_027e1054
@@ -4724,7 +4724,7 @@ _021047c4: .word data_027e0d3c
 	.global func_ov05_021047c8
 	arm_func_start func_ov05_021047c8
 func_ov05_021047c8: ; 0x021047c8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x34
 	ldr r0, _02104a28 ; =data_027e1054
 	ldr r0, [r0]
@@ -4732,7 +4732,7 @@ func_ov05_021047c8: ; 0x021047c8
 	ldrb r0, [r0, #0x95]
 	cmp r0, #0
 	addne sp, sp, #0x34
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldrh r0, [r1]
 	tst r0, #4
 	movne r1, #1
@@ -4744,7 +4744,7 @@ func_ov05_021047c8: ; 0x021047c8
 	moveq r0, #0
 	cmp r0, #0
 	addeq sp, sp, #0x34
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0210481c:
 	add r0, sp, #0x14
 	bl func_01ffbe34
@@ -4761,7 +4761,7 @@ _0210481c:
 	cmp r0, #1
 	beq _0210493c
 	add sp, sp, #0x34
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0210485c:
 	ldr r0, _02104a30 ; =data_027e0f74
 	ldr r1, _02104a34 ; =0x0000015f
@@ -4789,14 +4789,14 @@ _021048a8:
 	bl func_ov00_02097760
 	cmp r0, #0
 	addeq sp, sp, #0x34
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, _02104a38 ; =gItemManager
 	mov r1, #0
 	ldr r0, [r0]
 	bl _ZNK11ItemManager18IsTreasureSalvagedEj
 	cmp r0, #0
 	addne sp, sp, #0x34
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, _02104a3c ; =data_027e0f7c
 	mov r1, #0
 	ldr r0, [r0]
@@ -4819,7 +4819,7 @@ _021048a8:
 	mov r1, #0x12
 	bl func_02034984
 	add sp, sp, #0x34
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0210493c:
 	ldr r0, _02104a40 ; =data_027e077c
 	mov r1, #1
@@ -4828,14 +4828,14 @@ _0210493c:
 	moveq r1, r2
 	cmp r1, #0
 	addeq sp, sp, #0x34
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, _02104a38 ; =gItemManager
 	mov r1, #0x16
 	ldr r0, [r0]
 	bl _ZNK11ItemManager7HasItemEi
 	cmp r0, #0
 	addne sp, sp, #0x34
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, _02104a30 ; =data_027e0f74
 	ldr r1, _02104a44 ; =0x00000125
 	ldr r0, [r0]
@@ -4850,9 +4850,9 @@ _0210493c:
 	mov r11, #1
 	add r5, sp, #0x14
 _021049ac:
-	and sl, sb, #0xff
+	and r10, sb, #0xff
 	mov r0, r8
-	mov r1, sl
+	mov r1, r10
 	mov r2, r7
 	mov r3, r6
 	bl func_02034698
@@ -4864,14 +4864,14 @@ _021049ac:
 	str r5, [sp]
 	ldr r2, [sp, #8]
 	ldr r3, [sp, #4]
-	mov r1, sl
+	mov r1, r10
 	mov r0, #0xd0
 	bl func_02034984
 	add sb, sb, #1
 	cmp sb, #0x2a
 	blt _021049ac
 	add sp, sp, #0x34
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02104a04:
 	mov r2, #0
 	add r4, sp, #0x14
@@ -4881,7 +4881,7 @@ _02104a04:
 	str r4, [sp]
 	bl func_ov05_02104744
 	add sp, sp, #0x34
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov05_021047c8
 _02104a28: .word data_027e1054
@@ -5264,7 +5264,7 @@ _02104f24: .word data_027e0f94
 	.global func_ov05_02104f28
 	arm_func_start func_ov05_02104f28
 func_ov05_02104f28: ; 0x02104f28
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #0x68
 	ldr r2, _02105130 ; =data_027e0f64
 	ldr r1, _02105134 ; =data_027e0f94
@@ -5332,11 +5332,11 @@ func_ov05_02104f28: ; 0x02104f28
 	ldrsh lr, [r2, r3]
 	add r2, r7, #0xc
 	add r8, r5, r2
-	umull sl, sb, lr, r4
+	umull r10, sb, lr, r4
 	mla sb, lr, r1, sb
 	mov ip, lr, asr #0x1f
 	mla sb, ip, r4, sb
-	adds r4, sl, #0x800
+	adds r4, r10, #0x800
 	adc r1, sb, #0
 	mov r4, r4, lsr #0xc
 	orr r4, r4, r1, lsl #20
@@ -5368,13 +5368,13 @@ func_ov05_02104f28: ; 0x02104f28
 	add r0, sp, #0x38
 	bl func_ov00_020d0a80
 	add sp, sp, #0x68
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _021050cc:
 	add r0, r8, #0x200
 	ldrsh r0, [r0, #0x4a]
 	cmp r0, #0
 	addle sp, sp, #0x68
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	cmp r4, #0
 	addne r5, r5, #0x27
 	mov r3, #3
@@ -5394,7 +5394,7 @@ _021050cc:
 	str r4, [sp, #8]
 	bl func_ov00_020d0a80
 	add sp, sp, #0x68
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov05_02104f28
 _02105130: .word data_027e0f64
@@ -8488,16 +8488,16 @@ func_ov05_02107b74: ; 0x02107b74
 	.global func_ov05_02107bd4
 	arm_func_start func_ov05_02107bd4
 func_ov05_02107bd4: ; 0x02107bd4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
-	mov sl, r0
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	mov r10, r0
 	ldr r4, _02107c80 ; =0x47454c4c
 	ldr r11, _02107c84 ; =0x57544352
 	ldr r6, _02107c88 ; =data_027e0fe4
-	add sb, sl, #0x44
+	add sb, r10, #0x44
 	mov r8, #0
 	mvn r5, #0
 _02107bf4:
-	add r0, sl, r8, lsl #3
+	add r0, r10, r8, lsl #3
 	ldr r0, [r0, #0x44]
 	cmp r0, r5
 	beq _02107c68
@@ -8519,7 +8519,7 @@ _02107c30:
 	mov r0, r7
 	bl func_ov32_0217fd7c
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02107c4c:
 	bl func_ov26_02170150
 	cmp r0, #0
@@ -8527,14 +8527,14 @@ _02107c4c:
 	mov r0, r7
 	bl func_ov26_02170164
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02107c68:
 	add r8, r8, #1
 	cmp r8, #8
 	add sb, sb, #8
 	blt _02107bf4
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov05_02107bd4
 _02107c80: .word 0x47454c4c
@@ -8779,20 +8779,20 @@ _02107fb8:
 	.global func_ov05_02107fc0
 	arm_func_start func_ov05_02107fc0
 func_ov05_02107fc0: ; 0x02107fc0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	mov r1, #2
-	mov sl, r0
+	mov r10, r0
 	bl _ZN13LinkStateBase29HasFlags_PlayerLinkBase_Unk48Et
 	cmp r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	mov r6, #0
 	ldr r11, _02108088 ; =0x47454c4c
 	ldr r4, _0210808c ; =data_027e0fe4
 	mov sb, r6
-	add r8, sl, #0x44
+	add r8, r10, #0x44
 	mvn r5, #0
 _02107ff0:
-	add r0, sl, sb, lsl #3
+	add r0, r10, sb, lsl #3
 	ldr r0, [r0, #0x44]
 	cmp r0, r5
 	beq _02108060
@@ -8820,7 +8820,7 @@ _0210804c:
 	mov r6, #1
 	b _02108060
 _02108054:
-	add r0, sl, sb, lsl #3
+	add r0, r10, sb, lsl #3
 	str r5, [r0, #0x44]
 	str r5, [r0, #0x48]
 _02108060:
@@ -8829,11 +8829,11 @@ _02108060:
 	add r8, r8, #8
 	blt _02107ff0
 	cmp r6, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
-	mov r0, sl
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	mov r0, r10
 	mov r1, #2
 	bl _ZN13LinkStateBase26Clear_PlayerLinkBase_Unk48Et
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov05_02107fc0
 _02108088: .word 0x47454c4c
@@ -9105,21 +9105,21 @@ _02108340:
 	.global func_ov05_021083e0
 	arm_func_start func_ov05_021083e0
 func_ov05_021083e0: ; 0x021083e0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
-	mov sl, r0
-	ldrb r0, [sl]
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	mov r10, r0
+	ldrb r0, [r10]
 	mov r1, #0
 	eor r0, r0, #1
-	strb r0, [sl]
-	ldrb r0, [sl, #1]
+	strb r0, [r10]
+	ldrb r0, [r10, #1]
 	eor r0, r0, #1
-	strb r0, [sl, #1]
-	ldrb r0, [sl]
-	add r0, sl, r0, lsl #2
+	strb r0, [r10, #1]
+	ldrb r0, [r10]
+	add r0, r10, r0, lsl #2
 	ldr r0, [r0, #4]
 	str r1, [r0]
-	ldrb r0, [sl, #1]
-	add r0, sl, r0, lsl #2
+	ldrb r0, [r10, #1]
+	add r0, r10, r0, lsl #2
 	ldr r7, [r0, #4]
 	mov r0, r7
 	bl func_ov05_02108898
@@ -9133,7 +9133,7 @@ _0210843c:
 	mov r1, r4
 	bl func_ov05_02108888
 	bl func_ov05_02108884
-	ldr r2, [sl, #0xc]
+	ldr r2, [r10, #0xc]
 	mov r1, r0
 	add r0, r2, r6
 	bl func_ov05_02108860
@@ -9145,7 +9145,7 @@ _0210846c:
 	sub r11, r5, #1
 	mov r8, #0
 	cmp r11, #0
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0210847c:
 	mov r0, r7
 	mov r1, r8
@@ -9167,7 +9167,7 @@ _021084a8:
 	ldr r0, [r0, #0xc]
 	cmp r0, #0
 	blt _021084d8
-	mov r0, sl
+	mov r0, r10
 	mov r1, sb
 	mov r2, r4
 	bl func_ov05_021084f4
@@ -9179,13 +9179,13 @@ _021084e4:
 	add r8, r8, #1
 	cmp r8, r11
 	blt _0210847c
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	arm_func_end func_ov05_021083e0
 
 	.global func_ov05_021084f4
 	arm_func_start func_ov05_021084f4
 func_ov05_021084f4: ; 0x021084f4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #0x88
 	mov sb, r1
 	add r3, sp, #0x74
@@ -9236,7 +9236,7 @@ func_ov05_021084f4: ; 0x021084f4
 	add r0, r0, r1, asr #1
 	cmp r2, r0
 	addge sp, sp, #0x88
-	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	ldr r7, [sp, #0x74]
 	mov r5, #0
 	ldr r4, [sp, #0x7c]
@@ -9254,10 +9254,10 @@ func_ov05_021084f4: ; 0x021084f4
 	ldr r2, [sp, #0x80]
 	ldr r1, [sp, #0x6c]
 	mov r4, r0
-	add sl, r2, r1
-	cmp r4, sl
+	add r10, r2, r1
+	cmp r4, r10
 	addge sp, sp, #0x88
-	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	mov r0, r6
 	mov r1, sb
 	bl func_ov05_02108210
@@ -9297,7 +9297,7 @@ _02108670:
 	str r1, [r6, #8]
 _021086a8:
 	ldr r2, [sb, #0x34]
-	sub r4, sl, r4
+	sub r4, r10, r4
 	cmp r2, #5
 	ldrne r3, [r8, #0x34]
 	mov r1, #0
@@ -9328,7 +9328,7 @@ _0210870c:
 	ldrne r6, [sb, #0x38]
 	cmpne r6, #0
 	addeq sp, sp, #0x88
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	add r0, sp, #0x54
 	add r1, sp, #0x48
 	add r2, sp, #0x3c
@@ -9344,13 +9344,13 @@ _0210870c:
 	mov r2, r0
 	bl func_01ff9bc4
 	add sp, sp, #0x88
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _02108760:
 	cmp r7, #0
 	ldrne r5, [r8, #0x38]
 	cmpne r5, #0
 	addeq sp, sp, #0x88
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	add r0, sp, #0x48
 	add r1, sp, #0x54
 	add r2, sp, #0x30
@@ -9366,7 +9366,7 @@ _02108760:
 	mov r2, r0
 	bl func_01ff9bc4
 	add sp, sp, #0x88
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _021087b4:
 	cmp r0, #0
 	ldrne sb, [sb, #0x38]
@@ -9392,7 +9392,7 @@ _02108800:
 	ldrne r5, [r8, #0x38]
 	cmpne r5, #0
 	addeq sp, sp, #0x88
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	add r0, sp, #0x48
 	add r1, sp, #0x54
 	add r2, sp, #0x18
@@ -9410,7 +9410,7 @@ _02108800:
 	bl func_01ff9bc4
 _02108850:
 	add sp, sp, #0x88
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	arm_func_end func_ov05_021084f4
 
 	.global func_ov05_02108858
@@ -12179,7 +12179,7 @@ _0210ad84: .word 0x000004cd
 	.global func_ov05_0210ad88
 	arm_func_start func_ov05_0210ad88
 func_ov05_0210ad88: ; 0x0210ad88
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x100
 	mov r5, r0
 	bl _ZN13LinkStateBase18func_ov00_020a8d40Ev
@@ -12209,7 +12209,7 @@ _0210ade0:
 	mov r0, r5
 	bl _ZN13LinkStateBase15ChangeLinkStateEi
 	add sp, sp, #0x100
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0210ae00:
 	ldr r0, [r5, #0xc]
 	cmp r0, #0
@@ -12349,11 +12349,11 @@ _0210ae98:
 	mov r11, r7, asr #0x1f
 	adds r7, sb, #0x800
 	mla r8, r11, r3, r8
-	ldr sl, [sp, #0x28]
+	ldr r10, [sp, #0x28]
 	adc r3, r8, #0
 	mov r7, r7, lsr #0xc
 	orr r7, r7, r3, lsl #20
-	add r3, sl, r7
+	add r3, r10, r7
 	umull r8, r7, r6, ip
 	strh r0, [sp, #0x6c]
 	strb r0, [sp, #0x8e]
@@ -12454,7 +12454,7 @@ _0210ae98:
 	str r2, [r5, #4]
 	bl _ZN13LinkStateBase15ChangeLinkStateEi
 	add sp, sp, #0x100
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0210b1c0:
 	mov r0, #0x1000
 	rsb r0, r0, #0
@@ -12476,7 +12476,7 @@ _0210b1c0:
 	str r2, [r5, #4]
 	bl _ZN13LinkStateBase15ChangeLinkStateEi
 	add sp, sp, #0x100
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0210b214:
 	ldr r1, _0210b2a0 ; =data_ov05_02112894
 	mov r0, r5
@@ -12499,7 +12499,7 @@ _0210b244:
 	mov r0, r5
 	bl _ZN13LinkStateBase15ChangeLinkStateEi
 	add sp, sp, #0x100
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0210b264:
 	mov r0, r5
 	mov r1, r4
@@ -12507,7 +12507,7 @@ _0210b264:
 	add r0, r5, #0x24
 	bl func_0203516c
 	add sp, sp, #0x100
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov05_0210ad88
 _0210b280: .word data_027e0fe4
@@ -14460,26 +14460,26 @@ _0210cd14:
 	.global func_ov05_0210cd58
 	arm_func_start func_ov05_0210cd58
 func_ov05_0210cd58: ; 0x0210cd58
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	ldrb r6, [sp, #0x20]
 	mov r4, r0
 	mov r7, r1
 	mov r5, r2
-	mov sl, r3
+	mov r10, r3
 	cmp r6, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	ldr r0, [r4, #0x20]
 	cmp r0, #0
 	beq _0210cd90
 	bl func_ov00_020d3e80
-	movs sl, r0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	movs r10, r0
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _0210cd90:
 	ldrb r0, [r4, #3]
 	cmp r0, #0
 	beq _0210cda4
-	cmp sl, #0x10
-	andhs sl, sl, #0xf
+	cmp r10, #0x10
+	andhs r10, r10, #0xf
 _0210cda4:
 	ldrb r0, [sp, #0x20]
 	ldr r1, _0210cea8 ; =data_027e0c38
@@ -14502,7 +14502,7 @@ _0210cda4:
 	ldr r2, [r4, #0xc]
 	ldr r1, [r4, #0x14]
 	cmp r6, r7
-	ldmgtia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmgtia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	add r1, r2, r1
 	sub r8, r5, r3
 	cmp r8, r2
@@ -14512,7 +14512,7 @@ _0210cda4:
 	cmp sb, r1
 	movge sb, r1
 	cmp r8, sb
-	ldmgtia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmgtia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	bgt _0210ce9c
 _0210ce28:
 	mov r5, r6
@@ -14531,16 +14531,16 @@ _0210ce34:
 	ldrb r2, [r1, r0]
 	beq _0210ce70
 	and r2, r2, #0xf
-	orr r2, r2, sl, lsl #4
+	orr r2, r2, r10, lsl #4
 	strb r2, [r1, r0]
 	b _0210ce84
 _0210ce70:
 	and r2, r2, #0xf0
-	orr r2, r2, sl
+	orr r2, r2, r10
 	strb r2, [r1, r0]
 	b _0210ce84
 _0210ce80:
-	strb sl, [r1, r0]
+	strb r10, [r1, r0]
 _0210ce84:
 	add r5, r5, #1
 	cmp r5, r7
@@ -14552,7 +14552,7 @@ _0210ce90:
 _0210ce9c:
 	mov r0, #0
 	strb r0, [r4, #4]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov05_0210cd58
 _0210cea8: .word data_027e0c38
@@ -14560,23 +14560,23 @@ _0210cea8: .word data_027e0c38
 	.global func_ov05_0210ceac
 	arm_func_start func_ov05_0210ceac
 func_ov05_0210ceac: ; 0x0210ceac
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x10
 	ldr r8, [sp, #0x40]
 	mov r7, r1
 	ldr r1, [sp, #0x38]
 	ldr sb, [sp, #0x3c]
 	mov r4, r0
-	mov sl, r2
+	mov r10, r2
 	str r3, [sp, #4]
 	cmp r8, #0
 	str r1, [sp, #0x38]
 	addeq sp, sp, #0x10
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	mov r1, r3
 	subs r6, r1, r7
 	ldr r1, [sp, #0x38]
-	sub r5, r1, sl
+	sub r5, r1, r10
 	cmpeq r5, #0
 	bne _0210cf14
 	ldr r2, [sp, #0x38]
@@ -14585,7 +14585,7 @@ func_ov05_0210ceac: ; 0x0210ceac
 	str r8, [sp]
 	bl func_ov05_0210cd58
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0210cf14:
 	cmp r6, #0
 	strge r6, [sp, #8]
@@ -14616,14 +14616,14 @@ _0210cf14:
 	mov r1, r6, lsl #0xc
 	bl func_01ff9b24
 	ldr r0, [sp, #4]
-	mov r5, sl, lsl #0xc
+	mov r5, r10, lsl #0xc
 	cmp r7, r0
 	movle r11, #1
 	mvngt r11, #0
 	bl func_01ff9a18
 	mov r6, r0
 	ldr r0, [sp, #0x38]
-	cmp sl, r0
+	cmp r10, r0
 	bgt _0210cfb8
 	cmp r6, #0
 	rsblt r6, r6, #0
@@ -14633,10 +14633,10 @@ _0210cfb8:
 	rsbgt r6, r6, #0
 _0210cfc0:
 	ldr r0, [sp, #8]
-	mov sl, #0
+	mov r10, #0
 	cmp r0, #0
 	addlt sp, sp, #0x10
-	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0210cfd4:
 	ldr r0, [r4, #0x20]
 	cmp r0, #0
@@ -14654,20 +14654,20 @@ _0210cff0:
 	str r8, [sp]
 	bl func_ov05_0210cd58
 	ldr r0, [sp, #8]
-	add sl, sl, #1
-	cmp sl, r0
+	add r10, r10, #1
+	cmp r10, r0
 	add r7, r7, r11
 	add r5, r5, r6
 	ble _0210cfd4
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0210d02c:
 	mov r0, r6, lsl #0xc
 	mov r1, r5, lsl #0xc
 	bl func_01ff9b24
 	ldr r0, [sp, #0x38]
 	mov r5, r7, lsl #0xc
-	cmp sl, r0
+	cmp r10, r0
 	movle r0, #1
 	strle r0, [sp, #0xc]
 	mvngt r0, #0
@@ -14687,19 +14687,19 @@ _0210d07c:
 	cmp r11, #0
 	mov r7, #0
 	addlt sp, sp, #0x10
-	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0210d08c:
 	ldr r0, [r4, #0x20]
 	cmp r0, #0
 	beq _0210d0a8
 	add r1, r5, #0x800
-	mov r2, sl
+	mov r2, r10
 	mov r1, r1, asr #0xc
 	bl func_ov00_020d3e90
 _0210d0a8:
 	add r1, r5, #0x800
 	mov r0, r4
-	mov r2, sl
+	mov r2, r10
 	mov r3, sb
 	mov r1, r1, asr #0xc
 	str r8, [sp]
@@ -14708,10 +14708,10 @@ _0210d0a8:
 	add r7, r7, #1
 	cmp r7, r11
 	add r5, r5, r6
-	add sl, sl, r0
+	add r10, r10, r0
 	ble _0210d08c
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	arm_func_end func_ov05_0210ceac
 
 	.global func_ov05_0210d0e4
@@ -14984,7 +14984,7 @@ func_ov05_0210d3d8: ; 0x0210d3d8
 	.global func_ov05_0210d474
 	arm_func_start func_ov05_0210d474
 func_ov05_0210d474: ; 0x0210d474
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x20
 	mov r8, r0
 	ldr r0, [r8]
@@ -15032,12 +15032,12 @@ _0210d4e8:
 	mov r0, r5
 	mov r1, r7
 	bl func_ov00_020ce2f0
-	movs sl, r0
+	movs r10, r0
 	bne _0210d5e8
 	add r0, sb, sb, lsr #31
 	str r0, [sp, #4]
 	ldr r0, _0210d6d4 ; =data_027e0764
-	ldr sl, [r0, #0x10]
+	ldr r10, [r0, #0x10]
 	ldr sb, [r0, #0x14]
 	ldr r3, [r0, #8]
 	ldr r1, [r0]
@@ -15050,7 +15050,7 @@ _0210d4e8:
 	ldr r0, [sp, #4]
 	mla ip, r3, r11, ip
 	mla ip, r2, r1, ip
-	adds r3, sl, lr
+	adds r3, r10, lr
 	ldr r1, _0210d6d4 ; =data_027e0764
 	adc r2, sb, ip
 	str r3, [r1]
@@ -15082,21 +15082,21 @@ _0210d4e8:
 	bl func_01ff9e64
 	b _0210d684
 _0210d5e8:
-	cmp sl, sb
+	cmp r10, sb
 	bge _0210d684
 	mov r0, #0x1000
-	mov r1, sl
+	mov r1, r10
 	bl Divide
-	sub r1, sb, sl
+	sub r1, sb, r10
 	add r1, r1, r1, lsr #31
 	mov r1, r1, asr #0x1
 	add r2, r1, r1, lsr #31
 	ldr r3, [r5]
 	ldr r1, [r7]
 	sub r3, r3, r1
-	smull sl, sb, r3, r0
+	smull r10, sb, r3, r0
 	mov r1, #0
-	adds r3, sl, #0x800
+	adds r3, r10, #0x800
 	str r1, [sp, #0xc]
 	adc r1, sb, #0
 	mov r3, r3, lsr #0xc
@@ -15143,7 +15143,7 @@ _0210d6c4:
 	mov r0, #0
 	str r0, [r8]
 	add sp, sp, #0x20
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov05_0210d474
 _0210d6d4: .word data_027e0764
@@ -15298,9 +15298,9 @@ _0210d890: .word data_027e0f64
 	.global func_ov05_0210d894
 	arm_func_start func_ov05_0210d894
 func_ov05_0210d894: ; 0x0210d894
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
-	mov sl, r0
-	ldr r0, [sl]
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	mov r10, r0
+	ldr r0, [r10]
 	mov sb, r1
 	ldr r5, [r0, #4]
 	mov r8, r2
@@ -15330,7 +15330,7 @@ _0210d8ec:
 	mov r0, r0, lsl #0xd
 	movs r0, r0, lsr #0x1d
 	beq _0210d920
-	ldr r1, [sl]
+	ldr r1, [r10]
 	sub r0, r0, #1
 	ldrh r1, [r1, #0x48]
 	cmp r1, r0
@@ -15342,7 +15342,7 @@ _0210d920:
 	bne _0210d944
 	tst r1, r8
 	bne _0210d944
-	ldr r0, [sl]
+	ldr r0, [r10]
 	mov r1, r5
 	bl func_0200fa3c
 _0210d944:
@@ -15370,11 +15370,11 @@ _0210d988:
 	ldreq r0, [r5, #0x18]
 	cmpeq r0, #0
 	bne _0210d9bc
-	ldr r0, [sl]
+	ldr r0, [r10]
 	mov r1, r5
 	add r0, r0, #4
 	bl func_02012320
-	ldr r2, [sl]
+	ldr r2, [r10]
 	mov r1, r0
 	add r0, r2, #0x10
 	bl func_0201228c
@@ -15383,16 +15383,16 @@ _0210d9bc:
 	cmp r6, #0
 	bne _0210d8b8
 _0210d9c8:
-	ldr r1, [sl]
+	ldr r1, [r10]
 	ldrh r0, [r1, #0x48]
 	add r0, r0, #1
 	strh r0, [r1, #0x48]
-	ldr r1, [sl]
+	ldr r1, [r10]
 	ldrh r0, [r1, #0x48]
 	cmp r0, #1
 	movhi r0, #0
 	strhih r0, [r1, #0x48]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	arm_func_end func_ov05_0210d894
 
 	.global func_ov05_0210d9f0
@@ -16071,12 +16071,12 @@ func_ov05_0210e2a4: ; 0x0210e2a4
 	.global func_ov05_0210e2c4
 	arm_func_start func_ov05_0210e2c4
 func_ov05_0210e2c4: ; 0x0210e2c4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x14
-	mov sl, r0
-	ldmia sl, {r5, r6}
+	mov r10, r0
+	ldmia r10, {r5, r6}
 	mov r0, r5
-	ldr r4, [sl, #8]
+	ldr r4, [r10, #8]
 	mov sb, r1
 	mov r8, r2
 	mov r7, r3
@@ -16087,7 +16087,7 @@ func_ov05_0210e2c4: ; 0x0210e2c4
 	str r0, [sp, #0x10]
 	add r0, r5, r4
 	bl func_ov05_0210e288
-	ldr r1, [sl, #0xc]
+	ldr r1, [r10, #0xc]
 	mov r4, r0
 	add r0, r6, r1
 	bl func_ov05_0210e2a4
@@ -16102,7 +16102,7 @@ func_ov05_0210e2c4: ; 0x0210e2c4
 	str r4, [sp, #0xc]
 	bl func_ov05_0210e404
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	arm_func_end func_ov05_0210e2c4
 
 	.global func_ov05_0210e344
@@ -16167,7 +16167,7 @@ _0210e400: .word 0x04000500
 	.global func_ov05_0210e404
 	arm_func_start func_ov05_0210e404
 func_ov05_0210e404: ; 0x0210e404
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	ldr r4, [sp, #0x2c]
 	ldr r5, [sp, #0x28]
 	mov r4, r4, lsl #0x8
@@ -16195,18 +16195,18 @@ func_ov05_0210e404: ; 0x0210e404
 	mov r6, r8, lsr #0x10
 	mov r5, sb, lsr #0x10
 	str r7, [ip]
-	orr sl, r0, r1, lsl #16
+	orr r10, r0, r1, lsl #16
 	sub sb, ip, #0x78
 	mov r8, r3, lsr #0x10
 	mov r7, r2, lsr #0x10
 	mov r2, lr, lsr #0x10
 	mov r4, r4, lsr #0x10
-	str sl, [sb]
+	str r10, [sb]
 	orr r3, r7, r8, lsl #16
-	sub sl, ip, #0x74
-	str r3, [sl]
+	sub r10, ip, #0x74
+	str r3, [r10]
 	mov r3, #0
-	str r3, [sl]
+	str r3, [r10]
 	orr r0, r0, r6, lsl #16
 	str r0, [sb]
 	orr r0, r7, r2, lsl #16
@@ -16221,7 +16221,7 @@ func_ov05_0210e404: ; 0x0210e404
 	orr r0, r4, r8, lsl #16
 	str r0, [r7]
 	str r3, [ip, #4]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov05_0210e404
 _0210e4e0: .word 0x04000500
@@ -17611,16 +17611,16 @@ _0210f804: .word data_027e0f94
 	.global func_ov05_0210f808
 	arm_func_start func_ov05_0210f808
 func_ov05_0210f808: ; 0x0210f808
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x84
-	mov sl, r0
+	mov r10, r0
 	str r3, [sp, #8]
 	mov sb, r1
 	mov r6, r2
 	mov r4, #0
 	bl _ZN13LinkStateBase14GetPlayerAngleEv
 	ldrsh r5, [r0]
-	mov r0, sl
+	mov r0, r10
 	bl _ZN13LinkStateBase18func_ov00_020a8d40Ev
 	ldrsh r0, [r0, #0x5a]
 	cmp r0, #2
@@ -17630,7 +17630,7 @@ func_ov05_0210f808: ; 0x0210f808
 	strne r0, [sp, #0xc]
 	cmp r6, #0
 	beq _0210f884
-	mov r0, sl
+	mov r0, r10
 	bl _ZN13LinkStateBase12GetPlayerPosEv
 	mov r1, r0
 	add r2, sp, #0x2c
@@ -17650,7 +17650,7 @@ _0210f884:
 	bl _ZN13PlayerControl13GetTouchAngleEv
 	mov r5, r0
 _0210f89c:
-	ldr r0, [sl, #8]
+	ldr r0, [r10, #8]
 	ldr r1, [r0]
 	ldr r1, [r1, #0x5c]
 	blx r1
@@ -17667,7 +17667,7 @@ _0210f89c:
 	mov sb, r3, lsr #0xc
 	orr sb, sb, r0, lsl #20
 _0210f8dc:
-	ldr r0, [sl, #8]
+	ldr r0, [r10, #8]
 	mov r1, sb
 	ldr r2, [r0]
 	str r5, [sp, #0x14]
@@ -17682,19 +17682,19 @@ _0210f8dc:
 	ldr r0, [sp, #0xc]
 	cmp r0, #0
 	bne _0210fda4
-	mov r0, sl
+	mov r0, r10
 	bl _ZN13LinkStateBase18func_ov00_020a8d40Ev
 	ldr r0, [r0, #0xd4]
 	cmp r0, #0
 	ble _0210fa38
-	mov r0, sl
+	mov r0, r10
 	bl _ZN13LinkStateBase18func_ov00_020a8d40Ev
 	ldr r0, [r0, #0x70]
 	mov r0, r0, lsr #0x7
 	and r0, r0, #3
 	cmp r0, #2
 	bne _0210fa38
-	mov r0, sl
+	mov r0, r10
 	bl _ZN13LinkStateBase18func_ov00_020a8d40Ev
 	mov r1, r0
 	ldr r0, [r1, #0x114]
@@ -17725,10 +17725,10 @@ _0210f8dc:
 	mul r0, sb, r0
 	bl func_02002c14
 	mov sb, r0
-	mov r0, sl
+	mov r0, r10
 	bl _ZN13LinkStateBase12GetPlayerVelEv
 	ldr r4, [r0]
-	mov r0, sl
+	mov r0, r10
 	bl _ZN13LinkStateBase12GetPlayerVelEv
 	mov r1, r4, asr #0x1f
 	mov r2, r1, lsl #0xb
@@ -17739,10 +17739,10 @@ _0210f8dc:
 	mov r2, r3, lsr #0xc
 	orr r2, r2, r1, lsl #20
 	str r2, [r0]
-	mov r0, sl
+	mov r0, r10
 	bl _ZN13LinkStateBase12GetPlayerVelEv
 	ldr r4, [r0, #8]
-	mov r0, sl
+	mov r0, r10
 	bl _ZN13LinkStateBase12GetPlayerVelEv
 	mov r1, r4, asr #0x1f
 	mov r2, r1, lsl #0xb
@@ -17755,13 +17755,13 @@ _0210f8dc:
 	str r2, [r0, #8]
 	b _0210fc74
 _0210fa38:
-	mov r0, sl
+	mov r0, r10
 	bl _ZN13LinkStateBase18func_ov00_020a8d40Ev
 	ldr r1, [r0, #0xd4]
 	ldr r0, _021101e4 ; =0x00000ccd
 	cmp r1, r0
 	ble _0210fc44
-	mov r0, sl
+	mov r0, r10
 	bl _ZN13LinkStateBase19GetCurrentCharacterEv
 	cmp r0, #0
 	bne _0210fc44
@@ -17774,7 +17774,7 @@ _0210fa38:
 	cmp r0, #0
 	beq _0210fc30
 _0210fa80:
-	mov r0, sl
+	mov r0, r10
 	bl _ZN13LinkStateBase18func_ov00_020a8d40Ev
 	ldrsh r0, [r0, #0xca]
 	cmp r0, #0
@@ -17786,7 +17786,7 @@ _0210fa80:
 	mov r2, #0x10
 	str r4, [sp]
 	bl func_0204f614
-	mov r0, sl
+	mov r0, r10
 	bl _ZN13LinkStateBase18func_ov00_020a8d40Ev
 	ldrh r2, [r0, #0xca]
 	mov r0, #0x4c
@@ -17875,16 +17875,16 @@ _0210fbf0:
 	bl func_0204f754
 _0210fc04:
 	ldr r2, [sp, #8]
-	mov r0, sl
+	mov r0, r10
 	mov r1, r5
 	bl func_ov05_02110e0c
-	mov r0, sl
+	mov r0, r10
 	mov r1, #0
 	mov r2, #0x1000
 	bl _ZN13LinkStateBase18func_ov00_020a8294Eij
 	add sp, sp, #0x84
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0210fc30:
 	ldr r0, _021101d8 ; =data_027e0fb8
 	ldr r0, [r0]
@@ -17892,7 +17892,7 @@ _0210fc30:
 	mov sb, #0
 	b _0210fc74
 _0210fc44:
-	mov r0, sl
+	mov r0, r10
 	bl _ZN13LinkStateBase18func_ov00_020a8b80Ev
 	cmp r0, #0
 	beq _0210fc74
@@ -17900,12 +17900,12 @@ _0210fc44:
 	ldr r0, [r0]
 	bl _ZN13PlayerControl18func_ov00_020b129cEv
 	mov r3, r0
-	mov r0, sl
+	mov r0, r10
 	mov r1, sb
 	mov r2, r5
 	bl _ZN13LinkStateBase18func_ov00_020a8680Eisb
 _0210fc74:
-	mov r0, sl
+	mov r0, r10
 	bl _ZN13LinkStateBase18func_ov00_020a8d40Ev
 	add r0, r0, #0x114
 	add r3, sp, #0x20
@@ -17916,7 +17916,7 @@ _0210fc74:
 	ldreq r0, [sp, #0x28]
 	cmpeq r0, #0
 	beq _0210fd34
-	mov r0, sl
+	mov r0, r10
 	bl _ZN13LinkStateBase18func_ov00_020a8d40Ev
 	ldr r0, [r0, #0x70]
 	mov r0, r0, lsr #0x7
@@ -17926,7 +17926,7 @@ _0210fc74:
 	cmp r6, #0
 	bne _0210fd44
 	ldr r1, _021101fc ; =0x00000e39
-	mov r0, sl
+	mov r0, r10
 	mov r2, #0x800
 	bl _ZN13LinkStateBase18func_ov00_020a8294Eij
 	ldr r0, [sp, #0x20]
@@ -17938,7 +17938,7 @@ _0210fc74:
 	mov r0, r0, lsl #0x10
 	rsb r0, r5, r0, asr #16
 	mov r1, r0, lsl #0x10
-	mov r0, sl
+	mov r0, r10
 	mov r4, r1, asr #0x10
 	bl _ZN13LinkStateBase18func_ov00_020a8d40Ev
 	ldr r0, [r0, #0xd4]
@@ -17954,15 +17954,15 @@ _0210fc74:
 	str r0, [sp, #0x14]
 	b _0210fd44
 _0210fd34:
-	mov r0, sl
+	mov r0, r10
 	mov r1, #0
 	mov r2, #0x1000
 	bl _ZN13LinkStateBase18func_ov00_020a8294Eij
 _0210fd44:
-	mov r0, sl
+	mov r0, r10
 	bl _ZN13LinkStateBase28Get_PlayerControlData_Unk004Ev
 	ldr r1, [r0]
-	mov r0, sl
+	mov r0, r10
 	smull r2, r1, sb, r1
 	adds r3, r2, #0x800
 	adc r2, r1, #0
@@ -18024,7 +18024,7 @@ _0210fdcc:
 	movne r2, #0
 	mov r1, #0x1c
 	mla r1, r2, r1, r0
-	mov r0, sl
+	mov r0, r10
 	mov r2, r7
 	bl _ZN13LinkStateBase18func_ov00_020a8774EP5Vec3pi
 	cmp r0, #0
@@ -18045,23 +18045,23 @@ _0210fdcc:
 	orr r4, r4, r0, lsl #20
 	b _0210fed4
 _0210fe90:
-	mov r0, sl
+	mov r0, r10
 	bl _ZN13LinkStateBase18func_ov00_020a8d40Ev
 	mov r1, #1
 	strh r1, [r0, #0x5a]
 	ldr r4, [sp, #8]
 	ldr r3, _02110200 ; =0x000004cd
-	mov r0, sl
+	mov r0, r10
 	mov r1, r7
 	mov r2, #0x52
 	str r4, [sp]
 	bl func_ov05_02110e28
-	mov r0, sl
+	mov r0, r10
 	mov r1, #0
 	bl _ZN13LinkStateBase15ChangeLinkStateEi
 	add sp, sp, #0x84
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0210fed4:
 	add r6, r6, #1
 	cmp r6, #2
@@ -18071,10 +18071,10 @@ _0210fee4:
 	bl func_ov05_0210aaf8
 	bl _ZN15LinkStateFollow16MoveTowardTargetEv
 _0210feec:
-	mov r0, sl
+	mov r0, r10
 	bl _ZN13LinkStateBase19GetCurrentCharacterEv
 	cmp r0, #1
-	mov r0, sl
+	mov r0, r10
 	bne _0210ff3c
 	bl _ZN13LinkStateBase18func_ov00_020a8b80Ev
 	cmp r0, #0
@@ -18084,34 +18084,34 @@ _0210feec:
 	str r0, [sp]
 	ldr r3, [sp, #0x14]
 	ldr r5, [sp, #0xc]
-	mov r0, sl
+	mov r0, r10
 	mov r1, r4
 	str r5, [sp, #4]
 	bl func_ov05_02110228
-	mov r0, sl
+	mov r0, r10
 	bl func_ov05_0210f758
 	b _0211016c
 _0210ff3c:
 	bl _ZN13LinkStateBase18func_ov00_020a8b80Ev
 	cmp r0, #0
-	mov r0, sl
+	mov r0, r10
 	bne _0210ffc8
 	ldr r5, _02110204 ; =0xfffffd71
 	bl _ZN13LinkStateBase18func_ov00_020a8d40Ev
 	ldrsh r0, [r0, #0x5c]
 	cmp r0, #0
 	ble _0210ff70
-	mov r0, sl
+	mov r0, r10
 	bl _ZN13LinkStateBase18func_ov00_020a8d40Ev
 	ldr r0, [r0, #0x68]
 	add r5, r5, r0
 _0210ff70:
-	mov r0, sl
+	mov r0, r10
 	bl _ZN13LinkStateBase12GetPlayerVelEv
 	ldr r0, [r0, #4]
 	cmp r0, r5
 	blt _0210ff9c
-	mov r0, sl
+	mov r0, r10
 	bl _ZN13LinkStateBase28Get_PlayerControlData_Unk120Ev
 	ldr r1, _021101e0 ; =data_ov05_02112acc
 	ldr r1, [r1, #0x38]
@@ -18119,7 +18119,7 @@ _0210ff70:
 	bne _0210ffac
 _0210ff9c:
 	ldr r1, _02110208 ; =data_ov05_02112b04
-	mov r0, sl
+	mov r0, r10
 	mov r2, #1
 	bl _ZN13LinkStateBase18func_ov00_020a8a4cEii
 _0210ffac:
@@ -18127,7 +18127,7 @@ _0210ffac:
 	cmp r0, #0
 	beq _0211016c
 	ldr r1, _0211020c ; =data_ov00_020e5694
-	mov r0, sl
+	mov r0, r10
 	bl _ZN13LinkStateBase18func_ov00_020a8ab0Ei
 	b _0211016c
 _0210ffc8:
@@ -18136,11 +18136,11 @@ _0210ffc8:
 	ldr r1, [r1, #0x38]
 	cmp r1, r0
 	bne _02110054
-	mov r0, sl
+	mov r0, r10
 	bl _ZN13LinkStateBase18func_ov00_020a8d50Ev
 	cmp r0, #0x4000
 	bge _02110054
-	mov r0, sl
+	mov r0, r10
 	bl _ZN13LinkStateBase18func_ov00_020a8d40Ev
 	ldr r1, [r0, #0xe4]
 	cmp r1, #0
@@ -18151,20 +18151,20 @@ _0210ffc8:
 	cmp r0, #0
 	beq _02110020
 	ldr r1, _0211020c ; =data_ov00_020e5694
-	mov r0, sl
+	mov r0, r10
 	bl _ZN13LinkStateBase18func_ov00_020a8ab0Ei
 _02110020:
-	mov r0, sl
+	mov r0, r10
 	bl _ZN13LinkStateBase18func_ov00_020a8d40Ev
 	ldrb r0, [r0, #0x59]
 	cmp r0, #0
 	beq _0211016c
-	mov r0, sl
+	mov r0, r10
 	bl _ZN13LinkStateBase18func_ov00_020a8d40Ev
 	ldrb r0, [r0, #0x58]
 	cmp r0, #0
 	bne _0211016c
-	mov r0, sl
+	mov r0, r10
 	bl func_ov05_02110bb4
 	b _0211016c
 _02110054:
@@ -18173,7 +18173,7 @@ _02110054:
 	mov r6, #0
 	cmpeq r0, #0
 	bne _0211008c
-	mov r0, sl
+	mov r0, r10
 	bl _ZN13LinkStateBase18func_ov00_020a8d40Ev
 	mov r1, r0
 	add r0, sp, #0x1c
@@ -18185,14 +18185,14 @@ _02110054:
 _0211008c:
 	cmp r6, #0
 	beq _021100cc
-	mov r0, sl
+	mov r0, r10
 	bl _ZN13LinkStateBase18func_ov00_020a8d40Ev
 	add r0, r0, #0x44
 	bl func_01ff9cec
 	cmp r0, #0xcd
 	ble _021100cc
 	ldr r1, _02110210 ; =data_ov05_02112b14
-	mov r0, sl
+	mov r0, r10
 	mov r2, #1
 	bl _ZN13LinkStateBase18func_ov00_020a8a4cEii
 	ldr r0, _02110214 ; =data_ov00_020eec9c
@@ -18202,24 +18202,24 @@ _0211008c:
 _021100cc:
 	cmp r6, #0
 	beq _02110140
-	mov r0, sl
+	mov r0, r10
 	bl _ZN13LinkStateBase28Get_PlayerControlData_Unk120Ev
 	ldr r1, _021101e0 ; =data_ov05_02112acc
 	ldr r1, [r1, #0x48]
 	cmp r1, r0
 	bne _02110140
-	mov r0, sl
+	mov r0, r10
 	mov r1, #0
 	bl _ZN13LinkStateBase18func_ov00_020a8b3cEi
 	cmp r0, #0
 	bne _02110140
-	mov r0, sl
+	mov r0, r10
 	mov r1, #0x1000
 	mov r2, #0
 	bl _ZN13LinkStateBase18func_ov00_020a8b04Eib
 	cmp r0, #0
 	beq _02110130
-	mov r0, sl
+	mov r0, r10
 	bl _ZN13LinkStateBase12GetPlayerPosEv
 	mov r2, r0
 	ldr r0, _02110214 ; =data_ov00_020eec9c
@@ -18236,24 +18236,24 @@ _02110140:
 	str r0, [sp]
 	ldr r3, [sp, #0x14]
 	ldr r5, [sp, #0xc]
-	mov r0, sl
+	mov r0, r10
 	mov r1, r4
 	str r5, [sp, #4]
 	bl func_ov05_02110228
 _02110164:
-	mov r0, sl
+	mov r0, r10
 	bl func_ov05_0210f758
 _0211016c:
 	ldr r0, _021101e0 ; =data_ov05_02112acc
 	ldr r0, [r0, #0x20]
 	cmp r4, r0
 	ble _021101bc
-	mov r0, sl
+	mov r0, r10
 	bl _ZN13LinkStateBase19GetCurrentCharacterEv
 	cmp r0, #0
 	bne _021101a8
 	ldr r1, _021101d8 ; =data_027e0fb8
-	mov r0, sl
+	mov r0, r10
 	ldr r5, [r1]
 	bl _ZN13LinkStateBase12GetPlayerPosEv
 	mov r1, r0
@@ -18273,7 +18273,7 @@ _021101bc:
 _021101cc:
 	mov r0, r4
 	add sp, sp, #0x84
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov05_0210f808
 _021101d8: .word data_027e0fb8
@@ -18310,7 +18310,7 @@ func_ov05_02110224: ; 0x02110224
 	.global func_ov05_02110228
 	arm_func_start func_ov05_02110228
 func_ov05_02110228: ; 0x02110228
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	ldr r4, _02110580 ; =data_ov05_02112acc
 	mov r8, r1
 	ldr r1, [r4, #0x20]
@@ -18417,34 +18417,34 @@ _0211037c:
 	movne r7, #0x34
 _021103c0:
 	bl func_ov05_02107870
-	ldr sl, [r0, #0x14]
+	ldr r10, [r0, #0x14]
 	mvn r0, #0
-	cmp sl, r0
+	cmp r10, r0
 	ldrb r0, [sp, #0x24]
-	moveq sl, #0
+	moveq r10, #0
 	cmp r0, #0
 	movne r8, #0x44
 	bne _02110410
 	mvn r0, #0
-	cmp sl, r0
+	cmp r10, r0
 	beq _02110410
 	mov r0, r5
-	mov r1, sl
+	mov r1, r10
 	bl _ZN13LinkStateBase16IsEquipBeingUsedEi
 	cmp r0, #0
 	beq _02110410
-	cmp sl, #3
+	cmp r10, #3
 	moveq r8, #0x35
 	movne r8, #7
 _02110410:
 	mov r0, r5
 	bl _ZN13LinkStateBase20GetPlayerControlDataEv
-	ldr sl, [r0]
+	ldr r10, [r0]
 	mov r1, r6
-	ldr sl, [sl, #0x64]
+	ldr r10, [r10, #0x64]
 	mov r2, r7
 	mov r3, r8
-	blx sl
+	blx r10
 	ldrb r0, [sp, #0x20]
 	cmp r0, #0
 	beq _0211044c
@@ -18500,7 +18500,7 @@ _021104b4:
 	mov r1, r4
 	orr r2, r2, r3, lsl #20
 	bl _ZN13LinkStateBase12ApplyImpulseEii
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _021104fc:
 	mov r0, r5
 	bl _ZN13LinkStateBase28Get_PlayerControlData_Unk120Ev
@@ -18510,7 +18510,7 @@ _021104fc:
 	mov r1, #0
 	bl _ZN13LinkStateBase18func_ov00_020a8b3cEi
 	cmp r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _02110520:
 	ldrb r0, [sp, #0x24]
 	cmp r0, #0
@@ -18520,11 +18520,11 @@ _02110520:
 	bl _ZN13LinkStateBase18func_ov00_020a8a90Ei
 	ldrb r0, [sp, #0x20]
 	cmp r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	ldr r1, _02110584 ; =data_ov00_020e5694
 	mov r0, r5
 	bl _ZN13LinkStateBase18func_ov00_020a8ab0Ei
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _02110554:
 	ldrb r0, [sp, #0x20]
 	cmp r0, #0
@@ -18532,12 +18532,12 @@ _02110554:
 	ldr r1, _02110584 ; =data_ov00_020e5694
 	mov r0, r5
 	bl _ZN13LinkStateBase18func_ov00_020a8a90Ei
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _02110570:
 	mov r0, r5
 	mov r1, #1
 	bl func_ov05_0211058c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov05_02110228
 _02110580: .word data_ov05_02112acc
@@ -19621,7 +19621,7 @@ func_ov05_021113d0: ; 0x021113d0
 	.global func_ov05_021113dc
 	arm_func_start func_ov05_021113dc
 func_ov05_021113dc: ; 0x021113dc
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #0x58
 	mov r5, r0
 	bl _ZN13LinkStateBase12GetGrabActorEv
@@ -19649,7 +19649,7 @@ func_ov05_021113dc: ; 0x021113dc
 	mov r1, #5
 	bl _ZN13LinkStateBase15ChangeLinkStateEi
 	add sp, sp, #0x58
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _02111450:
 	ldr r0, _02111a5c ; =data_027e0f74
 	ldr r0, [r0]
@@ -19673,7 +19673,7 @@ _02111450:
 	mov r1, #2
 	bl _ZN13LinkStateBase15ChangeLinkStateEi
 	add sp, sp, #0x58
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _021114ac:
 	mov r0, #3
 	bl func_01fffcd8
@@ -19687,7 +19687,7 @@ _021114ac:
 	mov r1, #3
 	bl _ZN13LinkStateBase15ChangeLinkStateEi
 	add sp, sp, #0x58
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _021114e0:
 	mov r0, #4
 	bl func_01fffcd8
@@ -19701,7 +19701,7 @@ _021114e0:
 	mov r1, #4
 	bl _ZN13LinkStateBase15ChangeLinkStateEi
 	add sp, sp, #0x58
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _02111514:
 	mov r0, #1
 	bl func_01fffcd8
@@ -19715,7 +19715,7 @@ _02111514:
 	mov r1, #1
 	bl _ZN13LinkStateBase15ChangeLinkStateEi
 	add sp, sp, #0x58
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _02111548:
 	cmp r8, #2
 	cmpne r7, #8
@@ -19761,10 +19761,10 @@ _021115cc:
 	mov r0, r5
 	ldrsh r8, [r1]
 	bl _ZN13LinkStateBase14GetPlayerAngleEv
-	mov sl, r0
+	mov r10, r0
 	mov r0, r5
 	bl _ZN13LinkStateBase27Get_PlayerControlData_Unk32Ev
-	ldrsh r1, [sl]
+	ldrsh r1, [r10]
 	mov r3, r8
 	add r0, r1, r0
 	mov r0, r0, lsl #0x10
@@ -20051,7 +20051,7 @@ _02111a18:
 	str r3, [sp, #8]
 	bl _ZN13LinkStateBase23PlayerLinkBase_vfunc_58Ev
 	add sp, sp, #0x58
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _02111a3c:
 	mov r0, r5
 	bl _ZN13LinkStateBase15GetGrabActorRefEv
@@ -20060,7 +20060,7 @@ _02111a3c:
 	mov r1, #1
 	bl _ZN13LinkStateBase23PlayerLinkBase_vfunc_58Ev
 	add sp, sp, #0x58
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov05_021113dc
 _02111a5c: .word data_027e0f74
@@ -20230,10 +20230,10 @@ func_ov05_02111c6c: ; 0x02111c6c
 	.global func_ov05_02111c70
 	arm_func_start func_ov05_02111c70
 func_ov05_02111c70: ; 0x02111c70
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x10
-	mov sl, r0
-	ldrb r0, [sl, #5]
+	mov r10, r0
+	ldrb r0, [r10, #5]
 	mov sb, r1
 	cmp r0, #0
 	bne _02111cac
@@ -20244,7 +20244,7 @@ func_ov05_02111c70: ; 0x02111c70
 	bne _02111cac
 	cmp sb, #0
 	addne sp, sp, #0x10
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02111cac:
 	ldr r0, _02111e14 ; =data_027e0d38
 	ldr r0, [r0]
@@ -20256,7 +20256,7 @@ _02111cac:
 	ldr r0, [r0]
 	bl func_ov05_0210157c
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02111cd8:
 	ldr r1, _02111e1c ; =data_027e0f64
 	add r0, sp, #0xc
@@ -20276,7 +20276,7 @@ _02111cd8:
 	add r0, r0, #1
 	sub r11, r3, #1
 	add r8, r1, #1
-	ldrh r1, [sl, #0x28]
+	ldrh r1, [r10, #0x28]
 	cmp r11, #0
 	ldrb r2, [sp, #0xa]
 	str r0, [sp, #4]
@@ -20284,7 +20284,7 @@ _02111cd8:
 	sub r0, r2, #1
 	str r0, [sp]
 	ldr r0, [sp]
-	ldrh r2, [sl, #0x2a]
+	ldrh r2, [r10, #0x2a]
 	cmp r0, #0
 	movle r0, #0
 	strle r0, [sp]
@@ -20306,7 +20306,7 @@ _02111d7c:
 	bgt _02111de8
 	and r6, r11, #0xff
 _02111d90:
-	mov r0, sl
+	mov r0, r10
 	strb r6, [sp, #8]
 	strb r7, [sp, #9]
 	ldr r2, [r0]
@@ -20340,7 +20340,7 @@ _02111df8:
 	ldr r0, [r0]
 	bl func_ov05_02101530
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov05_02111c70
 _02111e10: .word data_027e0f74
@@ -20472,18 +20472,18 @@ _02111fb4: .word data_027e0d3c
 	.global func_ov05_02111fb8
 	arm_func_start func_ov05_02111fb8
 func_ov05_02111fb8: ; 0x02111fb8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	mov r4, r0
 	ldrb r0, [r4, #0x14]
 	cmp r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	ldrh r0, [r4, #0x16]
-	mov sl, #0
+	mov r10, #0
 	cmp r0, #0
 	subne r0, r0, #1
 	strneh r0, [r4, #0x16]
 _02111fe0:
-	add r0, r4, sl, lsl #1
+	add r0, r4, r10, lsl #1
 	ldrh r5, [r0, #0x20]
 	ldrh r0, [r0, #0x88]
 	ldrh r1, [r4, #0x16]
@@ -20537,11 +20537,11 @@ _0211207c:
 	and r7, r0, #0xff
 _021120a8:
 	orr r1, r5, r6, lsl #5
-	add r0, r4, sl, lsl #1
+	add r0, r4, r10, lsl #1
 	orr r1, r1, r7, lsl #10
-	add sl, sl, #1
+	add r10, r10, #1
 	strh r1, [r0, #0x20]
-	cmp sl, #7
+	cmp r10, #7
 	blt _02111fe0
 	mov r5, #0
 _021120c8:
@@ -20555,7 +20555,7 @@ _021120c8:
 	and r7, r0, #0x7c00
 	mov sb, r8, asr #0x5
 	mov r2, r2, asr #0xa
-	mov sl, r7, asr #0xa
+	mov r10, r7, asr #0xa
 	mov r3, r3, asr #0x5
 	mov r1, r1, lsl #0xc
 	and r6, r6, #0x1f
@@ -20564,7 +20564,7 @@ _021120c8:
 	and r7, r3, #0xff
 	and r8, r2, #0xff
 	and sb, sb, #0xff
-	and sl, sl, #0xff
+	and r10, r10, #0xff
 	movle r6, r0
 	ble _02112138
 	sub r0, r0, r6
@@ -20589,9 +20589,9 @@ _02112164:
 	ldrh r0, [r4, #0x16]
 	mov r1, r0, lsl #0xc
 	cmp r1, #0x1000
-	movle r8, sl
+	movle r8, r10
 	ble _02112190
-	sub r0, sl, r8
+	sub r0, r10, r8
 	mov r0, r0, lsl #0xc
 	bl Divide
 	add r0, r0, #0x800
@@ -20612,7 +20612,7 @@ _02112190:
 	cmp r0, #0
 	moveq r0, #0
 	streqb r0, [r4, #0x14]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	arm_func_end func_ov05_02111fb8
 
 	.global func_ov05_021121cc

--- a/asm/ov05.s
+++ b/asm/ov05.s
@@ -244,7 +244,7 @@ func_ov05_02100dc0: ; 0x02100dc0
 	.global func_ov05_02100e0c
 	arm_func_start func_ov05_02100e0c
 func_ov05_02100e0c: ; 0x02100e0c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	mov r5, r1
 	ldr r7, [r5, #8]
 	mov r6, r0
@@ -259,7 +259,7 @@ func_ov05_02100e0c: ; 0x02100e0c
 	mov r0, r6
 	mov r3, #1
 	bl func_ov05_02100dc0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _02100e4c:
 	blx func_ov00_0207bfc4
 	ldr r0, _0210105c ; =data_027e0d38
@@ -271,12 +271,12 @@ _02100e4c:
 	bl func_ov00_020a5e9c
 	mov r10, r0
 	ldr r0, _0210105c ; =data_027e0d38
-	mov sb, #0
+	mov r9, #0
 	ldr r0, [r0]
 	cmp r4, r10
 	ldr r8, [r0, #0x14]
 	cmpeq r8, r7
-	movne sb, #1
+	movne r9, #1
 	bne _02100ea0
 	bl func_ov00_02078b40
 	cmp r0, #0
@@ -351,15 +351,15 @@ _02100f90:
 	mov r7, #1
 	b _02101020
 _02100f98:
-	mov sb, #1
+	mov r9, #1
 	cmp r0, #0xd
-	moveq r7, sb
+	moveq r7, r9
 	b _02101020
 _02100fa8:
 	ldr r0, _02101064 ; =data_ov00_020d88a8
-	mov sb, #1
+	mov r9, #1
 	ldrh r0, [r0]
-	strb sb, [r6, #0x25]
+	strb r9, [r6, #0x25]
 	strh r0, [r6, #0x2a]
 	b _02101020
 _02100fc0:
@@ -399,13 +399,13 @@ _02101020:
 	bl func_ov00_020d7424
 	cmp r0, #0x34
 	cmpne r0, #0x35
-	moveq sb, #1
+	moveq r9, #1
 _02101044:
 	mov r0, r6
-	mov r1, sb
+	mov r1, r9
 	mov r2, r7
 	bl func_ov05_02100cb0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov05_02100e0c
 _02101058: .word data_ov00_020d88ae
@@ -574,15 +574,15 @@ func_ov05_021011fc: ; 0x021011fc
 	.global func_ov05_02101230
 	arm_func_start func_ov05_02101230
 func_ov05_02101230: ; 0x02101230
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x40
 	ldr r2, _0210141c ; =data_027e077c
 	mov r10, r0
 	ldr r0, [r2]
-	mov sb, r1
+	mov r9, r1
 	cmp r0, #0x22
 	addeq sp, sp, #0x40
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r2, [r10, #0xc]
 	ldr r0, [r10, #0x10]
 	mov r8, r2
@@ -596,7 +596,7 @@ func_ov05_02101230: ; 0x02101230
 	mov r11, r7
 _02101280:
 	ldr r0, [r8]
-	mov r1, sb
+	mov r1, r9
 	ldr r2, [r0]
 	ldr r2, [r2, #0xc]
 	blx r2
@@ -696,16 +696,16 @@ _021013bc:
 	str r1, [sp, #0x14]
 	bl func_ov05_021015c8
 _021013f4:
-	cmp sb, #0
+	cmp r9, #0
 	addne sp, sp, #0x40
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, [r10, #4]
 	cmp r0, #0
 	addeq sp, sp, #0x40
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	bl func_ov18_0216ad3c
 	add sp, sp, #0x40
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov05_02101230
 _0210141c: .word data_027e077c
@@ -1739,7 +1739,7 @@ _021021ec: .word data_ov00_020eec68
 	.global func_ov05_021021f0
 	arm_func_start func_ov05_021021f0
 func_ov05_021021f0: ; 0x021021f0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	mov r6, r0
 	ldr r3, [r6]
 	ldr r2, [r6, #4]
@@ -1760,7 +1760,7 @@ func_ov05_021021f0: ; 0x021021f0
 	bhs _02102378
 _0210223c:
 	ldr r0, [ip]
-	add sb, ip, #0x30
+	add r9, ip, #0x30
 	str r0, [lr]
 	ldr r0, [ip, #4]
 	add r8, lr, #0x30
@@ -1817,7 +1817,7 @@ _02102310:
 	stmia r8!, {r0, r1, r2, r3}
 	subs r7, r7, #1
 	bne _02102310
-	ldmia sb, {r0, r1}
+	ldmia r9, {r0, r1}
 	stmia r8, {r0, r1}
 	ldr r0, [ip, #0x98]
 	str r0, [lr, #0x98]
@@ -1851,7 +1851,7 @@ _02102378:
 	add r0, r0, #4
 	bl func_ov00_0209a508
 	mov r0, r5
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov05_021021f0
 _021023a8: .word 0xb60b60b7
@@ -1859,11 +1859,11 @@ _021023a8: .word 0xb60b60b7
 	.global func_ov05_021023ac
 	arm_func_start func_ov05_021023ac
 func_ov05_021023ac: ; 0x021023ac
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	ldr r3, _021026a4 ; =data_027e0618
 	mov r10, r0
 	ldr r0, [r3, #0xcc]
-	mov sb, r1
+	mov r9, r1
 	mov r8, r2
 	cmp r0, #0
 	mov r4, #0
@@ -1879,7 +1879,7 @@ func_ov05_021023ac: ; 0x021023ac
 	bl func_ov05_02103bb0
 	b _02102498
 _021023f8:
-	cmp sb, #1
+	cmp r9, #1
 	beq _02102498
 	cmp r8, #0
 	moveq r1, #1
@@ -1934,7 +1934,7 @@ _02102498:
 	movne r6, #1
 	ldr r0, [r0]
 	moveq r6, #0
-	cmp sb, #1
+	cmp r9, #1
 	moveq r7, #1
 	movne r7, #0
 	cmp r6, #0
@@ -2013,7 +2013,7 @@ _0210259c:
 	mov r1, r8
 	ldr r0, [r0]
 	bl func_ov05_0210112c
-	cmp sb, #2
+	cmp r9, #2
 	beq _02102608
 	ldr r0, _021026e4 ; =data_027e0fe4
 	mov r1, r8
@@ -2063,7 +2063,7 @@ _02102678:
 	bl func_ov05_02101af8
 _0210269c:
 	mov r0, r4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov05_021023ac
 _021026a4: .word data_027e0618
@@ -2181,9 +2181,9 @@ _02102824: .word data_027e0e60
 	.global func_ov05_02102828
 	arm_func_start func_ov05_02102828
 func_ov05_02102828: ; 0x02102828
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	ldr r0, _02102a38 ; =data_027e0d38
-	mov sb, r1
+	mov r9, r1
 	ldr r0, [r0]
 	mov r8, r2
 	bl func_ov00_02078b40
@@ -2202,7 +2202,7 @@ func_ov05_02102828: ; 0x02102828
 	moveq r6, #1
 _02102874:
 	ldr r0, _02102a38 ; =data_027e0d38
-	cmp sb, #1
+	cmp r9, #1
 	ldr r0, [r0]
 	moveq r7, #1
 	movne r7, #0
@@ -2278,8 +2278,8 @@ _02102978:
 	ldr r2, [r2, #0x28]
 	blx r2
 	cmp r7, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
-	cmp sb, #2
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
+	cmp r9, #2
 	beq _021029b0
 	ldr r0, _02102a64 ; =data_027e0fe4
 	mov r1, r8
@@ -2321,7 +2321,7 @@ _02102a10:
 	bl func_ov05_0210cb8c
 	ldr r0, _02102a4c ; =data_027e0de4
 	bl func_ov00_0207bb4c
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov05_02102828
 _02102a38: .word data_027e0d38
@@ -2546,7 +2546,7 @@ func_ov05_02102cfc: ; 0x02102cfc
 	.global func_ov05_02102d1c
 	arm_func_start func_ov05_02102d1c
 func_ov05_02102d1c: ; 0x02102d1c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x90
 	str r0, [sp, #0x28]
 	ldr r0, [r0, #0x904]
@@ -2557,7 +2557,7 @@ func_ov05_02102d1c: ; 0x02102d1c
 	ldrsh r0, [r0, #8]
 	cmp r0, #0
 	addle sp, sp, #0x90
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02102d4c:
 	cmp r1, #0
 	beq _02102d6c
@@ -2566,7 +2566,7 @@ _02102d4c:
 	ldrh r0, [r0, #0xa]
 	tst r0, #0x10
 	addne sp, sp, #0x90
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02102d6c:
 	ldr r8, _02103558 ; =data_020691a0
 	bl func_ov05_02103ba0
@@ -2698,13 +2698,13 @@ _02102ee8:
 	ldr r1, [r7]
 	ldr r0, [sp, #0x44]
 	bl func_ov00_020839d4
-	mov sb, r0
+	mov r9, r0
 	ldr r0, [sp, #0x44]
 	ldr r1, [r7, #8]
 	bl func_ov00_020839f8
 	str r0, [sp, #0x34]
 	ldr r1, [sp, #0x34]
-	mov r0, sb
+	mov r0, r9
 	add r2, r6, #8
 	mov r3, r11
 	bl func_ov05_02102b0c
@@ -2772,7 +2772,7 @@ _02103048:
 	mov r1, r10
 	str r2, [sp]
 	ldr r2, [sp, #0x2c]
-	mov r3, sb
+	mov r3, r9
 	str r2, [sp, #4]
 	ldr r2, [sp, #0x5c]
 	str r2, [sp, #8]
@@ -2802,7 +2802,7 @@ _02103048:
 	ldr r1, [sp, #0x48]
 	stmia sp, {r2, r10}
 	ldr r2, [sp, #0x60]
-	mov r3, sb
+	mov r3, r9
 	str r2, [sp, #8]
 	str r7, [sp, #0xc]
 	ldr r2, [r7, #0xc]
@@ -2917,13 +2917,13 @@ _0210327c:
 	cmp r10, #0
 	mov r4, #0
 	ble _021032d4
-	ldr sb, _02103568 ; =data_ov00_020e9360
+	ldr r9, _02103568 ; =data_ov00_020e9360
 	mov r7, r4
 _021032a4:
 	ldrh r2, [r6, #0x26]
 	cmp r5, r2
 	beq _021032c0
-	mov r0, sb
+	mov r0, r9
 	mov r1, r7
 	mov r5, r2
 	bl func_ov00_02079e68
@@ -2952,13 +2952,13 @@ _021032d4:
 	bl func_ov05_02103704
 	str r0, [sp, #0x70]
 	cmp r10, #0
-	mov sb, #0
+	mov r9, #0
 	ble _02103530
 	mov r4, #0x1000
 	ldr r6, _0210356c ; =data_ov05_021122a0
 	rsb r4, r4, #0
-	mov r7, sb
-	mov r11, sb
+	mov r7, r9
+	mov r11, r9
 _02103338:
 	mov r0, #3
 	str r0, [sp]
@@ -3087,8 +3087,8 @@ _02103498:
 	bl func_ov05_02103580
 	mov r0, #1
 	bl func_ov05_02103570
-	add sb, sb, #1
-	cmp sb, r10
+	add r9, r9, #1
+	cmp r9, r10
 	add r8, r8, #0x30
 	blt _02103338
 _02103530:
@@ -3097,11 +3097,11 @@ _02103530:
 	ldrsh r0, [r0, #8]
 	cmp r0, #0
 	addle sp, sp, #0x90
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, [sp, #0x28]
 	bl func_ov18_0216945c
 	add sp, sp, #0x90
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov05_02102d1c
 _02103558: .word data_020691a0
@@ -3317,7 +3317,7 @@ _02103738: .word data_027e0d44
 	.global func_ov05_0210373c
 	arm_func_start func_ov05_0210373c
 func_ov05_0210373c: ; 0x0210373c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x10
 	ldr r7, [sp, #0x44]
 	ldr r4, _021038c0 ; =data_027e0e60
@@ -3326,7 +3326,7 @@ func_ov05_0210373c: ; 0x0210373c
 	ldr r4, [r4]
 	mov r10, r0
 	add r6, r6, r5
-	mov sb, r1
+	mov r9, r1
 	mov r0, r4
 	mov r1, r6
 	mov r8, r2
@@ -3337,7 +3337,7 @@ func_ov05_0210373c: ; 0x0210373c
 	cmp r1, r0
 	beq _021038b4
 	mov r0, #0x30
-	mul ip, sb, r0
+	mul ip, r9, r0
 	mov r2, #0x4000
 	ldrb r3, [sp, #0x5c]
 	add r5, r10, ip
@@ -3412,11 +3412,11 @@ _02103878:
 	ldr r0, [sp, #0x58]
 	strh r1, [r5, #0x26]
 	str r0, [r5, #0x28]
-	add sb, sb, #1
+	add r9, r9, #1
 _021038b4:
-	mov r0, sb
+	mov r0, r9
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov05_0210373c
 _021038c0: .word data_027e0e60
@@ -3425,7 +3425,7 @@ _021038c4: .word data_ov05_021122a8
 	.global func_ov05_021038c8
 	arm_func_start func_ov05_021038c8
 func_ov05_021038c8: ; 0x021038c8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x18
 	ldr r7, [sp, #0x4c]
 	ldr r4, _02103a9c ; =data_027e0e60
@@ -3434,7 +3434,7 @@ func_ov05_021038c8: ; 0x021038c8
 	ldr r4, [r4]
 	mov r10, r0
 	add r6, r6, r5
-	mov sb, r1
+	mov r9, r1
 	mov r0, r4
 	mov r1, r6
 	mov r8, r2
@@ -3444,7 +3444,7 @@ func_ov05_021038c8: ; 0x021038c8
 	cmp r5, r11
 	beq _02103a90
 	mov r1, #0x30
-	mul lr, sb, r1
+	mul lr, r9, r1
 	add r5, r10, lr
 	mov ip, #0x4000
 	ldrb r3, [sp, #0x64]
@@ -3541,11 +3541,11 @@ _02103a54:
 	ldr r0, [sp, #0x60]
 	strh r1, [r5, #0x26]
 	str r0, [r5, #0x28]
-	add sb, sb, #1
+	add r9, r9, #1
 _02103a90:
-	mov r0, sb
+	mov r0, r9
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov05_021038c8
 _02103a9c: .word data_027e0e60
@@ -4559,7 +4559,7 @@ _02104570: .word data_027e0d3c
 	.global func_ov05_02104574
 	arm_func_start func_ov05_02104574
 func_ov05_02104574: ; 0x02104574
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x2c
 	ldr r2, _02104730 ; =data_027e1054
 	mov r4, r0
@@ -4568,7 +4568,7 @@ func_ov05_02104574: ; 0x02104574
 	ldrb r0, [r0, #0x95]
 	cmp r0, #0
 	addne sp, sp, #0x2c
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldrh r0, [r1]
 	tst r0, #4
 	movne r1, #1
@@ -4580,7 +4580,7 @@ func_ov05_02104574: ; 0x02104574
 	moveq r0, #0
 	cmp r0, #0
 	addeq sp, sp, #0x2c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _021045cc:
 	ldr r0, _02104734 ; =data_027e0d38
 	ldr r0, [r0]
@@ -4589,13 +4589,13 @@ _021045cc:
 	cmp r0, #1
 	cmpne r0, #0x32
 	addeq sp, sp, #0x2c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r0, sp, #0xc
 	bl func_01ffbe34
 	ldr r0, [sp, #0x18]
-	mov sb, #1
+	mov r9, #1
 	orr r0, r0, #0x1000
-	str sb, [sp, #0x10]
+	str r9, [sp, #0x10]
 	str r0, [sp, #0x18]
 	ldrb r0, [r4, #0x250]
 	cmp r0, #2
@@ -4612,22 +4612,22 @@ _021045cc:
 	add r0, r4, #0x1b8
 	bl func_02034a1c
 	cmp r5, #0x60
-	movgt r3, sb
+	movgt r3, r9
 	movle r3, #0
 	mov r0, r4
 	mov r1, r6
 	mov r2, r5
 	bl func_ov05_02104a48
 	add sp, sp, #0x2c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02104664:
 	ldr r7, _0210473c ; =data_027e0d3c
-	sub r0, sb, #2
+	sub r0, r9, #2
 	ldr r1, [r7]
 	ldr r10, [r1, #0x48]
 	cmp r10, r0
 	addeq sp, sp, #0x2c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r5, _02104738 ; =data_027e0f7c
 	ldr r6, _02104740 ; =gItemManager
 	add r4, r4, #0x200
@@ -4635,20 +4635,20 @@ _02104664:
 	add r8, sp, #0xc
 _02104694:
 	ldrsb r0, [r4, #0x4f]
-	cmp sb, r0
+	cmp r9, r0
 	beq _0210471c
 	ldr r0, [r6]
-	add r1, sb, #0x60
+	add r1, r9, #0x60
 	bl _ZNK11ItemManager7HasItemEi
 	cmp r0, #0
 	beq _0210471c
 	ldr r0, [r6]
-	and r1, sb, #0xff
+	and r1, r9, #0xff
 	bl _ZNK11ItemManager18IsTreasureSalvagedEj
 	cmp r0, #0
 	bne _0210471c
 	ldr r0, [r5]
-	and r1, sb, #0xff
+	and r1, r9, #0xff
 	bl func_ov00_0209d90c
 	ldrb r1, [r0, #1]
 	cmp r10, r1
@@ -4669,11 +4669,11 @@ _02104694:
 	mov r1, #0x18
 	bl func_02034984
 _0210471c:
-	add sb, sb, #1
-	cmp sb, #0x20
+	add r9, r9, #1
+	cmp r9, #0x20
 	blt _02104694
 	add sp, sp, #0x2c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov05_02104574
 _02104730: .word data_027e1054
@@ -4724,7 +4724,7 @@ _021047c4: .word data_027e0d3c
 	.global func_ov05_021047c8
 	arm_func_start func_ov05_021047c8
 func_ov05_021047c8: ; 0x021047c8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x34
 	ldr r0, _02104a28 ; =data_027e1054
 	ldr r0, [r0]
@@ -4732,7 +4732,7 @@ func_ov05_021047c8: ; 0x021047c8
 	ldrb r0, [r0, #0x95]
 	cmp r0, #0
 	addne sp, sp, #0x34
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldrh r0, [r1]
 	tst r0, #4
 	movne r1, #1
@@ -4744,7 +4744,7 @@ func_ov05_021047c8: ; 0x021047c8
 	moveq r0, #0
 	cmp r0, #0
 	addeq sp, sp, #0x34
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0210481c:
 	add r0, sp, #0x14
 	bl func_01ffbe34
@@ -4761,7 +4761,7 @@ _0210481c:
 	cmp r0, #1
 	beq _0210493c
 	add sp, sp, #0x34
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0210485c:
 	ldr r0, _02104a30 ; =data_027e0f74
 	ldr r1, _02104a34 ; =0x0000015f
@@ -4789,14 +4789,14 @@ _021048a8:
 	bl func_ov00_02097760
 	cmp r0, #0
 	addeq sp, sp, #0x34
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, _02104a38 ; =gItemManager
 	mov r1, #0
 	ldr r0, [r0]
 	bl _ZNK11ItemManager18IsTreasureSalvagedEj
 	cmp r0, #0
 	addne sp, sp, #0x34
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, _02104a3c ; =data_027e0f7c
 	mov r1, #0
 	ldr r0, [r0]
@@ -4819,7 +4819,7 @@ _021048a8:
 	mov r1, #0x12
 	bl func_02034984
 	add sp, sp, #0x34
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0210493c:
 	ldr r0, _02104a40 ; =data_027e077c
 	mov r1, #1
@@ -4828,14 +4828,14 @@ _0210493c:
 	moveq r1, r2
 	cmp r1, #0
 	addeq sp, sp, #0x34
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, _02104a38 ; =gItemManager
 	mov r1, #0x16
 	ldr r0, [r0]
 	bl _ZNK11ItemManager7HasItemEi
 	cmp r0, #0
 	addne sp, sp, #0x34
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, _02104a30 ; =data_027e0f74
 	ldr r1, _02104a44 ; =0x00000125
 	ldr r0, [r0]
@@ -4843,14 +4843,14 @@ _0210493c:
 	cmp r0, #0
 	bne _02104a04
 	ldr r4, _02104a2c ; =data_027e0d3c
-	mov sb, #0
+	mov r9, #0
 	mov r8, #0xd0
 	add r7, sp, #8
 	add r6, sp, #4
 	mov r11, #1
 	add r5, sp, #0x14
 _021049ac:
-	and r10, sb, #0xff
+	and r10, r9, #0xff
 	mov r0, r8
 	mov r1, r10
 	mov r2, r7
@@ -4867,11 +4867,11 @@ _021049ac:
 	mov r1, r10
 	mov r0, #0xd0
 	bl func_02034984
-	add sb, sb, #1
-	cmp sb, #0x2a
+	add r9, r9, #1
+	cmp r9, #0x2a
 	blt _021049ac
 	add sp, sp, #0x34
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02104a04:
 	mov r2, #0
 	add r4, sp, #0x14
@@ -4881,7 +4881,7 @@ _02104a04:
 	str r4, [sp]
 	bl func_ov05_02104744
 	add sp, sp, #0x34
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov05_021047c8
 _02104a28: .word data_027e1054
@@ -5264,7 +5264,7 @@ _02104f24: .word data_027e0f94
 	.global func_ov05_02104f28
 	arm_func_start func_ov05_02104f28
 func_ov05_02104f28: ; 0x02104f28
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #0x68
 	ldr r2, _02105130 ; =data_027e0f64
 	ldr r1, _02105134 ; =data_027e0f94
@@ -5332,12 +5332,12 @@ func_ov05_02104f28: ; 0x02104f28
 	ldrsh lr, [r2, r3]
 	add r2, r7, #0xc
 	add r8, r5, r2
-	umull r10, sb, lr, r4
-	mla sb, lr, r1, sb
+	umull r10, r9, lr, r4
+	mla r9, lr, r1, r9
 	mov ip, lr, asr #0x1f
-	mla sb, ip, r4, sb
+	mla r9, ip, r4, r9
 	adds r4, r10, #0x800
-	adc r1, sb, #0
+	adc r1, r9, #0
 	mov r4, r4, lsr #0xc
 	orr r4, r4, r1, lsl #20
 	add r1, r4, #0x800
@@ -5368,13 +5368,13 @@ func_ov05_02104f28: ; 0x02104f28
 	add r0, sp, #0x38
 	bl func_ov00_020d0a80
 	add sp, sp, #0x68
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _021050cc:
 	add r0, r8, #0x200
 	ldrsh r0, [r0, #0x4a]
 	cmp r0, #0
 	addle sp, sp, #0x68
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	cmp r4, #0
 	addne r5, r5, #0x27
 	mov r3, #3
@@ -5394,7 +5394,7 @@ _021050cc:
 	str r4, [sp, #8]
 	bl func_ov00_020d0a80
 	add sp, sp, #0x68
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov05_02104f28
 _02105130: .word data_027e0f64
@@ -5954,7 +5954,7 @@ _0210584c: .word data_027e077c
 	.global func_ov05_02105850
 	arm_func_start func_ov05_02105850
 func_ov05_02105850: ; 0x02105850
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0xc
 	mov r6, r0
 	bl func_ov05_021055d0
@@ -5975,7 +5975,7 @@ func_ov05_02105850: ; 0x02105850
 	str r1, [r6, #0x18]
 	bl func_ov05_02105dac
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _021058a8:
 	ldr r0, [r6, #0x1c]
 	cmp r0, #8
@@ -6064,7 +6064,7 @@ _021059e0:
 	mov r0, r6
 	bl func_ov05_02105d94
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _021059f0:
 	add r0, r6, #0x38
 	add r3, sp, #0
@@ -6109,13 +6109,13 @@ _02105a38:
 	ldrsh ip, [r5, r2]
 	ldr r2, _02105c14 ; =0x00000266
 	mov r3, #0
-	umull sb, r8, lr, r2
+	umull r9, r8, lr, r2
 	mla r8, lr, r3, r8
 	mov r7, lr, asr #0x1f
 	mla r8, r7, r2, r8
-	adds sb, sb, #0x800
+	adds r9, r9, #0x800
 	adc r7, r8, #0
-	mov r8, sb, lsr #0xc
+	mov r8, r9, lsr #0xc
 	ldr r1, [r0]
 	orr r8, r8, r7, lsl #20
 	add r1, r1, r8
@@ -6200,7 +6200,7 @@ _02105be0:
 	mvn r0, #0
 	str r0, [r6, #0x18]
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov05_02105850
 _02105bf0: .word data_027e0fb8
@@ -8488,12 +8488,12 @@ func_ov05_02107b74: ; 0x02107b74
 	.global func_ov05_02107bd4
 	arm_func_start func_ov05_02107bd4
 func_ov05_02107bd4: ; 0x02107bd4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	mov r10, r0
 	ldr r4, _02107c80 ; =0x47454c4c
 	ldr r11, _02107c84 ; =0x57544352
 	ldr r6, _02107c88 ; =data_027e0fe4
-	add sb, r10, #0x44
+	add r9, r10, #0x44
 	mov r8, #0
 	mvn r5, #0
 _02107bf4:
@@ -8502,7 +8502,7 @@ _02107bf4:
 	cmp r0, r5
 	beq _02107c68
 	ldr r0, [r6]
-	mov r1, sb
+	mov r1, r9
 	bl _ZN12ActorManager8GetActorEP8ActorRef
 	movs r7, r0
 	beq _02107c68
@@ -8519,7 +8519,7 @@ _02107c30:
 	mov r0, r7
 	bl func_ov32_0217fd7c
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02107c4c:
 	bl func_ov26_02170150
 	cmp r0, #0
@@ -8527,14 +8527,14 @@ _02107c4c:
 	mov r0, r7
 	bl func_ov26_02170164
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02107c68:
 	add r8, r8, #1
 	cmp r8, #8
-	add sb, sb, #8
+	add r9, r9, #8
 	blt _02107bf4
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov05_02107bd4
 _02107c80: .word 0x47454c4c
@@ -8779,20 +8779,20 @@ _02107fb8:
 	.global func_ov05_02107fc0
 	arm_func_start func_ov05_02107fc0
 func_ov05_02107fc0: ; 0x02107fc0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	mov r1, #2
 	mov r10, r0
 	bl _ZN13LinkStateBase29HasFlags_PlayerLinkBase_Unk48Et
 	cmp r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	mov r6, #0
 	ldr r11, _02108088 ; =0x47454c4c
 	ldr r4, _0210808c ; =data_027e0fe4
-	mov sb, r6
+	mov r9, r6
 	add r8, r10, #0x44
 	mvn r5, #0
 _02107ff0:
-	add r0, r10, sb, lsl #3
+	add r0, r10, r9, lsl #3
 	ldr r0, [r0, #0x44]
 	cmp r0, r5
 	beq _02108060
@@ -8820,20 +8820,20 @@ _0210804c:
 	mov r6, #1
 	b _02108060
 _02108054:
-	add r0, r10, sb, lsl #3
+	add r0, r10, r9, lsl #3
 	str r5, [r0, #0x44]
 	str r5, [r0, #0x48]
 _02108060:
-	add sb, sb, #1
-	cmp sb, #8
+	add r9, r9, #1
+	cmp r9, #8
 	add r8, r8, #8
 	blt _02107ff0
 	cmp r6, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	mov r0, r10
 	mov r1, #2
 	bl _ZN13LinkStateBase26Clear_PlayerLinkBase_Unk48Et
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov05_02107fc0
 _02108088: .word 0x47454c4c
@@ -9105,7 +9105,7 @@ _02108340:
 	.global func_ov05_021083e0
 	arm_func_start func_ov05_021083e0
 func_ov05_021083e0: ; 0x021083e0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	mov r10, r0
 	ldrb r0, [r10]
 	mov r1, #0
@@ -9145,12 +9145,12 @@ _0210846c:
 	sub r11, r5, #1
 	mov r8, #0
 	cmp r11, #0
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0210847c:
 	mov r0, r7
 	mov r1, r8
 	bl func_ov05_02108888
-	mov sb, r0
+	mov r9, r0
 	bl func_ov05_02108858
 	ldr r0, [r0, #0xc]
 	cmp r0, #0
@@ -9168,7 +9168,7 @@ _021084a8:
 	cmp r0, #0
 	blt _021084d8
 	mov r0, r10
-	mov r1, sb
+	mov r1, r9
 	mov r2, r4
 	bl func_ov05_021084f4
 _021084d8:
@@ -9179,17 +9179,17 @@ _021084e4:
 	add r8, r8, #1
 	cmp r8, r11
 	blt _0210847c
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	arm_func_end func_ov05_021083e0
 
 	.global func_ov05_021084f4
 	arm_func_start func_ov05_021084f4
 func_ov05_021084f4: ; 0x021084f4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #0x88
-	mov sb, r1
+	mov r9, r1
 	add r3, sp, #0x74
-	add r5, sb, #0x20
+	add r5, r9, #0x20
 	mov r8, r2
 	mov r6, r0
 	ldmia r5, {r0, r1, r2}
@@ -9208,12 +9208,12 @@ func_ov05_021084f4: ; 0x021084f4
 	ldr r1, [r5, #0x10]
 	mov r2, r3
 	str r1, [sp, #0x70]
-	ldr r3, [sb, #8]
+	ldr r3, [r9, #8]
 	add r1, sp, #0xc
 	str r3, [sp, #0xc]
-	ldr r3, [sb, #0xc]
+	ldr r3, [r9, #0xc]
 	str r3, [sp, #0x10]
-	ldr r3, [sb, #0x10]
+	ldr r3, [r9, #0x10]
 	str r3, [sp, #0x14]
 	bl func_01ff9bc4
 	ldr r1, [r8, #8]
@@ -9236,7 +9236,7 @@ func_ov05_021084f4: ; 0x021084f4
 	add r0, r0, r1, asr #1
 	cmp r2, r0
 	addge sp, sp, #0x88
-	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmgeia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	ldr r7, [sp, #0x74]
 	mov r5, #0
 	ldr r4, [sp, #0x7c]
@@ -9257,9 +9257,9 @@ func_ov05_021084f4: ; 0x021084f4
 	add r10, r2, r1
 	cmp r4, r10
 	addge sp, sp, #0x88
-	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmgeia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	mov r0, r6
-	mov r1, sb
+	mov r1, r9
 	bl func_ov05_02108210
 	mov r5, r0
 	mov r0, r6
@@ -9285,10 +9285,10 @@ _02108670:
 	cmp r3, #4
 	movge r7, #0
 	bge _021086a8
-	ldr r1, [sb]
+	ldr r1, [r9]
 	add r2, r6, #0xc
 	str r1, [r2, r3, lsl #3]
-	ldr r1, [sb, #4]
+	ldr r1, [r9, #4]
 	add r2, r2, r3, lsl #3
 	str r1, [r2, #4]
 	ldr r1, [r6, #8]
@@ -9296,7 +9296,7 @@ _02108670:
 	add r1, r1, #1
 	str r1, [r6, #8]
 _021086a8:
-	ldr r2, [sb, #0x34]
+	ldr r2, [r9, #0x34]
 	sub r4, r10, r4
 	cmp r2, #5
 	ldrne r3, [r8, #0x34]
@@ -9325,10 +9325,10 @@ _021086fc: ; jump table
 	b _021087b4 ; case 3
 _0210870c:
 	cmp r0, #0
-	ldrne r6, [sb, #0x38]
+	ldrne r6, [r9, #0x38]
 	cmpne r6, #0
 	addeq sp, sp, #0x88
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	add r0, sp, #0x54
 	add r1, sp, #0x48
 	add r2, sp, #0x3c
@@ -9344,13 +9344,13 @@ _0210870c:
 	mov r2, r0
 	bl func_01ff9bc4
 	add sp, sp, #0x88
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _02108760:
 	cmp r7, #0
 	ldrne r5, [r8, #0x38]
 	cmpne r5, #0
 	addeq sp, sp, #0x88
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	add r0, sp, #0x48
 	add r1, sp, #0x54
 	add r2, sp, #0x30
@@ -9366,11 +9366,11 @@ _02108760:
 	mov r2, r0
 	bl func_01ff9bc4
 	add sp, sp, #0x88
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _021087b4:
 	cmp r0, #0
-	ldrne sb, [sb, #0x38]
-	cmpne sb, #0
+	ldrne r9, [r9, #0x38]
+	cmpne r9, #0
 	beq _02108800
 	add r0, sp, #0x54
 	add r1, sp, #0x48
@@ -9378,9 +9378,9 @@ _021087b4:
 	bl func_01ff9bf8
 	add r0, r4, r4, lsr #31
 	mov r1, r0, asr #0x1
-	cmp sb, #0
-	cmpgt r1, sb
-	movgt r1, sb
+	cmp r9, #0
+	cmpgt r1, r9
+	movgt r1, r9
 	add r0, sp, #0x24
 	bl func_0202d95c
 	add r0, r5, #0x2c
@@ -9392,7 +9392,7 @@ _02108800:
 	ldrne r5, [r8, #0x38]
 	cmpne r5, #0
 	addeq sp, sp, #0x88
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	add r0, sp, #0x48
 	add r1, sp, #0x54
 	add r2, sp, #0x18
@@ -9410,7 +9410,7 @@ _02108800:
 	bl func_01ff9bc4
 _02108850:
 	add sp, sp, #0x88
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	arm_func_end func_ov05_021084f4
 
 	.global func_ov05_02108858
@@ -12179,7 +12179,7 @@ _0210ad84: .word 0x000004cd
 	.global func_ov05_0210ad88
 	arm_func_start func_ov05_0210ad88
 func_ov05_0210ad88: ; 0x0210ad88
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x100
 	mov r5, r0
 	bl _ZN13LinkStateBase18func_ov00_020a8d40Ev
@@ -12209,7 +12209,7 @@ _0210ade0:
 	mov r0, r5
 	bl _ZN13LinkStateBase15ChangeLinkStateEi
 	add sp, sp, #0x100
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0210ae00:
 	ldr r0, [r5, #0xc]
 	cmp r0, #0
@@ -12344,10 +12344,10 @@ _0210ae98:
 	ldrsh r6, [r1, r0]
 	mov r0, #0
 	mov r3, lr, lsl #0xc
-	umull sb, r8, r7, r3
+	umull r9, r8, r7, r3
 	mla r8, r7, lr, r8
 	mov r11, r7, asr #0x1f
-	adds r7, sb, #0x800
+	adds r7, r9, #0x800
 	mla r8, r11, r3, r8
 	ldr r10, [sp, #0x28]
 	adc r3, r8, #0
@@ -12454,7 +12454,7 @@ _0210ae98:
 	str r2, [r5, #4]
 	bl _ZN13LinkStateBase15ChangeLinkStateEi
 	add sp, sp, #0x100
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0210b1c0:
 	mov r0, #0x1000
 	rsb r0, r0, #0
@@ -12476,7 +12476,7 @@ _0210b1c0:
 	str r2, [r5, #4]
 	bl _ZN13LinkStateBase15ChangeLinkStateEi
 	add sp, sp, #0x100
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0210b214:
 	ldr r1, _0210b2a0 ; =data_ov05_02112894
 	mov r0, r5
@@ -12499,7 +12499,7 @@ _0210b244:
 	mov r0, r5
 	bl _ZN13LinkStateBase15ChangeLinkStateEi
 	add sp, sp, #0x100
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0210b264:
 	mov r0, r5
 	mov r1, r4
@@ -12507,7 +12507,7 @@ _0210b264:
 	add r0, r5, #0x24
 	bl func_0203516c
 	add sp, sp, #0x100
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov05_0210ad88
 _0210b280: .word data_027e0fe4
@@ -13459,7 +13459,7 @@ _0210bf4c: .word 0x00000155
 	.global func_ov05_0210bf50
 	arm_func_start func_ov05_0210bf50
 func_ov05_0210bf50: ; 0x0210bf50
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x14
 	mov r4, r0
 	bl _ZN13LinkStateBase14GetPlayerAngleEv
@@ -13503,7 +13503,7 @@ func_ov05_0210bf50: ; 0x0210bf50
 	mov r1, #2
 	bl _ZN13LinkStateBase15ChangeLinkStateEi
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _0210c004:
 	mov r0, #1
 	bl func_01fffcd8
@@ -13519,14 +13519,14 @@ _0210c004:
 	mov r0, r4
 	bl _ZN13LinkStateBase15ChangeLinkStateEi
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _0210c040:
 	ldr r0, _0210c200 ; =data_027e0fb8
 	ldr r0, [r0]
 	bl _ZN13PlayerControl18func_ov00_020b034cEv
 	cmp r0, #0xcd
 	addle sp, sp, #0x14
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	ldr r1, _0210c200 ; =data_027e0fb8
 	mov r0, r4
 	ldr r6, [r1]
@@ -13589,9 +13589,9 @@ _0210c040:
 	adc r5, r7, #0
 	mla ip, r2, r1, ip
 	adds r2, lr, #0x800
-	ldr sb, [r0]
+	ldr r9, [r0]
 	orr r8, r8, r5, lsl #20
-	add r5, sb, r8
+	add r5, r9, r8
 	str r5, [r0]
 	adc r1, ip, #0
 	mov r2, r2, lsr #0xc
@@ -13607,14 +13607,14 @@ _0210c040:
 	mov r1, #0
 	bl _ZN13LinkStateBase15ChangeLinkStateEi
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _0210c19c:
 	ldr r0, _0210c200 ; =data_027e0fb8
 	ldr r0, [r0]
 	bl _ZN13PlayerControl18func_ov00_020b13c4Ev
 	cmp r0, #0
 	addeq sp, sp, #0x14
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	mov r0, r4
 	bl _ZN13LinkStateBase14GetPlayerAngleEv
 	mov r5, r0
@@ -13633,7 +13633,7 @@ _0210c19c:
 	mov r1, #0
 	bl _ZN13LinkStateBase15ChangeLinkStateEi
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov05_0210bf50
 _0210c200: .word data_027e0fb8
@@ -14460,20 +14460,20 @@ _0210cd14:
 	.global func_ov05_0210cd58
 	arm_func_start func_ov05_0210cd58
 func_ov05_0210cd58: ; 0x0210cd58
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	ldrb r6, [sp, #0x20]
 	mov r4, r0
 	mov r7, r1
 	mov r5, r2
 	mov r10, r3
 	cmp r6, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	ldr r0, [r4, #0x20]
 	cmp r0, #0
 	beq _0210cd90
 	bl func_ov00_020d3e80
 	movs r10, r0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _0210cd90:
 	ldrb r0, [r4, #3]
 	cmp r0, #0
@@ -14486,33 +14486,33 @@ _0210cda4:
 	ldr r2, [r4, #8]
 	ldr r1, [r1, #0x14]
 	tst r0, #1
-	add sb, r2, r1
+	add r9, r2, r1
 	mov r0, r0, asr #0x1
 	ldr r8, [r4, #0x10]
 	subeq r3, r0, #1
 	movne r3, r0
 	sub r6, r7, r3
-	add r8, sb, r8
-	cmp r6, sb
+	add r8, r9, r8
+	cmp r6, r9
 	sub r8, r8, #1
 	add r7, r7, r0
-	movle r6, sb
+	movle r6, r9
 	cmp r7, r8
 	movge r7, r8
 	ldr r2, [r4, #0xc]
 	ldr r1, [r4, #0x14]
 	cmp r6, r7
-	ldmgtia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmgtia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	add r1, r2, r1
 	sub r8, r5, r3
 	cmp r8, r2
 	sub r1, r1, #1
-	add sb, r5, r0
+	add r9, r5, r0
 	movle r8, r2
-	cmp sb, r1
-	movge sb, r1
-	cmp r8, sb
-	ldmgtia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	cmp r9, r1
+	movge r9, r1
+	cmp r8, r9
+	ldmgtia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	bgt _0210ce9c
 _0210ce28:
 	mov r5, r6
@@ -14547,12 +14547,12 @@ _0210ce84:
 	ble _0210ce34
 _0210ce90:
 	add r8, r8, #1
-	cmp r8, sb
+	cmp r8, r9
 	ble _0210ce28
 _0210ce9c:
 	mov r0, #0
 	strb r0, [r4, #4]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov05_0210cd58
 _0210cea8: .word data_027e0c38
@@ -14560,19 +14560,19 @@ _0210cea8: .word data_027e0c38
 	.global func_ov05_0210ceac
 	arm_func_start func_ov05_0210ceac
 func_ov05_0210ceac: ; 0x0210ceac
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x10
 	ldr r8, [sp, #0x40]
 	mov r7, r1
 	ldr r1, [sp, #0x38]
-	ldr sb, [sp, #0x3c]
+	ldr r9, [sp, #0x3c]
 	mov r4, r0
 	mov r10, r2
 	str r3, [sp, #4]
 	cmp r8, #0
 	str r1, [sp, #0x38]
 	addeq sp, sp, #0x10
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	mov r1, r3
 	subs r6, r1, r7
 	ldr r1, [sp, #0x38]
@@ -14581,11 +14581,11 @@ func_ov05_0210ceac: ; 0x0210ceac
 	bne _0210cf14
 	ldr r2, [sp, #0x38]
 	mov r1, r3
-	mov r3, sb
+	mov r3, r9
 	str r8, [sp]
 	bl func_ov05_0210cd58
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0210cf14:
 	cmp r6, #0
 	strge r6, [sp, #8]
@@ -14636,7 +14636,7 @@ _0210cfc0:
 	mov r10, #0
 	cmp r0, #0
 	addlt sp, sp, #0x10
-	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmltia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0210cfd4:
 	ldr r0, [r4, #0x20]
 	cmp r0, #0
@@ -14649,7 +14649,7 @@ _0210cff0:
 	add r2, r5, #0x800
 	mov r0, r4
 	mov r1, r7
-	mov r3, sb
+	mov r3, r9
 	mov r2, r2, asr #0xc
 	str r8, [sp]
 	bl func_ov05_0210cd58
@@ -14660,7 +14660,7 @@ _0210cff0:
 	add r5, r5, r6
 	ble _0210cfd4
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0210d02c:
 	mov r0, r6, lsl #0xc
 	mov r1, r5, lsl #0xc
@@ -14687,7 +14687,7 @@ _0210d07c:
 	cmp r11, #0
 	mov r7, #0
 	addlt sp, sp, #0x10
-	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmltia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0210d08c:
 	ldr r0, [r4, #0x20]
 	cmp r0, #0
@@ -14700,7 +14700,7 @@ _0210d0a8:
 	add r1, r5, #0x800
 	mov r0, r4
 	mov r2, r10
-	mov r3, sb
+	mov r3, r9
 	mov r1, r1, asr #0xc
 	str r8, [sp]
 	bl func_ov05_0210cd58
@@ -14711,13 +14711,13 @@ _0210d0a8:
 	add r10, r10, r0
 	ble _0210d08c
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	arm_func_end func_ov05_0210ceac
 
 	.global func_ov05_0210d0e4
 	arm_func_start func_ov05_0210d0e4
 func_ov05_0210d0e4: ; 0x0210d0e4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0xc
 	ldr r5, [sp, #0x30]
 	ldr r4, [sp, #0x34]
@@ -14726,14 +14726,14 @@ func_ov05_0210d0e4: ; 0x0210d0e4
 	mov r7, r1
 	mov r6, r3
 	addne sp, sp, #0xc
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	ldr r0, _0210d30c ; =data_027e0d78
 	ldrb r0, [r0, #0xc]
 	cmp r0, #0
 	beq _0210d2f4
 	ldrb r1, [r8]
 	ldr r0, _0210d310 ; =data_027e077c
-	mov sb, #0
+	mov r9, #0
 	ldr r0, [r0]
 	cmp r1, #3
 	addls pc, pc, r1, lsl #2
@@ -14745,12 +14745,12 @@ _0210d138: ; jump table
 	b _0210d194 ; case 3
 _0210d148:
 	cmp r0, #0xd
-	moveq sb, #1
+	moveq r9, #1
 	b _0210d19c
 _0210d154:
 	cmp r0, #4
 	cmpne r0, #0x38
-	moveq sb, #1
+	moveq r9, #1
 	beq _0210d19c
 	cmp r0, #9
 	bne _0210d19c
@@ -14759,22 +14759,22 @@ _0210d154:
 	bl func_ov00_020cefdc
 	ldrb r0, [r0, #0x33]
 	cmp r0, #0
-	movne sb, #1
+	movne r9, #1
 	b _0210d19c
 _0210d188:
 	cmp r0, #0x11
-	moveq sb, #1
+	moveq r9, #1
 	b _0210d19c
 _0210d194:
 	cmp r0, #0x3d
-	moveq sb, #1
+	moveq r9, #1
 _0210d19c:
-	cmp sb, #0
+	cmp r9, #0
 	beq _0210d2f4
 	ldr r1, [r8, #8]
-	mov sb, #0
-	mov r2, sb
-	mov r3, sb
+	mov r9, #0
+	mov r2, r9
+	mov r3, r9
 	cmp r1, r5
 	bgt _0210d1cc
 	ldr r0, [r8, #0x10]
@@ -14794,7 +14794,7 @@ _0210d1e0:
 	ldr r0, [r8, #0x14]
 	add r0, r1, r0
 	cmp r4, r0
-	movlt sb, #1
+	movlt r9, #1
 _0210d1fc:
 	ldr r0, _0210d318 ; =data_027e0c38
 	cmp r7, #0
@@ -14813,7 +14813,7 @@ _0210d1fc:
 	cmpeq r1, r0
 	bne _0210d268
 _0210d23c:
-	cmp sb, #0
+	cmp r9, #0
 	beq _0210d28c
 	ldrb r7, [sp, #0x28]
 	mov r0, r8
@@ -14837,7 +14837,7 @@ _0210d268:
 _0210d28c:
 	cmp r2, #0
 	beq _0210d2bc
-	cmp sb, #0
+	cmp r9, #0
 	beq _0210d2b0
 	ldr r3, [sp, #0x2c]
 	ldr r0, _0210d31c ; =data_ov00_020ee6f8
@@ -14858,19 +14858,19 @@ _0210d2cc:
 	ldr r0, [r0]
 	cmp r0, #0
 	addeq sp, sp, #0xc
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	bl func_ov05_0210c980
 	mov r1, #1
 	strb r1, [r0, #0xa9]
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _0210d2f4:
 	mov r0, #0x8000
 	rsb r0, r0, #0
 	str r0, [r8, #0x24]
 	str r0, [r8, #0x28]
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov05_0210d0e4
 _0210d30c: .word data_027e0d78
@@ -14984,7 +14984,7 @@ func_ov05_0210d3d8: ; 0x0210d3d8
 	.global func_ov05_0210d474
 	arm_func_start func_ov05_0210d474
 func_ov05_0210d474: ; 0x0210d474
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x20
 	mov r8, r0
 	ldr r0, [r8]
@@ -15023,22 +15023,22 @@ _0210d4e8:
 	ldr r2, [r5, #0xc]
 	ldr r0, [r7, #0xc]
 	ldr r1, [r5, #4]
-	add sb, r2, r0
+	add r9, r2, r0
 	ldr r0, [r7, #4]
 	subs r0, r1, r0
 	rsbmi r0, r0, #0
-	cmp r0, sb
+	cmp r0, r9
 	bgt _0210d684
 	mov r0, r5
 	mov r1, r7
 	bl func_ov00_020ce2f0
 	movs r10, r0
 	bne _0210d5e8
-	add r0, sb, sb, lsr #31
+	add r0, r9, r9, lsr #31
 	str r0, [sp, #4]
 	ldr r0, _0210d6d4 ; =data_027e0764
 	ldr r10, [r0, #0x10]
-	ldr sb, [r0, #0x14]
+	ldr r9, [r0, #0x14]
 	ldr r3, [r0, #8]
 	ldr r1, [r0]
 	ldr r2, [r0, #0xc]
@@ -15052,7 +15052,7 @@ _0210d4e8:
 	mla ip, r2, r1, ip
 	adds r3, r10, lr
 	ldr r1, _0210d6d4 ; =data_027e0764
-	adc r2, sb, ip
+	adc r2, r9, ip
 	str r3, [r1]
 	str r2, [r1, #4]
 	mov r1, r2, lsr #0x10
@@ -15082,32 +15082,32 @@ _0210d4e8:
 	bl func_01ff9e64
 	b _0210d684
 _0210d5e8:
-	cmp r10, sb
+	cmp r10, r9
 	bge _0210d684
 	mov r0, #0x1000
 	mov r1, r10
 	bl Divide
-	sub r1, sb, r10
+	sub r1, r9, r10
 	add r1, r1, r1, lsr #31
 	mov r1, r1, asr #0x1
 	add r2, r1, r1, lsr #31
 	ldr r3, [r5]
 	ldr r1, [r7]
 	sub r3, r3, r1
-	smull r10, sb, r3, r0
+	smull r10, r9, r3, r0
 	mov r1, #0
 	adds r3, r10, #0x800
 	str r1, [sp, #0xc]
-	adc r1, sb, #0
+	adc r1, r9, #0
 	mov r3, r3, lsr #0xc
 	orr r3, r3, r1, lsl #20
 	str r3, [sp, #8]
 	ldr r3, [r5, #8]
 	ldr r1, [r7, #8]
 	sub r1, r3, r1
-	smull sb, r3, r1, r0
+	smull r9, r3, r1, r0
 	mov r0, #0x800
-	adds r1, sb, r0
+	adds r1, r9, r0
 	mov r0, #0
 	adc r0, r3, r0
 	mov r1, r1, lsr #0xc
@@ -15143,7 +15143,7 @@ _0210d6c4:
 	mov r0, #0
 	str r0, [r8]
 	add sp, sp, #0x20
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov05_0210d474
 _0210d6d4: .word data_027e0764
@@ -15298,10 +15298,10 @@ _0210d890: .word data_027e0f64
 	.global func_ov05_0210d894
 	arm_func_start func_ov05_0210d894
 func_ov05_0210d894: ; 0x0210d894
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	mov r10, r0
 	ldr r0, [r10]
-	mov sb, r1
+	mov r9, r1
 	ldr r5, [r0, #4]
 	mov r8, r2
 	cmp r5, #0
@@ -15337,8 +15337,8 @@ _0210d8ec:
 	bne _0210d944
 _0210d920:
 	ldr r1, [r5, #0x9c]
-	and r0, sb, r1
-	cmp sb, r0
+	and r0, r9, r1
+	cmp r9, r0
 	bne _0210d944
 	tst r1, r8
 	bne _0210d944
@@ -15392,7 +15392,7 @@ _0210d9c8:
 	cmp r0, #1
 	movhi r0, #0
 	strhih r0, [r1, #0x48]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	arm_func_end func_ov05_0210d894
 
 	.global func_ov05_0210d9f0
@@ -15984,9 +15984,9 @@ func_ov05_0210e19c: ; 0x0210e19c
 	.global func_ov05_0210e1b8
 	arm_func_start func_ov05_0210e1b8
 func_ov05_0210e1b8: ; 0x0210e1b8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	mov r8, r1
-	mov sb, r0
+	mov r9, r0
 	mov r4, r2
 	mov r7, r3
 	bl func_ov05_0210e184
@@ -15994,7 +15994,7 @@ func_ov05_0210e1b8: ; 0x0210e1b8
 	mov r0, r8
 	bl func_ov05_0210e19c
 	mov r5, r0
-	add r0, sb, r4
+	add r0, r9, r4
 	bl func_ov05_0210e184
 	mov r4, r0
 	add r0, r8, r7
@@ -16004,16 +16004,16 @@ func_ov05_0210e1b8: ; 0x0210e1b8
 	mov r3, r0
 	mov r0, r6
 	bl func_ov05_0210e398
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	arm_func_end func_ov05_0210e1b8
 
 	.global func_ov05_0210e20c
 	arm_func_start func_ov05_0210e20c
 func_ov05_0210e20c: ; 0x0210e20c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x10
 	mov r8, r1
-	mov sb, r0
+	mov r9, r0
 	mov r4, r2
 	mov r7, r3
 	bl func_ov05_0210e184
@@ -16021,7 +16021,7 @@ func_ov05_0210e20c: ; 0x0210e20c
 	mov r0, r8
 	bl func_ov05_0210e19c
 	mov r5, r0
-	add r0, sb, r4
+	add r0, r9, r4
 	bl func_ov05_0210e184
 	mov r4, r0
 	add r0, r8, r7
@@ -16040,7 +16040,7 @@ func_ov05_0210e20c: ; 0x0210e20c
 	str ip, [sp, #0xc]
 	bl func_ov05_0210e404
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	arm_func_end func_ov05_0210e20c
 
 	.global func_ov05_0210e288
@@ -16071,13 +16071,13 @@ func_ov05_0210e2a4: ; 0x0210e2a4
 	.global func_ov05_0210e2c4
 	arm_func_start func_ov05_0210e2c4
 func_ov05_0210e2c4: ; 0x0210e2c4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x14
 	mov r10, r0
 	ldmia r10, {r5, r6}
 	mov r0, r5
 	ldr r4, [r10, #8]
-	mov sb, r1
+	mov r9, r1
 	mov r8, r2
 	mov r7, r3
 	bl func_ov05_0210e288
@@ -16091,7 +16091,7 @@ func_ov05_0210e2c4: ; 0x0210e2c4
 	mov r4, r0
 	add r0, r6, r1
 	bl func_ov05_0210e2a4
-	str sb, [sp]
+	str r9, [sp]
 	str r8, [sp, #4]
 	mov r2, r4
 	mov r3, r0
@@ -16102,7 +16102,7 @@ func_ov05_0210e2c4: ; 0x0210e2c4
 	str r4, [sp, #0xc]
 	bl func_ov05_0210e404
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	arm_func_end func_ov05_0210e2c4
 
 	.global func_ov05_0210e344
@@ -16167,7 +16167,7 @@ _0210e400: .word 0x04000500
 	.global func_ov05_0210e404
 	arm_func_start func_ov05_0210e404
 func_ov05_0210e404: ; 0x0210e404
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	ldr r4, [sp, #0x2c]
 	ldr r5, [sp, #0x28]
 	mov r4, r4, lsl #0x8
@@ -16181,47 +16181,47 @@ func_ov05_0210e404: ; 0x0210e404
 	mov r3, r3, lsl #0x10
 	mov r2, r2, lsl #0x10
 	mov r4, r4, lsl #0x8
-	ldr sb, [sp, #0x20]
+	ldr r9, [sp, #0x20]
 	mov r7, #1
 	mov r4, r4, asr #0x10
 	mov r8, r4, lsl #0x10
-	mov r4, sb, lsl #0x8
+	mov r4, r9, lsl #0x8
 	mov lr, r1, lsl #0x10
 	mov r1, r4, asr #0x10
-	mov sb, r1, lsl #0x10
+	mov r9, r1, lsl #0x10
 	mov r4, r0, lsl #0x10
 	mov r1, r5, lsr #0x10
 	mov r0, r6, lsr #0x10
 	mov r6, r8, lsr #0x10
-	mov r5, sb, lsr #0x10
+	mov r5, r9, lsr #0x10
 	str r7, [ip]
 	orr r10, r0, r1, lsl #16
-	sub sb, ip, #0x78
+	sub r9, ip, #0x78
 	mov r8, r3, lsr #0x10
 	mov r7, r2, lsr #0x10
 	mov r2, lr, lsr #0x10
 	mov r4, r4, lsr #0x10
-	str r10, [sb]
+	str r10, [r9]
 	orr r3, r7, r8, lsl #16
 	sub r10, ip, #0x74
 	str r3, [r10]
 	mov r3, #0
 	str r3, [r10]
 	orr r0, r0, r6, lsl #16
-	str r0, [sb]
+	str r0, [r9]
 	orr r0, r7, r2, lsl #16
 	sub r7, ip, #0x6c
 	str r0, [r7]
 	orr r0, r5, r6, lsl #16
-	str r0, [sb]
+	str r0, [r9]
 	orr r0, r4, r2, lsl #16
 	str r0, [r7]
 	orr r0, r5, r1, lsl #16
-	str r0, [sb]
+	str r0, [r9]
 	orr r0, r4, r8, lsl #16
 	str r0, [r7]
 	str r3, [ip, #4]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov05_0210e404
 _0210e4e0: .word 0x04000500
@@ -17611,11 +17611,11 @@ _0210f804: .word data_027e0f94
 	.global func_ov05_0210f808
 	arm_func_start func_ov05_0210f808
 func_ov05_0210f808: ; 0x0210f808
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x84
 	mov r10, r0
 	str r3, [sp, #8]
-	mov sb, r1
+	mov r9, r1
 	mov r6, r2
 	mov r4, #0
 	bl _ZN13LinkStateBase14GetPlayerAngleEv
@@ -17643,7 +17643,7 @@ func_ov05_0210f808: ; 0x0210f808
 	mov r5, r0, asr #0x10
 	b _0210f89c
 _0210f884:
-	cmp sb, #0
+	cmp r9, #0
 	ble _0210f89c
 	ldr r0, _021101d8 ; =data_027e0fb8
 	ldr r0, [r0]
@@ -17657,18 +17657,18 @@ _0210f89c:
 	cmp r0, #0
 	beq _0210f8dc
 	mov r0, #0x1800
-	umull r3, r2, sb, r0
+	umull r3, r2, r9, r0
 	mov r1, #0
-	mla r2, sb, r1, r2
-	mov r1, sb, asr #0x1f
+	mla r2, r9, r1, r2
+	mov r1, r9, asr #0x1f
 	adds r3, r3, #0x800
 	mla r2, r1, r0, r2
 	adc r0, r2, #0
-	mov sb, r3, lsr #0xc
-	orr sb, sb, r0, lsl #20
+	mov r9, r3, lsr #0xc
+	orr r9, r9, r0, lsl #20
 _0210f8dc:
 	ldr r0, [r10, #8]
-	mov r1, sb
+	mov r1, r9
 	ldr r2, [r0]
 	str r5, [sp, #0x14]
 	ldr r2, [r2, #0x64]
@@ -17677,7 +17677,7 @@ _0210f8dc:
 	bl _ZN13LinkStateRoll18func_ov00_020aee84Ev
 	bl func_ov05_02106634
 	bl func_ov05_02107fc0
-	cmp sb, #0
+	cmp r9, #0
 	ble _0210fee4
 	ldr r0, [sp, #0xc]
 	cmp r0, #0
@@ -17714,7 +17714,7 @@ _0210f8dc:
 	mov r1, r1, lsl #0x1
 	ldrsh r1, [r0, r1]
 	ldr r0, _021101e0 ; =data_ov05_02112acc
-	smull r2, r1, sb, r1
+	smull r2, r1, r9, r1
 	adds r3, r2, #0x800
 	adc r2, r1, #0
 	mov r1, r3, lsr #0xc
@@ -17722,9 +17722,9 @@ _0210f8dc:
 	orr r1, r1, r2, lsl #20
 	cmp r1, r0
 	ble _0210fc74
-	mul r0, sb, r0
+	mul r0, r9, r0
 	bl func_02002c14
-	mov sb, r0
+	mov r9, r0
 	mov r0, r10
 	bl _ZN13LinkStateBase12GetPlayerVelEv
 	ldr r4, [r0]
@@ -17884,12 +17884,12 @@ _0210fc04:
 	bl _ZN13LinkStateBase18func_ov00_020a8294Eij
 	add sp, sp, #0x84
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0210fc30:
 	ldr r0, _021101d8 ; =data_027e0fb8
 	ldr r0, [r0]
 	bl _ZN13PlayerControl13StopFollowingEv
-	mov sb, #0
+	mov r9, #0
 	b _0210fc74
 _0210fc44:
 	mov r0, r10
@@ -17901,7 +17901,7 @@ _0210fc44:
 	bl _ZN13PlayerControl18func_ov00_020b129cEv
 	mov r3, r0
 	mov r0, r10
-	mov r1, sb
+	mov r1, r9
 	mov r2, r5
 	bl _ZN13LinkStateBase18func_ov00_020a8680Eisb
 _0210fc74:
@@ -17963,7 +17963,7 @@ _0210fd44:
 	bl _ZN13LinkStateBase28Get_PlayerControlData_Unk004Ev
 	ldr r1, [r0]
 	mov r0, r10
-	smull r2, r1, sb, r1
+	smull r2, r1, r9, r1
 	adds r3, r2, #0x800
 	adc r2, r1, #0
 	mov r4, r3, lsr #0xc
@@ -17991,7 +17991,7 @@ _0210fda4:
 	bl func_ov05_0210b96c
 	str r0, [sp, #0x10]
 	add r0, r0, #0x18
-	mov r11, sb, asr #0x1f
+	mov r11, r9, asr #0x1f
 	mov r6, #0
 	str r0, [sp, #0x18]
 _0210fdcc:
@@ -18007,8 +18007,8 @@ _0210fdcc:
 	add r0, r0, r1, lsl #2
 	ldrsh r1, [r0, #2]
 	mov r0, r1, asr #0x1f
-	umull r3, r2, sb, r1
-	mla r2, sb, r0, r2
+	umull r3, r2, r9, r1
+	mla r2, r9, r0, r2
 	mla r2, r11, r1, r2
 	mov r0, #0x800
 	adds r1, r3, r0
@@ -18061,7 +18061,7 @@ _0210fe90:
 	bl _ZN13LinkStateBase15ChangeLinkStateEi
 	add sp, sp, #0x84
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0210fed4:
 	add r6, r6, #1
 	cmp r6, #2
@@ -18168,7 +18168,7 @@ _02110020:
 	bl func_ov05_02110bb4
 	b _0211016c
 _02110054:
-	cmp sb, #0
+	cmp r9, #0
 	ldreq r0, [sp, #8]
 	mov r6, #0
 	cmpeq r0, #0
@@ -18273,7 +18273,7 @@ _021101bc:
 _021101cc:
 	mov r0, r4
 	add sp, sp, #0x84
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov05_0210f808
 _021101d8: .word data_027e0fb8
@@ -18310,7 +18310,7 @@ func_ov05_02110224: ; 0x02110224
 	.global func_ov05_02110228
 	arm_func_start func_ov05_02110228
 func_ov05_02110228: ; 0x02110228
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	ldr r4, _02110580 ; =data_ov05_02112acc
 	mov r8, r1
 	ldr r1, [r4, #0x20]
@@ -18338,14 +18338,14 @@ _02110264:
 	mov r1, r0, asr #0x1f
 	mov r3, r1, lsl #0xb
 	mov r2, #0x800
-	adds sb, r2, r0, lsl #11
+	adds r9, r2, r0, lsl #11
 	orr r3, r3, r0, lsr #21
 	adc r3, r3, #0
-	mov sb, sb, lsr #0xc
-	orr sb, sb, r3, lsl #20
-	rsb r3, sb, #0x1000
-	smull sb, r3, r6, r3
-	adds r6, sb, #0x800
+	mov r9, r9, lsr #0xc
+	orr r9, r9, r3, lsl #20
+	rsb r3, r9, #0x1000
+	smull r9, r3, r6, r3
+	adds r6, r9, #0x800
 	mov r1, r1, lsl #0xa
 	adc r3, r3, #0
 	adds r2, r2, r0, lsl #10
@@ -18374,11 +18374,11 @@ _021102dc:
 	mov r1, r4
 	mov r2, r7
 	adc r6, r6, #0
-	mov sb, r8, lsr #0xc
-	orr sb, sb, r6, lsl #20
+	mov r9, r8, lsr #0xc
+	orr r9, r9, r6, lsl #20
 	bl _ZN13LinkStateBase6TurnToEsii
 	ldr r0, [r5, #8]
-	mov r6, sb
+	mov r6, r9
 	ldr r1, [r0]
 	ldr r1, [r1, #0x5c]
 	blx r1
@@ -18492,7 +18492,7 @@ _021104b4:
 	movs r0, r0, asr #0x3
 	rsbmi r0, r0, #0
 	rsb r0, r0, #0x1000
-	smull r1, r0, sb, r0
+	smull r1, r0, r9, r0
 	adds r1, r1, #0x800
 	adc r3, r0, #0
 	mov r2, r1, lsr #0xc
@@ -18500,7 +18500,7 @@ _021104b4:
 	mov r1, r4
 	orr r2, r2, r3, lsl #20
 	bl _ZN13LinkStateBase12ApplyImpulseEii
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _021104fc:
 	mov r0, r5
 	bl _ZN13LinkStateBase28Get_PlayerControlData_Unk120Ev
@@ -18510,7 +18510,7 @@ _021104fc:
 	mov r1, #0
 	bl _ZN13LinkStateBase18func_ov00_020a8b3cEi
 	cmp r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _02110520:
 	ldrb r0, [sp, #0x24]
 	cmp r0, #0
@@ -18520,11 +18520,11 @@ _02110520:
 	bl _ZN13LinkStateBase18func_ov00_020a8a90Ei
 	ldrb r0, [sp, #0x20]
 	cmp r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	ldr r1, _02110584 ; =data_ov00_020e5694
 	mov r0, r5
 	bl _ZN13LinkStateBase18func_ov00_020a8ab0Ei
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _02110554:
 	ldrb r0, [sp, #0x20]
 	cmp r0, #0
@@ -18532,12 +18532,12 @@ _02110554:
 	ldr r1, _02110584 ; =data_ov00_020e5694
 	mov r0, r5
 	bl _ZN13LinkStateBase18func_ov00_020a8a90Ei
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _02110570:
 	mov r0, r5
 	mov r1, #1
 	bl func_ov05_0211058c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov05_02110228
 _02110580: .word data_ov05_02112acc
@@ -19621,7 +19621,7 @@ func_ov05_021113d0: ; 0x021113d0
 	.global func_ov05_021113dc
 	arm_func_start func_ov05_021113dc
 func_ov05_021113dc: ; 0x021113dc
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #0x58
 	mov r5, r0
 	bl _ZN13LinkStateBase12GetGrabActorEv
@@ -19635,12 +19635,12 @@ func_ov05_021113dc: ; 0x021113dc
 	bl _ZN17LinkStateInteract18func_ov00_020ab770EP5Vec3p
 	movs r8, r0
 	cmpeq r7, #0
-	moveq sb, #0
+	moveq r9, #0
 	mov r0, #5
-	movne sb, #1
+	movne r9, #1
 	bl func_01fffcd8
 	ldr r2, [r0]
-	mov r1, sb
+	mov r1, r9
 	ldr r2, [r2, #0x20]
 	blx r2
 	cmp r0, #0
@@ -19649,7 +19649,7 @@ func_ov05_021113dc: ; 0x021113dc
 	mov r1, #5
 	bl _ZN13LinkStateBase15ChangeLinkStateEi
 	add sp, sp, #0x58
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _02111450:
 	ldr r0, _02111a5c ; =data_027e0f74
 	ldr r0, [r0]
@@ -19664,7 +19664,7 @@ _02111450:
 	mov r0, #2
 	bl func_01fffcd8
 	ldr r2, [r0]
-	mov r1, sb
+	mov r1, r9
 	ldr r2, [r2, #0x20]
 	blx r2
 	cmp r0, #0
@@ -19673,12 +19673,12 @@ _02111450:
 	mov r1, #2
 	bl _ZN13LinkStateBase15ChangeLinkStateEi
 	add sp, sp, #0x58
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _021114ac:
 	mov r0, #3
 	bl func_01fffcd8
 	ldr r2, [r0]
-	mov r1, sb
+	mov r1, r9
 	ldr r2, [r2, #0x20]
 	blx r2
 	cmp r0, #0
@@ -19687,12 +19687,12 @@ _021114ac:
 	mov r1, #3
 	bl _ZN13LinkStateBase15ChangeLinkStateEi
 	add sp, sp, #0x58
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _021114e0:
 	mov r0, #4
 	bl func_01fffcd8
 	ldr r2, [r0]
-	mov r1, sb
+	mov r1, r9
 	ldr r2, [r2, #0x20]
 	blx r2
 	cmp r0, #0
@@ -19701,12 +19701,12 @@ _021114e0:
 	mov r1, #4
 	bl _ZN13LinkStateBase15ChangeLinkStateEi
 	add sp, sp, #0x58
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _02111514:
 	mov r0, #1
 	bl func_01fffcd8
 	ldr r2, [r0]
-	mov r1, sb
+	mov r1, r9
 	ldr r2, [r2, #0x20]
 	blx r2
 	cmp r0, #0
@@ -19715,7 +19715,7 @@ _02111514:
 	mov r1, #1
 	bl _ZN13LinkStateBase15ChangeLinkStateEi
 	add sp, sp, #0x58
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _02111548:
 	cmp r8, #2
 	cmpne r7, #8
@@ -19813,7 +19813,7 @@ _021116a4:
 	ldrb r0, [r5, #0x16]
 	cmp r0, #1
 	beq _02111960
-	cmp sb, #0
+	cmp r9, #0
 	beq _02111744
 	add r2, sp, #0x40
 	mov r1, #0
@@ -19903,11 +19903,11 @@ _02111744:
 	mov r7, r0, lsl #0xa
 	mov r0, #0x800
 	add r2, r3, #0x48
-	add sb, sp, #0xc
+	add r9, sp, #0xc
 	adds r8, r0, r1, lsl #10
 	orr r7, r7, r1, lsr #22
 	ldmia r2, {r0, r1, r2}
-	stmia sb, {r0, r1, r2}
+	stmia r9, {r0, r1, r2}
 	add r0, r3, #0x100
 	adc r1, r7, #0
 	mov r2, r8, lsr #0xc
@@ -20051,7 +20051,7 @@ _02111a18:
 	str r3, [sp, #8]
 	bl _ZN13LinkStateBase23PlayerLinkBase_vfunc_58Ev
 	add sp, sp, #0x58
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _02111a3c:
 	mov r0, r5
 	bl _ZN13LinkStateBase15GetGrabActorRefEv
@@ -20060,7 +20060,7 @@ _02111a3c:
 	mov r1, #1
 	bl _ZN13LinkStateBase23PlayerLinkBase_vfunc_58Ev
 	add sp, sp, #0x58
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov05_021113dc
 _02111a5c: .word data_027e0f74
@@ -20230,11 +20230,11 @@ func_ov05_02111c6c: ; 0x02111c6c
 	.global func_ov05_02111c70
 	arm_func_start func_ov05_02111c70
 func_ov05_02111c70: ; 0x02111c70
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x10
 	mov r10, r0
 	ldrb r0, [r10, #5]
-	mov sb, r1
+	mov r9, r1
 	cmp r0, #0
 	bne _02111cac
 	ldr r0, _02111e10 ; =data_027e0f74
@@ -20242,9 +20242,9 @@ func_ov05_02111c70: ; 0x02111c70
 	bl func_ov00_02097738
 	cmp r0, #0
 	bne _02111cac
-	cmp sb, #0
+	cmp r9, #0
 	addne sp, sp, #0x10
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02111cac:
 	ldr r0, _02111e14 ; =data_027e0d38
 	ldr r0, [r0]
@@ -20252,22 +20252,22 @@ _02111cac:
 	cmp r0, #1
 	bne _02111cd8
 	ldr r0, _02111e18 ; =data_027e0f68
-	mov r1, sb
+	mov r1, r9
 	ldr r0, [r0]
 	bl func_ov05_0210157c
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02111cd8:
 	ldr r1, _02111e1c ; =data_027e0f64
 	add r0, sp, #0xc
 	ldr r1, [r1]
-	add r1, r1, sb, lsl #2
+	add r1, r1, r9, lsl #2
 	ldr r1, [r1, #4]
 	bl func_ov00_02088130
 	ldr r1, _02111e1c ; =data_027e0f64
 	add r0, sp, #0xa
 	ldr r1, [r1]
-	add r1, r1, sb, lsl #2
+	add r1, r1, r9, lsl #2
 	ldr r1, [r1, #4]
 	bl func_ov00_02088144
 	ldrb r0, [sp, #0xd]
@@ -20322,7 +20322,7 @@ _02111d90:
 	beq _02111ddc
 	mov r0, r4
 	ldr r2, [r0]
-	mov r1, sb
+	mov r1, r9
 	ldr r2, [r2, #0x14]
 	blx r2
 _02111ddc:
@@ -20336,11 +20336,11 @@ _02111de8:
 	ble _02111d7c
 _02111df8:
 	ldr r0, _02111e18 ; =data_027e0f68
-	mov r1, sb
+	mov r1, r9
 	ldr r0, [r0]
 	bl func_ov05_02101530
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov05_02111c70
 _02111e10: .word data_027e0f74
@@ -20472,11 +20472,11 @@ _02111fb4: .word data_027e0d3c
 	.global func_ov05_02111fb8
 	arm_func_start func_ov05_02111fb8
 func_ov05_02111fb8: ; 0x02111fb8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	mov r4, r0
 	ldrb r0, [r4, #0x14]
 	cmp r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	ldrh r0, [r4, #0x16]
 	mov r10, #0
 	cmp r0, #0
@@ -20493,7 +20493,7 @@ _02111fe0:
 	and r6, r0, #0x7c00
 	mov r8, r7, asr #0x5
 	mov r2, r2, asr #0xa
-	mov sb, r6, asr #0xa
+	mov r9, r6, asr #0xa
 	mov r3, r3, asr #0x5
 	mov r1, r1, lsl #0xc
 	and r5, r5, #0x1f
@@ -20502,7 +20502,7 @@ _02111fe0:
 	and r6, r3, #0xff
 	and r7, r2, #0xff
 	and r8, r8, #0xff
-	and sb, sb, #0xff
+	and r9, r9, #0xff
 	movle r5, r0
 	ble _02112050
 	sub r0, r0, r5
@@ -20527,9 +20527,9 @@ _0211207c:
 	ldrh r0, [r4, #0x16]
 	mov r1, r0, lsl #0xc
 	cmp r1, #0x1000
-	movle r7, sb
+	movle r7, r9
 	ble _021120a8
-	sub r0, sb, r7
+	sub r0, r9, r7
 	mov r0, r0, lsl #0xc
 	bl Divide
 	add r0, r0, #0x800
@@ -20553,7 +20553,7 @@ _021120c8:
 	and r2, r6, #0x7c00
 	and r8, r0, #0x3e0
 	and r7, r0, #0x7c00
-	mov sb, r8, asr #0x5
+	mov r9, r8, asr #0x5
 	mov r2, r2, asr #0xa
 	mov r10, r7, asr #0xa
 	mov r3, r3, asr #0x5
@@ -20563,7 +20563,7 @@ _021120c8:
 	cmp r1, #0x1000
 	and r7, r3, #0xff
 	and r8, r2, #0xff
-	and sb, sb, #0xff
+	and r9, r9, #0xff
 	and r10, r10, #0xff
 	movle r6, r0
 	ble _02112138
@@ -20577,9 +20577,9 @@ _02112138:
 	ldrh r0, [r4, #0x16]
 	mov r1, r0, lsl #0xc
 	cmp r1, #0x1000
-	movle r7, sb
+	movle r7, r9
 	ble _02112164
-	sub r0, sb, r7
+	sub r0, r9, r7
 	mov r0, r0, lsl #0xc
 	bl Divide
 	add r0, r0, #0x800
@@ -20612,7 +20612,7 @@ _02112190:
 	cmp r0, #0
 	moveq r0, #0
 	streqb r0, [r4, #0x14]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	arm_func_end func_ov05_02111fb8
 
 	.global func_ov05_021121cc

--- a/asm/ov06.s
+++ b/asm/ov06.s
@@ -2200,7 +2200,7 @@ _02102560: .word 0x04001014
 	.global func_ov06_02102564
 	arm_func_start func_ov06_02102564
 func_ov06_02102564: ; 0x02102564
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	mov r4, r0
 	ldr r0, [r4, #0x178]
 	mov r7, #0
@@ -2212,12 +2212,12 @@ func_ov06_02102564: ; 0x02102564
 	ldr r6, _021026b4 ; =data_027e0d78
 	cmp r0, #1
 	movne r0, r7
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	mov sb, r4
-	add sl, r4, #0x184
+	add r10, r4, #0x184
 	mov r5, r7
 _021025a4:
-	mov r0, sl
+	mov r0, r10
 	add r1, sb, #0x100
 	ldr ip, [r0]
 	ldrh r8, [r1, #0x8e]
@@ -2233,16 +2233,16 @@ _021025a4:
 	cmp r0, #0
 	strne r7, [r4, #0x230]
 	movne r0, #1
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	add r7, r7, #1
 	cmp r7, #7
 	add sb, sb, #0x18
-	add sl, sl, #0x18
+	add r10, r10, #0x18
 	blt _021025a4
 	ldrb r0, [r4, #0x23b]
 	cmp r0, #0
 	movne r0, #0
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	ldr r1, [r4, #0x178]
 	ldr sb, [r6, #0x1c]
 	ldr r0, [r1, #0xc]
@@ -2274,7 +2274,7 @@ _02102634:
 	ldr r2, [r2, #4]
 	blx r2
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _02102688:
 	ldr r0, [r4, #0x178]
 	add r5, r5, #1
@@ -2287,7 +2287,7 @@ _021026a0:
 	mov r0, #0
 	ldrh r2, [r1, #6]
 	strh r2, [r1, #0xa]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov06_02102564
 _021026b4: .word data_027e0d78
@@ -2780,10 +2780,10 @@ _02102d60: .word 0x00000103
 	.global func_ov06_02102d64
 	arm_func_start func_ov06_02102d64
 func_ov06_02102d64: ; 0x02102d64
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x10
-	mov sl, r0
-	add r0, sl, #0x44
+	mov r10, r0
+	add r0, r10, #0x44
 	ldr r2, [r0]
 	mov r1, #0
 	ldr r2, [r2, #0x10]
@@ -2791,7 +2791,7 @@ func_ov06_02102d64: ; 0x02102d64
 	mov r0, #0
 	str r0, [sp, #0xc]
 	str r0, [sp, #8]
-	ldr r1, [sl, #0x178]
+	ldr r1, [r10, #0x178]
 	ldr r0, [r1, #0x20]
 	ldr r7, [r1, #0x1c]
 	add r0, r0, #1
@@ -2804,19 +2804,19 @@ func_ov06_02102d64: ; 0x02102d64
 _02102db8:
 	str r6, [sp]
 	str r6, [sp, #4]
-	ldr r0, [sl, #0x234]
+	ldr r0, [r10, #0x234]
 	mov r1, r7
 	mov r2, r11
 	add r3, sp, #8
 	bl func_020347b0
-	ldr r0, [sl, #0x178]
+	ldr r0, [r10, #0x178]
 	ldr r2, [r0]
 	ldr r1, [r0, #0x1c]
 	ldr r2, [r2, #0x10]
 	sub r1, r7, r1
 	blx r2
 	mov r8, r0
-	ldr sb, [sl, #0x70]
+	ldr sb, [r10, #0x70]
 	mov r1, r8
 	mov r0, sb
 	bl func_02023ea4
@@ -2833,24 +2833,24 @@ _02102db8:
 	ldr r8, [sp, #0xc]
 	add r1, r1, r1, lsr #31
 	sub r1, r8, r1, asr #1
-	add r0, sl, #0x44
+	add r0, r10, #0x44
 	ldr r8, [r0]
 	sub r2, r2, #7
 	ldr r8, [r8, #0xc]
 	and r1, r1, #0xff
 	and r2, r2, #0xff
 	blx r8
-	ldr r0, [sl, #0x178]
+	ldr r0, [r10, #0x178]
 	add r7, r7, #1
 	ldr r0, [r0, #0x20]
 	add r0, r0, #1
 	cmp r7, r0
 	blt _02102db8
 _02102e68:
-	mov r0, sl
+	mov r0, r10
 	bl func_ov06_02101ee8
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov06_02102d64
 _02102e78: .word 0x0000ffff

--- a/asm/ov06.s
+++ b/asm/ov06.s
@@ -2780,7 +2780,7 @@ _02102d60: .word 0x00000103
 	.global func_ov06_02102d64
 	arm_func_start func_ov06_02102d64
 func_ov06_02102d64: ; 0x02102d64
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x10
 	mov sl, r0
 	add r0, sl, #0x44
@@ -2800,13 +2800,13 @@ func_ov06_02102d64: ; 0x02102d64
 	ldr r4, _02102e78 ; =0x0000ffff
 	mov r5, #6
 	mov r6, #4
-	add fp, sp, #0xc
+	add r11, sp, #0xc
 _02102db8:
 	str r6, [sp]
 	str r6, [sp, #4]
 	ldr r0, [sl, #0x234]
 	mov r1, r7
-	mov r2, fp
+	mov r2, r11
 	add r3, sp, #8
 	bl func_020347b0
 	ldr r0, [sl, #0x178]
@@ -2850,7 +2850,7 @@ _02102e68:
 	mov r0, sl
 	bl func_ov06_02101ee8
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov06_02102d64
 _02102e78: .word 0x0000ffff

--- a/asm/ov06.s
+++ b/asm/ov06.s
@@ -1695,7 +1695,7 @@ _02101ee0:
 	.global func_ov06_02101ee8
 	arm_func_start func_ov06_02101ee8
 func_ov06_02101ee8: ; 0x02101ee8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	mov r8, r0
 	ldr r0, [r8]
 	mov r1, #0
@@ -1708,7 +1708,7 @@ func_ov06_02101ee8: ; 0x02101ee8
 	cmp r0, #0
 	ble _02101f9c
 	mvn r4, #0
-	add sb, r4, #0x10000
+	add r9, r4, #0x10000
 _02101f20:
 	ldr r1, [r8]
 	add r0, r8, r7, lsl #1
@@ -1717,7 +1717,7 @@ _02101f20:
 	mov r0, r6
 	bl func_02023ea4
 	mov r1, r0
-	cmp r1, sb
+	cmp r1, r9
 	ldreq r0, [r6]
 	ldreqh r1, [r0, #2]
 	mov r0, r6
@@ -1744,7 +1744,7 @@ _02101f20:
 _02101f9c:
 	mov r0, #0
 	strb r0, [r8, #0x41]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	arm_func_end func_ov06_02101ee8
 
 	.global func_ov06_02101fa8
@@ -2083,7 +2083,7 @@ _021023c4:
 	.global func_ov06_021023d8
 	arm_func_start func_ov06_021023d8
 func_ov06_021023d8: ; 0x021023d8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x24
 	mov r5, r0
 	ldr r1, [r5, #0x22c]
@@ -2095,7 +2095,7 @@ func_ov06_021023d8: ; 0x021023d8
 	mov r0, #1
 	mov r8, #0
 	strb r0, [sp, #0xe]
-	add sb, r5, #0x184
+	add r9, r5, #0x184
 	mov r7, r8
 	add r6, sp, #4
 _02102414:
@@ -2106,7 +2106,7 @@ _02102414:
 	cmp r0, #0
 	beq _02102444
 _0210242c:
-	mov r0, sb
+	mov r0, r9
 	mov r1, r7
 	mov r2, r4
 	mov r3, r6
@@ -2115,7 +2115,7 @@ _0210242c:
 _02102444:
 	add r8, r8, #1
 	cmp r8, #7
-	add sb, sb, #0x18
+	add r9, r9, #0x18
 	blt _02102414
 	ldr r0, [r5, #0x178]
 	add r3, sp, #4
@@ -2156,7 +2156,7 @@ _02102490:
 	str r4, [sp]
 	bl func_ov06_02101fa8
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov06_021023d8
 _021024ec: .word 0x00000102
@@ -2200,7 +2200,7 @@ _02102560: .word 0x04001014
 	.global func_ov06_02102564
 	arm_func_start func_ov06_02102564
 func_ov06_02102564: ; 0x02102564
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	mov r4, r0
 	ldr r0, [r4, #0x178]
 	mov r7, #0
@@ -2212,13 +2212,13 @@ func_ov06_02102564: ; 0x02102564
 	ldr r6, _021026b4 ; =data_027e0d78
 	cmp r0, #1
 	movne r0, r7
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
-	mov sb, r4
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
+	mov r9, r4
 	add r10, r4, #0x184
 	mov r5, r7
 _021025a4:
 	mov r0, r10
-	add r1, sb, #0x100
+	add r1, r9, #0x100
 	ldr ip, [r0]
 	ldrh r8, [r1, #0x8e]
 	ldr ip, [ip]
@@ -2233,18 +2233,18 @@ _021025a4:
 	cmp r0, #0
 	strne r7, [r4, #0x230]
 	movne r0, #1
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	add r7, r7, #1
 	cmp r7, #7
-	add sb, sb, #0x18
+	add r9, r9, #0x18
 	add r10, r10, #0x18
 	blt _021025a4
 	ldrb r0, [r4, #0x23b]
 	cmp r0, #0
 	movne r0, #0
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	ldr r1, [r4, #0x178]
-	ldr sb, [r6, #0x1c]
+	ldr r9, [r6, #0x1c]
 	ldr r0, [r1, #0xc]
 	ldr r5, [r1, #8]
 	add r0, r0, #1
@@ -2263,7 +2263,7 @@ _02102634:
 	beq _02102688
 	ldr r0, [r4, #0x234]
 	mov r1, r5
-	mov r2, sb
+	mov r2, r9
 	mov r3, r8
 	bl func_02034b90
 	cmp r0, #0
@@ -2274,7 +2274,7 @@ _02102634:
 	ldr r2, [r2, #4]
 	blx r2
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _02102688:
 	ldr r0, [r4, #0x178]
 	add r5, r5, #1
@@ -2287,7 +2287,7 @@ _021026a0:
 	mov r0, #0
 	ldrh r2, [r1, #6]
 	strh r2, [r1, #0xa]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov06_02102564
 _021026b4: .word data_027e0d78
@@ -2780,7 +2780,7 @@ _02102d60: .word 0x00000103
 	.global func_ov06_02102d64
 	arm_func_start func_ov06_02102d64
 func_ov06_02102d64: ; 0x02102d64
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x10
 	mov r10, r0
 	add r0, r10, #0x44
@@ -2816,15 +2816,15 @@ _02102db8:
 	sub r1, r7, r1
 	blx r2
 	mov r8, r0
-	ldr sb, [r10, #0x70]
+	ldr r9, [r10, #0x70]
 	mov r1, r8
-	mov r0, sb
+	mov r0, r9
 	bl func_02023ea4
 	mov r1, r0
 	cmp r1, r4
-	ldreq r0, [sb]
+	ldreq r0, [r9]
 	ldreqh r1, [r0, #2]
-	mov r0, sb
+	mov r0, r9
 	bl func_02023eec
 	str r5, [sp]
 	ldrsb r1, [r0, #2]
@@ -2850,7 +2850,7 @@ _02102e68:
 	mov r0, r10
 	bl func_ov06_02101ee8
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov06_02102d64
 _02102e78: .word 0x0000ffff

--- a/asm/ov08.s
+++ b/asm/ov08.s
@@ -771,25 +771,25 @@ func_ov08_021135b8: ; 0x021135b8
 	.global func_ov08_021135bc
 	arm_func_start func_ov08_021135bc
 func_ov08_021135bc: ; 0x021135bc
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #8
-	mov sl, r0
+	mov r10, r0
 	mov r8, #0
 	mov r0, #2
-	str r0, [sl]
+	str r0, [r10]
 	mov r7, #0x2000
 	rsb r7, r7, #0
-	strh r8, [sl, #0xe]
+	strh r8, [r10, #0xe]
 	mov r0, #0x1000
-	strh r0, [sl, #0x10]
+	strh r0, [r10, #0x10]
 	mov sb, r1
-	strh r8, [sl, #0x12]
+	strh r8, [r10, #0x12]
 	mov r5, r7, lsr #0x11
 	mov r6, #1
 	mov r4, r8
 	mov r11, r8
 _02113600:
-	ldr r0, [sl]
+	ldr r0, [r10]
 	cmp r8, r0
 	bge _02113648
 	mov r0, #0x10
@@ -805,23 +805,23 @@ _02113600:
 	str r6, [sp, #4]
 	bl func_ov08_021136c0
 _0211363c:
-	add r1, sl, r8, lsl #2
+	add r1, r10, r8, lsl #2
 	str r0, [r1, #4]
 	b _02113650
 _02113648:
-	add r0, sl, r8, lsl #2
+	add r0, r10, r8, lsl #2
 	str r4, [r0, #4]
 _02113650:
-	add r0, sl, r8
+	add r0, r10, r8
 	add r8, r8, #1
 	strb r11, [r0, #0xc]
 	cmp r8, #2
 	blt _02113600
-	mov r0, sl
+	mov r0, r10
 	bl func_ov00_020a1a3c
-	mov r0, sl
+	mov r0, r10
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	arm_func_end func_ov08_021135bc
 
 	.global func_ov08_02113678

--- a/asm/ov08.s
+++ b/asm/ov08.s
@@ -771,7 +771,7 @@ func_ov08_021135b8: ; 0x021135b8
 	.global func_ov08_021135bc
 	arm_func_start func_ov08_021135bc
 func_ov08_021135bc: ; 0x021135bc
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #8
 	mov r10, r0
 	mov r8, #0
@@ -782,7 +782,7 @@ func_ov08_021135bc: ; 0x021135bc
 	strh r8, [r10, #0xe]
 	mov r0, #0x1000
 	strh r0, [r10, #0x10]
-	mov sb, r1
+	mov r9, r1
 	strh r8, [r10, #0x12]
 	mov r5, r7, lsr #0x11
 	mov r6, #1
@@ -793,7 +793,7 @@ _02113600:
 	cmp r8, r0
 	bge _02113648
 	mov r0, #0x10
-	mov r1, sb
+	mov r1, r9
 	mov r2, #4
 	bl _ZN9SysObjectnwEmPjj
 	cmp r0, #0
@@ -821,7 +821,7 @@ _02113650:
 	bl func_ov00_020a1a3c
 	mov r0, r10
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	arm_func_end func_ov08_021135bc
 
 	.global func_ov08_02113678

--- a/asm/ov08.s
+++ b/asm/ov08.s
@@ -771,7 +771,7 @@ func_ov08_021135b8: ; 0x021135b8
 	.global func_ov08_021135bc
 	arm_func_start func_ov08_021135bc
 func_ov08_021135bc: ; 0x021135bc
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #8
 	mov sl, r0
 	mov r8, #0
@@ -787,7 +787,7 @@ func_ov08_021135bc: ; 0x021135bc
 	mov r5, r7, lsr #0x11
 	mov r6, #1
 	mov r4, r8
-	mov fp, r8
+	mov r11, r8
 _02113600:
 	ldr r0, [sl]
 	cmp r8, r0
@@ -814,14 +814,14 @@ _02113648:
 _02113650:
 	add r0, sl, r8
 	add r8, r8, #1
-	strb fp, [r0, #0xc]
+	strb r11, [r0, #0xc]
 	cmp r8, #2
 	blt _02113600
 	mov r0, sl
 	bl func_ov00_020a1a3c
 	mov r0, sl
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	arm_func_end func_ov08_021135bc
 
 	.global func_ov08_02113678

--- a/asm/ov09.s
+++ b/asm/ov09.s
@@ -4762,20 +4762,20 @@ func_ov09_021152fc: ; 0x021152fc
 	.global func_ov09_0211530c
 	arm_func_start func_ov09_0211530c
 func_ov09_0211530c: ; 0x0211530c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x3c
-	mov sb, r0
-	ldr r0, [sb, #0x1c]
+	mov r9, r0
+	ldr r0, [r9, #0x1c]
 	mov r8, r1
 	ldr r1, [r0, #0x460]
 	mov r7, r2
 	mov r6, r3
 	bl func_ov00_020a9624
 	mov r5, r0
-	ldr r0, [sb, #0x20]
-	ldr r1, [sb, #0x60]
+	ldr r0, [r9, #0x20]
+	ldr r1, [r9, #0x60]
 	bl func_ov00_020a9624
-	ldrh r1, [sb, #0x94]
+	ldrh r1, [r9, #0x94]
 	mov r4, r0
 	ldr r3, _02115404 ; =data_02050f54
 	mov r1, r1, asr #0x4
@@ -4811,7 +4811,7 @@ func_ov09_0211530c: ; 0x0211530c
 	mov r2, r0
 	str r3, [sp, #8]
 	bl func_01ff9bc4
-	ldr r1, [sb, #0xc]
+	ldr r1, [r9, #0xc]
 	add r0, sp, #0xc
 	bl func_01fffbec
 	add r0, sp, #0xc
@@ -4823,7 +4823,7 @@ func_ov09_0211530c: ; 0x0211530c
 	add r0, sp, #0xc
 	bl func_01ff9bc4
 	add sp, sp, #0x3c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov09_0211530c
 _02115404: .word data_02050f54
@@ -5029,7 +5029,7 @@ func_ov09_02115610: ; 0x02115610
 	.global func_ov09_021156a4
 	arm_func_start func_ov09_021156a4
 func_ov09_021156a4: ; 0x021156a4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0xdc
 	mov r5, r0
 	ldr r3, [r5, #0x6c]
@@ -5038,10 +5038,10 @@ func_ov09_021156a4: ; 0x021156a4
 	str r2, [sp, #8]
 	cmp r3, #0
 	addlt sp, sp, #0xdc
-	ldmltia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmltia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	cmp r6, #0
 	addeq sp, sp, #0xdc
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldrb r1, [r5, #0x9a]
 	cmp r1, #0
 	bne _021156e8
@@ -5075,14 +5075,14 @@ _021156e8:
 	add r6, sp, #0x58
 _02115750:
 	ldr r10, [sp, #0xc]
-	add sb, sp, #0x7c
+	add r9, sp, #0x7c
 	ldmia r10!, {r0, r1, r2, r3}
 	stmia sb!, {r0, r1, r2, r3}
 	ldmia r10!, {r0, r1, r2, r3}
 	stmia sb!, {r0, r1, r2, r3}
 	ldmia r10, {r0, r1, r2, r3}
 	mov lr, r11
-	stmia sb, {r0, r1, r2, r3}
+	stmia r9, {r0, r1, r2, r3}
 	ldmia lr!, {r0, r1, r2, r3}
 	add ip, sp, #0x34
 	stmia ip!, {r0, r1, r2, r3}
@@ -5133,13 +5133,13 @@ _02115804:
 	ldrsh r3, [r7, r3]
 	mov r2, r2, asr #0x4
 	mov r2, r2, lsl #0x1
-	smull sb, r3, r1, r3
-	adds sb, sb, #0x800
+	smull r9, r3, r1, r3
+	adds r9, r9, #0x800
 	adc r1, r3, #0
-	mov r3, sb, lsr #0xc
+	mov r3, r9, lsr #0xc
 	orr r3, r3, r1, lsl #20
 	mov r1, r3, lsl #0x10
-	mov sb, r1, asr #0x10
+	mov r9, r1, asr #0x10
 	mov r1, r2, lsl #0x1
 	add r2, r7, r2, lsl #1
 	ldrsh r1, [r7, r1]
@@ -5150,16 +5150,16 @@ _02115804:
 	mov r0, r8
 	mov r2, r1
 	bl func_01ff8e84
-	mov r0, sb, lsl #0x10
+	mov r0, r9, lsl #0x10
 	mov r0, r0, lsr #0x10
 	mov r0, r0, asr #0x4
 	mov r0, r0, lsl #0x1
 	mov r1, r0, lsl #0x1
 	add r0, r7, r0, lsl #1
-	ldrsh sb, [r0, #2]
+	ldrsh r9, [r0, #2]
 	ldrsh r10, [r7, r1]
 	mov r0, r8
-	mov r2, sb
+	mov r2, r9
 	mov r1, r10
 	blx func_01ff8abc
 	add r1, sp, #0x7c
@@ -5187,7 +5187,7 @@ _02115804:
 	mov r2, r1
 	bl func_01ff8690
 	mov r1, r10
-	mov r2, sb
+	mov r2, r9
 	mov r0, r6
 	blx func_01ff8230
 	add r1, sp, #0x34
@@ -5250,7 +5250,7 @@ _021159d0:
 	ldr r0, [r5, #0x54]
 	cmp r0, #0
 	addeq sp, sp, #0xdc
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r1, [r5, #0x58]
 	cmp r1, #0
 	bne _02115a44
@@ -5266,11 +5266,11 @@ _021159d0:
 	ldr r4, [r4, #0x10]
 	blx r4
 	add sp, sp, #0xdc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02115a44:
 	cmp r1, #1
 	addne sp, sp, #0xdc
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r1, [r0]
 	ldr r1, [r1, #8]
 	blx r1
@@ -5289,7 +5289,7 @@ _02115a44:
 	ldr r4, [r4, #0x10]
 	blx r4
 	add sp, sp, #0xdc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov09_021156a4
 _02115a9c: .word data_02050f54
@@ -5360,7 +5360,7 @@ func_ov09_02115b10: ; 0x02115b10
 	.global func_ov09_02115b5c
 	arm_func_start func_ov09_02115b5c
 func_ov09_02115b5c: ; 0x02115b5c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0xc0
 	mov r7, r1
 	ldr r1, [r7, #8]
@@ -5370,11 +5370,11 @@ func_ov09_02115b5c: ; 0x02115b5c
 	mov r8, r0
 	mov r5, #0
 	mvneq r6, #0
-	mvn sb, #0
+	mvn r9, #0
 _02115b88:
 	add r0, r8, r5, lsl #2
 	ldr r0, [r0, #0x458]
-	cmp r0, sb
+	cmp r0, r9
 	bne _02115bb4
 	ldr r0, [r7, #4]
 	mov r1, r4
@@ -5468,10 +5468,10 @@ _02115cdc:
 	ldr r0, [r0, #0x14]
 	cmp r0, #1
 	addne sp, sp, #0xc0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	cmp r6, #1
 	addhi sp, sp, #0xc0
-	ldmhiia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmhiia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	ldr r0, [r7, #4]
 	ldr r0, [r0]
 	and r0, r0, #4
@@ -5480,7 +5480,7 @@ _02115cdc:
 	movne r0, #0
 	cmp r0, #0
 	addne sp, sp, #0xc0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	add r0, sp, #0x30
 	mov r1, #0
 	bl func_0201b1bc
@@ -5500,7 +5500,7 @@ _02115cdc:
 	ldmia r5, {r0, r1, r2, r3}
 	stmia r4, {r0, r1, r2, r3}
 	add sp, sp, #0xc0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov09_02115b5c
 _02115d74: .word data_ov09_0211d9a4
@@ -12746,13 +12746,13 @@ _02119c9c:
 	.global func_ov09_02119cd4
 	arm_func_start func_ov09_02119cd4
 func_ov09_02119cd4: ; 0x02119cd4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x18
 	mov r10, r0
 	ldr r0, [r10, #4]
 	cmp r0, #1
 	addls sp, sp, #0x18
-	ldmlsia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmlsia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r3, _02119f98 ; =0x04000444
 	mov r1, #0
 	ldr r0, _02119f9c ; =0x21230000
@@ -12776,12 +12776,12 @@ func_ov09_02119cd4: ; 0x02119cd4
 	str r0, [r3, #0x28]
 	str r0, [r3, #0x28]
 	ldr r0, [r10, #4]
-	ldrh sb, [r10, #8]
+	ldrh r9, [r10, #8]
 	sub r0, r0, #1
-	cmp sb, r0
+	cmp r9, r0
 	bhs _02119f84
 	mov r0, #0x14
-	mla r7, sb, r0, r10
+	mla r7, r9, r0, r10
 	ldr r0, _02119fa4 ; =data_ov03_02100648
 	ldr r8, [r0]
 _02119d6c:
@@ -12908,8 +12908,8 @@ _02119e98:
 	mov r0, r1, lsr #0x10
 	str r0, [r5]
 	ldr r0, [r10, #4]
-	add sb, sb, #1
-	cmp sb, r0
+	add r9, r9, #1
+	cmp r9, r0
 	add r7, r7, #0x14
 	bhs _02119f68
 	ldr r0, [r7, #4]
@@ -12923,14 +12923,14 @@ _02119f68:
 	str r1, [r0]
 	ldr r0, [r10, #4]
 	sub r0, r0, #1
-	cmp sb, r0
+	cmp r9, r0
 	blo _02119d6c
 _02119f84:
 	ldr r0, _02119fb0 ; =0x04000448
 	mov r1, #1
 	str r1, [r0]
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov09_02119cd4
 _02119f98: .word 0x04000444
@@ -13635,7 +13635,7 @@ func_ov09_0211a604: ; 0x0211a604
 	.global func_ov09_0211a69c
 	arm_func_start func_ov09_0211a69c
 func_ov09_0211a69c: ; 0x0211a69c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	mov r8, r0
 	ldr r0, [r8, #0x8a4]
 	mov r7, r1
@@ -13643,8 +13643,8 @@ func_ov09_0211a69c: ; 0x0211a69c
 	mov r6, r2
 	mov r5, r3
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
-	ldr sb, _0211a748 ; =data_ov03_0210041c
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
+	ldr r9, _0211a748 ; =data_ov03_0210041c
 	mov r4, #0
 	mvn r10, #0
 _0211a6cc:
@@ -13662,7 +13662,7 @@ _0211a6cc:
 	moveq r0, r10
 	cmp r0, #0
 	blt _0211a734
-	ldr r0, [sb, r0, lsl #2]
+	ldr r0, [r9, r0, lsl #2]
 	mov r1, r7
 	bl strcmp
 	cmp r0, #0
@@ -13673,13 +13673,13 @@ _0211a6cc:
 	ldrne r0, [r0, #0x8b0]
 	strne r0, [r1]
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _0211a734:
 	add r4, r4, #1
 	cmp r4, #3
 	blo _0211a6cc
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov09_0211a69c
 _0211a748: .word data_ov03_0210041c
@@ -13687,18 +13687,18 @@ _0211a748: .word data_ov03_0210041c
 	.global func_ov09_0211a74c
 	arm_func_start func_ov09_0211a74c
 func_ov09_0211a74c: ; 0x0211a74c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #8
 	mov r10, r0
 	ldr r0, [r10, #0x8a4]
 	ldr r11, [sp, #0x30]
 	cmp r0, #0
 	str r3, [sp]
-	mov sb, r1
+	mov r9, r1
 	mov r8, r2
 	addeq sp, sp, #8
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	mvn r0, #0
 	mov r6, #0
 	str r0, [sp, #4]
@@ -13724,7 +13724,7 @@ _0211a788:
 	ldr r0, _0211a834 ; =data_ov03_0210041c
 	ldr r5, [r0, r7, lsl #2]
 _0211a7d8:
-	ldr r1, [sb, r4, lsl #2]
+	ldr r1, [r9, r4, lsl #2]
 	mov r0, r5
 	bl strcmp
 	cmp r0, #0
@@ -13737,7 +13737,7 @@ _0211a7d8:
 	strne r0, [r1]
 	ldr r0, _0211a834 ; =data_ov03_0210041c
 	ldr r0, [r0, r7, lsl #2]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0211a810:
 	add r4, r4, #1
 	cmp r4, r8
@@ -13748,7 +13748,7 @@ _0211a81c:
 	blo _0211a788
 	mov r0, #0
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov09_0211a74c
 _0211a834: .word data_ov03_0210041c
@@ -18365,7 +18365,7 @@ func_ov09_0211d174: ; 0x0211d174
 	.global func_ov09_0211d180
 	arm_func_start func_ov09_0211d180
 func_ov09_0211d180: ; 0x0211d180
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #0x9c
 	mov r4, r1
 	ldrsh r7, [r4, #0x1e]
@@ -18377,14 +18377,14 @@ func_ov09_0211d180: ; 0x0211d180
 	ldr r1, _0211d654 ; =0xfffffccd
 	str r2, [sp, #0x94]
 	add r3, r2, r1
-	ldr sb, [r4, #8]
+	ldr r9, [r4, #8]
 	ldr r1, _0211d658 ; =data_027e0e60
 	mov r5, r0
 	ldr r0, [r1]
 	add r1, sp, #0x90
 	mov r2, r6
 	str r3, [sp, #0x94]
-	str sb, [sp, #0x98]
+	str r9, [sp, #0x98]
 	bl func_ov00_02083ee0
 	ldr r1, [sp, #0x94]
 	cmp r1, r0
@@ -18397,10 +18397,10 @@ func_ov09_0211d180: ; 0x0211d180
 	ldr r2, [r5, #0x30]
 	mov r1, #0
 	sub r2, r2, r0
-	smull sb, r3, r2, r8
-	adds sb, sb, #0x800
+	smull r9, r3, r2, r8
+	adds r9, r9, #0x800
 	adc r2, r3, #0
-	mov r3, sb, lsr #0xc
+	mov r3, r9, lsr #0xc
 	orr r3, r3, r2, lsl #20
 	add r0, r0, r3
 	str r0, [sp, #0x80]
@@ -18439,22 +18439,22 @@ _0211d28c:
 	cmp r0, #0
 	beq _0211d2e0
 	ldr r3, [r0, #0x20]
-	ldr sb, [sp, #0x84]
+	ldr r9, [sp, #0x84]
 	ldr r3, [r3]
 	ldr r3, [r3, #4]
-	add r3, sb, r3
+	add r3, r9, r3
 	str r3, [r0, #0x28]
 	ldr r3, [r0, #0x20]
-	ldr sb, [sp, #0x88]
+	ldr r9, [sp, #0x88]
 	ldr r3, [r3]
 	ldr r3, [r3, #8]
-	add r3, sb, r3
+	add r3, r9, r3
 	str r3, [r0, #0x2c]
 	ldr r3, [r0, #0x20]
-	ldr sb, [sp, #0x8c]
+	ldr r9, [sp, #0x8c]
 	ldr r3, [r3]
 	ldr r3, [r3, #0xc]
-	add r3, sb, r3
+	add r3, r9, r3
 	str r3, [r0, #0x30]
 _0211d2e0:
 	add r1, r1, #4
@@ -18624,7 +18624,7 @@ _0211d420:
 	add r5, r5, #0x10
 	mov r4, #0
 	add r10, sp, #0x3c
-	add sb, sp, #0x18
+	add r9, sp, #0x18
 	mov r7, r8
 _0211d574:
 	ldr r1, [r5]
@@ -18662,7 +18662,7 @@ _0211d574:
 	str r0, [r1, #0x30]
 _0211d5f8:
 	and r0, r4, #1
-	mla r1, r0, r7, sb
+	mla r1, r0, r7, r9
 	mov r0, r5
 	bl func_ov00_020b7ea4
 _0211d608:
@@ -18671,7 +18671,7 @@ _0211d608:
 	add r5, r5, #4
 	blo _0211d574
 	add sp, sp, #0x9c
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 _0211d620:
 	add r3, r5, #0x10
 	mov r2, #0
@@ -18686,7 +18686,7 @@ _0211d628:
 	cmp r2, #4
 	blo _0211d628
 	add sp, sp, #0x9c
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov09_0211d180
 _0211d654: .word 0xfffffccd

--- a/asm/ov09.s
+++ b/asm/ov09.s
@@ -5029,7 +5029,7 @@ func_ov09_02115610: ; 0x02115610
 	.global func_ov09_021156a4
 	arm_func_start func_ov09_021156a4
 func_ov09_021156a4: ; 0x021156a4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0xdc
 	mov r5, r0
 	ldr r3, [r5, #0x6c]
@@ -5038,10 +5038,10 @@ func_ov09_021156a4: ; 0x021156a4
 	str r2, [sp, #8]
 	cmp r3, #0
 	addlt sp, sp, #0xdc
-	ldmltia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmltia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	cmp r6, #0
 	addeq sp, sp, #0xdc
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldrb r1, [r5, #0x9a]
 	cmp r1, #0
 	bne _021156e8
@@ -5067,7 +5067,7 @@ _021156e8:
 	ldr r2, [sp, #8]
 	bl func_ov09_02115e38
 	add r0, r6, #0x5c
-	add fp, r6, #0x1ac
+	add r11, r6, #0x1ac
 	ldr r7, _02115a9c ; =data_02050f54
 	str r0, [sp, #0xc]
 	mov r4, #0
@@ -5081,7 +5081,7 @@ _02115750:
 	ldmia sl!, {r0, r1, r2, r3}
 	stmia sb!, {r0, r1, r2, r3}
 	ldmia sl, {r0, r1, r2, r3}
-	mov lr, fp
+	mov lr, r11
 	stmia sb, {r0, r1, r2, r3}
 	ldmia lr!, {r0, r1, r2, r3}
 	add ip, sp, #0x34
@@ -5242,7 +5242,7 @@ _021159d0:
 	add r4, r4, #1
 	add r0, r0, #0x30
 	str r0, [sp, #0xc]
-	add fp, fp, #0x24
+	add r11, r11, #0x24
 	cmp r4, #7
 	blt _02115750
 	mov r0, r5
@@ -5250,7 +5250,7 @@ _021159d0:
 	ldr r0, [r5, #0x54]
 	cmp r0, #0
 	addeq sp, sp, #0xdc
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r1, [r5, #0x58]
 	cmp r1, #0
 	bne _02115a44
@@ -5266,11 +5266,11 @@ _021159d0:
 	ldr r4, [r4, #0x10]
 	blx r4
 	add sp, sp, #0xdc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02115a44:
 	cmp r1, #1
 	addne sp, sp, #0xdc
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r1, [r0]
 	ldr r1, [r1, #8]
 	blx r1
@@ -5289,7 +5289,7 @@ _02115a44:
 	ldr r4, [r4, #0x10]
 	blx r4
 	add sp, sp, #0xdc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov09_021156a4
 _02115a9c: .word data_02050f54
@@ -12746,13 +12746,13 @@ _02119c9c:
 	.global func_ov09_02119cd4
 	arm_func_start func_ov09_02119cd4
 func_ov09_02119cd4: ; 0x02119cd4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x18
 	mov sl, r0
 	ldr r0, [sl, #4]
 	cmp r0, #1
 	addls sp, sp, #0x18
-	ldmlsia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmlsia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r3, _02119f98 ; =0x04000444
 	mov r1, #0
 	ldr r0, _02119f9c ; =0x21230000
@@ -12791,7 +12791,7 @@ _02119d6c:
 	sub r5, r0, #0x74
 	add r4, sl, #0x1000
 	add r6, sp, #0xc
-	add fp, sp, #0
+	add r11, sp, #0
 _02119d88:
 	ldrb r0, [r4, #0xf50]
 	cmp r0, #0x58
@@ -12868,7 +12868,7 @@ _02119e98:
 	mov r0, r6
 	mov r1, r8
 	bl func_01fffbec
-	mov r0, fp
+	mov r0, r11
 	mov r1, r8
 	bl func_01fffbec
 	ldr r0, [sp, #0x10]
@@ -12930,7 +12930,7 @@ _02119f84:
 	mov r1, #1
 	str r1, [r0]
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov09_02119cd4
 _02119f98: .word 0x04000444
@@ -13687,23 +13687,23 @@ _0211a748: .word data_ov03_0210041c
 	.global func_ov09_0211a74c
 	arm_func_start func_ov09_0211a74c
 func_ov09_0211a74c: ; 0x0211a74c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #8
 	mov sl, r0
 	ldr r0, [sl, #0x8a4]
-	ldr fp, [sp, #0x30]
+	ldr r11, [sp, #0x30]
 	cmp r0, #0
 	str r3, [sp]
 	mov sb, r1
 	mov r8, r2
 	addeq sp, sp, #8
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	mvn r0, #0
 	mov r6, #0
 	str r0, [sp, #4]
 _0211a788:
-	cmp r6, fp
+	cmp r6, r11
 	bgt _0211a81c
 	add r0, sl, r6, lsl #2
 	ldr r2, [r0, #0x8a4]
@@ -13737,7 +13737,7 @@ _0211a7d8:
 	strne r0, [r1]
 	ldr r0, _0211a834 ; =data_ov03_0210041c
 	ldr r0, [r0, r7, lsl #2]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0211a810:
 	add r4, r4, #1
 	cmp r4, r8
@@ -13748,7 +13748,7 @@ _0211a81c:
 	blo _0211a788
 	mov r0, #0
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov09_0211a74c
 _0211a834: .word data_ov03_0210041c

--- a/asm/ov09.s
+++ b/asm/ov09.s
@@ -5029,7 +5029,7 @@ func_ov09_02115610: ; 0x02115610
 	.global func_ov09_021156a4
 	arm_func_start func_ov09_021156a4
 func_ov09_021156a4: ; 0x021156a4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0xdc
 	mov r5, r0
 	ldr r3, [r5, #0x6c]
@@ -5038,10 +5038,10 @@ func_ov09_021156a4: ; 0x021156a4
 	str r2, [sp, #8]
 	cmp r3, #0
 	addlt sp, sp, #0xdc
-	ldmltia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmltia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	cmp r6, #0
 	addeq sp, sp, #0xdc
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldrb r1, [r5, #0x9a]
 	cmp r1, #0
 	bne _021156e8
@@ -5074,13 +5074,13 @@ _021156e8:
 	add r8, sp, #0xac
 	add r6, sp, #0x58
 _02115750:
-	ldr sl, [sp, #0xc]
+	ldr r10, [sp, #0xc]
 	add sb, sp, #0x7c
-	ldmia sl!, {r0, r1, r2, r3}
+	ldmia r10!, {r0, r1, r2, r3}
 	stmia sb!, {r0, r1, r2, r3}
-	ldmia sl!, {r0, r1, r2, r3}
+	ldmia r10!, {r0, r1, r2, r3}
 	stmia sb!, {r0, r1, r2, r3}
-	ldmia sl, {r0, r1, r2, r3}
+	ldmia r10, {r0, r1, r2, r3}
 	mov lr, r11
 	stmia sb, {r0, r1, r2, r3}
 	ldmia lr!, {r0, r1, r2, r3}
@@ -5157,10 +5157,10 @@ _02115804:
 	mov r1, r0, lsl #0x1
 	add r0, r7, r0, lsl #1
 	ldrsh sb, [r0, #2]
-	ldrsh sl, [r7, r1]
+	ldrsh r10, [r7, r1]
 	mov r0, r8
 	mov r2, sb
-	mov r1, sl
+	mov r1, r10
 	blx func_01ff8abc
 	add r1, sp, #0x7c
 	mov r0, r8
@@ -5186,7 +5186,7 @@ _02115804:
 	mov r0, r6
 	mov r2, r1
 	bl func_01ff8690
-	mov r1, sl
+	mov r1, r10
 	mov r2, sb
 	mov r0, r6
 	blx func_01ff8230
@@ -5250,7 +5250,7 @@ _021159d0:
 	ldr r0, [r5, #0x54]
 	cmp r0, #0
 	addeq sp, sp, #0xdc
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r1, [r5, #0x58]
 	cmp r1, #0
 	bne _02115a44
@@ -5266,11 +5266,11 @@ _021159d0:
 	ldr r4, [r4, #0x10]
 	blx r4
 	add sp, sp, #0xdc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02115a44:
 	cmp r1, #1
 	addne sp, sp, #0xdc
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r1, [r0]
 	ldr r1, [r1, #8]
 	blx r1
@@ -5289,7 +5289,7 @@ _02115a44:
 	ldr r4, [r4, #0x10]
 	blx r4
 	add sp, sp, #0xdc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov09_021156a4
 _02115a9c: .word data_02050f54
@@ -12746,22 +12746,22 @@ _02119c9c:
 	.global func_ov09_02119cd4
 	arm_func_start func_ov09_02119cd4
 func_ov09_02119cd4: ; 0x02119cd4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x18
-	mov sl, r0
-	ldr r0, [sl, #4]
+	mov r10, r0
+	ldr r0, [r10, #4]
 	cmp r0, #1
 	addls sp, sp, #0x18
-	ldmlsia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmlsia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r3, _02119f98 ; =0x04000444
 	mov r1, #0
 	ldr r0, _02119f9c ; =0x21230000
 	str r1, [r3]
 	str r0, [r3, #0x64]
-	add r0, sl, #0x1f00
+	add r0, r10, #0x1f00
 	ldrh r2, [r0, #0x52]
 	ldr r0, _02119fa0 ; =0x42108000
-	add r1, sl, #0x1000
+	add r1, r10, #0x1000
 	orr r2, r2, #0x108000
 	orr r2, r2, #0x42000000
 	str r2, [r3, #0x7c]
@@ -12775,13 +12775,13 @@ func_ov09_02119cd4: ; 0x02119cd4
 	str r0, [r3, #0x28]
 	str r0, [r3, #0x28]
 	str r0, [r3, #0x28]
-	ldr r0, [sl, #4]
-	ldrh sb, [sl, #8]
+	ldr r0, [r10, #4]
+	ldrh sb, [r10, #8]
 	sub r0, r0, #1
 	cmp sb, r0
 	bhs _02119f84
 	mov r0, #0x14
-	mla r7, sb, r0, sl
+	mla r7, sb, r0, r10
 	ldr r0, _02119fa4 ; =data_ov03_02100648
 	ldr r8, [r0]
 _02119d6c:
@@ -12789,7 +12789,7 @@ _02119d6c:
 	mov r1, #3
 	str r1, [r0]
 	sub r5, r0, #0x74
-	add r4, sl, #0x1000
+	add r4, r10, #0x1000
 	add r6, sp, #0xc
 	add r11, sp, #0
 _02119d88:
@@ -12907,7 +12907,7 @@ _02119e98:
 	str r0, [r5]
 	mov r0, r1, lsr #0x10
 	str r0, [r5]
-	ldr r0, [sl, #4]
+	ldr r0, [r10, #4]
 	add sb, sb, #1
 	cmp sb, r0
 	add r7, r7, #0x14
@@ -12921,7 +12921,7 @@ _02119f68:
 	ldr r0, _02119fac ; =0x04000504
 	mov r1, #0
 	str r1, [r0]
-	ldr r0, [sl, #4]
+	ldr r0, [r10, #4]
 	sub r0, r0, #1
 	cmp sb, r0
 	blo _02119d6c
@@ -12930,7 +12930,7 @@ _02119f84:
 	mov r1, #1
 	str r1, [r0]
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov09_02119cd4
 _02119f98: .word 0x04000444
@@ -13635,7 +13635,7 @@ func_ov09_0211a604: ; 0x0211a604
 	.global func_ov09_0211a69c
 	arm_func_start func_ov09_0211a69c
 func_ov09_0211a69c: ; 0x0211a69c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	mov r8, r0
 	ldr r0, [r8, #0x8a4]
 	mov r7, r1
@@ -13643,10 +13643,10 @@ func_ov09_0211a69c: ; 0x0211a69c
 	mov r6, r2
 	mov r5, r3
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	ldr sb, _0211a748 ; =data_ov03_0210041c
 	mov r4, #0
-	mvn sl, #0
+	mvn r10, #0
 _0211a6cc:
 	cmp r4, r5
 	bgt _0211a734
@@ -13659,7 +13659,7 @@ _0211a6cc:
 	blt _0211a734
 	cmp r1, #0
 	ldrneh r0, [r1, #8]
-	moveq r0, sl
+	moveq r0, r10
 	cmp r0, #0
 	blt _0211a734
 	ldr r0, [sb, r0, lsl #2]
@@ -13673,13 +13673,13 @@ _0211a6cc:
 	ldrne r0, [r0, #0x8b0]
 	strne r0, [r1]
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _0211a734:
 	add r4, r4, #1
 	cmp r4, #3
 	blo _0211a6cc
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov09_0211a69c
 _0211a748: .word data_ov03_0210041c
@@ -13687,10 +13687,10 @@ _0211a748: .word data_ov03_0210041c
 	.global func_ov09_0211a74c
 	arm_func_start func_ov09_0211a74c
 func_ov09_0211a74c: ; 0x0211a74c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #8
-	mov sl, r0
-	ldr r0, [sl, #0x8a4]
+	mov r10, r0
+	ldr r0, [r10, #0x8a4]
 	ldr r11, [sp, #0x30]
 	cmp r0, #0
 	str r3, [sp]
@@ -13698,14 +13698,14 @@ func_ov09_0211a74c: ; 0x0211a74c
 	mov r8, r2
 	addeq sp, sp, #8
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	mvn r0, #0
 	mov r6, #0
 	str r0, [sp, #4]
 _0211a788:
 	cmp r6, r11
 	bgt _0211a81c
-	add r0, sl, r6, lsl #2
+	add r0, r10, r6, lsl #2
 	ldr r2, [r0, #0x8a4]
 	cmp r2, #0
 	beq _0211a81c
@@ -13732,12 +13732,12 @@ _0211a7d8:
 	ldr r1, [sp, #0x34]
 	add sp, sp, #8
 	cmp r1, #0
-	addne r0, sl, r6, lsl #2
+	addne r0, r10, r6, lsl #2
 	ldrne r0, [r0, #0x8b0]
 	strne r0, [r1]
 	ldr r0, _0211a834 ; =data_ov03_0210041c
 	ldr r0, [r0, r7, lsl #2]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0211a810:
 	add r4, r4, #1
 	cmp r4, r8
@@ -13748,7 +13748,7 @@ _0211a81c:
 	blo _0211a788
 	mov r0, #0
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov09_0211a74c
 _0211a834: .word data_ov03_0210041c
@@ -18365,7 +18365,7 @@ func_ov09_0211d174: ; 0x0211d174
 	.global func_ov09_0211d180
 	arm_func_start func_ov09_0211d180
 func_ov09_0211d180: ; 0x0211d180
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #0x9c
 	mov r4, r1
 	ldrsh r7, [r4, #0x1e]
@@ -18623,7 +18623,7 @@ _0211d420:
 	mov r8, #0xc
 	add r5, r5, #0x10
 	mov r4, #0
-	add sl, sp, #0x3c
+	add r10, sp, #0x3c
 	add sb, sp, #0x18
 	mov r7, r8
 _0211d574:
@@ -18642,9 +18642,9 @@ _0211d574:
 	mov r0, r4, lsr #0x1
 	mul ip, r0, r8
 	ldr r0, [r1, #0x20]
-	ldr r3, [sl, ip]
+	ldr r3, [r10, ip]
 	ldr r2, [r0]
-	add r0, sl, ip
+	add r0, r10, ip
 	ldr r2, [r2, #4]
 	add r2, r3, r2
 	str r2, [r1, #0x28]
@@ -18671,7 +18671,7 @@ _0211d608:
 	add r5, r5, #4
 	blo _0211d574
 	add sp, sp, #0x9c
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 _0211d620:
 	add r3, r5, #0x10
 	mov r2, #0
@@ -18686,7 +18686,7 @@ _0211d628:
 	cmp r2, #4
 	blo _0211d628
 	add sp, sp, #0x9c
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov09_0211d180
 _0211d654: .word 0xfffffccd

--- a/asm/ov10.s
+++ b/asm/ov10.s
@@ -5087,7 +5087,7 @@ _02115934: .word 0x00ca0002
 	.global func_ov10_02115938
 	arm_func_start func_ov10_02115938
 func_ov10_02115938: ; 0x02115938
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x44
 	mov sb, r0
 	ldr r0, _02115b68 ; =data_027e0cbc
@@ -5177,11 +5177,11 @@ _02115a4c:
 	and r0, r1, r0
 	cmp r0, #0x1000000
 	addne sp, sp, #0x44
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	mov r6, #0
 	mov r7, r6
 	add r8, sb, #0x18
-	mov sl, #0x32000
+	mov r10, #0x32000
 	mov r11, r6
 _02115aa4:
 	ldr r0, [sb, #0x10]
@@ -5197,7 +5197,7 @@ _02115ab4: ; jump table
 _02115ac8:
 	mov r0, r7, asr #0x1
 	add r2, r7, r0, lsr #30
-	mov r0, sl
+	mov r0, r10
 	mov r1, r11
 	sub r2, r4, r2, asr #2
 	bl func_ov00_020d03f8
@@ -5238,7 +5238,7 @@ _02115b4c:
 	add r8, r8, #0x18
 	blt _02115aa4
 	add sp, sp, #0x44
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov10_02115938
 _02115b68: .word data_027e0cbc
@@ -5883,10 +5883,10 @@ _02116278: .word 0x00000112
 	.global func_ov10_0211627c
 	arm_func_start func_ov10_0211627c
 func_ov10_0211627c: ; 0x0211627c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x28
 	mov r4, r0
-	mov sl, r1
+	mov r10, r1
 	mov sb, r2
 	bl func_ov10_0211642c
 	add r0, sp, #8
@@ -5941,7 +5941,7 @@ _0211633c:
 	str sb, [sp]
 	ldr r1, _02116428 ; =0x00000112
 	mov r2, r8
-	mov r3, sl
+	mov r3, r10
 	str r6, [sp, #4]
 	bl func_02034b0c
 _0211635c:
@@ -5979,7 +5979,7 @@ _021163b8:
 _021163c8:
 	mov r0, r6
 	mov r1, r5
-	mov r2, sl
+	mov r2, r10
 	mov r3, sb
 	str r4, [sp]
 	bl func_ov10_02116228
@@ -5992,16 +5992,16 @@ _021163e4:
 	bl func_ov10_0211a8ac
 	cmp r0, #0
 	addeq sp, sp, #0x28
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	mov r0, #0x19
 	add r4, sp, #8
 	mov r1, r0
-	mov r2, sl
+	mov r2, r10
 	mov r3, sb
 	str r4, [sp]
 	bl func_ov10_02116228
 	add sp, sp, #0x28
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov10_0211627c
 _02116428: .word 0x00000112
@@ -6009,11 +6009,11 @@ _02116428: .word 0x00000112
 	.global func_ov10_0211642c
 	arm_func_start func_ov10_0211642c
 func_ov10_0211642c: ; 0x0211642c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x38
 	str r0, [sp, #8]
 	add r0, r0, #0x200
-	mov sl, r1
+	mov r10, r1
 	ldrh r1, [r0, #0xc8]
 	ldr r0, [sp, #8]
 	mov sb, r2
@@ -6061,7 +6061,7 @@ _021164c4:
 	ldr r3, [sp, #0x10]
 	add r1, r5, #0x37
 	mov r0, r11
-	add r2, r2, sl
+	add r2, r2, r10
 	add r3, r3, sb
 	bl func_02034984
 _021164fc:
@@ -6074,13 +6074,13 @@ _02116508:
 	ldr r1, _02116538 ; =0x00000112
 	add r4, sp, #0x18
 	str sb, [sp]
-	mov r3, sl
+	mov r3, r10
 	add r0, r0, #0xa8
 	add r2, r2, #3
 	str r4, [sp, #4]
 	bl func_02034b0c
 	add sp, sp, #0x38
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov10_0211642c
 _02116538: .word 0x00000112
@@ -7025,10 +7025,10 @@ _02117038: .word data_ov00_020eec68
 	.global func_ov10_0211703c
 	arm_func_start func_ov10_0211703c
 func_ov10_0211703c: ; 0x0211703c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x44
-	mov sl, r0
-	ldr r0, [sl, #0x14]
+	mov r10, r0
+	ldr r0, [r10, #0x14]
 	mov r1, #0xf000
 	mov r0, r0, lsl #0xc
 	bl Divide
@@ -7038,12 +7038,12 @@ func_ov10_0211703c: ; 0x0211703c
 	bl func_01ffbe34
 	mov r0, #1
 	strb r0, [sp, #0x2e]
-	add r8, sl, #0x18
+	add r8, r10, #0x18
 	mov r7, r6
 	add r4, sp, #4
 	mov r11, #0xfa000
 _02117080:
-	ldr r0, [sl, #0x10]
+	ldr r0, [r10, #0x10]
 	cmp r7, #4
 	subeq r5, r5, #0xc00
 	cmp r0, #7
@@ -7129,7 +7129,7 @@ _02117160:
 	b _021172cc
 _021171b4:
 	ldr r1, _0211736c ; =data_027e0d54
-	ldr r0, [sl, #8]
+	ldr r0, [r10, #8]
 	ldrh r1, [r1, #0x16]
 	blx func_ov10_02113358
 	bl func_ov10_0211a8fc
@@ -7205,7 +7205,7 @@ _021172cc:
 	add r7, r7, #1
 	cmp r7, #5
 	blt _02117080
-	ldr r0, [sl, #0x10]
+	ldr r0, [r10, #0x10]
 	cmp r0, #3
 	beq _02117308
 	cmp r0, #4
@@ -7239,11 +7239,11 @@ _02117320:
 	orr r3, r3, r1, lsl #20
 	add r3, r3, #0x800
 	ldrh r1, [r0, #0x16]
-	ldr r0, [sl, #8]
+	ldr r0, [r10, #8]
 	mov r3, r3, asr #0xc
 	blx func_ov10_02113890
 	add sp, sp, #0x44
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov10_0211703c
 _0211736c: .word data_027e0d54
@@ -7393,7 +7393,7 @@ _02117520: .word func_ov10_0211ccec - 1
 	.global func_ov10_02117524
 	arm_func_start func_ov10_02117524
 func_ov10_02117524: ; 0x02117524
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x30
 	ldr r2, _021177c4 ; =0x0003f500
 	mov sb, r1
@@ -7407,7 +7407,7 @@ func_ov10_02117524: ; 0x02117524
 	add r1, r2, #0xf300
 	str r0, [sp, #0x24]
 	add r0, r2, #0x3e800
-	add sl, r4, #0x30000
+	add r10, r4, #0x30000
 	str r3, [sp, #0x18]
 	str r8, [sp, #0x20]
 	mov r11, r8
@@ -7449,7 +7449,7 @@ _021175c8:
 	b _02117664
 _021175ec:
 	ldr r1, _021177c8 ; =data_ov10_0211f400
-	mov r0, sl
+	mov r0, r10
 	ldr r1, [r1]
 	ldr r1, [r1, sb, lsl #2]
 	add r1, r1, #0x204
@@ -7480,7 +7480,7 @@ _02117634:
 _02117658:
 	add sp, sp, #0x30
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02117664:
 	mov r1, #0
 	str r1, [sp]
@@ -7500,7 +7500,7 @@ _02117664:
 	cmp r0, #0
 	addeq sp, sp, #0x30
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, [sp, #0x24]
 	add r8, r8, #1
 	add r0, r0, #0x1400
@@ -7510,7 +7510,7 @@ _02117664:
 	add r0, r0, #0x1400
 	str r0, [sp, #0x20]
 	ldr r0, [sp, #0x1c]
-	add sl, sl, #0x80
+	add r10, r10, #0x80
 	add r0, r0, #0x500
 	str r0, [sp, #0x1c]
 	add r5, r5, #0x80
@@ -7572,7 +7572,7 @@ _02117764:
 _021177b8:
 	mov r0, #1
 	add sp, sp, #0x30
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov10_02117524
 _021177c4: .word 0x0003f500
@@ -7833,9 +7833,9 @@ _02117b14: .word data_ov10_0211f400
 	.global func_ov10_02117b18
 	arm_func_start func_ov10_02117b18
 func_ov10_02117b18: ; 0x02117b18
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	ldr r8, _02117c10 ; =data_027e0d54
-	mov sl, r0
+	mov r10, r0
 	ldrh r0, [r8, #0x14]
 	blx func_020400f4
 	mov sb, #0
@@ -7845,7 +7845,7 @@ func_ov10_02117b18: ; 0x02117b18
 	mov r5, #2
 	mov r11, #3
 _02117b44:
-	cmp sl, #0
+	cmp r10, #0
 	beq _02117b58
 	ldrh r0, [r8, #0x16]
 	cmp sb, r0
@@ -7900,7 +7900,7 @@ _02117bfc:
 	blx func_02040100
 	mov r0, #0
 	strb r0, [r8, #0xd]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov10_02117b18
 _02117c10: .word data_027e0d54
@@ -7909,17 +7909,17 @@ _02117c14: .word data_ov10_0211f400
 	.global func_ov10_02117c18
 	arm_func_start func_ov10_02117c18
 func_ov10_02117c18: ; 0x02117c18
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x104
 	ldr r2, _02117d94 ; =data_ov10_0211f400
-	mov sl, r0
+	mov r10, r0
 	str r1, [r2]
-	ldrb r0, [sl, #0xc]
+	ldrb r0, [r10, #0xc]
 	cmp r0, #0
-	ldreq r0, [sl, #0x10]
+	ldreq r0, [r10, #0x10]
 	cmpeq r0, #0
 	addne sp, sp, #0x104
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r1, _02117d98 ; =data_027e0618
 	mov r0, #0
 	str r0, [sp]
@@ -7944,7 +7944,7 @@ func_ov10_02117c18: ; 0x02117c18
 	mov r7, r5
 	mov r8, r5
 _02117ca0:
-	ldrh r1, [sl, #0x16]
+	ldrh r1, [r10, #0x16]
 	ldr r3, [r4]
 	ldr r0, _02117dac ; =data_ov00_020e9e18
 	ldr r1, [r3, r1, lsl #2]
@@ -7952,7 +7952,7 @@ _02117ca0:
 	add r1, r1, #4
 	add r1, r1, r6
 	bl func_02007984
-	ldrh r1, [sl, #0x16]
+	ldrh r1, [r10, #0x16]
 	ldr r3, [r4]
 	mov r0, r11
 	ldr r1, [r3, r1, lsl #2]
@@ -7961,7 +7961,7 @@ _02117ca0:
 	add r1, r1, #0x2800
 	add r1, r1, r7
 	bl func_02007984
-	ldrh r1, [sl, #0x16]
+	ldrh r1, [r10, #0x16]
 	ldr r3, [r4]
 	add r0, sp, #0x84
 	ldr r1, [r3, r1, lsl #2]
@@ -7970,7 +7970,7 @@ _02117ca0:
 	add r1, r1, #0x3000
 	add r1, r1, r8
 	bl func_020078d8
-	ldrh r1, [sl, #0x16]
+	ldrh r1, [r10, #0x16]
 	ldr r3, [r4]
 	add r0, sp, #4
 	ldr r1, [r3, r1, lsl #2]
@@ -7979,7 +7979,7 @@ _02117ca0:
 	add r1, r1, #0x3000
 	add r1, r1, r8
 	bl func_02007984
-	ldrh r1, [sl, #0x16]
+	ldrh r1, [r10, #0x16]
 	ldr r3, [r4]
 	mov r0, sb
 	ldr r1, [r3, r1, lsl #2]
@@ -7995,17 +7995,17 @@ _02117ca0:
 	cmp r5, #2
 	blt _02117ca0
 _02117d68:
-	mov r0, sl
+	mov r0, r10
 	bl func_ov00_0207a2d8
 	ldr r0, _02117db0 ; =data_027e08e4
 	ldr r2, _02117db4 ; =func_ov10_02117b18
 	ldr r3, [sp]
 	mov r4, #1
 	mov r1, #0
-	strb r4, [sl, #0xd]
+	strb r4, [r10, #0xd]
 	blx func_0202f360
 	add sp, sp, #0x104
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov10_02117c18
 _02117d94: .word data_ov10_0211f400
@@ -8574,7 +8574,7 @@ _02118530: .word func_ov10_021183d8 - 1
 	.global func_ov10_02118534
 	arm_func_start func_ov10_02118534
 func_ov10_02118534: ; 0x02118534
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	mov r0, r0, lsl #0x10
 	mov r0, r0, lsr #0x10
 	mov r1, #1
@@ -8583,10 +8583,10 @@ func_ov10_02118534: ; 0x02118534
 	ldr r5, _021185d8 ; =data_027e0d54
 	ldr r0, [r5, #0x10]
 	cmp r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	mov r6, #0
 	ldr sb, _021185dc ; =data_ov00_020ec758
-	ldr sl, _021185e0 ; =data_ov00_020ec218
+	ldr r10, _021185e0 ; =data_ov00_020ec218
 	ldr r4, _021185e4 ; =data_ov10_0211f400
 	mov r7, r6
 	mov r8, r6
@@ -8603,7 +8603,7 @@ _02118578:
 	bl func_02007984
 	ldrh r1, [r5, #0x16]
 	ldr r2, [r4]
-	mov r0, sl
+	mov r0, r10
 	ldr r1, [r2, r1, lsl #2]
 	mov r2, #0x500
 	add r1, r1, #4
@@ -8615,7 +8615,7 @@ _02118578:
 	add r7, r7, #0x80
 	add r8, r8, #0x500
 	blt _02118578
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov10_02118534
 _021185d8: .word data_027e0d54
@@ -8789,13 +8789,13 @@ _021187f0: .word func_ov10_021186e8 - 1
 	.global func_ov10_021187f4
 	arm_func_start func_ov10_021187f4
 func_ov10_021187f4: ; 0x021187f4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	ldr r2, _021188b4 ; =data_ov00_020ec678
-	mov sl, r0
+	mov r10, r0
 	ldrb r0, [r2]
 	cmp r1, r0
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	ldr sb, _021188b8 ; =data_ov00_020ec218
 	strb r1, [r2]
 	mov r0, sb
@@ -8811,7 +8811,7 @@ func_ov10_021187f4: ; 0x021187f4
 	mov r8, r6
 	mov r5, #0x500
 _02118848:
-	ldrh r1, [sl, #0x16]
+	ldrh r1, [r10, #0x16]
 	ldr r2, [r4]
 	mov r0, sb
 	ldr r1, [r2, r1, lsl #2]
@@ -8824,20 +8824,20 @@ _02118848:
 	cmp r6, #2
 	add r8, r8, #0x500
 	blt _02118848
-	mov r0, sl
+	mov r0, r10
 	bl func_ov00_0207a2d8
 	orr r0, r7, #0x10
 	mov r1, r0, lsl #0x10
 	mov r4, #1
-	strb r4, [sl, #0xd]
+	strb r4, [r10, #0xd]
 	mov r3, r1, lsr #0x10
 	ldr r0, _021188c0 ; =data_027e08e4
 	ldr r2, _021188c4 ; =func_ov10_021186e8
 	mov r1, #0
-	strb r4, [sl, #0xe]
+	strb r4, [r10, #0xe]
 	blx func_0202f360
 	mov r0, r4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov10_021187f4
 _021188b4: .word data_ov00_020ec678
@@ -8849,9 +8849,9 @@ _021188c4: .word func_ov10_021186e8 - 1
 	.global func_ov10_021188c8
 	arm_func_start func_ov10_021188c8
 func_ov10_021188c8: ; 0x021188c8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	mov sb, r1
-	mov sl, r0
+	mov r10, r0
 	ldr r1, _02118964 ; =data_ov00_020ec218
 	mov r0, sb
 	bl func_ov01_020f7c08
@@ -8861,7 +8861,7 @@ func_ov10_021188c8: ; 0x021188c8
 	mov r8, r7
 	mov r5, #0x500
 _021188f4:
-	ldrh r1, [sl, #0x16]
+	ldrh r1, [r10, #0x16]
 	ldr r2, [r4]
 	mov r0, sb
 	ldr r1, [r2, r1, lsl #2]
@@ -8876,19 +8876,19 @@ _021188f4:
 	blt _021188f4
 	cmp r6, #0
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
-	mov r0, sl
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	mov r0, r10
 	bl func_ov00_0207a2d8
 	mov r4, #1
-	strb r4, [sl, #0xd]
+	strb r4, [r10, #0xd]
 	ldr r0, _0211896c ; =data_027e08e4
 	ldr r2, _02118970 ; =func_ov10_021186e8
 	mov r3, r6
 	mov r1, #0
-	strb r4, [sl, #0xe]
+	strb r4, [r10, #0xe]
 	blx func_0202f360
 	mov r0, r4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov10_021188c8
 _02118964: .word data_ov00_020ec218
@@ -9572,7 +9572,7 @@ _02119110:
 	.global func_ov10_02119154
 	arm_func_start func_ov10_02119154
 func_ov10_02119154: ; 0x02119154
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x4c
 	ldr r1, _0211951c ; =0x0400101c
 	mov r2, #0
@@ -9595,12 +9595,12 @@ func_ov10_02119154: ; 0x02119154
 	add r0, r1, r0, lsr #30
 	mov r2, #1
 	str r0, [sp, #8]
-	mov sl, #0x64000
+	mov r10, #0x64000
 	mvn r0, #0
 	strb r2, [sp, #0x36]
 	add r8, r11, #0x18
 	mov r7, r6
-	rsb sl, sl, #0
+	rsb r10, r10, #0
 	add r4, sp, #0xc
 	str r0, [sp, #4]
 _021191d0:
@@ -9803,14 +9803,14 @@ _02119468:
 	bl func_ov00_020d00c4
 	b _02119504
 _021194bc:
-	umull lr, ip, r6, sl
+	umull lr, ip, r6, r10
 	adds r1, lr, #0x800
 	mov lr, r1, lsr #0xc
 	ldr r1, [sp, #4]
 	mov r0, #0
 	mla ip, r6, r1, ip
 	mov sb, r6, asr #0x1f
-	mla ip, sb, sl, ip
+	mla ip, sb, r10, ip
 	mov r2, #0
 	mov r1, r2
 	adc r1, ip, r1
@@ -9827,7 +9827,7 @@ _02119504:
 	cmp r7, #8
 	blt _021191d0
 	add sp, sp, #0x4c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov10_02119154
 _0211951c: .word 0x0400101c
@@ -9835,7 +9835,7 @@ _0211951c: .word 0x0400101c
 	.global func_ov10_02119520
 	arm_func_start func_ov10_02119520
 func_ov10_02119520: ; 0x02119520
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x24
 	mov r7, r0
 	ldr r0, [r7, #0x14]
@@ -9851,13 +9851,13 @@ func_ov10_02119520: ; 0x02119520
 	strb r0, [sp, #0xe]
 	mov r6, r5
 	rsb r8, r8, #0
-	mvn sl, #0
+	mvn r10, #0
 	add r4, sp, #4
 _02119568:
 	ldr ip, [r7, #0x10]
 	mov r2, r11
 	cmp ip, #2
-	moveq r0, sl
+	moveq r0, r10
 	movne r0, #1
 	cmp r6, #3
 	cmpne r6, #6
@@ -10049,7 +10049,7 @@ _021197f0:
 	b _02119888
 _02119844:
 	umull lr, ip, r5, r8
-	mla ip, r5, sl, ip
+	mla ip, r5, r10, ip
 	mov sb, r5, asr #0x1f
 	adds r1, lr, #0x800
 	mov r0, #0
@@ -10070,7 +10070,7 @@ _02119888:
 	cmp r6, #8
 	blt _02119568
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov10_02119520
 _0211989c: .word 0x66666667
@@ -10224,7 +10224,7 @@ func_ov10_02119a14: ; 0x02119a14
 	.global func_ov10_02119a6c
 	arm_func_start func_ov10_02119a6c
 func_ov10_02119a6c: ; 0x02119a6c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	mov r4, r0
 	mov r5, r1
 	mov r1, r4
@@ -10244,13 +10244,13 @@ func_ov10_02119a6c: ; 0x02119a6c
 	mov r3, #1
 	ldr r6, [r2]
 	ldmib r2, {r5, r8}
-	umull sl, sb, r8, r6
+	umull r10, sb, r8, r6
 	mla sb, r8, r5, sb
 	ldr r7, [r2, #0xc]
 	ldr lr, [r2, #0x10]
 	mla sb, r7, r6, sb
 	ldr ip, [r2, #0x14]
-	adds r6, lr, sl
+	adds r6, lr, r10
 	adc r5, ip, sb
 	str r6, [r2]
 	str r5, [r2, #4]
@@ -10262,10 +10262,10 @@ func_ov10_02119a6c: ; 0x02119a6c
 	umull r8, r7, r6, lr
 	mla r7, r6, ip, r7
 	ldr r5, [r2, #0xc]
-	ldr sl, [r2, #0x10]
+	ldr r10, [r2, #0x10]
 	mla r7, r5, lr, r7
 	ldr sb, [r2, #0x14]
-	adds r6, sl, r8
+	adds r6, r10, r8
 	adc r5, sb, r7
 	str r6, [r2]
 	str r5, [r2, #4]
@@ -10275,7 +10275,7 @@ func_ov10_02119a6c: ; 0x02119a6c
 	mov r1, #0x80
 	strb r3, [r4, #0x7d]
 	blx func_0202f134
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov10_02119a6c
 _02119b3c: .word 0x415a454a
@@ -10366,7 +10366,7 @@ _02119c6c: .word 0x415a454a
 	.global func_ov10_02119c70
 	arm_func_start func_ov10_02119c70
 func_ov10_02119c70: ; 0x02119c70
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #4
 	mov r5, r0
 	strh r1, [r5]
@@ -10386,15 +10386,15 @@ func_ov10_02119c70: ; 0x02119c70
 	mov r8, #0
 	mov r7, #0x16
 _02119cbc:
-	add sl, sb, #0x180
+	add r10, sb, #0x180
 	add r6, sb, #0x440
 _02119cc4:
 	mov r0, r8
-	mov r1, sl
+	mov r1, r10
 	mov r2, r7
 	bl func_020078c0
-	add sl, sl, #0x16
-	cmp sl, r6
+	add r10, r10, #0x16
+	cmp r10, r6
 	blo _02119cc4
 	mov r0, r6
 	blx func_ov00_0207a4f0
@@ -10408,15 +10408,15 @@ _02119cc4:
 	mov r8, #0
 	mov r7, #0x14
 _02119d0c:
-	mov sl, r4
+	mov r10, r4
 	add r6, r4, #0x3c
 _02119d14:
 	mov r0, r8
-	mov r1, sl
+	mov r1, r10
 	mov r2, r7
 	bl func_020078c0
-	add sl, sl, #0x14
-	cmp sl, r6
+	add r10, r10, #0x14
+	cmp r10, r6
 	blo _02119d14
 	mov r0, r4
 	blx func_ov00_0207c170
@@ -10461,7 +10461,7 @@ _02119db0:
 	blt _02119db0
 	mov r0, r5
 	add sp, sp, #4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov10_02119c70
 _02119dd4: .word func_ov10_02112d40 - 1
@@ -10487,7 +10487,7 @@ func_ov10_02119ddc: ; 0x02119ddc
 	.global func_ov10_02119e0c
 	arm_func_start func_ov10_02119e0c
 func_ov10_02119e0c: ; 0x02119e0c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	mov r4, r0
 	add r6, r4, #4
 	add r0, r4, #0x204
@@ -10495,7 +10495,7 @@ func_ov10_02119e0c: ; 0x02119e0c
 	add r7, r6, #0x2800
 	add r8, r0, #0x3000
 	add sb, r1, #0x3000
-	add sl, r6, #0x3400
+	add r10, r6, #0x3400
 	mov r5, #0
 _02119e34:
 	mov r0, r6
@@ -10506,7 +10506,7 @@ _02119e34:
 	blx func_ov00_0207a5f4
 	mov r0, sb
 	blx func_ov00_0207a68c
-	mov r0, sl
+	mov r0, r10
 	blx func_ov00_0207a6d0
 	add r5, r5, #1
 	cmp r5, #2
@@ -10514,17 +10514,17 @@ _02119e34:
 	add r7, r7, #0x500
 	add r8, r8, #0x80
 	add sb, sb, #0x80
-	add sl, sl, #0x80
+	add r10, r10, #0x80
 	blt _02119e34
 	mov r0, r4
 	bl func_ov10_02119ddc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	arm_func_end func_ov10_02119e0c
 
 	.global func_ov10_02119e88
 	arm_func_start func_ov10_02119e88
 func_ov10_02119e88: ; 0x02119e88
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x14
 	add r4, r0, #4
 	add r5, r1, #4
@@ -10544,7 +10544,7 @@ func_ov10_02119e88: ; 0x02119e88
 	str r3, [sp, #4]
 	add r8, r1, #0x3000
 	add sb, r4, #0x3400
-	add sl, r5, #0x3400
+	add r10, r5, #0x3400
 	str r0, [sp, #0x10]
 _02119ee0:
 	mov r0, r5
@@ -10575,7 +10575,7 @@ _02119f0c:
 	bl func_02007984
 	b _02119f54
 _02119f48:
-	mov r0, sl
+	mov r0, r10
 	mov r1, sb
 	bl func_02007984
 _02119f54:
@@ -10594,12 +10594,12 @@ _02119f54:
 	add r7, r7, #0x80
 	add r8, r8, #0x80
 	add sb, sb, #0x80
-	add sl, sl, #0x80
+	add r10, r10, #0x80
 	str r0, [sp, #0x10]
 	cmp r0, #2
 	blt _02119ee0
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	arm_func_end func_ov10_02119e88
 
 	.global func_ov10_02119fa8
@@ -11074,7 +11074,7 @@ _0211a5d0:
 	.global func_ov10_0211a5f4
 	arm_func_start func_ov10_0211a5f4
 func_ov10_0211a5f4: ; 0x0211a5f4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x1c
 	mov sb, r0
 	add r1, sb, #0x3000
@@ -11105,7 +11105,7 @@ _0211a648:
 	add r7, sb, #4
 	str r0, [sp, #0x14]
 	add r11, sb, #0x304
-	add sl, sb, #0x284
+	add r10, sb, #0x284
 	add r5, sb, #0x204
 	add r6, sb, #0x104
 _0211a674:
@@ -11170,7 +11170,7 @@ _0211a72c:
 	b _0211a7e4
 _0211a748:
 	ldrh r1, [sb]
-	add r0, sl, #0x3000
+	add r0, r10, #0x3000
 	mov r2, #0x80
 	mul r3, r1, r4
 	add r1, r3, #0x3280
@@ -11212,7 +11212,7 @@ _0211a7b8:
 _0211a7d8:
 	add sp, sp, #0x1c
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0211a7e4:
 	mov r3, #0
 	str r3, [sp]
@@ -11228,7 +11228,7 @@ _0211a7e4:
 	cmp r0, #0
 	addeq sp, sp, #0x1c
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0211a820:
 	add r8, r8, #1
 	cmp r8, #0xa
@@ -11244,11 +11244,11 @@ _0211a820:
 	cmp r0, #0
 	addeq sp, sp, #0x1c
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0211a85c:
 	mov r0, #1
 	add sp, sp, #0x1c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov10_0211a5f4
 _0211a868: .word 0x0003f500
@@ -15717,10 +15717,10 @@ _0211cd48: .word data_ov10_0211e980
 	.global func_ov10_0211cd4c
 	arm_func_start func_ov10_0211cd4c
 func_ov10_0211cd4c: ; 0x0211cd4c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x14
 	ldr r2, _0211cdd0 ; =0x0003f500
-	mov sl, r0
+	mov r10, r0
 	mul r0, r1, r2
 	mov r8, #0
 	add sb, r0, #0
@@ -15734,7 +15734,7 @@ _0211cd7c:
 	str r7, [sp, #4]
 	str r6, [sp, #8]
 	str r5, [sp, #0xc]
-	mov r0, sl
+	mov r0, r10
 	mov r1, sb
 	mov r2, r11
 	mov r3, r7
@@ -15743,14 +15743,14 @@ _0211cd7c:
 	cmp r0, #0
 	addeq sp, sp, #0x14
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	add r8, r8, #1
 	cmp r8, #2
 	add sb, sb, #0x1400
 	blt _0211cd7c
 	mov r0, #1
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov10_0211cd4c
 _0211cdd0: .word 0x0003f500
@@ -15758,10 +15758,10 @@ _0211cdd0: .word 0x0003f500
 	.global func_ov10_0211cdd4
 	arm_func_start func_ov10_0211cdd4
 func_ov10_0211cdd4: ; 0x0211cdd4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x14
 	ldr r2, _0211ce58 ; =0x0003f500
-	mov sl, r0
+	mov r10, r0
 	mul r0, r1, r2
 	mov r8, #0
 	add sb, r0, #0x3e800
@@ -15775,7 +15775,7 @@ _0211ce04:
 	str r7, [sp, #4]
 	str r6, [sp, #8]
 	str r5, [sp, #0xc]
-	mov r0, sl
+	mov r0, r10
 	mov r1, sb
 	mov r2, r11
 	mov r3, r7
@@ -15784,14 +15784,14 @@ _0211ce04:
 	cmp r0, #0
 	addeq sp, sp, #0x14
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	add r8, r8, #1
 	cmp r8, #2
 	add sb, sb, #0x500
 	blt _0211ce04
 	mov r0, #1
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov10_0211cdd4
 _0211ce58: .word 0x0003f500
@@ -15921,7 +15921,7 @@ func_ov10_0211cfa0: ; 0x0211cfa0
 	.global func_ov10_0211cfd8
 	arm_func_start func_ov10_0211cfd8
 func_ov10_0211cfd8: ; 0x0211cfd8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x20
 	ldr r1, _0211d0a8 ; =0x000037fc
 	str r0, [sp, #0x14]
@@ -15943,7 +15943,7 @@ _0211d00c:
 	cmp r1, r0
 	bne _0211d078
 _0211d028:
-	ldr sl, [sp, #0x18]
+	ldr r10, [sp, #0x18]
 	mov r8, #0
 _0211d030:
 	str r7, [sp]
@@ -15951,7 +15951,7 @@ _0211d030:
 	str r6, [sp, #8]
 	str r5, [sp, #0xc]
 	mov r0, sb
-	mov r1, sl
+	mov r1, r10
 	mov r2, r11
 	mov r3, r7
 	str r4, [sp, #0x10]
@@ -15959,10 +15959,10 @@ _0211d030:
 	cmp r0, #0
 	addeq sp, sp, #0x20
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	add r8, r8, #1
 	cmp r8, #0x3c
-	add sl, sl, #0x1000
+	add r10, r10, #0x1000
 	blt _0211d030
 _0211d078:
 	ldr r0, [sp, #0x18]
@@ -15976,7 +15976,7 @@ _0211d078:
 	blt _0211d00c
 	mov r0, #1
 	add sp, sp, #0x20
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov10_0211cfd8
 _0211d0a8: .word 0x000037fc
@@ -16026,10 +16026,10 @@ _0211d138: .word 0x0007ea00
 	.global func_ov10_0211d13c
 	arm_func_start func_ov10_0211d13c
 func_ov10_0211d13c: ; 0x0211d13c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x14
 	ldr r3, _0211d260 ; =0x0003f500
-	mov sl, r2
+	mov r10, r2
 	mul r4, r1, r3
 	mul r1, r0, r3
 	add r0, r4, #0xfe
@@ -16037,7 +16037,7 @@ func_ov10_0211d13c: ; 0x0211d13c
 	add r7, r1, #0x2800
 	add r8, r0, #0x3700
 	mov r6, #0
-	add r4, sl, #0xf00
+	add r4, r10, #0xf00
 	mov r5, #6
 	mov r11, #1
 _0211d174:
@@ -16046,14 +16046,14 @@ _0211d174:
 	stmib sp, {r0, r5, r11}
 	str r0, [sp, #0x10]
 	mov r0, r7
-	mov r1, sl
+	mov r1, r10
 	mov r2, #0x1000
 	mov r3, #0
 	blx func_02040464
 	cmp r0, #0
 	addeq sp, sp, #0x14
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldrh r0, [r4, #0xfe]
 	mov r3, #0
 	cmp r0, #0
@@ -16075,7 +16075,7 @@ _0211d174:
 	bne _0211d23c
 	add sp, sp, #0x14
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0211d200:
 	str r0, [sp, #4]
 	mov r0, #7
@@ -16084,14 +16084,14 @@ _0211d200:
 	str r0, [sp, #0xc]
 	mov r0, #2
 	str r0, [sp, #0x10]
-	mov r0, sl
+	mov r0, r10
 	mov r1, sb
 	mov r2, #0x1000
 	blx func_02040464
 	cmp r0, #0
 	addeq sp, sp, #0x14
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0211d23c:
 	add r7, r7, #0x1000
 	add r8, r8, #0x1000
@@ -16101,7 +16101,7 @@ _0211d23c:
 	blt _0211d174
 	mov r0, #1
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov10_0211d13c
 _0211d260: .word 0x0003f500

--- a/asm/ov10.s
+++ b/asm/ov10.s
@@ -5087,7 +5087,7 @@ _02115934: .word 0x00ca0002
 	.global func_ov10_02115938
 	arm_func_start func_ov10_02115938
 func_ov10_02115938: ; 0x02115938
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x44
 	mov sb, r0
 	ldr r0, _02115b68 ; =data_027e0cbc
@@ -5177,12 +5177,12 @@ _02115a4c:
 	and r0, r1, r0
 	cmp r0, #0x1000000
 	addne sp, sp, #0x44
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	mov r6, #0
 	mov r7, r6
 	add r8, sb, #0x18
 	mov sl, #0x32000
-	mov fp, r6
+	mov r11, r6
 _02115aa4:
 	ldr r0, [sb, #0x10]
 	cmp r0, #4
@@ -5198,7 +5198,7 @@ _02115ac8:
 	mov r0, r7, asr #0x1
 	add r2, r7, r0, lsr #30
 	mov r0, sl
-	mov r1, fp
+	mov r1, r11
 	sub r2, r4, r2, asr #2
 	bl func_ov00_020d03f8
 	add r0, r0, #0x800
@@ -5238,7 +5238,7 @@ _02115b4c:
 	add r8, r8, #0x18
 	blt _02115aa4
 	add sp, sp, #0x44
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov10_02115938
 _02115b68: .word data_027e0cbc
@@ -5883,7 +5883,7 @@ _02116278: .word 0x00000112
 	.global func_ov10_0211627c
 	arm_func_start func_ov10_0211627c
 func_ov10_0211627c: ; 0x0211627c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x28
 	mov r4, r0
 	mov sl, r1
@@ -5900,7 +5900,7 @@ func_ov10_0211627c: ; 0x0211627c
 	add r5, r4, #0x130
 	mov r7, r0
 	mov r8, #0x13
-	mov fp, #1
+	mov r11, #1
 	add r6, sp, #8
 	mov r4, #0x88
 _021162cc:
@@ -5913,7 +5913,7 @@ _021162cc:
 	b _0211633c
 _021162e8:
 	mov r0, r7
-	mov r1, fp
+	mov r1, r11
 	bl func_ov10_0211a86c
 	cmp r0, #0
 	bne _0211633c
@@ -5992,7 +5992,7 @@ _021163e4:
 	bl func_ov10_0211a8ac
 	cmp r0, #0
 	addeq sp, sp, #0x28
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	mov r0, #0x19
 	add r4, sp, #8
 	mov r1, r0
@@ -6001,7 +6001,7 @@ _021163e4:
 	str r4, [sp]
 	bl func_ov10_02116228
 	add sp, sp, #0x28
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov10_0211627c
 _02116428: .word 0x00000112
@@ -6009,7 +6009,7 @@ _02116428: .word 0x00000112
 	.global func_ov10_0211642c
 	arm_func_start func_ov10_0211642c
 func_ov10_0211642c: ; 0x0211642c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x38
 	str r0, [sp, #8]
 	add r0, r0, #0x200
@@ -6033,7 +6033,7 @@ func_ov10_0211642c: ; 0x0211642c
 	subs r7, r5, #1
 	str r0, [sp, #0xc]
 	bmi _02116508
-	ldr fp, _02116538 ; =0x00000112
+	ldr r11, _02116538 ; =0x00000112
 	mov r8, r7, lsl #0x2
 _02116494:
 	subs r5, r4, r8
@@ -6050,7 +6050,7 @@ _021164ac:
 	movgt r6, #0
 	bgt _021164fc
 _021164c4:
-	mov r0, fp
+	mov r0, r11
 	add r1, r7, #3
 	add r2, sp, #0x14
 	add r3, sp, #0x10
@@ -6060,7 +6060,7 @@ _021164c4:
 	ldr r2, [sp, #0x14]
 	ldr r3, [sp, #0x10]
 	add r1, r5, #0x37
-	mov r0, fp
+	mov r0, r11
 	add r2, r2, sl
 	add r3, r3, sb
 	bl func_02034984
@@ -6080,7 +6080,7 @@ _02116508:
 	str r4, [sp, #4]
 	bl func_02034b0c
 	add sp, sp, #0x38
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov10_0211642c
 _02116538: .word 0x00000112
@@ -7025,7 +7025,7 @@ _02117038: .word data_ov00_020eec68
 	.global func_ov10_0211703c
 	arm_func_start func_ov10_0211703c
 func_ov10_0211703c: ; 0x0211703c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x44
 	mov sl, r0
 	ldr r0, [sl, #0x14]
@@ -7041,7 +7041,7 @@ func_ov10_0211703c: ; 0x0211703c
 	add r8, sl, #0x18
 	mov r7, r6
 	add r4, sp, #4
-	mov fp, #0xfa000
+	mov r11, #0xfa000
 _02117080:
 	ldr r0, [sl, #0x10]
 	cmp r7, #4
@@ -7084,14 +7084,14 @@ _021170f0: ; jump table
 _02117104:
 	mov r0, r4
 	bl func_01ffbe34
-	umull lr, ip, r6, fp
+	umull lr, ip, r6, r11
 	adds r1, lr, #0x800
 	mov r2, #0
 	mov lr, r1, lsr #0xc
 	mov r1, r2
 	mla ip, r6, r1, ip
 	mov sb, r6, asr #0x1f
-	mla ip, sb, fp, ip
+	mla ip, sb, r11, ip
 	adc r1, ip, r1
 	orr lr, lr, r1, lsl #20
 	mov r0, #1
@@ -7243,7 +7243,7 @@ _02117320:
 	mov r3, r3, asr #0xc
 	blx func_ov10_02113890
 	add sp, sp, #0x44
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov10_0211703c
 _0211736c: .word data_027e0d54
@@ -7393,7 +7393,7 @@ _02117520: .word func_ov10_0211ccec - 1
 	.global func_ov10_02117524
 	arm_func_start func_ov10_02117524
 func_ov10_02117524: ; 0x02117524
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x30
 	ldr r2, _021177c4 ; =0x0003f500
 	mov sb, r1
@@ -7410,7 +7410,7 @@ func_ov10_02117524: ; 0x02117524
 	add sl, r4, #0x30000
 	str r3, [sp, #0x18]
 	str r8, [sp, #0x20]
-	mov fp, r8
+	mov r11, r8
 	mov r5, r8
 	str r0, [sp, #0x1c]
 	add r6, r1, #0x30000
@@ -7444,7 +7444,7 @@ _021175c8:
 	ldr r1, [r1, sb, lsl #2]
 	add r1, r1, #4
 	add r1, r1, #0x2800
-	add r1, r1, fp
+	add r1, r1, r11
 	str r1, [r4, r8, lsl #2]
 	b _02117664
 _021175ec:
@@ -7480,7 +7480,7 @@ _02117634:
 _02117658:
 	add sp, sp, #0x30
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02117664:
 	mov r1, #0
 	str r1, [sp]
@@ -7500,13 +7500,13 @@ _02117664:
 	cmp r0, #0
 	addeq sp, sp, #0x30
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, [sp, #0x24]
 	add r8, r8, #1
 	add r0, r0, #0x1400
 	str r0, [sp, #0x24]
 	ldr r0, [sp, #0x20]
-	add fp, fp, #0x500
+	add r11, r11, #0x500
 	add r0, r0, #0x1400
 	str r0, [sp, #0x20]
 	ldr r0, [sp, #0x1c]
@@ -7572,7 +7572,7 @@ _02117764:
 _021177b8:
 	mov r0, #1
 	add sp, sp, #0x30
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov10_02117524
 _021177c4: .word 0x0003f500
@@ -7833,7 +7833,7 @@ _02117b14: .word data_ov10_0211f400
 	.global func_ov10_02117b18
 	arm_func_start func_ov10_02117b18
 func_ov10_02117b18: ; 0x02117b18
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	ldr r8, _02117c10 ; =data_027e0d54
 	mov sl, r0
 	ldrh r0, [r8, #0x14]
@@ -7843,7 +7843,7 @@ func_ov10_02117b18: ; 0x02117b18
 	mov r7, sb
 	mov r6, #1
 	mov r5, #2
-	mov fp, #3
+	mov r11, #3
 _02117b44:
 	cmp sl, #0
 	beq _02117b58
@@ -7866,7 +7866,7 @@ _02117b58:
 	bl func_ov10_02117524
 	cmp r0, #0
 	beq _02117bbc
-	mov r0, fp
+	mov r0, r11
 	mov r1, sb
 	bl func_ov10_02117524
 	cmp r0, #0
@@ -7900,7 +7900,7 @@ _02117bfc:
 	blx func_02040100
 	mov r0, #0
 	strb r0, [r8, #0xd]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov10_02117b18
 _02117c10: .word data_027e0d54
@@ -7909,7 +7909,7 @@ _02117c14: .word data_ov10_0211f400
 	.global func_ov10_02117c18
 	arm_func_start func_ov10_02117c18
 func_ov10_02117c18: ; 0x02117c18
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x104
 	ldr r2, _02117d94 ; =data_ov10_0211f400
 	mov sl, r0
@@ -7919,7 +7919,7 @@ func_ov10_02117c18: ; 0x02117c18
 	ldreq r0, [sl, #0x10]
 	cmpeq r0, #0
 	addne sp, sp, #0x104
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r1, _02117d98 ; =data_027e0618
 	mov r0, #0
 	str r0, [sp]
@@ -7937,7 +7937,7 @@ func_ov10_02117c18: ; 0x02117c18
 	ldr r1, [r1]
 	bl func_ov10_02119a14
 	mov r5, #0
-	ldr fp, _02117da4 ; =data_ov00_020ec218
+	ldr r11, _02117da4 ; =data_ov00_020ec218
 	ldr sb, _02117da8 ; =data_ov00_020ec758
 	ldr r4, _02117d94 ; =data_ov10_0211f400
 	mov r6, r5
@@ -7954,7 +7954,7 @@ _02117ca0:
 	bl func_02007984
 	ldrh r1, [sl, #0x16]
 	ldr r3, [r4]
-	mov r0, fp
+	mov r0, r11
 	ldr r1, [r3, r1, lsl #2]
 	mov r2, #0x500
 	add r1, r1, #4
@@ -8005,7 +8005,7 @@ _02117d68:
 	strb r4, [sl, #0xd]
 	blx func_0202f360
 	add sp, sp, #0x104
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov10_02117c18
 _02117d94: .word data_ov10_0211f400
@@ -8574,7 +8574,7 @@ _02118530: .word func_ov10_021183d8 - 1
 	.global func_ov10_02118534
 	arm_func_start func_ov10_02118534
 func_ov10_02118534: ; 0x02118534
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	mov r0, r0, lsl #0x10
 	mov r0, r0, lsr #0x10
 	mov r1, #1
@@ -8583,20 +8583,20 @@ func_ov10_02118534: ; 0x02118534
 	ldr r5, _021185d8 ; =data_027e0d54
 	ldr r0, [r5, #0x10]
 	cmp r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	mov r6, #0
 	ldr sb, _021185dc ; =data_ov00_020ec758
 	ldr sl, _021185e0 ; =data_ov00_020ec218
 	ldr r4, _021185e4 ; =data_ov10_0211f400
 	mov r7, r6
 	mov r8, r6
-	mov fp, #0x80
+	mov r11, #0x80
 _02118578:
 	ldrh r1, [r5, #0x16]
 	ldr r2, [r4]
 	mov r0, sb
 	ldr r1, [r2, r1, lsl #2]
-	mov r2, fp
+	mov r2, r11
 	add r1, r1, #4
 	add r1, r1, #0x3400
 	add r1, r1, r7
@@ -8615,7 +8615,7 @@ _02118578:
 	add r7, r7, #0x80
 	add r8, r8, #0x500
 	blt _02118578
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov10_02118534
 _021185d8: .word data_027e0d54
@@ -9572,16 +9572,16 @@ _02119110:
 	.global func_ov10_02119154
 	arm_func_start func_ov10_02119154
 func_ov10_02119154: ; 0x02119154
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x4c
 	ldr r1, _0211951c ; =0x0400101c
 	mov r2, #0
 	str r2, [r1]
-	mov fp, r0
-	ldr r0, [fp, #0x10]
+	mov r11, r0
+	ldr r0, [r11, #0x10]
 	mov r1, #0xf000
 	cmp r0, #0
-	ldr r0, [fp, #0x14]
+	ldr r0, [r11, #0x14]
 	subeq r4, r2, #1
 	mov r0, r0, lsl #0xc
 	movne r4, #1
@@ -9598,7 +9598,7 @@ func_ov10_02119154: ; 0x02119154
 	mov sl, #0x64000
 	mvn r0, #0
 	strb r2, [sp, #0x36]
-	add r8, fp, #0x18
+	add r8, r11, #0x18
 	mov r7, r6
 	rsb sl, sl, #0
 	add r4, sp, #0xc
@@ -9608,7 +9608,7 @@ _021191d0:
 	cmpne r7, #7
 	ldreq r0, [sp, #8]
 	addeq r5, r5, r0, asr #2
-	ldr r0, [fp, #0x10]
+	ldr r0, [r11, #0x10]
 	cmp r0, #0
 	beq _021191f8
 	cmp r0, #4
@@ -9827,7 +9827,7 @@ _02119504:
 	cmp r7, #8
 	blt _021191d0
 	add sp, sp, #0x4c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov10_02119154
 _0211951c: .word 0x0400101c
@@ -9835,14 +9835,14 @@ _0211951c: .word 0x0400101c
 	.global func_ov10_02119520
 	arm_func_start func_ov10_02119520
 func_ov10_02119520: ; 0x02119520
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x24
 	mov r7, r0
 	ldr r0, [r7, #0x14]
 	mov r1, #0xf000
 	mov r0, r0, lsl #0xc
 	bl Divide
-	mov fp, r0
+	mov r11, r0
 	add r0, sp, #4
 	mov r5, #0
 	bl func_01ffbe34
@@ -9855,7 +9855,7 @@ func_ov10_02119520: ; 0x02119520
 	add r4, sp, #4
 _02119568:
 	ldr ip, [r7, #0x10]
-	mov r2, fp
+	mov r2, r11
 	cmp ip, #2
 	moveq r0, sl
 	movne r0, #1
@@ -10070,7 +10070,7 @@ _02119888:
 	cmp r6, #8
 	blt _02119568
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov10_02119520
 _0211989c: .word 0x66666667
@@ -10524,7 +10524,7 @@ _02119e34:
 	.global func_ov10_02119e88
 	arm_func_start func_ov10_02119e88
 func_ov10_02119e88: ; 0x02119e88
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x14
 	add r4, r0, #4
 	add r5, r1, #4
@@ -10536,7 +10536,7 @@ func_ov10_02119e88: ; 0x02119e88
 	add r7, r1, #0x204
 	str r0, [sp, #8]
 	mov r0, #0
-	add fp, r6, #0x3000
+	add r11, r6, #0x3000
 	add r6, r7, #0x3000
 	add r1, r1, #0x304
 	add r7, r8, #0x3000
@@ -10560,7 +10560,7 @@ _02119ee0:
 	bl func_02007984
 _02119f0c:
 	mov r0, r6
-	mov r1, fp
+	mov r1, r11
 	mov r2, #0x80
 	bl func_020078d8
 	mov r0, r8
@@ -10588,7 +10588,7 @@ _02119f54:
 	add r0, r0, #0x500
 	str r0, [sp, #8]
 	ldr r0, [sp, #0x10]
-	add fp, fp, #0x80
+	add r11, r11, #0x80
 	add r0, r0, #1
 	add r6, r6, #0x80
 	add r7, r7, #0x80
@@ -10599,7 +10599,7 @@ _02119f54:
 	cmp r0, #2
 	blt _02119ee0
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	arm_func_end func_ov10_02119e88
 
 	.global func_ov10_02119fa8
@@ -11074,7 +11074,7 @@ _0211a5d0:
 	.global func_ov10_0211a5f4
 	arm_func_start func_ov10_0211a5f4
 func_ov10_0211a5f4: ; 0x0211a5f4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x1c
 	mov sb, r0
 	add r1, sb, #0x3000
@@ -11104,7 +11104,7 @@ _0211a648:
 	mov r8, #0
 	add r7, sb, #4
 	str r0, [sp, #0x14]
-	add fp, sb, #0x304
+	add r11, sb, #0x304
 	add sl, sb, #0x284
 	add r5, sb, #0x204
 	add r6, sb, #0x104
@@ -11178,7 +11178,7 @@ _0211a748:
 	b _0211a7e4
 _0211a764:
 	ldrh r1, [sb]
-	add r0, fp, #0x3000
+	add r0, r11, #0x3000
 	mov r2, #0x80
 	mul r3, r1, r4
 	add r1, r3, #0xf300
@@ -11212,7 +11212,7 @@ _0211a7b8:
 _0211a7d8:
 	add sp, sp, #0x1c
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0211a7e4:
 	mov r3, #0
 	str r3, [sp]
@@ -11228,7 +11228,7 @@ _0211a7e4:
 	cmp r0, #0
 	addeq sp, sp, #0x1c
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0211a820:
 	add r8, r8, #1
 	cmp r8, #0xa
@@ -11244,11 +11244,11 @@ _0211a820:
 	cmp r0, #0
 	addeq sp, sp, #0x1c
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0211a85c:
 	mov r0, #1
 	add sp, sp, #0x1c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov10_0211a5f4
 _0211a868: .word 0x0003f500
@@ -15717,7 +15717,7 @@ _0211cd48: .word data_ov10_0211e980
 	.global func_ov10_0211cd4c
 	arm_func_start func_ov10_0211cd4c
 func_ov10_0211cd4c: ; 0x0211cd4c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x14
 	ldr r2, _0211cdd0 ; =0x0003f500
 	mov sl, r0
@@ -15728,7 +15728,7 @@ func_ov10_0211cd4c: ; 0x0211cd4c
 	mov r6, #7
 	mov r5, #0xa
 	mov r4, #2
-	mov fp, #0x1400
+	mov r11, #0x1400
 _0211cd7c:
 	str r7, [sp]
 	str r7, [sp, #4]
@@ -15736,21 +15736,21 @@ _0211cd7c:
 	str r5, [sp, #0xc]
 	mov r0, sl
 	mov r1, sb
-	mov r2, fp
+	mov r2, r11
 	mov r3, r7
 	str r4, [sp, #0x10]
 	blx func_02040464
 	cmp r0, #0
 	addeq sp, sp, #0x14
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r8, r8, #1
 	cmp r8, #2
 	add sb, sb, #0x1400
 	blt _0211cd7c
 	mov r0, #1
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov10_0211cd4c
 _0211cdd0: .word 0x0003f500
@@ -15758,7 +15758,7 @@ _0211cdd0: .word 0x0003f500
 	.global func_ov10_0211cdd4
 	arm_func_start func_ov10_0211cdd4
 func_ov10_0211cdd4: ; 0x0211cdd4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x14
 	ldr r2, _0211ce58 ; =0x0003f500
 	mov sl, r0
@@ -15769,7 +15769,7 @@ func_ov10_0211cdd4: ; 0x0211cdd4
 	mov r6, #7
 	mov r5, #0xa
 	mov r4, #2
-	mov fp, #0x500
+	mov r11, #0x500
 _0211ce04:
 	str r7, [sp]
 	str r7, [sp, #4]
@@ -15777,21 +15777,21 @@ _0211ce04:
 	str r5, [sp, #0xc]
 	mov r0, sl
 	mov r1, sb
-	mov r2, fp
+	mov r2, r11
 	mov r3, r7
 	str r4, [sp, #0x10]
 	blx func_02040464
 	cmp r0, #0
 	addeq sp, sp, #0x14
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r8, r8, #1
 	cmp r8, #2
 	add sb, sb, #0x500
 	blt _0211ce04
 	mov r0, #1
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov10_0211cdd4
 _0211ce58: .word 0x0003f500
@@ -15921,7 +15921,7 @@ func_ov10_0211cfa0: ; 0x0211cfa0
 	.global func_ov10_0211cfd8
 	arm_func_start func_ov10_0211cfd8
 func_ov10_0211cfd8: ; 0x0211cfd8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x20
 	ldr r1, _0211d0a8 ; =0x000037fc
 	str r0, [sp, #0x14]
@@ -15933,7 +15933,7 @@ func_ov10_0211cfd8: ; 0x0211cfd8
 	mov r6, #7
 	mov r5, #0xa
 	mov r4, #2
-	mov fp, #4
+	mov r11, #4
 _0211d00c:
 	ldr r0, [sp, #0x14]
 	cmp r0, #0
@@ -15952,14 +15952,14 @@ _0211d030:
 	str r5, [sp, #0xc]
 	mov r0, sb
 	mov r1, sl
-	mov r2, fp
+	mov r2, r11
 	mov r3, r7
 	str r4, [sp, #0x10]
 	blx func_02040464
 	cmp r0, #0
 	addeq sp, sp, #0x20
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r8, r8, #1
 	cmp r8, #0x3c
 	add sl, sl, #0x1000
@@ -15976,7 +15976,7 @@ _0211d078:
 	blt _0211d00c
 	mov r0, #1
 	add sp, sp, #0x20
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov10_0211cfd8
 _0211d0a8: .word 0x000037fc
@@ -16026,7 +16026,7 @@ _0211d138: .word 0x0007ea00
 	.global func_ov10_0211d13c
 	arm_func_start func_ov10_0211d13c
 func_ov10_0211d13c: ; 0x0211d13c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x14
 	ldr r3, _0211d260 ; =0x0003f500
 	mov sl, r2
@@ -16039,11 +16039,11 @@ func_ov10_0211d13c: ; 0x0211d13c
 	mov r6, #0
 	add r4, sl, #0xf00
 	mov r5, #6
-	mov fp, #1
+	mov r11, #1
 _0211d174:
 	mov r0, #0
 	str r0, [sp]
-	stmib sp, {r0, r5, fp}
+	stmib sp, {r0, r5, r11}
 	str r0, [sp, #0x10]
 	mov r0, r7
 	mov r1, sl
@@ -16053,7 +16053,7 @@ _0211d174:
 	cmp r0, #0
 	addeq sp, sp, #0x14
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldrh r0, [r4, #0xfe]
 	mov r3, #0
 	cmp r0, #0
@@ -16075,7 +16075,7 @@ _0211d174:
 	bne _0211d23c
 	add sp, sp, #0x14
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0211d200:
 	str r0, [sp, #4]
 	mov r0, #7
@@ -16091,7 +16091,7 @@ _0211d200:
 	cmp r0, #0
 	addeq sp, sp, #0x14
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0211d23c:
 	add r7, r7, #0x1000
 	add r8, r8, #0x1000
@@ -16101,7 +16101,7 @@ _0211d23c:
 	blt _0211d174
 	mov r0, #1
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov10_0211d13c
 _0211d260: .word 0x0003f500

--- a/asm/ov10.s
+++ b/asm/ov10.s
@@ -2751,12 +2751,12 @@ _02114250: .word data_027e0d54
 	.global func_ov10_02114254
 	arm_func_start func_ov10_02114254
 func_ov10_02114254: ; 0x02114254
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	mov r4, r0
 	ldr r0, [r4, #0x10]
 	cmp r0, #3
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	mov r6, #0
 	mov r5, r6
 _02114274:
@@ -2775,7 +2775,7 @@ _02114274:
 	bl func_ov10_02114330
 	cmp r0, #0
 	movne r0, #1
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	add r0, r6, #1
 	mov r0, r0, lsl #0x10
 	mov r6, r0, lsr #0x10
@@ -2783,10 +2783,10 @@ _02114274:
 	blo _02114274
 	mov r6, #0
 	mov r8, r4
-	add sb, r4, #0xa8
+	add r9, r4, #0xa8
 	mov r5, r6
 _021142d8:
-	mov r0, sb
+	mov r0, r9
 	ldr ip, [r0]
 	ldrh r7, [r8, #0xb2]
 	ldr ip, [ip]
@@ -2800,14 +2800,14 @@ _021142d8:
 	bl func_ov10_02114330
 	cmp r0, #0
 	movne r0, #1
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	add r6, r6, #1
 	cmp r6, #1
 	add r8, r8, #0x18
-	add sb, sb, #0x18
+	add r9, r9, #0x18
 	blt _021142d8
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	arm_func_end func_ov10_02114254
 
 	.global func_ov10_02114330
@@ -4974,12 +4974,12 @@ _021157c0: .word data_027e0d54
 	.global func_ov10_021157c4
 	arm_func_start func_ov10_021157c4
 func_ov10_021157c4: ; 0x021157c4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	mov r4, r0
 	ldr r0, [r4, #0x10]
 	cmp r0, #1
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	ldr r1, _0211588c ; =data_027e0d54
 	ldr r0, [r4, #8]
 	ldrh r6, [r1, #0x16]
@@ -4997,13 +4997,13 @@ func_ov10_021157c4: ; 0x021157c4
 	bl func_ov10_02115890
 	cmp r0, #0
 	movne r0, #1
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	mov r6, #0
 	mov r8, r4
-	add sb, r4, #0x18
+	add r9, r4, #0x18
 	mov r5, r6
 _02115834:
-	mov r0, sb
+	mov r0, r9
 	ldr ip, [r0]
 	ldrh r7, [r8, #0x22]
 	ldr ip, [ip]
@@ -5017,14 +5017,14 @@ _02115834:
 	bl func_ov10_02115890
 	cmp r0, #0
 	movne r0, #1
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	add r6, r6, #1
 	cmp r6, #4
 	add r8, r8, #0x18
-	add sb, sb, #0x18
+	add r9, r9, #0x18
 	blt _02115834
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov10_021157c4
 _0211588c: .word data_027e0d54
@@ -5087,9 +5087,9 @@ _02115934: .word 0x00ca0002
 	.global func_ov10_02115938
 	arm_func_start func_ov10_02115938
 func_ov10_02115938: ; 0x02115938
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x44
-	mov sb, r0
+	mov r9, r0
 	ldr r0, _02115b68 ; =data_027e0cbc
 	mov r1, #0x2e
 	bl func_0203d7e0
@@ -5107,7 +5107,7 @@ func_ov10_02115938: ; 0x02115938
 	str r4, [sp]
 	bl func_0203493c
 _02115984:
-	ldr r0, [sb, #0x14]
+	ldr r0, [r9, #0x14]
 	mov r1, #0xf000
 	mov r0, r0, lsl #0xc
 	bl Divide
@@ -5117,7 +5117,7 @@ _02115984:
 	bl func_01ffbe34
 	mov r0, #1
 	strb r0, [sp, #0xe]
-	ldr r0, [sb, #0x10]
+	ldr r0, [r9, #0x10]
 	cmp r0, #3
 	beq _021159c4
 	cmp r0, #4
@@ -5162,29 +5162,29 @@ _02115a30:
 	bl func_0203493c
 _02115a4c:
 	mov r1, #0
-	ldr r0, [sb, #8]
+	ldr r0, [r9, #8]
 	mov r2, r1
 	mov r3, r1
 	blx func_ov10_02113890
 	mov r2, #0
-	ldr r0, [sb, #8]
+	ldr r0, [r9, #8]
 	mov r3, r2
 	mov r1, #1
 	blx func_ov10_02113890
 	mov r0, #0x10000
-	ldr r1, [sb, #0x90]
+	ldr r1, [r9, #0x90]
 	rsb r0, r0, #0
 	and r0, r1, r0
 	cmp r0, #0x1000000
 	addne sp, sp, #0x44
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	mov r6, #0
 	mov r7, r6
-	add r8, sb, #0x18
+	add r8, r9, #0x18
 	mov r10, #0x32000
 	mov r11, r6
 _02115aa4:
-	ldr r0, [sb, #0x10]
+	ldr r0, [r9, #0x10]
 	cmp r0, #4
 	addls pc, pc, r0, lsl #2
 	b _02115b0c
@@ -5238,7 +5238,7 @@ _02115b4c:
 	add r8, r8, #0x18
 	blt _02115aa4
 	add sp, sp, #0x44
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov10_02115938
 _02115b68: .word data_027e0cbc
@@ -5883,11 +5883,11 @@ _02116278: .word 0x00000112
 	.global func_ov10_0211627c
 	arm_func_start func_ov10_0211627c
 func_ov10_0211627c: ; 0x0211627c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x28
 	mov r4, r0
 	mov r10, r1
-	mov sb, r2
+	mov r9, r2
 	bl func_ov10_0211642c
 	add r0, sp, #8
 	bl func_01ffbe34
@@ -5938,7 +5938,7 @@ _02116318:
 _0211633c:
 	sub r1, r8, #0x13
 	mla r0, r1, r4, r5
-	str sb, [sp]
+	str r9, [sp]
 	ldr r1, _02116428 ; =0x00000112
 	mov r2, r8
 	mov r3, r10
@@ -5980,7 +5980,7 @@ _021163c8:
 	mov r0, r6
 	mov r1, r5
 	mov r2, r10
-	mov r3, sb
+	mov r3, r9
 	str r4, [sp]
 	bl func_ov10_02116228
 	add r5, r5, #1
@@ -5992,16 +5992,16 @@ _021163e4:
 	bl func_ov10_0211a8ac
 	cmp r0, #0
 	addeq sp, sp, #0x28
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	mov r0, #0x19
 	add r4, sp, #8
 	mov r1, r0
 	mov r2, r10
-	mov r3, sb
+	mov r3, r9
 	str r4, [sp]
 	bl func_ov10_02116228
 	add sp, sp, #0x28
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov10_0211627c
 _02116428: .word 0x00000112
@@ -6009,14 +6009,14 @@ _02116428: .word 0x00000112
 	.global func_ov10_0211642c
 	arm_func_start func_ov10_0211642c
 func_ov10_0211642c: ; 0x0211642c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x38
 	str r0, [sp, #8]
 	add r0, r0, #0x200
 	mov r10, r1
 	ldrh r1, [r0, #0xc8]
 	ldr r0, [sp, #8]
-	mov sb, r2
+	mov r9, r2
 	ldr r0, [r0, #0x10]
 	blx func_ov10_02113358
 	ldrb r1, [r0, #0x94]
@@ -6062,7 +6062,7 @@ _021164c4:
 	add r1, r5, #0x37
 	mov r0, r11
 	add r2, r2, r10
-	add r3, r3, sb
+	add r3, r3, r9
 	bl func_02034984
 _021164fc:
 	sub r8, r8, #4
@@ -6073,14 +6073,14 @@ _02116508:
 	ldr r2, [sp, #0xc]
 	ldr r1, _02116538 ; =0x00000112
 	add r4, sp, #0x18
-	str sb, [sp]
+	str r9, [sp]
 	mov r3, r10
 	add r0, r0, #0xa8
 	add r2, r2, #3
 	str r4, [sp, #4]
 	bl func_02034b0c
 	add sp, sp, #0x38
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov10_0211642c
 _02116538: .word 0x00000112
@@ -6906,18 +6906,18 @@ _02116ea8: .word data_027e05f8
 	.global func_ov10_02116eac
 	arm_func_start func_ov10_02116eac
 func_ov10_02116eac: ; 0x02116eac
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	mov r4, r0
 	ldr r0, [r4, #0x10]
 	cmp r0, #1
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	mov r6, #0
 	mov r8, r4
-	add sb, r4, #0x18
+	add r9, r4, #0x18
 	mov r5, r6
 _02116ed4:
-	mov r0, sb
+	mov r0, r9
 	ldr ip, [r0]
 	ldrh r7, [r8, #0x22]
 	ldr ip, [ip]
@@ -6931,14 +6931,14 @@ _02116ed4:
 	bl func_ov10_02116f2c
 	cmp r0, #0
 	movne r0, #1
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	add r6, r6, #1
 	cmp r6, #5
 	add r8, r8, #0x18
-	add sb, sb, #0x18
+	add r9, r9, #0x18
 	blt _02116ed4
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	arm_func_end func_ov10_02116eac
 
 	.global func_ov10_02116f2c
@@ -7025,7 +7025,7 @@ _02117038: .word data_ov00_020eec68
 	.global func_ov10_0211703c
 	arm_func_start func_ov10_0211703c
 func_ov10_0211703c: ; 0x0211703c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x44
 	mov r10, r0
 	ldr r0, [r10, #0x14]
@@ -7090,8 +7090,8 @@ _02117104:
 	mov lr, r1, lsr #0xc
 	mov r1, r2
 	mla ip, r6, r1, ip
-	mov sb, r6, asr #0x1f
-	mla ip, sb, r11, ip
+	mov r9, r6, asr #0x1f
+	mla ip, r9, r11, ip
 	adc r1, ip, r1
 	orr lr, lr, r1, lsl #20
 	mov r0, #1
@@ -7106,16 +7106,16 @@ _02117104:
 	bl func_ov00_020d00c4
 	b _021172cc
 _02117160:
-	mov sb, #0xfa000
-	umull lr, ip, r6, sb
-	adds sb, lr, #0x800
+	mov r9, #0xfa000
+	umull lr, ip, r6, r9
+	adds r9, lr, #0x800
 	mov r2, #0
-	mov lr, sb, lsr #0xc
-	mov sb, r2
-	mla ip, r6, sb, ip
+	mov lr, r9, lsr #0xc
+	mov r9, r2
+	mla ip, r6, r9, ip
 	mov r1, r6, asr #0x1f
-	mov sb, #0xfa000
-	mla ip, r1, sb, ip
+	mov r9, #0xfa000
+	mla ip, r1, r9, ip
 	mov r1, r2
 	adc r1, ip, r1
 	orr lr, lr, r1, lsl #20
@@ -7135,16 +7135,16 @@ _021171b4:
 	bl func_ov10_0211a8fc
 	cmp r0, #0
 	beq _021172cc
-	mov sb, #0x3c000
-	umull lr, ip, r6, sb
-	adds sb, lr, #0x800
+	mov r9, #0x3c000
+	umull lr, ip, r6, r9
+	adds r9, lr, #0x800
 	mov r1, #0
-	mov lr, sb, lsr #0xc
-	mov sb, r1
-	mla ip, r6, sb, ip
+	mov lr, r9, lsr #0xc
+	mov r9, r1
+	mla ip, r6, r9, ip
 	mov r2, r6, asr #0x1f
-	mov sb, #0x3c000
-	mla ip, r2, sb, ip
+	mov r9, #0x3c000
+	mla ip, r2, r9, ip
 	mov r2, r1
 	adc r2, ip, r2
 	orr lr, lr, r2, lsl #20
@@ -7157,16 +7157,16 @@ _021171b4:
 	bl func_ov00_020d00c4
 	b _021172cc
 _02117224:
-	mov sb, #0x7d000
-	umull lr, ip, r6, sb
-	adds sb, lr, #0x800
+	mov r9, #0x7d000
+	umull lr, ip, r6, r9
+	adds r9, lr, #0x800
 	mov r2, #0
-	mov lr, sb, lsr #0xc
-	mov sb, r2
-	mla ip, r6, sb, ip
+	mov lr, r9, lsr #0xc
+	mov r9, r2
+	mla ip, r6, r9, ip
 	mov r1, r6, asr #0x1f
-	mov sb, #0x7d000
-	mla ip, r1, sb, ip
+	mov r9, #0x7d000
+	mla ip, r1, r9, ip
 	mov r1, r2
 	adc r1, ip, r1
 	orr lr, lr, r1, lsl #20
@@ -7179,16 +7179,16 @@ _02117224:
 	bl func_ov00_020d00c4
 	b _021172cc
 _02117278:
-	mov sb, #0x64000
-	umull lr, ip, r6, sb
-	adds sb, lr, #0x800
+	mov r9, #0x64000
+	umull lr, ip, r6, r9
+	adds r9, lr, #0x800
 	mov r2, #0
-	mov lr, sb, lsr #0xc
-	mov sb, r2
-	mla ip, r6, sb, ip
+	mov lr, r9, lsr #0xc
+	mov r9, r2
+	mla ip, r6, r9, ip
 	mov r1, r6, asr #0x1f
-	mov sb, #0x64000
-	mla ip, r1, sb, ip
+	mov r9, #0x64000
+	mla ip, r1, r9, ip
 	mov r1, r2
 	adc r1, ip, r1
 	orr lr, lr, r1, lsl #20
@@ -7243,7 +7243,7 @@ _02117320:
 	mov r3, r3, asr #0xc
 	blx func_ov10_02113890
 	add sp, sp, #0x44
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov10_0211703c
 _0211736c: .word data_027e0d54
@@ -7393,11 +7393,11 @@ _02117520: .word func_ov10_0211ccec - 1
 	.global func_ov10_02117524
 	arm_func_start func_ov10_02117524
 func_ov10_02117524: ; 0x02117524
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x30
 	ldr r2, _021177c4 ; =0x0003f500
-	mov sb, r1
-	mul r2, sb, r2
+	mov r9, r1
+	mul r2, r9, r2
 	mov r3, #0xc
 	mov r8, #0
 	mul r3, r0, r3
@@ -7431,7 +7431,7 @@ _021175a4:
 	ldr r1, _021177c8 ; =data_ov10_0211f400
 	ldr r0, [sp, #0x24]
 	ldr r1, [r1]
-	ldr r1, [r1, sb, lsl #2]
+	ldr r1, [r1, r9, lsl #2]
 	add r2, r1, #4
 	ldr r1, [sp, #0x20]
 	add r1, r2, r1
@@ -7441,7 +7441,7 @@ _021175c8:
 	ldr r1, _021177c8 ; =data_ov10_0211f400
 	ldr r0, [sp, #0x1c]
 	ldr r1, [r1]
-	ldr r1, [r1, sb, lsl #2]
+	ldr r1, [r1, r9, lsl #2]
 	add r1, r1, #4
 	add r1, r1, #0x2800
 	add r1, r1, r11
@@ -7451,7 +7451,7 @@ _021175ec:
 	ldr r1, _021177c8 ; =data_ov10_0211f400
 	mov r0, r10
 	ldr r1, [r1]
-	ldr r1, [r1, sb, lsl #2]
+	ldr r1, [r1, r9, lsl #2]
 	add r1, r1, #0x204
 	add r1, r1, #0x3000
 	add r1, r1, r5
@@ -7461,7 +7461,7 @@ _02117610:
 	ldr r1, _021177c8 ; =data_ov10_0211f400
 	mov r0, r6
 	ldr r1, [r1]
-	ldr r1, [r1, sb, lsl #2]
+	ldr r1, [r1, r9, lsl #2]
 	add r1, r1, #0x304
 	add r1, r1, #0x3000
 	add r1, r1, r5
@@ -7471,7 +7471,7 @@ _02117634:
 	ldr r1, _021177c8 ; =data_ov10_0211f400
 	mov r0, r7
 	ldr r1, [r1]
-	ldr r1, [r1, sb, lsl #2]
+	ldr r1, [r1, r9, lsl #2]
 	add r1, r1, #4
 	add r1, r1, #0x3400
 	add r1, r1, r5
@@ -7480,7 +7480,7 @@ _02117634:
 _02117658:
 	add sp, sp, #0x30
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02117664:
 	mov r1, #0
 	str r1, [sp]
@@ -7500,7 +7500,7 @@ _02117664:
 	cmp r0, #0
 	addeq sp, sp, #0x30
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, [sp, #0x24]
 	add r8, r8, #1
 	add r0, r0, #0x1400
@@ -7544,7 +7544,7 @@ _02117744:
 	ldr r2, [r0]
 	ldr r0, [sp, #0x18]
 	ldr r1, [r1, r0]
-	ldr r0, [r2, sb, lsl #2]
+	ldr r0, [r2, r9, lsl #2]
 	bl func_ov10_02119fa8
 	b _021177b8
 _02117764:
@@ -7555,7 +7555,7 @@ _02117764:
 	ldr r1, _021177d4 ; =data_ov10_0211e788
 	ldr r0, [r0]
 	ldr r1, [r1, r2]
-	ldr r0, [r0, sb, lsl #2]
+	ldr r0, [r0, r9, lsl #2]
 	bl func_ov10_02119fa8
 	ldr r0, [sp, #0x2c]
 	mov r1, r4
@@ -7567,12 +7567,12 @@ _02117764:
 	ldr r2, [r0]
 	ldr r0, [sp, #0x18]
 	ldr r1, [r1, r0]
-	ldr r0, [r2, sb, lsl #2]
+	ldr r0, [r2, r9, lsl #2]
 	bl func_ov10_02119fa8
 _021177b8:
 	mov r0, #1
 	add sp, sp, #0x30
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov10_02117524
 _021177c4: .word 0x0003f500
@@ -7833,14 +7833,14 @@ _02117b14: .word data_ov10_0211f400
 	.global func_ov10_02117b18
 	arm_func_start func_ov10_02117b18
 func_ov10_02117b18: ; 0x02117b18
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	ldr r8, _02117c10 ; =data_027e0d54
 	mov r10, r0
 	ldrh r0, [r8, #0x14]
 	blx func_020400f4
-	mov sb, #0
+	mov r9, #0
 	ldr r4, _02117c14 ; =data_ov10_0211f400
-	mov r7, sb
+	mov r7, r9
 	mov r6, #1
 	mov r5, #2
 	mov r11, #3
@@ -7848,31 +7848,31 @@ _02117b44:
 	cmp r10, #0
 	beq _02117b58
 	ldrh r0, [r8, #0x16]
-	cmp sb, r0
+	cmp r9, r0
 	beq _02117be8
 _02117b58:
 	mov r0, r7
-	mov r1, sb
+	mov r1, r9
 	bl func_ov10_02117524
 	cmp r0, #0
 	beq _02117bbc
 	mov r0, r6
-	mov r1, sb
+	mov r1, r9
 	bl func_ov10_02117524
 	cmp r0, #0
 	beq _02117bbc
 	mov r0, r5
-	mov r1, sb
+	mov r1, r9
 	bl func_ov10_02117524
 	cmp r0, #0
 	beq _02117bbc
 	mov r0, r11
-	mov r1, sb
+	mov r1, r9
 	bl func_ov10_02117524
 	cmp r0, #0
 	beq _02117bbc
 	mov r0, #4
-	mov r1, sb
+	mov r1, r9
 	bl func_ov10_02117524
 	cmp r0, #0
 	bne _02117bd0
@@ -7884,23 +7884,23 @@ _02117bbc:
 	b _02117bfc
 _02117bd0:
 	ldr r0, [r4]
-	ldr r0, [r0, sb, lsl #2]
+	ldr r0, [r0, r9, lsl #2]
 	bl func_ov10_0211a108
 	ldr r0, [r4]
-	ldr r0, [r0, sb, lsl #2]
+	ldr r0, [r0, r9, lsl #2]
 	bl func_ov10_0211a2fc
 _02117be8:
-	add r0, sb, #1
+	add r0, r9, #1
 	mov r0, r0, lsl #0x10
-	mov sb, r0, lsr #0x10
-	cmp sb, #2
+	mov r9, r0, lsr #0x10
+	cmp r9, #2
 	blo _02117b44
 _02117bfc:
 	ldrh r0, [r8, #0x14]
 	blx func_02040100
 	mov r0, #0
 	strb r0, [r8, #0xd]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov10_02117b18
 _02117c10: .word data_027e0d54
@@ -7909,7 +7909,7 @@ _02117c14: .word data_ov10_0211f400
 	.global func_ov10_02117c18
 	arm_func_start func_ov10_02117c18
 func_ov10_02117c18: ; 0x02117c18
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x104
 	ldr r2, _02117d94 ; =data_ov10_0211f400
 	mov r10, r0
@@ -7919,7 +7919,7 @@ func_ov10_02117c18: ; 0x02117c18
 	ldreq r0, [r10, #0x10]
 	cmpeq r0, #0
 	addne sp, sp, #0x104
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r1, _02117d98 ; =data_027e0618
 	mov r0, #0
 	str r0, [sp]
@@ -7938,7 +7938,7 @@ func_ov10_02117c18: ; 0x02117c18
 	bl func_ov10_02119a14
 	mov r5, #0
 	ldr r11, _02117da4 ; =data_ov00_020ec218
-	ldr sb, _02117da8 ; =data_ov00_020ec758
+	ldr r9, _02117da8 ; =data_ov00_020ec758
 	ldr r4, _02117d94 ; =data_ov10_0211f400
 	mov r6, r5
 	mov r7, r5
@@ -7981,7 +7981,7 @@ _02117ca0:
 	bl func_02007984
 	ldrh r1, [r10, #0x16]
 	ldr r3, [r4]
-	mov r0, sb
+	mov r0, r9
 	ldr r1, [r3, r1, lsl #2]
 	mov r2, #0x80
 	add r1, r1, #4
@@ -8005,7 +8005,7 @@ _02117d68:
 	strb r4, [r10, #0xd]
 	blx func_0202f360
 	add sp, sp, #0x104
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov10_02117c18
 _02117d94: .word data_ov10_0211f400
@@ -8574,7 +8574,7 @@ _02118530: .word func_ov10_021183d8 - 1
 	.global func_ov10_02118534
 	arm_func_start func_ov10_02118534
 func_ov10_02118534: ; 0x02118534
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	mov r0, r0, lsl #0x10
 	mov r0, r0, lsr #0x10
 	mov r1, #1
@@ -8583,9 +8583,9 @@ func_ov10_02118534: ; 0x02118534
 	ldr r5, _021185d8 ; =data_027e0d54
 	ldr r0, [r5, #0x10]
 	cmp r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	mov r6, #0
-	ldr sb, _021185dc ; =data_ov00_020ec758
+	ldr r9, _021185dc ; =data_ov00_020ec758
 	ldr r10, _021185e0 ; =data_ov00_020ec218
 	ldr r4, _021185e4 ; =data_ov10_0211f400
 	mov r7, r6
@@ -8594,7 +8594,7 @@ func_ov10_02118534: ; 0x02118534
 _02118578:
 	ldrh r1, [r5, #0x16]
 	ldr r2, [r4]
-	mov r0, sb
+	mov r0, r9
 	ldr r1, [r2, r1, lsl #2]
 	mov r2, r11
 	add r1, r1, #4
@@ -8615,7 +8615,7 @@ _02118578:
 	add r7, r7, #0x80
 	add r8, r8, #0x500
 	blt _02118578
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov10_02118534
 _021185d8: .word data_027e0d54
@@ -8709,7 +8709,7 @@ _021186e4: .word data_ov00_020ec218
 	.global func_ov10_021186e8
 	arm_func_start func_ov10_021186e8
 func_ov10_021186e8: ; 0x021186e8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	mov r4, r0
 	mov r0, r4, lsl #0x10
 	mov r1, #0
@@ -8717,22 +8717,22 @@ func_ov10_021186e8: ; 0x021186e8
 	mov r0, r0, lsr #0x10
 	bl func_ov01_020f79bc
 	tst r4, #0x80000000
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	ldr r4, _02118768 ; =data_027e0d54
 	ldr r0, [r4, #0x10]
 	cmp r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	mov r5, #0
 	ldr r7, _0211876c ; =data_ov00_020ec218
 	ldr r8, _02118770 ; =data_ov10_0211f400
 	mov r6, r5
-	mov sb, #0x500
+	mov r9, #0x500
 _02118730:
 	ldrh r1, [r4, #0x16]
 	ldr r2, [r8]
 	mov r0, r7
 	ldr r1, [r2, r1, lsl #2]
-	mov r2, sb
+	mov r2, r9
 	add r1, r1, #4
 	add r1, r1, #0x2800
 	add r1, r1, r6
@@ -8741,7 +8741,7 @@ _02118730:
 	cmp r5, #2
 	add r6, r6, #0x500
 	blt _02118730
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov10_021186e8
 _02118768: .word data_027e0d54
@@ -8789,16 +8789,16 @@ _021187f0: .word func_ov10_021186e8 - 1
 	.global func_ov10_021187f4
 	arm_func_start func_ov10_021187f4
 func_ov10_021187f4: ; 0x021187f4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	ldr r2, _021188b4 ; =data_ov00_020ec678
 	mov r10, r0
 	ldrb r0, [r2]
 	cmp r1, r0
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
-	ldr sb, _021188b8 ; =data_ov00_020ec218
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
+	ldr r9, _021188b8 ; =data_ov00_020ec218
 	strb r1, [r2]
-	mov r0, sb
+	mov r0, r9
 	mov r1, #0x500
 	blx func_0202f134
 	mov r0, #0
@@ -8813,7 +8813,7 @@ func_ov10_021187f4: ; 0x021187f4
 _02118848:
 	ldrh r1, [r10, #0x16]
 	ldr r2, [r4]
-	mov r0, sb
+	mov r0, r9
 	ldr r1, [r2, r1, lsl #2]
 	mov r2, r5
 	add r1, r1, #4
@@ -8837,7 +8837,7 @@ _02118848:
 	strb r4, [r10, #0xe]
 	blx func_0202f360
 	mov r0, r4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov10_021187f4
 _021188b4: .word data_ov00_020ec678
@@ -8849,11 +8849,11 @@ _021188c4: .word func_ov10_021186e8 - 1
 	.global func_ov10_021188c8
 	arm_func_start func_ov10_021188c8
 func_ov10_021188c8: ; 0x021188c8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
-	mov sb, r1
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
+	mov r9, r1
 	mov r10, r0
 	ldr r1, _02118964 ; =data_ov00_020ec218
-	mov r0, sb
+	mov r0, r9
 	bl func_ov01_020f7c08
 	mov r7, #0
 	ldr r4, _02118968 ; =data_ov10_0211f400
@@ -8863,7 +8863,7 @@ func_ov10_021188c8: ; 0x021188c8
 _021188f4:
 	ldrh r1, [r10, #0x16]
 	ldr r2, [r4]
-	mov r0, sb
+	mov r0, r9
 	ldr r1, [r2, r1, lsl #2]
 	mov r2, r5
 	add r1, r1, #4
@@ -8876,7 +8876,7 @@ _021188f4:
 	blt _021188f4
 	cmp r6, #0
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	mov r0, r10
 	bl func_ov00_0207a2d8
 	mov r4, #1
@@ -8888,7 +8888,7 @@ _021188f4:
 	strb r4, [r10, #0xe]
 	blx func_0202f360
 	mov r0, r4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov10_021188c8
 _02118964: .word data_ov00_020ec218
@@ -8948,7 +8948,7 @@ _02118a10: .word data_ov10_0211f400
 	arm_func_start func_ov10_02118a14
 func_ov10_02118a14: ; 0x02118a14
 	stmdb sp!, {r0, r1, r2, r3}
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x80
 	ldr r4, _02118b28 ; =data_ov00_020ec754
 	mov r7, r0
@@ -8962,7 +8962,7 @@ func_ov10_02118a14: ; 0x02118a14
 	cmp r0, #0
 	addeq sp, sp, #0x80
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	addeq sp, sp, #0x10
 	bxeq lr
 	add r0, sp, #0xa4
@@ -8980,13 +8980,13 @@ func_ov10_02118a14: ; 0x02118a14
 	ldr r8, _02118b2c ; =data_ov10_0211f400
 	mov r6, r5
 	add r4, sp, #0
-	mov sb, #0x80
+	mov r9, #0x80
 _02118a9c:
 	ldrh r1, [r7, #0x16]
 	ldr r2, [r8]
 	mov r0, r4
 	ldr r1, [r2, r1, lsl #2]
-	mov r2, sb
+	mov r2, r9
 	add r1, r1, #0x304
 	add r1, r1, #0x3000
 	add r1, r1, r6
@@ -8999,7 +8999,7 @@ _02118a9c:
 	cmp r0, #0
 	addne sp, sp, #0x80
 	movne r0, #1
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	addne sp, sp, #0x10
 	bxne lr
 	mov r0, r7
@@ -9014,7 +9014,7 @@ _02118a9c:
 	blx func_0202f360
 	mov r0, r4
 	add sp, sp, #0x80
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	add sp, sp, #0x10
 	bx lr
 	.align 2, 0
@@ -9381,18 +9381,18 @@ _02118ed0: .word data_027e05f8
 	.global func_ov10_02118ed4
 	arm_func_start func_ov10_02118ed4
 func_ov10_02118ed4: ; 0x02118ed4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	mov r4, r0
 	ldr r0, [r4, #0x10]
 	cmp r0, #3
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	mov r6, #0
 	mov r8, r4
-	add sb, r4, #0x18
+	add r9, r4, #0x18
 	mov r5, r6
 _02118efc:
-	mov r0, sb
+	mov r0, r9
 	ldr ip, [r0]
 	ldrh r7, [r8, #0x22]
 	ldr ip, [ip]
@@ -9406,14 +9406,14 @@ _02118efc:
 	bl func_ov10_02118f54
 	cmp r0, #0
 	movne r0, #1
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	add r6, r6, #1
 	cmp r6, #8
 	add r8, r8, #0x18
-	add sb, sb, #0x18
+	add r9, r9, #0x18
 	blt _02118efc
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	arm_func_end func_ov10_02118ed4
 
 	.global func_ov10_02118f54
@@ -9572,7 +9572,7 @@ _02119110:
 	.global func_ov10_02119154
 	arm_func_start func_ov10_02119154
 func_ov10_02119154: ; 0x02119154
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x4c
 	ldr r1, _0211951c ; =0x0400101c
 	mov r2, #0
@@ -9643,16 +9643,16 @@ _02119230: ; jump table
 _02119250:
 	mov r0, r4
 	bl func_01ffbe34
-	mov sb, #0xfa000
-	umull lr, ip, r6, sb
-	adds sb, lr, #0x800
+	mov r9, #0xfa000
+	umull lr, ip, r6, r9
+	adds r9, lr, #0x800
 	mov r2, #0
-	mov lr, sb, lsr #0xc
-	mov sb, r2
-	mla ip, r6, sb, ip
+	mov lr, r9, lsr #0xc
+	mov r9, r2
+	mla ip, r6, r9, ip
 	mov r1, r6, asr #0x1f
-	mov sb, #0xfa000
-	mla ip, r1, sb, ip
+	mov r9, #0xfa000
+	mla ip, r1, r9, ip
 	mov r1, r2
 	adc r1, ip, r1
 	orr lr, lr, r1, lsl #20
@@ -9668,16 +9668,16 @@ _02119250:
 	bl func_ov00_020d00c4
 	b _02119504
 _021192b8:
-	mov sb, #0xfa000
-	umull lr, ip, r6, sb
-	adds sb, lr, #0x800
+	mov r9, #0xfa000
+	umull lr, ip, r6, r9
+	adds r9, lr, #0x800
 	mov r2, #0
-	mov lr, sb, lsr #0xc
-	mov sb, r2
-	mla ip, r6, sb, ip
+	mov lr, r9, lsr #0xc
+	mov r9, r2
+	mla ip, r6, r9, ip
 	mov r1, r6, asr #0x1f
-	mov sb, #0xfa000
-	mla ip, r1, sb, ip
+	mov r9, #0xfa000
+	mla ip, r1, r9, ip
 	mov r1, r2
 	adc r1, ip, r1
 	orr lr, lr, r1, lsl #20
@@ -9691,16 +9691,16 @@ _021192b8:
 	bl func_ov00_020d00c4
 	b _02119504
 _02119310:
-	mov sb, #0xfa000
-	umull lr, ip, r6, sb
-	adds sb, lr, #0x800
+	mov r9, #0xfa000
+	umull lr, ip, r6, r9
+	adds r9, lr, #0x800
 	mov r2, #0
-	mov lr, sb, lsr #0xc
-	mov sb, r2
-	mla ip, r6, sb, ip
+	mov lr, r9, lsr #0xc
+	mov r9, r2
+	mla ip, r6, r9, ip
 	mov r1, r6, asr #0x1f
-	mov sb, #0xfa000
-	mla ip, r1, sb, ip
+	mov r9, #0xfa000
+	mla ip, r1, r9, ip
 	mov r1, r2
 	adc r1, ip, r1
 	orr lr, lr, r1, lsl #20
@@ -9714,16 +9714,16 @@ _02119310:
 	bl func_ov00_020d00c4
 	b _02119504
 _02119368:
-	mov sb, #0xfa000
-	umull lr, ip, r6, sb
-	adds sb, lr, #0x800
+	mov r9, #0xfa000
+	umull lr, ip, r6, r9
+	adds r9, lr, #0x800
 	mov r2, #0
-	mov lr, sb, lsr #0xc
-	mov sb, r2
-	mla ip, r6, sb, ip
+	mov lr, r9, lsr #0xc
+	mov r9, r2
+	mla ip, r6, r9, ip
 	mov r1, r6, asr #0x1f
-	mov sb, #0xfa000
-	mla ip, r1, sb, ip
+	mov r9, #0xfa000
+	mla ip, r1, r9, ip
 	mov r1, r2
 	adc r1, ip, r1
 	orr lr, lr, r1, lsl #20
@@ -9737,16 +9737,16 @@ _02119368:
 	bl func_ov00_020d00c4
 	b _02119504
 _021193c0:
-	mov sb, #0xfa000
-	umull lr, ip, r6, sb
-	adds sb, lr, #0x800
+	mov r9, #0xfa000
+	umull lr, ip, r6, r9
+	adds r9, lr, #0x800
 	mov r2, #0
-	mov lr, sb, lsr #0xc
-	mov sb, r2
-	mla ip, r6, sb, ip
+	mov lr, r9, lsr #0xc
+	mov r9, r2
+	mla ip, r6, r9, ip
 	mov r1, r6, asr #0x1f
-	mov sb, #0xfa000
-	mla ip, r1, sb, ip
+	mov r9, #0xfa000
+	mla ip, r1, r9, ip
 	mov r1, r2
 	adc r1, ip, r1
 	orr lr, lr, r1, lsl #20
@@ -9759,16 +9759,16 @@ _021193c0:
 	bl func_ov00_020d00c4
 	b _02119504
 _02119414:
-	mov sb, #0xfa000
-	umull lr, ip, r6, sb
-	adds sb, lr, #0x800
+	mov r9, #0xfa000
+	umull lr, ip, r6, r9
+	adds r9, lr, #0x800
 	mov r2, #0
-	mov lr, sb, lsr #0xc
-	mov sb, r2
-	mla ip, r6, sb, ip
+	mov lr, r9, lsr #0xc
+	mov r9, r2
+	mla ip, r6, r9, ip
 	mov r1, r6, asr #0x1f
-	mov sb, #0xfa000
-	mla ip, r1, sb, ip
+	mov r9, #0xfa000
+	mla ip, r1, r9, ip
 	mov r1, r2
 	adc r1, ip, r1
 	orr lr, lr, r1, lsl #20
@@ -9781,16 +9781,16 @@ _02119414:
 	bl func_ov00_020d00c4
 	b _02119504
 _02119468:
-	mov sb, #0x7d000
-	umull sb, ip, r6, sb
-	adds sb, sb, #0x800
+	mov r9, #0x7d000
+	umull r9, ip, r6, r9
+	adds r9, r9, #0x800
 	mov r1, #0
-	mov lr, sb, lsr #0xc
-	mov sb, r1
-	mla ip, r6, sb, ip
+	mov lr, r9, lsr #0xc
+	mov r9, r1
+	mla ip, r6, r9, ip
 	mov r2, r6, asr #0x1f
-	mov sb, #0x7d000
-	mla ip, r2, sb, ip
+	mov r9, #0x7d000
+	mla ip, r2, r9, ip
 	mov r2, r1
 	adc r2, ip, r2
 	orr lr, lr, r2, lsl #20
@@ -9809,8 +9809,8 @@ _021194bc:
 	ldr r1, [sp, #4]
 	mov r0, #0
 	mla ip, r6, r1, ip
-	mov sb, r6, asr #0x1f
-	mla ip, sb, r10, ip
+	mov r9, r6, asr #0x1f
+	mla ip, r9, r10, ip
 	mov r2, #0
 	mov r1, r2
 	adc r1, ip, r1
@@ -9827,7 +9827,7 @@ _02119504:
 	cmp r7, #8
 	blt _021191d0
 	add sp, sp, #0x4c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov10_02119154
 _0211951c: .word 0x0400101c
@@ -9835,7 +9835,7 @@ _0211951c: .word 0x0400101c
 	.global func_ov10_02119520
 	arm_func_start func_ov10_02119520
 func_ov10_02119520: ; 0x02119520
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x24
 	mov r7, r0
 	ldr r0, [r7, #0x14]
@@ -9865,10 +9865,10 @@ _02119568:
 	bne _021195a4
 	mov r3, r0, lsl #0xc
 	ldr r0, _0211989c ; =0x66666667
-	smull r1, sb, r0, r3
+	smull r1, r9, r0, r3
 	mov r0, r3, lsr #0x1f
-	add sb, r0, sb, asr #1
-	add r2, r2, sb
+	add r9, r0, r9, asr #1
+	add r2, r2, r9
 _021195a4:
 	cmp ip, #2
 	bne _021195bc
@@ -9890,16 +9890,16 @@ _021195c8: ; jump table
 	b _021197f0 ; case 6
 	b _02119844 ; case 7
 _021195e8:
-	mov sb, #0xfa000
-	umull lr, ip, r5, sb
-	adds sb, lr, #0x800
+	mov r9, #0xfa000
+	umull lr, ip, r5, r9
+	adds r9, lr, #0x800
 	mov r2, #0
-	mov lr, sb, lsr #0xc
-	mov sb, r2
-	mla ip, r5, sb, ip
+	mov lr, r9, lsr #0xc
+	mov r9, r2
+	mla ip, r5, r9, ip
 	mov r1, r5, asr #0x1f
-	mov sb, #0xfa000
-	mla ip, r1, sb, ip
+	mov r9, #0xfa000
+	mla ip, r1, r9, ip
 	mov r1, r2
 	adc r1, ip, r1
 	orr lr, lr, r1, lsl #20
@@ -9913,16 +9913,16 @@ _021195e8:
 	bl func_ov00_020d00c4
 	b _02119888
 _02119640:
-	mov sb, #0xfa000
-	umull lr, ip, r5, sb
-	adds sb, lr, #0x800
+	mov r9, #0xfa000
+	umull lr, ip, r5, r9
+	adds r9, lr, #0x800
 	mov r2, #0
-	mov lr, sb, lsr #0xc
-	mov sb, r2
-	mla ip, r5, sb, ip
+	mov lr, r9, lsr #0xc
+	mov r9, r2
+	mla ip, r5, r9, ip
 	mov r1, r5, asr #0x1f
-	mov sb, #0xfa000
-	mla ip, r1, sb, ip
+	mov r9, #0xfa000
+	mla ip, r1, r9, ip
 	mov r1, r2
 	adc r1, ip, r1
 	orr lr, lr, r1, lsl #20
@@ -9936,16 +9936,16 @@ _02119640:
 	bl func_ov00_020d00c4
 	b _02119888
 _02119698:
-	mov sb, #0x7d000
-	umull lr, ip, r5, sb
-	adds sb, lr, #0x800
+	mov r9, #0x7d000
+	umull lr, ip, r5, r9
+	adds r9, lr, #0x800
 	mov r2, #0
-	mov lr, sb, lsr #0xc
-	mov sb, r2
-	mla ip, r5, sb, ip
+	mov lr, r9, lsr #0xc
+	mov r9, r2
+	mla ip, r5, r9, ip
 	mov r1, r5, asr #0x1f
-	mov sb, #0x7d000
-	mla ip, r1, sb, ip
+	mov r9, #0x7d000
+	mla ip, r1, r9, ip
 	mov r1, r2
 	adc r1, ip, r1
 	orr lr, lr, r1, lsl #20
@@ -9959,16 +9959,16 @@ _02119698:
 	bl func_ov00_020d00c4
 	b _02119888
 _021196f0:
-	mov sb, #0xfa000
-	umull lr, ip, r5, sb
-	adds sb, lr, #0x800
+	mov r9, #0xfa000
+	umull lr, ip, r5, r9
+	adds r9, lr, #0x800
 	mov r2, #0
-	mov lr, sb, lsr #0xc
-	mov sb, r2
-	mla ip, r5, sb, ip
+	mov lr, r9, lsr #0xc
+	mov r9, r2
+	mla ip, r5, r9, ip
 	mov r1, r5, asr #0x1f
-	mov sb, #0xfa000
-	mla ip, r1, sb, ip
+	mov r9, #0xfa000
+	mla ip, r1, r9, ip
 	mov r1, r2
 	adc r1, ip, r1
 	orr lr, lr, r1, lsl #20
@@ -9982,16 +9982,16 @@ _021196f0:
 	bl func_ov00_020d00c4
 	b _02119888
 _02119748:
-	mov sb, #0xfa000
-	umull lr, ip, r5, sb
-	adds sb, lr, #0x800
+	mov r9, #0xfa000
+	umull lr, ip, r5, r9
+	adds r9, lr, #0x800
 	mov r2, #0
-	mov lr, sb, lsr #0xc
-	mov sb, r2
-	mla ip, r5, sb, ip
+	mov lr, r9, lsr #0xc
+	mov r9, r2
+	mla ip, r5, r9, ip
 	mov r1, r5, asr #0x1f
-	mov sb, #0xfa000
-	mla ip, r1, sb, ip
+	mov r9, #0xfa000
+	mla ip, r1, r9, ip
 	mov r1, r2
 	adc r1, ip, r1
 	orr lr, lr, r1, lsl #20
@@ -10004,16 +10004,16 @@ _02119748:
 	bl func_ov00_020d00c4
 	b _02119888
 _0211979c:
-	mov sb, #0xfa000
-	umull lr, ip, r5, sb
-	adds sb, lr, #0x800
+	mov r9, #0xfa000
+	umull lr, ip, r5, r9
+	adds r9, lr, #0x800
 	mov r2, #0
-	mov lr, sb, lsr #0xc
-	mov sb, r2
-	mla ip, r5, sb, ip
+	mov lr, r9, lsr #0xc
+	mov r9, r2
+	mla ip, r5, r9, ip
 	mov r1, r5, asr #0x1f
-	mov sb, #0xfa000
-	mla ip, r1, sb, ip
+	mov r9, #0xfa000
+	mla ip, r1, r9, ip
 	mov r1, r2
 	adc r1, ip, r1
 	orr lr, lr, r1, lsl #20
@@ -10026,16 +10026,16 @@ _0211979c:
 	bl func_ov00_020d00c4
 	b _02119888
 _021197f0:
-	mov sb, #0x7d000
-	umull lr, ip, r5, sb
-	adds sb, lr, #0x800
+	mov r9, #0x7d000
+	umull lr, ip, r5, r9
+	adds r9, lr, #0x800
 	mov r1, #0
-	mov lr, sb, lsr #0xc
-	mov sb, r1
-	mla ip, r5, sb, ip
+	mov lr, r9, lsr #0xc
+	mov r9, r1
+	mla ip, r5, r9, ip
 	mov r2, r5, asr #0x1f
-	mov sb, #0x7d000
-	mla ip, r2, sb, ip
+	mov r9, #0x7d000
+	mla ip, r2, r9, ip
 	mov r2, r1
 	adc r2, ip, r2
 	orr lr, lr, r2, lsl #20
@@ -10050,16 +10050,16 @@ _021197f0:
 _02119844:
 	umull lr, ip, r5, r8
 	mla ip, r5, r10, ip
-	mov sb, r5, asr #0x1f
+	mov r9, r5, asr #0x1f
 	adds r1, lr, #0x800
 	mov r0, #0
 	str r0, [sp]
-	mla ip, sb, r8, ip
+	mla ip, r9, r8, ip
 	mov r2, #0
-	mov sb, r2
+	mov r9, r2
 	mov r1, r1, lsr #0xc
-	adc sb, ip, sb
-	orr r1, r1, sb, lsl #20
+	adc r9, ip, r9
+	orr r1, r1, r9, lsl #20
 	add r1, r1, #0x800
 	add r0, r7, #0xc0
 	mov r3, r4
@@ -10070,7 +10070,7 @@ _02119888:
 	cmp r6, #8
 	blt _02119568
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov10_02119520
 _0211989c: .word 0x66666667
@@ -10224,7 +10224,7 @@ func_ov10_02119a14: ; 0x02119a14
 	.global func_ov10_02119a6c
 	arm_func_start func_ov10_02119a6c
 func_ov10_02119a6c: ; 0x02119a6c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	mov r4, r0
 	mov r5, r1
 	mov r1, r4
@@ -10244,14 +10244,14 @@ func_ov10_02119a6c: ; 0x02119a6c
 	mov r3, #1
 	ldr r6, [r2]
 	ldmib r2, {r5, r8}
-	umull r10, sb, r8, r6
-	mla sb, r8, r5, sb
+	umull r10, r9, r8, r6
+	mla r9, r8, r5, r9
 	ldr r7, [r2, #0xc]
 	ldr lr, [r2, #0x10]
-	mla sb, r7, r6, sb
+	mla r9, r7, r6, r9
 	ldr ip, [r2, #0x14]
 	adds r6, lr, r10
-	adc r5, ip, sb
+	adc r5, ip, r9
 	str r6, [r2]
 	str r5, [r2, #4]
 	mov r5, r5, lsr #0x18
@@ -10264,9 +10264,9 @@ func_ov10_02119a6c: ; 0x02119a6c
 	ldr r5, [r2, #0xc]
 	ldr r10, [r2, #0x10]
 	mla r7, r5, lr, r7
-	ldr sb, [r2, #0x14]
+	ldr r9, [r2, #0x14]
 	adds r6, r10, r8
-	adc r5, sb, r7
+	adc r5, r9, r7
 	str r6, [r2]
 	str r5, [r2, #4]
 	mov r2, r5, lsr #0x18
@@ -10275,7 +10275,7 @@ func_ov10_02119a6c: ; 0x02119a6c
 	mov r1, #0x80
 	strb r3, [r4, #0x7d]
 	blx func_0202f134
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov10_02119a6c
 _02119b3c: .word 0x415a454a
@@ -10366,7 +10366,7 @@ _02119c6c: .word 0x415a454a
 	.global func_ov10_02119c70
 	arm_func_start func_ov10_02119c70
 func_ov10_02119c70: ; 0x02119c70
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #4
 	mov r5, r0
 	strh r1, [r5]
@@ -10380,14 +10380,14 @@ func_ov10_02119c70: ; 0x02119c70
 	str r4, [sp]
 	bl func_0204f614
 	add r0, r5, #4
-	add sb, r0, #0x2800
+	add r9, r0, #0x2800
 	add r0, r5, #0x204
 	add r4, r0, #0x3000
 	mov r8, #0
 	mov r7, #0x16
 _02119cbc:
-	add r10, sb, #0x180
-	add r6, sb, #0x440
+	add r10, r9, #0x180
+	add r6, r9, #0x440
 _02119cc4:
 	mov r0, r8
 	mov r1, r10
@@ -10398,13 +10398,13 @@ _02119cc4:
 	blo _02119cc4
 	mov r0, r6
 	blx func_ov00_0207a4f0
-	mov r0, sb
+	mov r0, r9
 	blx func_ov00_0207a5ac
-	add sb, sb, #0x500
-	cmp sb, r4
+	add r9, r9, #0x500
+	cmp r9, r4
 	blo _02119cbc
 	add r0, r5, #0x304
-	add sb, r0, #0x3000
+	add r9, r0, #0x3000
 	mov r8, #0
 	mov r7, #0x14
 _02119d0c:
@@ -10423,15 +10423,15 @@ _02119d14:
 	mov r0, r4
 	blx func_ov00_0207a5f4
 	add r4, r4, #0x80
-	cmp r4, sb
+	cmp r4, r9
 	blo _02119d0c
 	add r0, r5, #4
 	add r6, r0, #0x3400
 _02119d54:
-	mov r0, sb
+	mov r0, r9
 	blx func_ov00_0207a6ac
-	add sb, sb, #0x80
-	cmp sb, r6
+	add r9, r9, #0x80
+	cmp r9, r6
 	blo _02119d54
 	add r0, r5, #0x104
 	add r4, r0, #0x3400
@@ -10461,7 +10461,7 @@ _02119db0:
 	blt _02119db0
 	mov r0, r5
 	add sp, sp, #4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov10_02119c70
 _02119dd4: .word func_ov10_02112d40 - 1
@@ -10487,14 +10487,14 @@ func_ov10_02119ddc: ; 0x02119ddc
 	.global func_ov10_02119e0c
 	arm_func_start func_ov10_02119e0c
 func_ov10_02119e0c: ; 0x02119e0c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	mov r4, r0
 	add r6, r4, #4
 	add r0, r4, #0x204
 	add r1, r4, #0x304
 	add r7, r6, #0x2800
 	add r8, r0, #0x3000
-	add sb, r1, #0x3000
+	add r9, r1, #0x3000
 	add r10, r6, #0x3400
 	mov r5, #0
 _02119e34:
@@ -10504,7 +10504,7 @@ _02119e34:
 	blx func_ov00_0207a5ac
 	mov r0, r8
 	blx func_ov00_0207a5f4
-	mov r0, sb
+	mov r0, r9
 	blx func_ov00_0207a68c
 	mov r0, r10
 	blx func_ov00_0207a6d0
@@ -10513,18 +10513,18 @@ _02119e34:
 	add r6, r6, #0x1400
 	add r7, r7, #0x500
 	add r8, r8, #0x80
-	add sb, sb, #0x80
+	add r9, r9, #0x80
 	add r10, r10, #0x80
 	blt _02119e34
 	mov r0, r4
 	bl func_ov10_02119ddc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	arm_func_end func_ov10_02119e0c
 
 	.global func_ov10_02119e88
 	arm_func_start func_ov10_02119e88
 func_ov10_02119e88: ; 0x02119e88
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x14
 	add r4, r0, #4
 	add r5, r1, #4
@@ -10543,7 +10543,7 @@ func_ov10_02119e88: ; 0x02119e88
 	str r2, [sp]
 	str r3, [sp, #4]
 	add r8, r1, #0x3000
-	add sb, r4, #0x3400
+	add r9, r4, #0x3400
 	add r10, r5, #0x3400
 	str r0, [sp, #0x10]
 _02119ee0:
@@ -10571,12 +10571,12 @@ _02119f0c:
 	mov r2, #0x80
 	cmp r0, #0
 	beq _02119f48
-	mov r1, sb
+	mov r1, r9
 	bl func_02007984
 	b _02119f54
 _02119f48:
 	mov r0, r10
-	mov r1, sb
+	mov r1, r9
 	bl func_02007984
 _02119f54:
 	ldr r0, [sp, #0xc]
@@ -10593,13 +10593,13 @@ _02119f54:
 	add r6, r6, #0x80
 	add r7, r7, #0x80
 	add r8, r8, #0x80
-	add sb, sb, #0x80
+	add r9, r9, #0x80
 	add r10, r10, #0x80
 	str r0, [sp, #0x10]
 	cmp r0, #2
 	blt _02119ee0
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	arm_func_end func_ov10_02119e88
 
 	.global func_ov10_02119fa8
@@ -11074,17 +11074,17 @@ _0211a5d0:
 	.global func_ov10_0211a5f4
 	arm_func_start func_ov10_0211a5f4
 func_ov10_0211a5f4: ; 0x0211a5f4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x1c
-	mov sb, r0
-	add r1, sb, #0x3000
+	mov r9, r0
+	add r1, r9, #0x3000
 	ldr r0, [r1, #0x504]
 	tst r0, #1
 	beq _0211a648
 	tst r0, #2
 	beq _0211a648
 	ldr r2, [r1, #0x504]
-	add r0, sb, #0x204
+	add r0, r9, #0x204
 	orr r2, r2, #0x30
 	str r2, [r1, #0x504]
 	add r5, r0, #0x3000
@@ -11097,20 +11097,20 @@ _0211a630:
 	add r5, r5, #0x80
 	blo _0211a630
 _0211a648:
-	add r0, sb, #0x84
+	add r0, r9, #0x84
 	str r0, [sp, #0x18]
-	add r0, sb, #0x384
+	add r0, r9, #0x384
 	ldr r4, _0211a868 ; =0x0003f500
 	mov r8, #0
-	add r7, sb, #4
+	add r7, r9, #4
 	str r0, [sp, #0x14]
-	add r11, sb, #0x304
-	add r10, sb, #0x284
-	add r5, sb, #0x204
-	add r6, sb, #0x104
+	add r11, r9, #0x304
+	add r10, r9, #0x284
+	add r5, r9, #0x204
+	add r6, r9, #0x104
 _0211a674:
 	mov r1, r8, lsr #0x5
-	add r1, sb, r1, lsl #2
+	add r1, r9, r1, lsl #2
 	add r1, r1, #0x3000
 	ldr r2, [r1, #0x504]
 	and r0, r8, #0x1f
@@ -11132,28 +11132,28 @@ _0211a6a0: ; jump table
 	b _0211a7a0 ; case 8
 	b _0211a7b8 ; case 9
 _0211a6c8:
-	ldrh r1, [sb]
+	ldrh r1, [r9]
 	mov r0, r7
 	mov r2, #0x1400
 	mul r3, r1, r4
 	add r1, r3, #0
 	b _0211a7e4
 _0211a6e0:
-	ldrh r1, [sb]
+	ldrh r1, [r9]
 	add r0, r7, #0x1400
 	mov r2, #0x1400
 	mul r3, r1, r4
 	add r1, r3, #0x1400
 	b _0211a7e4
 _0211a6f8:
-	ldrh r1, [sb]
+	ldrh r1, [r9]
 	add r0, r7, #0x2800
 	mov r2, #0x500
 	mul r3, r1, r4
 	add r1, r3, #0x3e800
 	b _0211a7e4
 _0211a710:
-	ldrh r1, [sb]
+	ldrh r1, [r9]
 	add r0, r6, #0x2c00
 	mov r2, #0x500
 	mul r3, r1, r4
@@ -11161,7 +11161,7 @@ _0211a710:
 	add r1, r1, #0x30000
 	b _0211a7e4
 _0211a72c:
-	ldrh r1, [sb]
+	ldrh r1, [r9]
 	add r0, r5, #0x3000
 	mov r2, #0x80
 	mul r3, r1, r4
@@ -11169,7 +11169,7 @@ _0211a72c:
 	add r1, r1, #0x30000
 	b _0211a7e4
 _0211a748:
-	ldrh r1, [sb]
+	ldrh r1, [r9]
 	add r0, r10, #0x3000
 	mov r2, #0x80
 	mul r3, r1, r4
@@ -11177,7 +11177,7 @@ _0211a748:
 	add r1, r1, #0x3c000
 	b _0211a7e4
 _0211a764:
-	ldrh r1, [sb]
+	ldrh r1, [r9]
 	add r0, r11, #0x3000
 	mov r2, #0x80
 	mul r3, r1, r4
@@ -11185,7 +11185,7 @@ _0211a764:
 	add r1, r1, #0x30000
 	b _0211a7e4
 _0211a780:
-	ldrh r1, [sb]
+	ldrh r1, [r9]
 	ldr r0, [sp, #0x14]
 	mov r2, #0x80
 	mul r3, r1, r4
@@ -11194,14 +11194,14 @@ _0211a780:
 	add r1, r1, #0x3c000
 	b _0211a7e4
 _0211a7a0:
-	ldrh r1, [sb]
+	ldrh r1, [r9]
 	add r0, r7, #0x3400
 	mov r2, #0x80
 	mul r3, r1, r4
 	add r1, r3, #0x3f400
 	b _0211a7e4
 _0211a7b8:
-	ldrh r1, [sb]
+	ldrh r1, [r9]
 	ldr r0, [sp, #0x18]
 	mov r2, #0x80
 	mul r3, r1, r4
@@ -11212,7 +11212,7 @@ _0211a7b8:
 _0211a7d8:
 	add sp, sp, #0x1c
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0211a7e4:
 	mov r3, #0
 	str r3, [sp]
@@ -11228,27 +11228,27 @@ _0211a7e4:
 	cmp r0, #0
 	addeq sp, sp, #0x1c
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0211a820:
 	add r8, r8, #1
 	cmp r8, #0xa
 	blo _0211a674
-	add r0, sb, #0x3000
+	add r0, r9, #0x3000
 	ldr r0, [r0, #0x504]
 	tst r0, #1
 	beq _0211a85c
 	tst r0, #2
 	beq _0211a85c
-	ldrh r0, [sb]
+	ldrh r0, [r9]
 	bl func_ov10_0211cfd8
 	cmp r0, #0
 	addeq sp, sp, #0x1c
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0211a85c:
 	mov r0, #1
 	add sp, sp, #0x1c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov10_0211a5f4
 _0211a868: .word 0x0003f500
@@ -15717,13 +15717,13 @@ _0211cd48: .word data_ov10_0211e980
 	.global func_ov10_0211cd4c
 	arm_func_start func_ov10_0211cd4c
 func_ov10_0211cd4c: ; 0x0211cd4c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x14
 	ldr r2, _0211cdd0 ; =0x0003f500
 	mov r10, r0
 	mul r0, r1, r2
 	mov r8, #0
-	add sb, r0, #0
+	add r9, r0, #0
 	mov r7, r8
 	mov r6, #7
 	mov r5, #0xa
@@ -15735,7 +15735,7 @@ _0211cd7c:
 	str r6, [sp, #8]
 	str r5, [sp, #0xc]
 	mov r0, r10
-	mov r1, sb
+	mov r1, r9
 	mov r2, r11
 	mov r3, r7
 	str r4, [sp, #0x10]
@@ -15743,14 +15743,14 @@ _0211cd7c:
 	cmp r0, #0
 	addeq sp, sp, #0x14
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r8, r8, #1
 	cmp r8, #2
-	add sb, sb, #0x1400
+	add r9, r9, #0x1400
 	blt _0211cd7c
 	mov r0, #1
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov10_0211cd4c
 _0211cdd0: .word 0x0003f500
@@ -15758,13 +15758,13 @@ _0211cdd0: .word 0x0003f500
 	.global func_ov10_0211cdd4
 	arm_func_start func_ov10_0211cdd4
 func_ov10_0211cdd4: ; 0x0211cdd4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x14
 	ldr r2, _0211ce58 ; =0x0003f500
 	mov r10, r0
 	mul r0, r1, r2
 	mov r8, #0
-	add sb, r0, #0x3e800
+	add r9, r0, #0x3e800
 	mov r7, r8
 	mov r6, #7
 	mov r5, #0xa
@@ -15776,7 +15776,7 @@ _0211ce04:
 	str r6, [sp, #8]
 	str r5, [sp, #0xc]
 	mov r0, r10
-	mov r1, sb
+	mov r1, r9
 	mov r2, r11
 	mov r3, r7
 	str r4, [sp, #0x10]
@@ -15784,14 +15784,14 @@ _0211ce04:
 	cmp r0, #0
 	addeq sp, sp, #0x14
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r8, r8, #1
 	cmp r8, #2
-	add sb, sb, #0x500
+	add r9, r9, #0x500
 	blt _0211ce04
 	mov r0, #1
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov10_0211cdd4
 _0211ce58: .word 0x0003f500
@@ -15921,12 +15921,12 @@ func_ov10_0211cfa0: ; 0x0211cfa0
 	.global func_ov10_0211cfd8
 	arm_func_start func_ov10_0211cfd8
 func_ov10_0211cfd8: ; 0x0211cfd8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x20
 	ldr r1, _0211d0a8 ; =0x000037fc
 	str r0, [sp, #0x14]
 	mov r0, #0
-	ldr sb, _0211d0ac ; =data_ov10_0211e998
+	ldr r9, _0211d0ac ; =data_ov10_0211e998
 	str r1, [sp, #0x18]
 	str r0, [sp, #0x1c]
 	mov r7, r0
@@ -15950,7 +15950,7 @@ _0211d030:
 	str r7, [sp, #4]
 	str r6, [sp, #8]
 	str r5, [sp, #0xc]
-	mov r0, sb
+	mov r0, r9
 	mov r1, r10
 	mov r2, r11
 	mov r3, r7
@@ -15959,7 +15959,7 @@ _0211d030:
 	cmp r0, #0
 	addeq sp, sp, #0x20
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r8, r8, #1
 	cmp r8, #0x3c
 	add r10, r10, #0x1000
@@ -15976,7 +15976,7 @@ _0211d078:
 	blt _0211d00c
 	mov r0, #1
 	add sp, sp, #0x20
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov10_0211cfd8
 _0211d0a8: .word 0x000037fc
@@ -16026,14 +16026,14 @@ _0211d138: .word 0x0007ea00
 	.global func_ov10_0211d13c
 	arm_func_start func_ov10_0211d13c
 func_ov10_0211d13c: ; 0x0211d13c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x14
 	ldr r3, _0211d260 ; =0x0003f500
 	mov r10, r2
 	mul r4, r1, r3
 	mul r1, r0, r3
 	add r0, r4, #0xfe
-	add sb, r4, #0x2800
+	add r9, r4, #0x2800
 	add r7, r1, #0x2800
 	add r8, r0, #0x3700
 	mov r6, #0
@@ -16053,7 +16053,7 @@ _0211d174:
 	cmp r0, #0
 	addeq sp, sp, #0x14
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldrh r0, [r4, #0xfe]
 	mov r3, #0
 	cmp r0, #0
@@ -16075,7 +16075,7 @@ _0211d174:
 	bne _0211d23c
 	add sp, sp, #0x14
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0211d200:
 	str r0, [sp, #4]
 	mov r0, #7
@@ -16085,23 +16085,23 @@ _0211d200:
 	mov r0, #2
 	str r0, [sp, #0x10]
 	mov r0, r10
-	mov r1, sb
+	mov r1, r9
 	mov r2, #0x1000
 	blx func_02040464
 	cmp r0, #0
 	addeq sp, sp, #0x14
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0211d23c:
 	add r7, r7, #0x1000
 	add r8, r8, #0x1000
-	add sb, sb, #0x1000
+	add r9, r9, #0x1000
 	add r6, r6, #1
 	cmp r6, #0x3c
 	blt _0211d174
 	mov r0, #1
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov10_0211d13c
 _0211d260: .word 0x0003f500

--- a/asm/ov12.s
+++ b/asm/ov12.s
@@ -1920,7 +1920,7 @@ _021144b8: .word data_ov12_02137d20
 	.global func_ov12_021144bc
 	arm_func_start func_ov12_021144bc
 func_ov12_021144bc: ; 0x021144bc
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x3c
 	movs r7, r1
 	mov r8, r0
@@ -1965,7 +1965,7 @@ _0211454c:
 	ldr r2, _021146d0 ; =0x00000aab
 	add r0, r8, #0x78
 	bl func_0202b154
-	mov sb, r7
+	mov r9, r7
 	bl func_ov12_02114b28
 	cmp r0, #0
 	beq _02114590
@@ -1974,11 +1974,11 @@ _0211454c:
 	mov r0, #0x1200
 	mul r0, r7, r0
 	add r0, r0, #0x800
-	mov sb, r0, asr #0xc
+	mov r9, r0, asr #0xc
 _02114590:
 	add r3, sp, #0x24
 	mov r0, r8
-	mov r2, sb
+	mov r2, r9
 	add r1, r8, #0x760
 	bl _ZN5Actor18func_ov00_020c2988EP5Vec3piS1_
 	cmp r6, #0
@@ -2059,7 +2059,7 @@ _021145fc:
 _021146c4:
 	mov r0, r4
 	add sp, sp, #0x3c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov12_021144bc
 _021146d0: .word 0x00000aab
@@ -2203,7 +2203,7 @@ _021148a4: .word data_027e0ff8
 	.global func_ov12_021148a8
 	arm_func_start func_ov12_021148a8
 func_ov12_021148a8: ; 0x021148a8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x10
 	mov r10, r0
 	ldr r0, _02114a90 ; =0x00005555
@@ -2277,17 +2277,17 @@ _021149a0:
 	ldrsh r1, [r10, #0x78]
 	ldr r3, _02114a90 ; =0x00005555
 	cmp r0, #1
-	mov sb, #0x2000
+	mov r9, #0x2000
 	moveq r2, #0x3c00
 	add r0, r10, #0x48
-	moveq sb, #0x3000
+	moveq r9, #0x3000
 	bl func_ov00_020c54a0
 	cmp r0, #0
 	movne r6, #1
 	bne _02114a04
 	str r5, [sp]
 	ldrsh r1, [r10, #0x78]
-	mov r2, sb
+	mov r2, r9
 	add r0, r10, #0x48
 	sub r1, r1, #0x8000
 	mov r1, r1, lsl #0x10
@@ -2326,14 +2326,14 @@ _02114a30:
 	orr r1, r2, r1, asr #2
 	mov r0, r6
 	strb r1, [r10, #0x239]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02114a78:
 	add r7, r7, #1
 	cmp r7, #2
 	blt _021148cc
 	mov r0, r6
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov12_021148a8
 _02114a90: .word 0x00005555
@@ -5851,7 +5851,7 @@ _021178f8: .word func_ov12_02117a94
 	.global func_ov12_021178fc
 	arm_func_start func_ov12_021178fc
 func_ov12_021178fc: ; 0x021178fc
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	ldr r1, _021179fc ; =data_ov12_02137c64
 	mov r11, r0
 	ldr r0, [r1]
@@ -5865,7 +5865,7 @@ func_ov12_021178fc: ; 0x021178fc
 	beq _02117934
 _0211792c:
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02117934:
 	ldr r1, _02117a04 ; =data_027e0d78
 	ldrh r0, [r1, #0x34]
@@ -5877,7 +5877,7 @@ _02117934:
 	ldr r5, [r1, #0x10]
 	ldr r6, [r1, #0x14]
 	ldr r10, [r0, #0x24]
-	sub sb, r8, #0x91
+	sub r9, r8, #0x91
 	mov r7, #0
 _02117964:
 	ldr r0, [r4]
@@ -5887,12 +5887,12 @@ _02117964:
 	mov r2, r6
 	bl func_ov12_021183b0
 	cmp r8, r0
-	movgt sb, r7
+	movgt r9, r7
 	add r7, r7, #1
 	movgt r8, r0
 	cmp r7, #3
 	blt _02117964
-	cmp sb, #0
+	cmp r9, #0
 	blt _021179f4
 	cmp r10, r7
 	beq _021179cc
@@ -5900,26 +5900,26 @@ _02117964:
 	mov r1, #1
 	ldr r2, [r0]
 	ldr r0, _02117a0c ; =data_ov12_02137d28
-	str sb, [r2, #0x24]
+	str r9, [r2, #0x24]
 	strb r1, [r11, #0x14]
 	ldr r0, [r0]
-	add r1, sb, #1
+	add r1, r9, #1
 	mov r2, #2
 	bl func_ov12_02117ab4
 _021179cc:
 	ldr r0, _02117a08 ; =data_ov12_02137d20
-	mov r1, sb
+	mov r1, r9
 	ldr r0, [r0]
 	bl func_ov12_0211776c
 	cmp r0, #0
 	beq _021179f4
 	ldr r0, _02117a08 ; =data_ov12_02137d20
-	mov r1, sb
+	mov r1, r9
 	ldr r0, [r0]
 	bl func_ov12_02117718
 _021179f4:
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov12_021178fc
 _021179fc: .word data_ov12_02137c64
@@ -6680,7 +6680,7 @@ _02118424: .word data_027e0d3c
 	.global func_ov12_02118428
 	arm_func_start func_ov12_02118428
 func_ov12_02118428: ; 0x02118428
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x128
 	ldr r3, _021187fc ; =data_027e0c38
 	add r4, sp, #0xbc
@@ -6735,7 +6735,7 @@ func_ov12_02118428: ; 0x02118428
 	cmp r0, #0
 	addeq sp, sp, #0x128
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, _02118808 ; =data_027e0e60
 	add r1, sp, #0xbc
 	ldr r0, [r0]
@@ -6768,7 +6768,7 @@ func_ov12_02118428: ; 0x02118428
 _0211857c:
 	ldr r1, [r8, #0x98]
 	add r0, sp, #0x8c
-	mov sb, r1, asr #0x1
+	mov r9, r1, asr #0x1
 	bl func_01ff9cec
 	mov r10, r0
 	add r0, sp, #0xa4
@@ -6795,17 +6795,17 @@ _021185d8:
 	str r1, [sp, #0x74]
 	str r1, [sp, #0x68]
 	ldr r1, [sp, #0xac]
-	cmp r10, sb
-	movle sb, r10
+	cmp r10, r9
+	movle r9, r10
 	str r0, [sp, #0x78]
 	str r0, [sp, #0x6c]
-	mov r0, sb
+	mov r0, r9
 	str r1, [sp, #0x7c]
 	str r1, [sp, #0x70]
 	add r1, sp, #0x80
 	mov r2, r7
 	mov r3, r7
-	sub r10, r10, sb
+	sub r10, r10, r9
 	bl func_01ff9e64
 	ldr r0, _0211880c ; =0x0000ffff
 	strh r6, [sp, #0xf4]
@@ -6913,7 +6913,7 @@ _0211877c:
 	addne sp, sp, #0x128
 	str r1, [r0]
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, _02118800 ; =data_027e0d3c
 	ldr r2, [sp, #0x14]
 	ldr r0, [r0]
@@ -6928,7 +6928,7 @@ _0211877c:
 	ldr r1, [sp, #0x14]
 	str r2, [r1]
 	add sp, sp, #0x128
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov12_02118428
 _021187fc: .word data_027e0c38
@@ -7036,13 +7036,13 @@ func_ov12_021188ec: ; 0x021188ec
 	.global func_ov12_0211893c
 	arm_func_start func_ov12_0211893c
 func_ov12_0211893c: ; 0x0211893c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	mov r10, r0
 	bl func_ov12_021174d4
 	ldr r0, _021189c0 ; =data_ov12_02137d2c
 	ldr r7, _021189c4 ; =data_ov12_02134704
 	ldr r8, _021189c8 ; =data_ov12_02134708
-	ldr sb, _021189cc ; =data_ov12_02134700
+	ldr r9, _021189cc ; =data_ov12_02134700
 	ldr r4, _021189d0 ; =data_027e0ce0
 	str r10, [r0]
 	mov r6, #0
@@ -7058,7 +7058,7 @@ _0211896c:
 	ldrb r2, [r7]
 	mov r1, r6
 	str r2, [sp]
-	ldrb r2, [sb]
+	ldrb r2, [r9]
 	ldrb r3, [r8]
 	bl func_ov12_02117cc0
 _0211899c:
@@ -7067,10 +7067,10 @@ _0211899c:
 	cmp r6, #3
 	add r7, r7, #1
 	add r8, r8, #1
-	add sb, sb, #1
+	add r9, r9, #1
 	blt _0211896c
 	mov r0, r10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov12_0211893c
 _021189c0: .word data_ov12_02137d2c
@@ -8743,7 +8743,7 @@ _02119de0: .word data_027e0e58
 	.global func_ov12_02119de4
 	arm_func_start func_ov12_02119de4
 func_ov12_02119de4: ; 0x02119de4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	mov r6, r0
 	mov r5, r1
 	bl func_ov12_0211f6a0
@@ -8754,7 +8754,7 @@ func_ov12_02119de4: ; 0x02119de4
 	mov r1, r5
 	mov r2, #0
 	bl func_ov05_0210e4e4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _02119e14:
 	ldr r1, _0211a3c8 ; =data_027e0f94
 	mov r0, r6
@@ -9064,16 +9064,16 @@ _0211a274:
 	ldr r0, _0211a3f4 ; =data_027e0e58
 	ldr r4, _0211a3c8 ; =data_027e0f94
 	ldr r7, [r0]
-	add sb, r6, #0x7c
+	add r9, r6, #0x7c
 	mov r8, #0
 _0211a2a8:
 	mov r0, r7
-	mov r1, sb
+	mov r1, r9
 	mov r2, r4
 	bl func_ov00_0207c474
 	add r8, r8, #1
 	cmp r8, #3
-	add sb, sb, #0xc
+	add r9, r9, #0xc
 	blo _0211a2a8
 	b _0211a2f8
 _0211a2cc:
@@ -9102,16 +9102,16 @@ _0211a2f8:
 	ldr r0, _0211a3f4 ; =data_027e0e58
 	ldr r4, _0211a3c8 ; =data_027e0f94
 	ldr r7, [r0]
-	add sb, r6, #0xdc
+	add r9, r6, #0xdc
 	mov r8, #0
 _0211a330:
 	mov r0, r7
-	mov r1, sb
+	mov r1, r9
 	mov r2, r4
 	bl func_ov00_0207c474
 	add r8, r8, #1
 	cmp r8, #5
-	add sb, sb, #0xc
+	add r9, r9, #0xc
 	blo _0211a330
 	b _0211a378
 _0211a354:
@@ -9145,7 +9145,7 @@ _0211a378:
 	mov r0, r0, asr #0x4
 	and r0, r0, #3
 	str r0, [r6, #0x124]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov12_02119de4
 _0211a3c8: .word data_027e0f94
@@ -9709,7 +9709,7 @@ func_ov12_0211aa94: ; 0x0211aa94
 	.global func_ov12_0211aaa0
 	arm_func_start func_ov12_0211aaa0
 func_ov12_0211aaa0: ; 0x0211aaa0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x10
 	mov r10, r0
 	blx func_ov04_0210b3f0
@@ -9741,7 +9741,7 @@ func_ov12_0211aaa0: ; 0x0211aaa0
 	ldr r8, _0211acfc ; =data_ov12_02135e40
 	ldr r4, _0211ad00 ; =data_027e0ce0
 	str r0, [r10, #0x238]
-	mov sb, #0
+	mov r9, #0
 	add r5, r10, #0x40
 	add r6, sp, #8
 	mov r11, #0xa4
@@ -9752,20 +9752,20 @@ _0211ab30:
 	ldr r0, [r0]
 	ldr r1, [r4, #4]
 	add r0, r7, r0
-	str r0, [r6, sb, lsl #2]
+	str r0, [r6, r9, lsl #2]
 	mov r0, r11
 	mov r2, #4
 	bl _ZN9SysObjectnwEmPjj
 	cmp r0, #0
 	beq _0211ab68
-	ldr r1, [r6, sb, lsl #2]
+	ldr r1, [r6, r9, lsl #2]
 	blx func_ov04_0210b2d8
 _0211ab68:
-	add r1, r10, sb, lsl #2
-	add sb, sb, #1
+	add r1, r10, r9, lsl #2
+	add r9, r9, #1
 	str r0, [r1, #0x1a0]
 	str r5, [r0, #0x9c]
-	cmp sb, #2
+	cmp r9, #2
 	add r8, r8, #0x10
 	blt _0211ab30
 	ldr r0, [r10, #0x1a0]
@@ -9864,7 +9864,7 @@ _0211aca0:
 	bl func_02035370
 	mov r0, r10
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov12_0211aaa0
 _0211acf4: .word data_ov12_02135e80
@@ -9995,17 +9995,17 @@ func_ov12_0211ae28: ; 0x0211ae28
 	.global func_ov12_0211ae4c
 	arm_func_start func_ov12_0211ae4c
 func_ov12_0211ae4c: ; 0x0211ae4c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x20
 	mov r4, r1
 	mov r5, #0x19000
 	umull r7, r6, r4, r5
 	mov r1, #0
 	mla r6, r4, r1, r6
-	mov sb, r4, asr #0x1f
+	mov r9, r4, asr #0x1f
 	adds r8, r7, #0x800
-	mla r6, sb, r5, r6
-	mov r1, sb, lsl #0x10
+	mla r6, r9, r5, r6
+	mov r1, r9, lsl #0x10
 	adc r5, r6, #0
 	mov r8, r8, lsr #0xc
 	orr r8, r8, r5, lsl #20
@@ -10017,13 +10017,13 @@ func_ov12_0211ae4c: ; 0x0211ae4c
 	orr r1, r1, r4, lsr #16
 	mov r6, r0, lsr #0xc
 	adc r0, r1, #0
-	add sb, sp, #0x10
+	add r9, sp, #0x10
 	add r11, sp, #0
 	mov lr, r2
 	mov ip, r3
 	orr r6, r6, r0, lsl #20
 	ldmia r10, {r0, r1, r2, r3}
-	stmia sb, {r0, r1, r2, r3}
+	stmia r9, {r0, r1, r2, r3}
 	ldmia r7, {r0, r1, r2, r3}
 	stmia r11, {r0, r1, r2, r3}
 	cmp r4, #0xa4
@@ -10033,12 +10033,12 @@ func_ov12_0211ae4c: ; 0x0211ae4c
 	str r6, [sp, #4]
 	bgt _0211aefc
 	mov r0, r5
-	mov r1, sb
+	mov r1, r9
 	mov r2, #0
 	mov r3, #1
 	bl func_ov00_020b45f8
 	add sp, sp, #0x20
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0211aefc:
 	ldr r1, _0211af5c ; =0x00000266
 	cmp r4, r1
@@ -10049,12 +10049,12 @@ _0211aefc:
 	mov r3, r0
 	mov r0, r5
 	ldr r4, [r0]
-	mov r1, sb
+	mov r1, r9
 	ldr r4, [r4, #0x60]
 	mov r2, r11
 	blx r4
 	add sp, sp, #0x20
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0211af38:
 	mov r0, r5
 	mov r1, r11
@@ -10062,7 +10062,7 @@ _0211af38:
 	mov r3, #1
 	bl func_ov00_020b45f8
 	add sp, sp, #0x20
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov12_0211ae4c
 _0211af54: .word data_ov12_02134734
@@ -10082,7 +10082,7 @@ _0211af6c: .word func_ov00_0207a1c8
 	.global func_ov12_0211af70
 	arm_func_start func_ov12_0211af70
 func_ov12_0211af70: ; 0x0211af70
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	mov r4, r0
 	ldr r0, [r4, #0x23c]
 	cmp r0, #0x15
@@ -10129,14 +10129,14 @@ _0211b018:
 	mov r6, #0
 	ldr r2, [ip]
 	ldmib ip, {r0, r7, r8}
-	umull r3, sb, r7, r2
-	mla sb, r7, r0, sb
+	umull r3, r9, r7, r2
+	mla r9, r7, r0, r9
 	ldr r1, [ip, #0x10]
-	mla sb, r8, r2, sb
+	mla r9, r8, r2, r9
 	adds r3, r1, r3
 	ldr r0, [ip, #0x14]
 	umull r5, lr, r7, r3
-	adc r2, r0, sb
+	adc r2, r0, r9
 	mla lr, r7, r2, lr
 	mov r7, r6, lsl #0x4
 	mla lr, r8, r3, lr
@@ -10166,11 +10166,11 @@ _0211b0a0:
 	ldr r0, [r4, #0x140]
 	beq _0211b0b8
 	bl func_ov00_020c0e04
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _0211b0b8:
 	ldr r1, [r0, #0x18]
 	bl func_ov00_020c0e24
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov12_0211af70
 _0211b0c4: .word data_027e0f74
@@ -10835,14 +10835,14 @@ _0211b9c0: .word data_ov00_020eec9c
 	.global func_ov12_0211b9c4
 	arm_func_start func_ov12_0211b9c4
 func_ov12_0211b9c4: ; 0x0211b9c4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0xc
 	ldrb r3, [r0, #0x14c]
-	mov sb, r2
+	mov r9, r2
 	cmp r3, #0
 	addeq sp, sp, #0xc
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	mov r2, #0xc
 	mul r8, r1, r2
 	add r7, r0, #0xd4
@@ -10852,7 +10852,7 @@ func_ov12_0211b9c4: ; 0x0211b9c4
 	cmp r2, r1
 	addge sp, sp, #0xc
 	movge r0, #0
-	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmgeia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	add r5, r0, #0xd0
 	ldr r1, [r5, r8]
 	add r4, r0, #0xd8
@@ -10875,18 +10875,18 @@ func_ov12_0211b9c4: ; 0x0211b9c4
 	bge _0211ba84
 	ldr r0, [r5, r8]
 	sub r1, r2, #0x148
-	str r0, [sb]
+	str r0, [r9]
 	ldr r2, [r7, r8]
 	add sp, sp, #0xc
-	str r2, [sb, #4]
+	str r2, [r9, #4]
 	ldr r2, [r4, r8]
 	mov r0, #1
-	stmib sb, {r1, r2}
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	stmib r9, {r1, r2}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _0211ba84:
 	mov r0, #0
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov12_0211b9c4
 _0211ba90: .word data_027e0e60
@@ -11101,7 +11101,7 @@ _0211bcd8:
 	.global func_ov12_0211bce8
 	arm_func_start func_ov12_0211bce8
 func_ov12_0211bce8: ; 0x0211bce8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	mov r10, r0
 	mov r0, #0
 	str r0, [r10]
@@ -11218,16 +11218,16 @@ _0211be94:
 	mov r0, #0x1fc
 	mul r6, r8, r0
 	ldr r0, _0211bf28 ; =0x00001fe0
-	mov sb, #0
+	mov r9, #0
 	mla r5, r8, r0, r11
 	b _0211bebc
 _0211beac:
-	mla r1, sb, r4, r5
+	mla r1, r9, r4, r5
 	add r0, r7, r6
 	bl func_ov12_02118d10
-	add sb, sb, #1
+	add r9, r9, #1
 _0211bebc:
-	cmp sb, #0x3c
+	cmp r9, #0x3c
 	blt _0211beac
 	add r0, r8, #1
 	mov r0, r0, lsl #0x10
@@ -11244,7 +11244,7 @@ _0211bed0:
 	str r0, [r2, #0x10]
 	mov r0, r10
 	strb r1, [r10, #0x70d]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov12_0211bce8
 _0211bf00: .word func_ov12_02118ca4
@@ -11398,17 +11398,17 @@ func_ov12_0211c0a4: ; 0x0211c0a4
 	.global func_ov12_0211c0cc
 	arm_func_start func_ov12_0211c0cc
 func_ov12_0211c0cc: ; 0x0211c0cc
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	mov r10, r0
-	mov sb, #0
+	mov r9, #0
 	add r6, r10, #8
 	mov r8, #0x3b
-	mov r7, sb
+	mov r7, r9
 	mov r11, #0x88
 	mov r4, #0x1fc
 _0211c0ec:
-	add r1, r10, sb
-	mul r5, sb, r4
+	add r1, r10, r9
+	mul r5, r9, r4
 	strb r8, [r1, #0x709]
 	strb r7, [r1, #0x700]
 	strb r7, [r1, #0x6fc]
@@ -11422,15 +11422,15 @@ _0211c0ec:
 	bl func_ov12_02118dc8
 	mov r2, r0
 	ldr r0, [r10, #4]
-	mov r1, sb
+	mov r1, r9
 	mov r3, r11
 	ldr r5, [r0]
 	ldr r5, [r5, #0x24]
 	blx r5
-	add r0, sb, #1
+	add r0, r9, #1
 	mov r0, r0, lsl #0x10
-	mov sb, r0, lsr #0x10
-	cmp sb, #2
+	mov r9, r0, lsr #0x10
+	cmp r9, #2
 	blo _0211c0ec
 	mov r1, #0
 	add r0, r10, #0x400
@@ -11460,7 +11460,7 @@ _0211c0ec:
 	bic r0, r0, #0x80
 	strb r0, [r10, #0x6f8]
 	strh r4, [r1, #6]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	arm_func_end func_ov12_0211c0cc
 
 	.global func_ov12_0211c1c4
@@ -11690,14 +11690,14 @@ _0211c4d4:
 	.global func_ov12_0211c4dc
 	arm_func_start func_ov12_0211c4dc
 func_ov12_0211c4dc: ; 0x0211c4dc
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0xc
 	mov r10, r0
 	mov r6, #0
 	strb r6, [r10, #0x71a]
 	add r2, r10, #0x700
 	mov r0, #1
-	mov sb, r1
+	mov r9, r1
 	ldrh r7, [r2, #4]
 	mov r1, r0
 	mov r4, r6
@@ -11808,7 +11808,7 @@ _0211c668:
 	mov r0, r0, lsr #0x19
 	cmp r0, #0xa
 	bhs _0211c6d0
-	cmp sb, #0
+	cmp r9, #0
 	bne _0211c694
 	cmp r0, #6
 	bhs _0211c6c0
@@ -11873,7 +11873,7 @@ _0211c754:
 	str r0, [sp]
 	blt _0211c62c
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov12_0211c4dc
 _0211c774: .word data_ov12_0213470c
@@ -14749,7 +14749,7 @@ _0211ed14: .word data_ov12_021347f4
 	.global func_ov12_0211ed18
 	arm_func_start func_ov12_0211ed18
 func_ov12_0211ed18: ; 0x0211ed18
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x2c
 	add r1, sp, #0x20
 	str r1, [sp]
@@ -14771,7 +14771,7 @@ func_ov12_0211ed18: ; 0x0211ed18
 	add r4, r3, #0x50
 	add r7, r3, #0x5c
 	add r6, r3, #0x68
-	add sb, r3, #0x74
+	add r9, r3, #0x74
 	add r8, r3, #0x80
 	str r0, [sp, #4]
 _0211ed7c:
@@ -14791,7 +14791,7 @@ _0211ed7c:
 	bl func_02034698
 	ldr r0, _0211ee50 ; =0x0000013b
 	ldr r1, [r10], #4
-	mov r2, sb
+	mov r2, r9
 	mov r3, r8
 	add r6, r6, #4
 	add r7, r7, #4
@@ -14799,7 +14799,7 @@ _0211ed7c:
 	ldr r0, [sp, #4]
 	add r8, r8, #4
 	add r0, r0, #1
-	add sb, sb, #4
+	add r9, r9, #4
 	str r0, [sp, #4]
 	cmp r0, #3
 	blt _0211ed7c
@@ -14824,7 +14824,7 @@ _0211ed7c:
 	sub r3, r2, #1
 	bl func_0203d77c
 	add sp, sp, #0x2c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov12_0211ed18
 _0211ee44: .word data_ov12_021347fc
@@ -14917,7 +14917,7 @@ _0211ef44: .word data_027e0d38
 	.global func_ov12_0211ef48
 	arm_func_start func_ov12_0211ef48
 func_ov12_0211ef48: ; 0x0211ef48
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x30
 	ldr r2, _0211f47c ; =data_027e0d38
 	mov r10, r0
@@ -14928,9 +14928,9 @@ func_ov12_0211ef48: ; 0x0211ef48
 	bl func_ov05_0210274c
 	add r0, sp, #0x10
 	bl func_01ffbe34
-	ldr sb, [r10, #0x38]
+	ldr r9, [r10, #0x38]
 	ldr r8, [r10, #0x34]
-	mov r1, sb, lsl #0xc
+	mov r1, r9, lsl #0xc
 	mov r0, r10
 	mov r11, r8, lsl #0xc
 	str r1, [sp, #4]
@@ -15053,7 +15053,7 @@ _0211f128:
 	mov r0, #0x13c
 	bl func_02034984
 	ldr r0, _0211f484 ; =data_ov12_0213dd0c
-	add r1, r8, sb
+	add r1, r8, r9
 	ldr r0, [r0]
 	ldr r0, [r0, #0xc]
 	cmp r1, r0
@@ -15062,7 +15062,7 @@ _0211f128:
 	moveq r2, #0
 	moveq r5, #0x100
 	beq _0211f1f0
-	cmp sb, r0
+	cmp r9, r0
 	mvneq r2, #0xff
 	moveq r5, #0
 	beq _0211f1f0
@@ -15199,8 +15199,8 @@ _0211f344:
 _0211f35c:
 	mov r5, #0
 	mov r6, r5
-	mov r4, sb
-	cmp sb, #0x63
+	mov r4, r9
+	cmp r9, #0x63
 	ble _0211f380
 _0211f370:
 	sub r4, r4, #0x64
@@ -15249,9 +15249,9 @@ _0211f3e4:
 	mov r0, r1
 	cmp r1, #0
 	cmpne r0, #4
-	cmpne sb, #1
+	cmpne r9, #1
 	beq _0211f43c
-	cmp sb, #0
+	cmp r9, #0
 	bne _0211f45c
 	blx func_0202ab48
 	cmp r0, #2
@@ -15267,7 +15267,7 @@ _0211f43c:
 	str r2, [sp]
 	bl func_0203493c
 	add sp, sp, #0x30
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0211f45c:
 	mov r2, #0
 	ldr r0, _0211f480 ; =0x0000013b
@@ -15276,7 +15276,7 @@ _0211f45c:
 	str r2, [sp]
 	bl func_0203493c
 	add sp, sp, #0x30
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov12_0211ef48
 _0211f47c: .word data_027e0d38
@@ -15777,7 +15777,7 @@ func_ov12_0211fa98: ; 0x0211fa98
 	.global func_ov12_0211fad0
 	arm_func_start func_ov12_0211fad0
 func_ov12_0211fad0: ; 0x0211fad0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #8
 	mov r2, #0
 	mov r6, #1
@@ -15791,12 +15791,12 @@ func_ov12_0211fad0: ; 0x0211fad0
 	mov r7, r6
 _0211fb00:
 	ldrb r0, [r10, #0x89]
-	mov sb, r7, lsl r8
+	mov r9, r7, lsl r8
 	tst r0, r7, lsl r8
 	beq _0211fbb8
-	cmp sb, #1
+	cmp r9, #1
 	beq _0211fb24
-	cmp sb, #2
+	cmp r9, #2
 	beq _0211fb64
 	b _0211fb9c
 _0211fb24:
@@ -15809,7 +15809,7 @@ _0211fb24:
 	cmp r0, #0
 	bne _0211fc18
 	ldrb r0, [r10, #0x89]
-	mvn r1, sb
+	mvn r1, r9
 	and r0, r0, r1
 	strb r0, [r10, #0x89]
 	ldrb r0, [r10, #0x88]
@@ -15824,7 +15824,7 @@ _0211fb64:
 	cmp r0, #0
 	beq _0211fc18
 	ldrb r0, [r10, #0x89]
-	mvn r1, sb
+	mvn r1, r9
 	and r0, r0, r1
 	strb r0, [r10, #0x89]
 	ldrb r0, [r10, #0x88]
@@ -15832,7 +15832,7 @@ _0211fb64:
 	strb r0, [r10, #0x88]
 	b _0211fc18
 _0211fb9c:
-	mvn r1, sb
+	mvn r1, r9
 	and r0, r0, r1
 	strb r0, [r10, #0x89]
 	ldrb r0, [r10, #0x88]
@@ -15841,30 +15841,30 @@ _0211fb9c:
 	b _0211fc18
 _0211fbb8:
 	ldrb r0, [r10, #0x88]
-	tst r0, sb
+	tst r0, r9
 	beq _0211fc18
-	cmp sb, #1
+	cmp r9, #1
 	beq _0211fbd8
-	cmp sb, #2
+	cmp r9, #2
 	beq _0211fbf0
 	b _0211fc08
 _0211fbd8:
 	bl func_ov12_0211bc54
 	bl func_ov12_0211c034
 	ldrb r0, [r10, #0x89]
-	orr r0, r0, sb
+	orr r0, r0, r9
 	strb r0, [r10, #0x89]
 	b _0211fc18
 _0211fbf0:
 	ldr r0, [r4]
 	bl func_ov12_021134f4
 	ldrb r0, [r10, #0x89]
-	orr r0, r0, sb
+	orr r0, r0, r9
 	strb r0, [r10, #0x89]
 	b _0211fc18
 _0211fc08:
 	mov r1, r0
-	mvn r0, sb
+	mvn r0, r9
 	and r0, r1, r0
 	strb r0, [r10, #0x88]
 _0211fc18:
@@ -15997,7 +15997,7 @@ _0211fdbc:
 _0211fde8:
 	ldr r0, [sp, #4]
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov12_0211fad0
 _0211fdf4: .word data_027e0d54
@@ -17461,14 +17461,14 @@ _02121068: .word 0x00000133
 	.global func_ov12_0212106c
 	arm_func_start func_ov12_0212106c
 func_ov12_0212106c: ; 0x0212106c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #8
 	mov r10, r0
 	bl func_ov12_02120ff0
 	ldr r0, [r10, #0x14]
 	cmp r0, #0x6a
 	addne sp, sp, #8
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, _02121234 ; =data_ov12_02137c64
 	mov r1, #0
 	ldr r0, [r0]
@@ -17494,7 +17494,7 @@ _021210bc:
 	mov r6, #7
 	mov r7, #8
 	mov r8, #0xa
-	mov sb, #9
+	mov r9, #9
 	bl func_0203493c
 	add r0, r10, #0xa8
 	str r0, [sp]
@@ -17552,7 +17552,7 @@ _021210bc:
 	mov r3, r3, asr #0xc
 	bl func_0203493c
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _021211d8:
 	bl func_ov12_02113208
 	cmp r0, #0
@@ -17567,17 +17567,17 @@ _021211d8:
 	mov r3, r3, asr #0xc
 	bl func_0203493c
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02121210:
 	ldr r2, [r10, #0xc8]
 	ldr r3, [r10, #0xcc]
 	mov r0, r4
-	mov r1, sb
+	mov r1, r9
 	mov r2, r2, asr #0xc
 	mov r3, r3, asr #0xc
 	bl func_0203493c
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov12_0212106c
 _02121234: .word data_ov12_02137c64
@@ -17638,16 +17638,16 @@ _021212e4: .word data_ov12_02137c64
 	.global func_ov12_021212e8
 	arm_func_start func_ov12_021212e8
 func_ov12_021212e8: ; 0x021212e8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #4
 	mov r10, r0
 	bl func_ov12_02120ff0
 	ldr r0, [r10, #0x14]
 	cmp r0, #0x6a
 	addne sp, sp, #4
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	ldr r0, _0212142c ; =data_ov12_02137c64
-	mov sb, #0
+	mov r9, #0
 	ldr r0, [r0]
 	mov r5, #1
 	ldr r0, [r0, #0x994]
@@ -17661,7 +17661,7 @@ func_ov12_021212e8: ; 0x021212e8
 	mov r7, #2
 	mov r8, #3
 	mov r1, #4
-	ldrne sb, [r10, #0x15c]
+	ldrne r9, [r10, #0x15c]
 	bne _0212136c
 	add r0, r10, #0xa8
 	str r0, [sp]
@@ -17688,7 +17688,7 @@ _0212136c:
 	mov r0, r4
 	mov r1, r5
 	mov r2, r2, asr #0xc
-	add r3, sb, r3, asr #12
+	add r3, r9, r3, asr #12
 	bl func_0203493c
 	b _021213d4
 _021213b8:
@@ -17697,7 +17697,7 @@ _021213b8:
 	mov r0, r4
 	mov r1, r6
 	mov r2, r2, asr #0xc
-	add r3, sb, r3, asr #12
+	add r3, r9, r3, asr #12
 	bl func_0203493c
 _021213d4:
 	add r0, r10, #0xdc
@@ -17707,10 +17707,10 @@ _021213d4:
 	mov r0, r4
 	mov r1, r7
 	mov r2, r2, asr #0xc
-	add r3, sb, r3, asr #12
+	add r3, r9, r3, asr #12
 	bl func_0203493c
 	add sp, sp, #4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 _02121400:
 	add r0, r10, #0xdc
 	str r0, [sp]
@@ -17719,10 +17719,10 @@ _02121400:
 	mov r0, r4
 	mov r1, r8
 	mov r2, r2, asr #0xc
-	add r3, sb, r3, asr #12
+	add r3, r9, r3, asr #12
 	bl func_0203493c
 	add sp, sp, #4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov12_021212e8
 _0212142c: .word data_ov12_02137c64
@@ -19030,7 +19030,7 @@ _021224cc: .word 0x00002710
 	.global func_ov12_021224d0
 	arm_func_start func_ov12_021224d0
 func_ov12_021224d0: ; 0x021224d0
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #8
 	mov r6, r0
 	ldr r0, [r6, #0x10]
@@ -19039,7 +19039,7 @@ func_ov12_021224d0: ; 0x021224d0
 	mov r5, r1
 	mov r4, r2
 	cmp r0, #5
-	mov sb, #0
+	mov r9, #0
 	addls pc, pc, r0, lsl #2
 	b _021226bc
 _02122500: ; jump table
@@ -19064,7 +19064,7 @@ _02122518:
 	add r1, r1, r10
 	sub r3, r8, r3
 	bl func_020349cc
-	mov sb, #1
+	mov r9, #1
 	b _02122568
 _02122558:
 	ldr r0, [r6]
@@ -19082,7 +19082,7 @@ _02122574:
 	mov r10, r0
 	cmp r10, #0
 	bgt _02122594
-	cmp sb, #0
+	cmp r9, #0
 	beq _021225b8
 _02122594:
 	ldr r0, [r6, #0x18]
@@ -19092,7 +19092,7 @@ _02122594:
 	mov r3, r8
 	add r1, r1, r10
 	bl func_020349cc
-	mov sb, #1
+	mov r9, #1
 	b _021225c8
 _021225b8:
 	ldr r0, [r6]
@@ -19111,7 +19111,7 @@ _021225d8:
 	mov r10, r0
 	cmp r10, #0
 	bgt _021225f8
-	cmp sb, #0
+	cmp r9, #0
 	beq _0212261c
 _021225f8:
 	ldr r0, [r6, #0x18]
@@ -19121,7 +19121,7 @@ _021225f8:
 	mov r3, r8
 	add r1, r1, r10
 	bl func_020349cc
-	mov sb, #1
+	mov r9, #1
 	b _0212262c
 _0212261c:
 	ldr r0, [r6]
@@ -19140,7 +19140,7 @@ _0212263c:
 	mov r10, r0
 	cmp r10, #0
 	bgt _0212265c
-	cmp sb, #0
+	cmp r9, #0
 	beq _0212267c
 _0212265c:
 	ldr r0, [r6, #0x18]
@@ -19172,7 +19172,7 @@ _02122690:
 	bl func_020349cc
 _021226bc:
 	add sp, sp, #8
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov12_021224d0
 _021226c4: .word 0x00002710
@@ -19375,7 +19375,7 @@ _02122918: .word func_ov12_021202d8
 	.global func_ov12_0212291c
 	arm_func_start func_ov12_0212291c
 func_ov12_0212291c: ; 0x0212291c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x20
 	mov r10, r0
 	bl func_ov12_021258e0
@@ -19557,7 +19557,7 @@ _02122bac:
 	bl func_ov12_02122370
 	ldrh r6, [r5, #0x14]
 	mov r7, #0
-	ldr sb, _02122f44 ; =data_ov12_02134854
+	ldr r9, _02122f44 ; =data_ov12_02134854
 	ldr r4, _02122f48 ; =data_ov12_0213dc5c
 	mov r8, r0
 	mov r5, r7
@@ -19568,7 +19568,7 @@ _02122c00:
 	mov r1, #0x64
 	add r0, r10, r0
 	strb r5, [r0, #0x354]
-	ldrb r0, [sb]
+	ldrb r0, [r9]
 	mul r2, r0, r8
 	mov r0, r2, lsl #0x1
 	bl func_01ff9b4c
@@ -19587,7 +19587,7 @@ _02122c50:
 	add r5, r5, #1
 	cmp r5, #0x10
 	mov r6, r0, lsr #0x10
-	add sb, sb, #1
+	add r9, r9, #1
 	blt _02122c00
 	ldrb r0, [r10, #0x364]
 	cmp r0, #5
@@ -19775,7 +19775,7 @@ _02122efc:
 	add r5, r5, #0x28
 	blt _02122efc
 	add sp, sp, #0x20
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov12_0212291c
 _02122f28: .word data_ov00_020ee698
@@ -21093,7 +21093,7 @@ func_ov12_02123f8c: ; 0x02123f8c
 	.global func_ov12_02123fac
 	arm_func_start func_ov12_02123fac
 func_ov12_02123fac: ; 0x02123fac
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #0x48
 	ldr r1, _021243f8 ; =data_ov00_020ee698
 	mov r4, r0
@@ -21202,7 +21202,7 @@ _02124138:
 	mov r2, #8
 	mov lr, #0x2e
 	mov ip, #0xa
-	mov sb, #4
+	mov r9, #4
 	mov r0, r4
 	mov r3, r5
 	str r10, [sp, #8]
@@ -21211,10 +21211,10 @@ _02124138:
 	str r2, [sp, #0x24]
 	str lr, [sp, #0x10]
 	str ip, [sp, #0x14]
-	str sb, [sp, #0x18]
+	str r9, [sp, #0x18]
 	bl func_ov12_0212445c
 	cmp r0, #0
-	add sb, sp, #0x28
+	add r9, sp, #0x28
 	mov r2, #8
 	beq _021241d4
 	add r0, r5, #0xd8
@@ -21222,9 +21222,9 @@ _02124138:
 	mov r1, r7
 	mov r0, #0xab
 	mov r3, r10
-	str sb, [sp, #4]
+	str r9, [sp, #4]
 	bl func_020349cc
-	mov r7, sb
+	mov r7, r9
 	mov r1, r6
 	add r3, r5, #0xd8
 	mov r0, #0xab
@@ -21240,9 +21240,9 @@ _021241d4:
 	ldr r0, _021243fc ; =0x0000016b
 	mov r1, r7
 	mov r3, r10
-	stmia sp, {r5, sb}
+	stmia sp, {r5, r9}
 	bl func_020349cc
-	mov r7, sb
+	mov r7, r9
 	ldr r0, _021243fc ; =0x0000016b
 	mov r1, r6
 	mov r3, r5
@@ -21266,11 +21266,11 @@ _02124210:
 	add r6, r4, #0x68
 	add r7, r4, #0x300
 	mov r8, r5
-	mov sb, #1
+	mov r9, #1
 _02124248:
 	ldrsb r0, [r7, #0x66]
 	cmp r0, #1
-	movge r1, sb
+	movge r1, r9
 	movlt r1, r8
 	mov r0, r6
 	bl func_ov12_02124fac
@@ -21368,7 +21368,7 @@ _021243b8:
 	mov r0, r4
 	bl func_ov12_02124afc
 	add sp, sp, #0x48
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _021243d0:
 	bl func_ov12_021245a8
 	ldr r1, [r4, #0x10]
@@ -21379,7 +21379,7 @@ _021243d0:
 	mov r0, r4
 	bl func_ov12_02124afc
 	add sp, sp, #0x48
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov12_02123fac
 _021243f8: .word data_ov00_020ee698
@@ -24707,9 +24707,9 @@ _02126de0: .word func_ov12_02126cfc
 	.global func_ov12_02126de4
 	arm_func_start func_ov12_02126de4
 func_ov12_02126de4: ; 0x02126de4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	mov r8, r1
-	mov sb, r0
+	mov r9, r0
 	mov r0, r8
 	mov r7, r2
 	mov r6, r3
@@ -24729,12 +24729,12 @@ func_ov12_02126de4: ; 0x02126de4
 	mov r1, #0x80
 	blx func_0202f134
 _02126e38:
-	mov r0, sb
+	mov r0, r9
 	mov r1, r7
 	mov r2, r4
 	mov r3, r6
 	bl func_ov12_02126d28
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov12_02126de4
 _02126e50: .word data_ov00_020ec758
@@ -25888,7 +25888,7 @@ _02127dc8: .word data_ov00_020eec9c
 	.global func_ov12_02127dcc
 	arm_func_start func_ov12_02127dcc
 func_ov12_02127dcc: ; 0x02127dcc
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0xc
 	mov r4, #5
 	mov r10, r0
@@ -25964,17 +25964,17 @@ _02127eb8:
 	str r4, [sp, #8]
 	bl func_ov01_020f802c
 _02127eec:
-	add sb, r10, #0x1ac
-	str sb, [r10, #0x414]
+	add r9, r10, #0x1ac
+	str r9, [r10, #0x414]
 	ldr r0, [r10, #0x418]
 	mov r4, #0x58
 	cmp r0, #1
 	cmpne r0, #6
 	bne _02127f5c
-	add sb, r10, #0x1ac
+	add r9, r10, #0x1ac
 	mov r7, #0
 	mov r8, r10
-	mov r6, sb
+	mov r6, r9
 	mov r5, r7
 	mov r11, #0x1000
 _02127f20:
@@ -25984,27 +25984,27 @@ _02127f20:
 	str r5, [sp]
 	ldr r1, [r8, #0x1bc]
 	ldr r2, [r8, #0x1c0]
-	mov r0, sb
+	mov r0, r9
 	mov r3, r11
 	bl func_ov01_020f7f34
 	add r7, r7, #1
 	cmp r7, #6
 	add r8, r8, #0x58
-	add sb, sb, #0x58
+	add r9, r9, #0x58
 	blt _02127f20
 	b _02127fac
 _02127f5c:
 	ldr r8, _02127ffc ; =data_ov12_021348f8
 	mov r7, r10
 	mov r6, #0
-	mov r5, sb
+	mov r5, r9
 	mov r11, #0xc000
 _02127f70:
 	add r0, r6, #1
 	mla r1, r0, r4, r5
 	str r1, [r7, #0x1b8]
 	ldrb r1, [r8], #1
-	mov r0, sb
+	mov r0, r9
 	mov r3, r11
 	str r1, [sp]
 	ldr r1, [r7, #0x1bc]
@@ -26013,7 +26013,7 @@ _02127f70:
 	add r6, r6, #1
 	cmp r6, #6
 	add r7, r7, #0x58
-	add sb, sb, #0x58
+	add r9, r9, #0x58
 	blt _02127f70
 _02127fac:
 	ldr r1, _02128000 ; =0x0002005b
@@ -26034,7 +26034,7 @@ _02127fac:
 	mov r0, #0x19
 	str r0, [r10, #0x10]
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov12_02127dcc
 _02127ff8: .word 0x0000015a
@@ -26044,9 +26044,9 @@ _02128000: .word 0x0002005b
 	.global func_ov12_02128004
 	arm_func_start func_ov12_02128004
 func_ov12_02128004: ; 0x02128004
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #4
-	mov sb, r0
+	mov r9, r0
 	bl func_ov12_0211bc54
 	ldrb r0, [r0, #0x6f8]
 	mov r0, r0, lsl #0x1a
@@ -26057,9 +26057,9 @@ func_ov12_02128004: ; 0x02128004
 	beq _02128094
 	mov r0, #7
 	ldr r6, _0212831c ; =data_ov12_021348f8
-	mov r7, sb
-	str r0, [sb, #0x418]
-	add r8, sb, #0x1ac
+	mov r7, r9
+	str r0, [r9, #0x418]
+	add r8, r9, #0x1ac
 	mov r5, #0
 	mov r4, #0xc000
 _0212804c:
@@ -26075,19 +26075,19 @@ _0212804c:
 	add r7, r7, #0x58
 	add r8, r8, #0x58
 	blt _0212804c
-	mov r0, sb
+	mov r0, r9
 	mov r1, #0xf
 	mov r2, #3
 	bl func_ov12_02128dec
 	add sp, sp, #4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 _02128094:
 	ldr r0, _02128320 ; =data_027e05f8
 	mov r4, #0
 	ldrh r0, [r0, #2]
 	tst r0, #2
 	bne _021280c8
-	mov r1, sb
+	mov r1, r9
 _021280ac:
 	ldrb r0, [r1, #0x202]
 	cmp r0, #0
@@ -26114,12 +26114,12 @@ _021280ec:
 	cmp r0, #0
 	beq _0212813c
 	mov r0, #1
-	str r0, [sb, #0x418]
+	str r0, [r9, #0x418]
 	mov r1, #0
-	ldr r0, [sb, #4]
+	ldr r0, [r9, #4]
 	mov r2, r1
 	bl func_ov12_02120028
-	mov r0, sb
+	mov r0, r9
 	mov r1, #0x13
 	mov r2, #2
 	bl func_ov12_02128dec
@@ -26130,8 +26130,8 @@ _021280ec:
 	b _0212819c
 _0212813c:
 	ldr r6, _0212831c ; =data_ov12_021348f8
-	mov r7, sb
-	add r8, sb, #0x1ac
+	mov r7, r9
+	add r8, r9, #0x1ac
 	mov r5, #0
 	mov r4, #0xc000
 _02128150:
@@ -26147,7 +26147,7 @@ _02128150:
 	add r7, r7, #0x58
 	add r8, r8, #0x58
 	blt _02128150
-	mov r0, sb
+	mov r0, r9
 	mov r1, #0x15
 	mov r2, #3
 	bl func_ov12_02128dec
@@ -26159,20 +26159,20 @@ _0212819c:
 	mov r1, #0x99
 	bl func_ov00_020d77e4
 	add sp, sp, #4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 _021281b0:
 	bl func_ov61_021792ec
 	sub r1, r4, #1
 	mov r2, #0
 	bl func_ov61_02179ce4
 	mov r0, #0x58
-	mla r0, r4, r0, sb
-	str r4, [sb, #0x418]
+	mla r0, r4, r0, r9
+	str r4, [r9, #0x418]
 	mov r5, #0
 	ldr r6, _0212831c ; =data_ov12_021348f8
-	mov r7, sb
+	mov r7, r9
 	strb r5, [r0, #0x203]
-	add r8, sb, #0x1ac
+	add r8, r9, #0x1ac
 	mov r10, #0xc000
 _021281e4:
 	cmp r5, r4
@@ -26191,7 +26191,7 @@ _02128208:
 	add r7, r7, #0x58
 	add r8, r8, #0x58
 	blt _021281e4
-	mov r0, sb
+	mov r0, r9
 	mov r1, #0x16
 	mov r2, #3
 	bl func_ov12_02128dec
@@ -26202,13 +26202,13 @@ _02128208:
 	mov r1, #0xc
 	bl func_ov00_020d716c
 	add sp, sp, #4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 _02128250:
 	mov r0, #7
 	ldr r6, _0212831c ; =data_ov12_021348f8
-	mov r7, sb
-	str r0, [sb, #0x418]
-	add r8, sb, #0x1ac
+	mov r7, r9
+	str r0, [r9, #0x418]
+	add r8, r9, #0x1ac
 	mov r5, #0
 	mov r4, #0xc000
 _0212826c:
@@ -26224,7 +26224,7 @@ _0212826c:
 	add r7, r7, #0x58
 	add r8, r8, #0x58
 	blt _0212826c
-	mov r0, sb
+	mov r0, r9
 	mov r1, #0x19
 	mov r2, #3
 	bl func_ov12_02128dec
@@ -26235,28 +26235,28 @@ _0212826c:
 	mov r1, #0xc
 	bl func_ov00_020d716c
 	add sp, sp, #4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 _021282cc:
 	ldr r0, _02128328 ; =data_ov00_020eec68
 	bl func_ov00_020d7180
 	cmp r0, #0
-	ldreqb r0, [sb, #0x3a6]
+	ldreqb r0, [r9, #0x3a6]
 	cmpeq r0, #0
 	addne sp, sp, #4
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
-	ldr r0, [sb, #0x10]
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
+	ldr r0, [r9, #0x10]
 	sub r0, r0, #1
 	cmp r0, #0
 	addgt sp, sp, #4
-	str r0, [sb, #0x10]
-	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	str r0, [r9, #0x10]
+	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	ldr r0, _02128328 ; =data_ov00_020eec68
 	mov r1, #0x27
 	mov r2, #0
 	mov r3, #0x7f
 	bl func_ov00_020d70a4
 	add sp, sp, #4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov12_02128004
 _0212831c: .word data_ov12_021348f8
@@ -27951,7 +27951,7 @@ _021298cc: .word data_ov12_0213dca8
 	.global func_ov12_021298d0
 	arm_func_start func_ov12_021298d0
 func_ov12_021298d0: ; 0x021298d0
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #0x100
 	mov r5, r0
 	add r0, r5, #0x54
@@ -28093,13 +28093,13 @@ _02129ad0:
 	ldr r1, [r0]
 	ldr r1, [r1, #0xb4]
 	blx r1
-	mov sb, r0
+	mov r9, r0
 	mov r0, r7
-	add r1, r7, sb
+	add r1, r7, r9
 	bl Divide
-	add r1, r7, sb
+	add r1, r7, r9
 	mov r7, r0
-	mov r0, sb
+	mov r0, r9
 	bl Divide
 	add r2, sp, #0x80
 	rsb r0, r0, #0
@@ -28126,7 +28126,7 @@ _02129ad0:
 _02129b78:
 	cmp r8, r6, lsl #1
 	addge sp, sp, #0x100
-	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmgeia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	ldrb r0, [r5, #0x258]
 	cmp r0, #0
 	ldreq r0, [r5, #0x234]
@@ -28136,7 +28136,7 @@ _02129b78:
 	ldreq r0, [r4, #0x234]
 	cmpeq r0, #0
 	addne sp, sp, #0x100
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	ldr r0, [r5, #0x250]
 	add sp, sp, #0x100
 	add r0, r0, #1
@@ -28144,7 +28144,7 @@ _02129b78:
 	ldr r0, [r4, #0x250]
 	add r0, r0, #1
 	str r0, [r4, #0x250]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _02129bcc:
 	ldr r1, [r5, #0x48]
 	add r0, sp, #0x44
@@ -28168,7 +28168,7 @@ _02129bcc:
 	bl func_01fffb4c
 	cmp r0, #0
 	addeq sp, sp, #0x100
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	mov r0, r5
 	ldr r1, [r0]
 	ldr r1, [r1, #0xb4]
@@ -28203,7 +28203,7 @@ _02129bcc:
 	mov r8, r0
 	cmp r8, #0
 	addle sp, sp, #0x100
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	add r0, sp, #0x38
 	add r3, sp, #8
 	ldmia r0, {r0, r1, r2}
@@ -28216,7 +28216,7 @@ _02129bcc:
 	mov r8, r0
 	mov r0, r7
 	bl func_01ff991c
-	mov sb, r0
+	mov r9, r0
 	add r0, sp, #0xd0
 	mov r1, r0
 	bl func_01ff9c2c
@@ -28239,11 +28239,11 @@ _02129bcc:
 	rsb r1, r0, #0x1000
 	add r0, r0, #0x1000
 	mul r1, r8, r1
-	mul r0, sb, r0
+	mul r0, r9, r0
 	add r1, r1, #0x800
 	add r0, r0, #0x800
 	mov r8, r1, asr #0xc
-	mov sb, r0, asr #0xc
+	mov r9, r0, asr #0xc
 	b _02129d7c
 _02129d58:
 	ldr r1, _02129ddc ; =0x0000099a
@@ -28263,7 +28263,7 @@ _02129d7c:
 	bl func_01ff9e64
 	add r2, sp, #0xd0
 	add r1, sp, #8
-	mov r0, sb
+	mov r0, r9
 	mov r3, r2
 	bl func_01ff9e64
 	ldr r0, [sp, #0xdc]
@@ -28279,7 +28279,7 @@ _02129d7c:
 	ldr r0, [sp, #0xd8]
 	str r0, [r4, #0x68]
 	add sp, sp, #0x100
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov12_021298d0
 _02129ddc: .word 0x0000099a
@@ -29252,7 +29252,7 @@ _0212aa88: .word data_ov12_0213dc88
 	.global func_ov12_0212aa8c
 	arm_func_start func_ov12_0212aa8c
 func_ov12_0212aa8c: ; 0x0212aa8c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #0x30
 	ldr r1, _0212ad00 ; =data_027e0e60
 	mov r10, r0
@@ -29279,10 +29279,10 @@ _0212aad4:
 	umull r6, r5, r3, r1
 	mla r5, r3, r0, r5
 	ldr r2, [r4, #0xc]
-	ldr sb, [r4, #0x10]
+	ldr r9, [r4, #0x10]
 	mla r5, r2, r1, r5
 	ldr r8, [r4, #0x14]
-	adds r0, sb, r6
+	adds r0, r9, r6
 	adc r8, r8, r5
 	stmia r4, {r0, r8}
 	cmp r7, #0
@@ -29296,7 +29296,7 @@ _0212aad4:
 _0212ab2c:
 	ldr r0, [sp]
 	cmp r0, #0
-	movle sb, #0
+	movle r9, #0
 	ble _0212ab90
 	ldr r1, [r4]
 	ldmib r4, {r0, r3}
@@ -29305,38 +29305,38 @@ _0212ab2c:
 	ldr r2, [r4, #0xc]
 	ldr ip, [r4, #0x10]
 	mla r5, r2, r1, r5
-	ldr sb, [r4, #0x14]
+	ldr r9, [r4, #0x14]
 	adds r0, ip, r6
-	adc sb, sb, r5
-	stmia r4, {r0, sb}
+	adc r9, r9, r5
+	stmia r4, {r0, r9}
 	ldr r0, [sp]
 	cmp r0, #0
 	beq _0212ab90
-	umull r0, r2, sb, r0
+	umull r0, r2, r9, r0
 	ldr r0, [sp, #4]
 	mov r1, #0
-	mla r2, sb, r0, r2
+	mla r2, r9, r0, r2
 	ldr r0, [sp]
 	mla r2, r1, r0, r2
-	mov sb, r2
+	mov r9, r2
 _0212ab90:
 	ldr r0, _0212ad00 ; =data_027e0e60
 	mov r1, r8
 	ldr r0, [r0]
-	mov r2, sb
+	mov r2, r9
 	bl func_ov00_020840a0
 	mov r5, r0
 	ldr r0, _0212ad00 ; =data_027e0e60
 	ldr r2, _0212ad08 ; =func_ov00_020b1940
 	ldr r6, [r0]
 	mov r0, r8
-	mov r1, sb
+	mov r1, r9
 	bl func_ov00_020b199c
 	cmp r0, #0
 	beq _0212acec
 	mov r0, r6
 	mov r1, r8
-	mov r2, sb
+	mov r2, r9
 	bl func_ov00_02083e34
 	ldr r1, [r10, #0x18]
 	cmp r0, r1
@@ -29351,7 +29351,7 @@ _0212ab90:
 	bl func_ov00_02083c24
 	str r0, [sp, #0x24]
 	ldr r2, [r10, #0x4c]
-	mov r1, sb
+	mov r1, r9
 	mov r0, r6
 	str r2, [sp, #0x28]
 	bl func_ov00_02083c50
@@ -29412,7 +29412,7 @@ _0212acec:
 	cmp r0, #0
 	beq _0212aad4
 	add sp, sp, #0x30
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov12_0212aa8c
 _0212ad00: .word data_027e0e60
@@ -29931,24 +29931,24 @@ func_ov12_0212b350: ; 0x0212b350
 	.global func_ov12_0212b358
 	arm_func_start func_ov12_0212b358
 func_ov12_0212b358: ; 0x0212b358
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
-	mov sb, r0
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
+	mov r9, r0
 	mov r8, r1
 	mov r7, r2
 	blx func_ov04_0210be04
 	ldr r0, _0212b448 ; =data_ov12_02136bf4
-	add r1, sb, #0x190
-	str r0, [sb]
+	add r1, r9, #0x190
+	str r0, [r9]
 	mov r0, #0
 	mov r2, #0x600
-	str r0, [sb, #0x188]
+	str r0, [r9, #0x188]
 	bl func_020078f4
 	ldr r1, _0212b44c ; =data_027e0ce0
 	mov r0, r8, lsl #0x2
 	ldr r1, [r1, #4]
 	mov r2, #4
 	bl func_0202e9f4
-	str r0, [sb, #0x18c]
+	str r0, [r9, #0x18c]
 	cmp r8, #0
 	mov r5, #0
 	ble _0212b3dc
@@ -29960,7 +29960,7 @@ _0212b3b8:
 	mov r0, r6
 	mov r2, r4
 	bl func_0202e9f4
-	ldr r1, [sb, #0x18c]
+	ldr r1, [r9, #0x18c]
 	str r0, [r1, r5, lsl #2]
 	add r5, r5, #1
 	cmp r5, r8
@@ -29976,7 +29976,7 @@ _0212b3f0:
 	cmp r7, #0
 	ble _0212b414
 _0212b3fc:
-	ldr r0, [sb, #0x18c]
+	ldr r0, [r9, #0x18c]
 	ldr r0, [r0, r4, lsl #2]
 	str r1, [r0, r3, lsl #2]
 	add r3, r3, #1
@@ -29987,16 +29987,16 @@ _0212b414:
 	cmp r4, r8
 	blt _0212b3f0
 _0212b420:
-	add r1, sb, #0x190
+	add r1, r9, #0x190
 	mov r0, #0
 	mov r2, #0x600
 	bl func_020078f4
 	mov r0, #0x80
-	strh r0, [sb, #0x2c]
+	strh r0, [r9, #0x2c]
 	mov r1, #0x60
-	mov r0, sb
-	strh r1, [sb, #0x2e]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	mov r0, r9
+	strh r1, [r9, #0x2e]
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov12_0212b358
 _0212b448: .word data_ov12_02136bf4
@@ -30095,47 +30095,47 @@ _0212b564: .word data_ov12_02136bf4
 	.global func_ov12_0212b568
 	arm_func_start func_ov12_0212b568
 func_ov12_0212b568: ; 0x0212b568
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
-	mov sb, r0
-	ldrh r0, [sb, #0x28]
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
+	mov r9, r0
+	ldrh r0, [r9, #0x28]
 	mov r7, #0
 	cmp r0, #0
 	ble _0212b5f0
 	add r4, sp, #0
 	mov r6, r7
 _0212b588:
-	ldrh r0, [sb, #0x2a]
+	ldrh r0, [r9, #0x2a]
 	mov r8, r6
 	cmp r0, #0
 	ble _0212b5e0
 	and r5, r7, #0xff
 _0212b59c:
-	mov r0, sb
+	mov r0, r9
 	strb r5, [sp]
 	strb r8, [sp, #1]
 	ldr r2, [r0]
 	mov r1, r4
 	ldr r2, [r2, #0x60]
 	blx r2
-	ldr r1, [sb, #0x40]
+	ldr r1, [r9, #0x40]
 	add r8, r8, #1
 	cmp r0, r1
-	strgt r0, [sb, #0x40]
-	ldr r1, [sb, #0x44]
+	strgt r0, [r9, #0x40]
+	ldr r1, [r9, #0x44]
 	cmp r0, r1
-	strlt r0, [sb, #0x44]
-	ldrh r0, [sb, #0x2a]
+	strlt r0, [r9, #0x44]
+	ldrh r0, [r9, #0x2a]
 	cmp r8, r0
 	blt _0212b59c
 _0212b5e0:
-	ldrh r0, [sb, #0x28]
+	ldrh r0, [r9, #0x28]
 	add r7, r7, #1
 	cmp r7, r0
 	blt _0212b588
 _0212b5f0:
-	mov r0, sb
+	mov r0, r9
 	blx func_ov04_0210bfa8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	arm_func_end func_ov12_0212b568
 
 	.global func_ov12_0212b5fc
@@ -30195,20 +30195,20 @@ _0212b680: .word func_ov12_0212b684
 	.global func_ov12_0212b684
 	arm_func_start func_ov12_0212b684
 func_ov12_0212b684: ; 0x0212b684
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x1c
 	mov r10, r0
 	ldr r0, [r10, #0x188]
 	cmp r0, #0
 	addeq sp, sp, #0x1c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldrh r0, [r10, #0x28]
-	ldrh sb, [r10, #0x2a]
+	ldrh r9, [r10, #0x2a]
 	cmp r0, #0x40
 	str r0, [sp]
-	cmpls sb, #0x30
+	cmpls r9, #0x30
 	addhi sp, sp, #0x1c
-	ldmhiia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmhiia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	mov r0, #0
 	str r0, [sp, #4]
 	strb r0, [sp, #8]
@@ -30216,9 +30216,9 @@ func_ov12_0212b684: ; 0x0212b684
 	ldr r0, [sp]
 	cmp r0, #0
 	addle sp, sp, #0x1c
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0212b6dc:
-	cmp sb, #0
+	cmp r9, #0
 	mov r8, #0
 	ble _0212b824
 	ldr r0, [sp, #4]
@@ -30299,7 +30299,7 @@ _0212b700:
 	ldr r3, [r3, #0xa8]
 	blx r3
 	add r8, r8, #1
-	cmp r8, sb
+	cmp r8, r9
 	blt _0212b700
 _0212b824:
 	ldr r0, [sp, #4]
@@ -30309,7 +30309,7 @@ _0212b824:
 	cmp r1, r0
 	blt _0212b6dc
 	add sp, sp, #0x1c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	arm_func_end func_ov12_0212b684
 
 	.global func_ov12_0212b844
@@ -30522,7 +30522,7 @@ func_ov12_0212ba6c: ; 0x0212ba6c
 	.global func_ov12_0212ba84
 	arm_func_start func_ov12_0212ba84
 func_ov12_0212ba84: ; 0x0212ba84
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x1c
 	mov r6, r2
 	mov r7, r1
@@ -30539,12 +30539,12 @@ func_ov12_0212ba84: ; 0x0212ba84
 	ldr r2, [r2, #0x60]
 	blx r2
 	ldr r1, _0212bb9c ; =data_027e0e60
-	mov sb, r0
+	mov r9, r0
 	ldr r0, [r1]
 	ldrb r1, [r6]
 	bl func_ov00_02083c24
 	str r0, [sp, #0x10]
-	str sb, [sp, #0x14]
+	str r9, [sp, #0x14]
 	str r4, [sp, #0x18]
 	mov r0, r8
 	ldr r2, [r0]
@@ -30590,11 +30590,11 @@ _0212bb18:
 _0212bb84:
 	add sp, sp, #0x1c
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _0212bb90:
 	mov r0, #1
 	add sp, sp, #0x1c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov12_0212ba84
 _0212bb9c: .word data_027e0e60
@@ -31571,12 +31571,12 @@ _0212c760: .word data_027e0fe0
 	.global func_ov12_0212c764
 	arm_func_start func_ov12_0212c764
 func_ov12_0212c764: ; 0x0212c764
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	ldr r0, _0212c7cc ; =data_027e0d44
 	ldr r1, _0212c7d0 ; =data_ov12_02137340
-	ldr sb, [r0]
+	ldr r9, [r0]
 	ldr r2, _0212c7d4 ; =data_ov12_02137344
-	mov r0, sb
+	mov r0, r9
 	mov r3, #1
 	blx func_ov04_02105c64
 	mov r8, #0
@@ -31587,7 +31587,7 @@ func_ov12_0212c764: ; 0x0212c764
 _0212c798:
 	str r6, [sp]
 	ldr r2, [r5, r8, lsl #2]
-	mov r0, sb
+	mov r0, r9
 	mov r1, r7
 	mov r3, r4
 	blx func_ov04_02105b10
@@ -31595,9 +31595,9 @@ _0212c798:
 	cmp r7, #0x41
 	add r8, r8, #1
 	ble _0212c798
-	mov r0, sb
+	mov r0, r9
 	blx func_ov04_02105cd0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov12_0212c764
 _0212c7cc: .word data_027e0d44
@@ -36158,7 +36158,7 @@ _02130248: .word data_027e0d3c
 	.global func_ov12_0213024c
 	arm_func_start func_ov12_0213024c
 func_ov12_0213024c: ; 0x0213024c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x104
 	ldr r2, _0213069c ; =0x0000ffff
 	mov r1, #0
@@ -36321,7 +36321,7 @@ _02130484:
 	add r2, r4, #0xcc
 	cmp r3, r2
 	addeq sp, sp, #0x104
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _021304a4:
 	ldr r1, [r3]
 	add r3, r3, #0xc
@@ -36332,7 +36332,7 @@ _021304a4:
 	cmp r3, r2
 	bne _021304a4
 	add sp, sp, #0x104
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _021304cc:
 	mov r0, #0x1000
 	mov r1, #0
@@ -36395,18 +36395,18 @@ _02130598:
 	ldrh r7, [r1, #4]
 	str r4, [sp, #0x1c]
 	mov r4, r8, asr #0x1f
-	umull lr, sb, r0, r8
-	mla sb, r0, r4, sb
+	umull lr, r9, r0, r8
+	mla r9, r0, r4, r9
 	ldr r5, [r2, #8]
 	adds r4, lr, #0x800
-	mla sb, ip, r8, sb
+	mla r9, ip, r8, r9
 	ldr r10, [r2]
 	mov r7, r7, lsl #0xc
 	str r5, [sp, #0x24]
 	mov r5, r7, asr #0x1f
 	str r5, [sp, #0x20]
 	ldr r6, [r1, #8]
-	adc r8, sb, #0
+	adc r8, r9, #0
 	mov r4, r4, lsr #0xc
 	orr r4, r4, r8, lsl #20
 	add r10, r10, r4
@@ -36414,22 +36414,22 @@ _02130598:
 	mov r5, r6, asr #0x1f
 	str r5, [sp, #0x28]
 	ldr lr, [sp, #0x20]
-	umull sb, r8, r4, r7
+	umull r9, r8, r4, r7
 	mla r8, r4, lr, r8
 	ldr r4, [sp, #0x18]
 	ldr r5, [r3]
 	mla r8, r4, r7, r8
-	adds r7, sb, #0x800
+	adds r7, r9, #0x800
 	adc r4, r8, #0
 	mov r7, r7, lsr #0xc
 	orr r7, r7, r4, lsl #20
 	ldr r4, [sp, #0x1c]
-	ldr sb, [sp, #0x28]
+	ldr r9, [sp, #0x28]
 	add r4, r4, r7, asr #12
 	mov r4, r4, lsl #0x10
 	mov r8, r4, lsr #0x10
 	umull r7, r4, r0, r6
-	mla r4, r0, sb, r4
+	mla r4, r0, r9, r4
 	mla r4, ip, r6, r4
 	adds r7, r7, #0x800
 	adc r4, r4, #0
@@ -36454,7 +36454,7 @@ _02130598:
 	cmp r11, #2
 	blo _02130598
 	add sp, sp, #0x104
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov12_0213024c
 _0213069c: .word 0x0000ffff
@@ -37728,7 +37728,7 @@ _021316fc:
 	.global func_ov12_02131708
 	arm_func_start func_ov12_02131708
 func_ov12_02131708: ; 0x02131708
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x94
 	mov r10, r0
 	ldr r0, [r10, #0x130]
@@ -37763,7 +37763,7 @@ _0213176c:
 	mov r0, #1
 	strb r0, [r10, #0x754]
 	ldr r1, _02131a1c ; =data_027e0764
-	ldrsh sb, [r10, #0x78]
+	ldrsh r9, [r10, #0x78]
 	ldr r2, [r1]
 	ldmib r1, {r0, r6}
 	umull r3, r4, r6, r2
@@ -37773,33 +37773,33 @@ _0213176c:
 	mla r4, r5, r2, r4
 	ldr r7, [r1, #0x14]
 	adds r11, r8, r3
-	and r0, sb, #0xc000
+	and r0, r9, #0xc000
 	mov r3, r0, lsl #0x10
-	adc sb, r7, r4
+	adc r9, r7, r4
 	mov r0, #0x64
 	str r11, [r1]
-	umull r4, r2, sb, r0
+	umull r4, r2, r9, r0
 	mov lr, #0
-	mla r2, sb, lr, r2
+	mla r2, r9, lr, r2
 	mov r4, lr
 	mla r2, r4, r0, r2
 	mov ip, r3, lsr #0x10
-	str sb, [r1, #4]
+	str r9, [r1, #4]
 	cmp r2, #0xa
 	bge _02131838
 	umull r3, r2, r6, r11
-	mla r2, r6, sb, r2
+	mla r2, r6, r9, r2
 	mla r2, r5, r11, r2
 	adds r11, r8, r3
-	adc sb, r7, r2
-	umull r2, r3, sb, r0
-	mla r3, sb, lr, r3
+	adc r9, r7, r2
+	umull r2, r3, r9, r0
+	mla r3, r9, lr, r3
 	mla r3, r4, r0, r3
 	cmp r3, #0x32
 	addge r0, ip, #0x4000
 	str r11, [r1]
 	movge r0, r0, lsl #0x10
-	str sb, [r1, #4]
+	str r9, [r1, #4]
 	movge ip, r0, lsr #0x10
 	bge _02131838
 	sub r0, ip, #0x4000
@@ -37811,7 +37811,7 @@ _02131838:
 	ldr r3, [r2, #8]
 	ldr r0, [r2, #0xc]
 	umull r5, r4, r3, r11
-	mla r4, r3, sb, r4
+	mla r4, r3, r9, r4
 	mla r4, r0, r11, r4
 	ldr r3, [r2, #0x10]
 	ldr r0, [r2, #0x14]
@@ -37838,16 +37838,16 @@ _0213189c:
 	strh r0, [sp, #0x18]
 _021318ac:
 	sub r0, ip, #0x8000
-	mov sb, #0
+	mov r9, #0
 	ldr r7, _02131a20 ; =data_02050f54
 	ldr r6, _02131a24 ; =0x0000ffff
 	strh r0, [sp, #0x1a]
 	add r4, r10, #0x8c
 	add r8, sp, #0x14
-	mov r5, sb
+	mov r5, r9
 	mov r11, #0x33
 _021318d0:
-	mov r0, sb, lsl #0x1
+	mov r0, r9, lsl #0x1
 	ldr r1, [r10, #0x48]
 	ldrh r0, [r8, r0]
 	str r1, [r10, #0x73c]
@@ -37911,8 +37911,8 @@ _021318d0:
 	bl func_01ffbe78
 	cmp r0, #0
 	beq _021319dc
-	add sb, sb, #1
-	cmp sb, #4
+	add r9, r9, #1
+	cmp r9, #4
 	blt _021318d0
 _021319dc:
 	ldr r0, [r10, #0x238]
@@ -37931,7 +37931,7 @@ _02131a00:
 	str r1, [r10, #0x21c]
 	str r0, [r10, #0x220]
 	add sp, sp, #0x94
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov12_02131708
 _02131a1c: .word data_027e0764

--- a/asm/ov12.s
+++ b/asm/ov12.s
@@ -2203,12 +2203,12 @@ _021148a4: .word data_027e0ff8
 	.global func_ov12_021148a8
 	arm_func_start func_ov12_021148a8
 func_ov12_021148a8: ; 0x021148a8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x10
 	mov sl, r0
 	ldr r0, _02114a90 ; =0x00005555
 	mov r6, #0
-	ldr fp, _02114a94 ; =data_027e0f94
+	ldr r11, _02114a94 ; =data_027e0f94
 	mov r7, r6
 	add r5, sp, #4
 	rsb r4, r0, #0x8000
@@ -2230,11 +2230,11 @@ _021148cc:
 	str r0, [sp, #0xc]
 	b _02114924
 _0211490c:
-	ldr r1, [fp]
-	ldr r0, [fp, #4]
+	ldr r1, [r11]
+	ldr r0, [r11, #4]
 	str r1, [sp, #4]
 	str r0, [sp, #8]
-	ldr r0, [fp, #8]
+	ldr r0, [r11, #8]
 	str r0, [sp, #0xc]
 _02114924:
 	ldr r0, _02114a98 ; =data_ov12_02137c64
@@ -2326,14 +2326,14 @@ _02114a30:
 	orr r1, r2, r1, asr #2
 	mov r0, r6
 	strb r1, [sl, #0x239]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02114a78:
 	add r7, r7, #1
 	cmp r7, #2
 	blt _021148cc
 	mov r0, r6
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov12_021148a8
 _02114a90: .word 0x00005555
@@ -5851,9 +5851,9 @@ _021178f8: .word func_ov12_02117a94
 	.global func_ov12_021178fc
 	arm_func_start func_ov12_021178fc
 func_ov12_021178fc: ; 0x021178fc
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	ldr r1, _021179fc ; =data_ov12_02137c64
-	mov fp, r0
+	mov r11, r0
 	ldr r0, [r1]
 	add r0, r0, #0x7f0
 	bl func_ov12_02120144
@@ -5865,7 +5865,7 @@ func_ov12_021178fc: ; 0x021178fc
 	beq _02117934
 _0211792c:
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02117934:
 	ldr r1, _02117a04 ; =data_027e0d78
 	ldrh r0, [r1, #0x34]
@@ -5901,7 +5901,7 @@ _02117964:
 	ldr r2, [r0]
 	ldr r0, _02117a0c ; =data_ov12_02137d28
 	str sb, [r2, #0x24]
-	strb r1, [fp, #0x14]
+	strb r1, [r11, #0x14]
 	ldr r0, [r0]
 	add r1, sb, #1
 	mov r2, #2
@@ -5919,7 +5919,7 @@ _021179cc:
 	bl func_ov12_02117718
 _021179f4:
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov12_021178fc
 _021179fc: .word data_ov12_02137c64
@@ -6680,7 +6680,7 @@ _02118424: .word data_027e0d3c
 	.global func_ov12_02118428
 	arm_func_start func_ov12_02118428
 func_ov12_02118428: ; 0x02118428
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x128
 	ldr r3, _021187fc ; =data_027e0c38
 	add r4, sp, #0xbc
@@ -6735,7 +6735,7 @@ func_ov12_02118428: ; 0x02118428
 	cmp r0, #0
 	addeq sp, sp, #0x128
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, _02118808 ; =data_027e0e60
 	add r1, sp, #0xbc
 	ldr r0, [r0]
@@ -6785,7 +6785,7 @@ _0211857c:
 	cmp sl, #0
 	stmia r7, {r0, r1, r2}
 	ble _0211877c
-	ldr fp, _02118808 ; =data_027e0e60
+	ldr r11, _02118808 ; =data_027e0e60
 	add r5, r8, #0x8c
 	add r4, sp, #0x44
 	mov r6, #0
@@ -6831,7 +6831,7 @@ _021185d8:
 	str r0, [sp, #8]
 	str r6, [sp, #0xc]
 	str r6, [sp, #0x10]
-	ldr r0, [fp]
+	ldr r0, [r11]
 	mov r2, r7
 	add r3, sp, #0x74
 	bl func_01ffbe78
@@ -6881,7 +6881,7 @@ _021185d8:
 	cmp r0, r1
 	movlt sl, #0
 _02118740:
-	ldr r0, [fp]
+	ldr r0, [r11]
 	mov r1, r7
 	mov r2, #0
 	bl func_ov00_02083ee0
@@ -6913,7 +6913,7 @@ _0211877c:
 	addne sp, sp, #0x128
 	str r1, [r0]
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, _02118800 ; =data_027e0d3c
 	ldr r2, [sp, #0x14]
 	ldr r0, [r0]
@@ -6928,7 +6928,7 @@ _0211877c:
 	ldr r1, [sp, #0x14]
 	str r2, [r1]
 	add sp, sp, #0x128
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov12_02118428
 _021187fc: .word data_027e0c38
@@ -7036,7 +7036,7 @@ func_ov12_021188ec: ; 0x021188ec
 	.global func_ov12_0211893c
 	arm_func_start func_ov12_0211893c
 func_ov12_0211893c: ; 0x0211893c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	mov sl, r0
 	bl func_ov12_021174d4
 	ldr r0, _021189c0 ; =data_ov12_02137d2c
@@ -7047,11 +7047,11 @@ func_ov12_0211893c: ; 0x0211893c
 	str sl, [r0]
 	mov r6, #0
 	mov r5, #0x54
-	mov fp, #4
+	mov r11, #4
 _0211896c:
 	ldr r1, [r4, #4]
 	mov r0, r5
-	mov r2, fp
+	mov r2, r11
 	bl _ZN9SysObjectnwEmPjj
 	cmp r0, #0
 	beq _0211899c
@@ -7070,7 +7070,7 @@ _0211899c:
 	add sb, sb, #1
 	blt _0211896c
 	mov r0, sl
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov12_0211893c
 _021189c0: .word data_ov12_02137d2c
@@ -9709,7 +9709,7 @@ func_ov12_0211aa94: ; 0x0211aa94
 	.global func_ov12_0211aaa0
 	arm_func_start func_ov12_0211aaa0
 func_ov12_0211aaa0: ; 0x0211aaa0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x10
 	mov sl, r0
 	blx func_ov04_0210b3f0
@@ -9744,7 +9744,7 @@ func_ov12_0211aaa0: ; 0x0211aaa0
 	mov sb, #0
 	add r5, sl, #0x40
 	add r6, sp, #8
-	mov fp, #0xa4
+	mov r11, #0xa4
 _0211ab30:
 	mov r1, r8
 	add r0, r7, #8
@@ -9753,7 +9753,7 @@ _0211ab30:
 	ldr r1, [r4, #4]
 	add r0, r7, r0
 	str r0, [r6, sb, lsl #2]
-	mov r0, fp
+	mov r0, r11
 	mov r2, #4
 	bl _ZN9SysObjectnwEmPjj
 	cmp r0, #0
@@ -9864,7 +9864,7 @@ _0211aca0:
 	bl func_02035370
 	mov r0, sl
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov12_0211aaa0
 _0211acf4: .word data_ov12_02135e80
@@ -9995,7 +9995,7 @@ func_ov12_0211ae28: ; 0x0211ae28
 	.global func_ov12_0211ae4c
 	arm_func_start func_ov12_0211ae4c
 func_ov12_0211ae4c: ; 0x0211ae4c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x20
 	mov r4, r1
 	mov r5, #0x19000
@@ -10018,14 +10018,14 @@ func_ov12_0211ae4c: ; 0x0211ae4c
 	mov r6, r0, lsr #0xc
 	adc r0, r1, #0
 	add sb, sp, #0x10
-	add fp, sp, #0
+	add r11, sp, #0
 	mov lr, r2
 	mov ip, r3
 	orr r6, r6, r0, lsl #20
 	ldmia sl, {r0, r1, r2, r3}
 	stmia sb, {r0, r1, r2, r3}
 	ldmia r7, {r0, r1, r2, r3}
-	stmia fp, {r0, r1, r2, r3}
+	stmia r11, {r0, r1, r2, r3}
 	cmp r4, #0xa4
 	str lr, [sp, #0x10]
 	str r8, [sp, #0x14]
@@ -10038,7 +10038,7 @@ func_ov12_0211ae4c: ; 0x0211ae4c
 	mov r3, #1
 	bl func_ov00_020b45f8
 	add sp, sp, #0x20
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0211aefc:
 	ldr r1, _0211af5c ; =0x00000266
 	cmp r4, r1
@@ -10051,18 +10051,18 @@ _0211aefc:
 	ldr r4, [r0]
 	mov r1, sb
 	ldr r4, [r4, #0x60]
-	mov r2, fp
+	mov r2, r11
 	blx r4
 	add sp, sp, #0x20
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0211af38:
 	mov r0, r5
-	mov r1, fp
+	mov r1, r11
 	mov r2, #0
 	mov r3, #1
 	bl func_ov00_020b45f8
 	add sp, sp, #0x20
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov12_0211ae4c
 _0211af54: .word data_ov12_02134734
@@ -11101,7 +11101,7 @@ _0211bcd8:
 	.global func_ov12_0211bce8
 	arm_func_start func_ov12_0211bce8
 func_ov12_0211bce8: ; 0x0211bce8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	mov sl, r0
 	mov r0, #0
 	str r0, [sl]
@@ -11211,7 +11211,7 @@ _0211be58:
 	bl func_02007a44
 	mov r8, #0
 	add r7, sl, #8
-	ldr fp, _0211bf24 ; =data_ov12_02139c60
+	ldr r11, _0211bf24 ; =data_ov12_02139c60
 	mov r4, #0x88
 	b _0211bed0
 _0211be94:
@@ -11219,7 +11219,7 @@ _0211be94:
 	mul r6, r8, r0
 	ldr r0, _0211bf28 ; =0x00001fe0
 	mov sb, #0
-	mla r5, r8, r0, fp
+	mla r5, r8, r0, r11
 	b _0211bebc
 _0211beac:
 	mla r1, sb, r4, r5
@@ -11244,7 +11244,7 @@ _0211bed0:
 	str r0, [r2, #0x10]
 	mov r0, sl
 	strb r1, [sl, #0x70d]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov12_0211bce8
 _0211bf00: .word func_ov12_02118ca4
@@ -11398,13 +11398,13 @@ func_ov12_0211c0a4: ; 0x0211c0a4
 	.global func_ov12_0211c0cc
 	arm_func_start func_ov12_0211c0cc
 func_ov12_0211c0cc: ; 0x0211c0cc
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	mov sl, r0
 	mov sb, #0
 	add r6, sl, #8
 	mov r8, #0x3b
 	mov r7, sb
-	mov fp, #0x88
+	mov r11, #0x88
 	mov r4, #0x1fc
 _0211c0ec:
 	add r1, sl, sb
@@ -11423,7 +11423,7 @@ _0211c0ec:
 	mov r2, r0
 	ldr r0, [sl, #4]
 	mov r1, sb
-	mov r3, fp
+	mov r3, r11
 	ldr r5, [r0]
 	ldr r5, [r5, #0x24]
 	blx r5
@@ -11460,7 +11460,7 @@ _0211c0ec:
 	bic r0, r0, #0x80
 	strb r0, [sl, #0x6f8]
 	strh r4, [r1, #6]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	arm_func_end func_ov12_0211c0cc
 
 	.global func_ov12_0211c1c4
@@ -11690,7 +11690,7 @@ _0211c4d4:
 	.global func_ov12_0211c4dc
 	arm_func_start func_ov12_0211c4dc
 func_ov12_0211c4dc: ; 0x0211c4dc
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0xc
 	mov sl, r0
 	mov r6, #0
@@ -11796,7 +11796,7 @@ _0211c62c:
 	mov r0, r0, lsl #0x18
 	cmp r1, r0, lsr #31
 	bne _0211c754
-	ldr fp, _0211c774 ; =data_ov12_0213470c
+	ldr r11, _0211c774 ; =data_ov12_0213470c
 	add r5, r7, #0x88
 	add r8, r7, #6
 	and r4, r6, #0xff
@@ -11822,7 +11822,7 @@ _0211c694:
 	ldrb r1, [r8]
 	mov r1, r1, lsl #0x19
 	mov r1, r1, lsr #0x19
-	ldr r1, [fp, r1, lsl #2]
+	ldr r1, [r11, r1, lsl #2]
 	blx r1
 _0211c6c0:
 	ldrb r0, [r8, #1]
@@ -11873,7 +11873,7 @@ _0211c754:
 	str r0, [sp]
 	blt _0211c62c
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov12_0211c4dc
 _0211c774: .word data_ov12_0213470c
@@ -14749,7 +14749,7 @@ _0211ed14: .word data_ov12_021347f4
 	.global func_ov12_0211ed18
 	arm_func_start func_ov12_0211ed18
 func_ov12_0211ed18: ; 0x0211ed18
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x2c
 	add r1, sp, #0x20
 	str r1, [sp]
@@ -14761,8 +14761,8 @@ func_ov12_0211ed18: ; 0x0211ed18
 	ldr r5, _0211ee48 ; =data_ov12_02134808
 	ldr r4, _0211ee4c ; =data_ov12_02134814
 	ldmia r5, {r0, r1, r2}
-	add fp, sp, #0x14
-	stmia fp, {r0, r1, r2}
+	add r11, sp, #0x14
+	stmia r11, {r0, r1, r2}
 	ldmia r4, {r0, r1, r2}
 	add sl, sp, #8
 	stmia sl, {r0, r1, r2}
@@ -14783,7 +14783,7 @@ _0211ed7c:
 	mov r3, r4
 	bl func_02034698
 	ldr r0, _0211ee50 ; =0x0000013b
-	ldr r1, [fp], #4
+	ldr r1, [r11], #4
 	mov r2, r7
 	mov r3, r6
 	add r4, r4, #4
@@ -14824,7 +14824,7 @@ _0211ed7c:
 	sub r3, r2, #1
 	bl func_0203d77c
 	add sp, sp, #0x2c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov12_0211ed18
 _0211ee44: .word data_ov12_021347fc
@@ -14917,7 +14917,7 @@ _0211ef44: .word data_027e0d38
 	.global func_ov12_0211ef48
 	arm_func_start func_ov12_0211ef48
 func_ov12_0211ef48: ; 0x0211ef48
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x30
 	ldr r2, _0211f47c ; =data_027e0d38
 	mov sl, r0
@@ -14932,7 +14932,7 @@ func_ov12_0211ef48: ; 0x0211ef48
 	ldr r8, [sl, #0x34]
 	mov r1, sb, lsl #0xc
 	mov r0, sl
-	mov fp, r8, lsl #0xc
+	mov r11, r8, lsl #0xc
 	str r1, [sp, #4]
 	bl func_ov12_0211f4b0
 	mov r2, #0
@@ -15067,7 +15067,7 @@ _0211f128:
 	moveq r5, #0
 	beq _0211f1f0
 	ldr r0, [sl, #0x40]
-	mul r0, fp, r0
+	mul r0, r11, r0
 	add r0, r0, #0x800
 	mov r0, r0, asr #0xc
 	rsb r0, r0, #0x1000
@@ -15083,7 +15083,7 @@ _0211f1a4:
 	moveq r5, #0x100
 	beq _0211f1f0
 	ldr r0, [sp, #4]
-	mul r2, fp, r1
+	mul r2, r11, r1
 	mul r1, r0, r1
 	add r0, r2, #0x800
 	mov r2, r0, asr #0xc
@@ -15134,9 +15134,9 @@ _0211f268:
 	ldr r1, [sl, #0x5c]
 	ldr r0, [sl, #0x60]
 	mov r7, #0
-	sub fp, r1, r0
+	sub r11, r1, r0
 	cmp r4, #0
-	subeq r7, r7, fp
+	subeq r7, r7, r11
 	beq _0211f29c
 	str r7, [sp]
 	ldr r2, [sl, #0x64]
@@ -15147,7 +15147,7 @@ _0211f268:
 _0211f29c:
 	cmp r4, #0
 	cmpeq r5, #0
-	subeq r7, r7, fp
+	subeq r7, r7, r11
 	beq _0211f2cc
 	mov r0, #0
 	str r0, [sp]
@@ -15267,7 +15267,7 @@ _0211f43c:
 	str r2, [sp]
 	bl func_0203493c
 	add sp, sp, #0x30
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0211f45c:
 	mov r2, #0
 	ldr r0, _0211f480 ; =0x0000013b
@@ -15276,7 +15276,7 @@ _0211f45c:
 	str r2, [sp]
 	bl func_0203493c
 	add sp, sp, #0x30
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov12_0211ef48
 _0211f47c: .word data_027e0d38
@@ -15777,7 +15777,7 @@ func_ov12_0211fa98: ; 0x0211fa98
 	.global func_ov12_0211fad0
 	arm_func_start func_ov12_0211fad0
 func_ov12_0211fad0: ; 0x0211fad0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #8
 	mov r2, #0
 	mov r6, #1
@@ -15787,7 +15787,7 @@ func_ov12_0211fad0: ; 0x0211fad0
 	mov sl, r0
 	str r1, [sp]
 	mov r8, r2
-	mov fp, r2
+	mov r11, r2
 	mov r7, r6
 _0211fb00:
 	ldrb r0, [sl, #0x89]
@@ -15805,7 +15805,7 @@ _0211fb24:
 	ldr r0, [r0, #0x20]
 	cmp r0, #1
 	moveq r0, r6
-	movne r0, fp
+	movne r0, r11
 	cmp r0, #0
 	bne _0211fc18
 	ldrb r0, [sl, #0x89]
@@ -15997,7 +15997,7 @@ _0211fdbc:
 _0211fde8:
 	ldr r0, [sp, #4]
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov12_0211fad0
 _0211fdf4: .word data_027e0d54
@@ -17461,14 +17461,14 @@ _02121068: .word 0x00000133
 	.global func_ov12_0212106c
 	arm_func_start func_ov12_0212106c
 func_ov12_0212106c: ; 0x0212106c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #8
 	mov sl, r0
 	bl func_ov12_02120ff0
 	ldr r0, [sl, #0x14]
 	cmp r0, #0x6a
 	addne sp, sp, #8
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, _02121234 ; =data_ov12_02137c64
 	mov r1, #0
 	ldr r0, [r0]
@@ -17489,7 +17489,7 @@ _021210bc:
 	mov r0, r4
 	mov r2, r2, asr #0xc
 	mov r3, r3, asr #0xc
-	mov fp, #2
+	mov r11, #2
 	mov r5, #3
 	mov r6, #7
 	mov r7, #8
@@ -17509,7 +17509,7 @@ _021210bc:
 	str r0, [sp]
 	ldr r2, [sl, #0x94]
 	ldr r3, [sl, #0x98]
-	mov r1, fp
+	mov r1, r11
 	mov r0, r4
 	mov r2, r2, asr #0xc
 	mov r3, r3, asr #0xc
@@ -17552,7 +17552,7 @@ _021210bc:
 	mov r3, r3, asr #0xc
 	bl func_0203493c
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _021211d8:
 	bl func_ov12_02113208
 	cmp r0, #0
@@ -17567,7 +17567,7 @@ _021211d8:
 	mov r3, r3, asr #0xc
 	bl func_0203493c
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02121210:
 	ldr r2, [sl, #0xc8]
 	ldr r3, [sl, #0xcc]
@@ -17577,7 +17577,7 @@ _02121210:
 	mov r3, r3, asr #0xc
 	bl func_0203493c
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov12_0212106c
 _02121234: .word data_ov12_02137c64
@@ -19375,7 +19375,7 @@ _02122918: .word func_ov12_021202d8
 	.global func_ov12_0212291c
 	arm_func_start func_ov12_0212291c
 func_ov12_0212291c: ; 0x0212291c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x20
 	mov sl, r0
 	bl func_ov12_021258e0
@@ -19384,8 +19384,8 @@ func_ov12_0212291c: ; 0x0212291c
 	ldr r2, [r0, #0x2c]
 	ldr r0, [r1]
 	cmp r2, #0
-	moveq fp, #1
-	movne fp, #0
+	moveq r11, #1
+	movne r11, #0
 	bl func_ov12_02113208
 	str r0, [sl, #0x34c]
 	mov r0, #1
@@ -19630,7 +19630,7 @@ _02122cf4:
 	ldr r0, [sp, #0xc]
 	bl func_ov12_0211357c
 _02122cfc:
-	cmp fp, #0
+	cmp r11, #0
 	moveq r0, #0
 	movne r0, #1
 	strb r0, [sl, #0x36e]
@@ -19650,7 +19650,7 @@ _02122cfc:
 	strb r1, [sl, #0x370]
 	strb r1, [sl, #0x371]
 	str r1, [sl, #0x328]
-	cmp fp, #0
+	cmp r11, #0
 	strb r1, [sl, #0x368]
 	movne r0, #0xd8
 	bne _02122d74
@@ -19775,7 +19775,7 @@ _02122efc:
 	add r5, r5, #0x28
 	blt _02122efc
 	add sp, sp, #0x20
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov12_0212291c
 _02122f28: .word data_ov00_020ee698
@@ -25888,7 +25888,7 @@ _02127dc8: .word data_ov00_020eec9c
 	.global func_ov12_02127dcc
 	arm_func_start func_ov12_02127dcc
 func_ov12_02127dcc: ; 0x02127dcc
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0xc
 	mov r4, #5
 	mov sl, r0
@@ -25976,7 +25976,7 @@ _02127eec:
 	mov r8, sl
 	mov r6, sb
 	mov r5, r7
-	mov fp, #0x1000
+	mov r11, #0x1000
 _02127f20:
 	add r0, r7, #1
 	mla r1, r0, r4, r6
@@ -25985,7 +25985,7 @@ _02127f20:
 	ldr r1, [r8, #0x1bc]
 	ldr r2, [r8, #0x1c0]
 	mov r0, sb
-	mov r3, fp
+	mov r3, r11
 	bl func_ov01_020f7f34
 	add r7, r7, #1
 	cmp r7, #6
@@ -25998,14 +25998,14 @@ _02127f5c:
 	mov r7, sl
 	mov r6, #0
 	mov r5, sb
-	mov fp, #0xc000
+	mov r11, #0xc000
 _02127f70:
 	add r0, r6, #1
 	mla r1, r0, r4, r5
 	str r1, [r7, #0x1b8]
 	ldrb r1, [r8], #1
 	mov r0, sb
-	mov r3, fp
+	mov r3, r11
 	str r1, [sp]
 	ldr r1, [r7, #0x1bc]
 	ldr r2, [r7, #0x1c0]
@@ -26034,7 +26034,7 @@ _02127fac:
 	mov r0, #0x19
 	str r0, [sl, #0x10]
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov12_02127dcc
 _02127ff8: .word 0x0000015a
@@ -30195,20 +30195,20 @@ _0212b680: .word func_ov12_0212b684
 	.global func_ov12_0212b684
 	arm_func_start func_ov12_0212b684
 func_ov12_0212b684: ; 0x0212b684
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x1c
 	mov sl, r0
 	ldr r0, [sl, #0x188]
 	cmp r0, #0
 	addeq sp, sp, #0x1c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldrh r0, [sl, #0x28]
 	ldrh sb, [sl, #0x2a]
 	cmp r0, #0x40
 	str r0, [sp]
 	cmpls sb, #0x30
 	addhi sp, sp, #0x1c
-	ldmhiia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmhiia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	mov r0, #0
 	str r0, [sp, #4]
 	strb r0, [sp, #8]
@@ -30216,7 +30216,7 @@ func_ov12_0212b684: ; 0x0212b684
 	ldr r0, [sp]
 	cmp r0, #0
 	addle sp, sp, #0x1c
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0212b6dc:
 	cmp sb, #0
 	mov r8, #0
@@ -30226,7 +30226,7 @@ _0212b6dc:
 	and r7, r0, #0xff
 	add r5, sp, #8
 	add r4, sp, #0x12
-	add fp, sp, #0xe
+	add r11, sp, #0xe
 _0212b700:
 	mov r0, r6
 	mov r1, sl
@@ -30264,7 +30264,7 @@ _0212b700:
 	mov r1, r4
 	ldr r3, [r3, #0xa8]
 	blx r3
-	mov r0, fp
+	mov r0, r11
 	mov r1, sl
 	mov r2, r5
 	mov r3, #2
@@ -30278,7 +30278,7 @@ _0212b700:
 	mov r2, r0
 	mov r0, sl
 	ldr r3, [r0]
-	mov r1, fp
+	mov r1, r11
 	ldr r3, [r3, #0xa8]
 	blx r3
 	add r0, sp, #0xa
@@ -30309,7 +30309,7 @@ _0212b824:
 	cmp r1, r0
 	blt _0212b6dc
 	add sp, sp, #0x1c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	arm_func_end func_ov12_0212b684
 
 	.global func_ov12_0212b844
@@ -36158,7 +36158,7 @@ _02130248: .word data_027e0d3c
 	.global func_ov12_0213024c
 	arm_func_start func_ov12_0213024c
 func_ov12_0213024c: ; 0x0213024c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x104
 	ldr r2, _0213069c ; =0x0000ffff
 	mov r1, #0
@@ -36321,7 +36321,7 @@ _02130484:
 	add r2, r4, #0xcc
 	cmp r3, r2
 	addeq sp, sp, #0x104
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _021304a4:
 	ldr r1, [r3]
 	add r3, r3, #0xc
@@ -36332,7 +36332,7 @@ _021304a4:
 	cmp r3, r2
 	bne _021304a4
 	add sp, sp, #0x104
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _021304cc:
 	mov r0, #0x1000
 	mov r1, #0
@@ -36373,9 +36373,9 @@ _02130548:
 	mov r1, #0x5800
 	bl Divide
 	ldr r1, _021306a4 ; =0x00000d9a
-	mov fp, #0
+	mov r11, #0
 	umull r3, r2, r0, r1
-	mla r2, r0, fp, r2
+	mla r2, r0, r11, r2
 	mov ip, r0, asr #0x1f
 	mla r2, ip, r1, r2
 	adds r3, r3, #0x800
@@ -36440,7 +36440,7 @@ _02130598:
 	strne sl, [r5, #0x58]
 	add r6, r4, r6
 	ldr r4, [r3]
-	add fp, fp, #1
+	add r11, r11, #1
 	cmp r4, #0
 	strneh r8, [r4, #0x74]
 	mov r4, r6, lsl #0x10
@@ -36451,10 +36451,10 @@ _02130598:
 	strne r5, [r4, #0x70]
 	add r2, r2, #0xc
 	add r3, r3, #0xc
-	cmp fp, #2
+	cmp r11, #2
 	blo _02130598
 	add sp, sp, #0x104
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov12_0213024c
 _0213069c: .word 0x0000ffff
@@ -37728,7 +37728,7 @@ _021316fc:
 	.global func_ov12_02131708
 	arm_func_start func_ov12_02131708
 func_ov12_02131708: ; 0x02131708
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x94
 	mov sl, r0
 	ldr r0, [sl, #0x130]
@@ -37772,12 +37772,12 @@ _0213176c:
 	ldr r8, [r1, #0x10]
 	mla r4, r5, r2, r4
 	ldr r7, [r1, #0x14]
-	adds fp, r8, r3
+	adds r11, r8, r3
 	and r0, sb, #0xc000
 	mov r3, r0, lsl #0x10
 	adc sb, r7, r4
 	mov r0, #0x64
-	str fp, [r1]
+	str r11, [r1]
 	umull r4, r2, sb, r0
 	mov lr, #0
 	mla r2, sb, lr, r2
@@ -37787,17 +37787,17 @@ _0213176c:
 	str sb, [r1, #4]
 	cmp r2, #0xa
 	bge _02131838
-	umull r3, r2, r6, fp
+	umull r3, r2, r6, r11
 	mla r2, r6, sb, r2
-	mla r2, r5, fp, r2
-	adds fp, r8, r3
+	mla r2, r5, r11, r2
+	adds r11, r8, r3
 	adc sb, r7, r2
 	umull r2, r3, sb, r0
 	mla r3, sb, lr, r3
 	mla r3, r4, r0, r3
 	cmp r3, #0x32
 	addge r0, ip, #0x4000
-	str fp, [r1]
+	str r11, [r1]
 	movge r0, r0, lsl #0x10
 	str sb, [r1, #4]
 	movge ip, r0, lsr #0x10
@@ -37810,9 +37810,9 @@ _02131838:
 	mov r1, #0
 	ldr r3, [r2, #8]
 	ldr r0, [r2, #0xc]
-	umull r5, r4, r3, fp
+	umull r5, r4, r3, r11
 	mla r4, r3, sb, r4
-	mla r4, r0, fp, r4
+	mla r4, r0, r11, r4
 	ldr r3, [r2, #0x10]
 	ldr r0, [r2, #0x14]
 	adds r6, r3, r5
@@ -37845,7 +37845,7 @@ _021318ac:
 	add r4, sl, #0x8c
 	add r8, sp, #0x14
 	mov r5, sb
-	mov fp, #0x33
+	mov r11, #0x33
 _021318d0:
 	mov r0, sb, lsl #0x1
 	ldr r1, [sl, #0x48]
@@ -37903,7 +37903,7 @@ _021318d0:
 	strb r5, [sp, #0x91]
 	str r4, [sp]
 	ldr r0, [sl, #8]
-	stmib sp, {r0, fp}
+	stmib sp, {r0, r11}
 	str r5, [sp, #0xc]
 	ldr r0, _02131a28 ; =data_027e0e60
 	str r5, [sp, #0x10]
@@ -37931,7 +37931,7 @@ _02131a00:
 	str r1, [sl, #0x21c]
 	str r0, [sl, #0x220]
 	add sp, sp, #0x94
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov12_02131708
 _02131a1c: .word data_027e0764

--- a/asm/ov12.s
+++ b/asm/ov12.s
@@ -2203,9 +2203,9 @@ _021148a4: .word data_027e0ff8
 	.global func_ov12_021148a8
 	arm_func_start func_ov12_021148a8
 func_ov12_021148a8: ; 0x021148a8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x10
-	mov sl, r0
+	mov r10, r0
 	ldr r0, _02114a90 ; =0x00005555
 	mov r6, #0
 	ldr r11, _02114a94 ; =data_027e0f94
@@ -2260,35 +2260,35 @@ _02114964:
 	bne _02114a78
 _02114974:
 	mov r0, r5
-	add r1, sl, #0x48
+	add r1, r10, #0x48
 	bl func_01ff9ec0
 	cmp r0, #0x1c00
 	ble _021149a0
 	ldr r0, _02114aa0 ; =0x0000019a
-	add r1, sl, #0x48
+	add r1, r10, #0x48
 	mov r2, r5
 	bl func_0202bf58
 	cmp r0, #0
 	bne _02114a78
 _021149a0:
-	ldr r0, [sl, #0x570]
+	ldr r0, [r10, #0x570]
 	mov r2, #0x2800
 	str r5, [sp]
-	ldrsh r1, [sl, #0x78]
+	ldrsh r1, [r10, #0x78]
 	ldr r3, _02114a90 ; =0x00005555
 	cmp r0, #1
 	mov sb, #0x2000
 	moveq r2, #0x3c00
-	add r0, sl, #0x48
+	add r0, r10, #0x48
 	moveq sb, #0x3000
 	bl func_ov00_020c54a0
 	cmp r0, #0
 	movne r6, #1
 	bne _02114a04
 	str r5, [sp]
-	ldrsh r1, [sl, #0x78]
+	ldrsh r1, [r10, #0x78]
 	mov r2, sb
-	add r0, sl, #0x48
+	add r0, r10, #0x48
 	sub r1, r1, #0x8000
 	mov r1, r1, lsl #0x10
 	mov r3, r4
@@ -2300,40 +2300,40 @@ _02114a04:
 	cmp r6, #0
 	beq _02114a78
 	cmp r8, #0
-	addeq r0, sl, #0x740
+	addeq r0, r10, #0x740
 	beq _02114a30
-	add r0, sl, #0x344
+	add r0, r10, #0x344
 	mov r1, r8
 	add r0, r0, #0x400
 	bl func_ov12_02116218
-	add r0, sl, #0x344
+	add r0, r10, #0x344
 	add r0, r0, #0x400
 _02114a30:
-	str r0, [sl, #0x75c]
-	ldrb r1, [sl, #0x238]
+	str r0, [r10, #0x75c]
+	ldrb r1, [r10, #0x238]
 	mov r0, r7, lsl #0x18
 	mov r3, r0, asr #0x18
 	bic r2, r1, #0xc0
 	and r1, r2, #0xff
 	mov r0, r3, lsl #0x1e
 	orr r0, r1, r0, lsr #24
-	strb r0, [sl, #0x238]
-	ldrb r2, [sl, #0x239]
+	strb r0, [r10, #0x238]
+	ldrb r2, [r10, #0x239]
 	and r1, r3, #0xfc
 	add sp, sp, #0x10
 	bic r3, r2, #0x3f
 	and r2, r3, #0xff
 	orr r1, r2, r1, asr #2
 	mov r0, r6
-	strb r1, [sl, #0x239]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	strb r1, [r10, #0x239]
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02114a78:
 	add r7, r7, #1
 	cmp r7, #2
 	blt _021148cc
 	mov r0, r6
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov12_021148a8
 _02114a90: .word 0x00005555
@@ -5851,7 +5851,7 @@ _021178f8: .word func_ov12_02117a94
 	.global func_ov12_021178fc
 	arm_func_start func_ov12_021178fc
 func_ov12_021178fc: ; 0x021178fc
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	ldr r1, _021179fc ; =data_ov12_02137c64
 	mov r11, r0
 	ldr r0, [r1]
@@ -5865,7 +5865,7 @@ func_ov12_021178fc: ; 0x021178fc
 	beq _02117934
 _0211792c:
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02117934:
 	ldr r1, _02117a04 ; =data_027e0d78
 	ldrh r0, [r1, #0x34]
@@ -5876,7 +5876,7 @@ _02117934:
 	ldr r0, [r4]
 	ldr r5, [r1, #0x10]
 	ldr r6, [r1, #0x14]
-	ldr sl, [r0, #0x24]
+	ldr r10, [r0, #0x24]
 	sub sb, r8, #0x91
 	mov r7, #0
 _02117964:
@@ -5894,7 +5894,7 @@ _02117964:
 	blt _02117964
 	cmp sb, #0
 	blt _021179f4
-	cmp sl, r7
+	cmp r10, r7
 	beq _021179cc
 	ldr r0, _02117a08 ; =data_ov12_02137d20
 	mov r1, #1
@@ -5919,7 +5919,7 @@ _021179cc:
 	bl func_ov12_02117718
 _021179f4:
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov12_021178fc
 _021179fc: .word data_ov12_02137c64
@@ -6680,7 +6680,7 @@ _02118424: .word data_027e0d3c
 	.global func_ov12_02118428
 	arm_func_start func_ov12_02118428
 func_ov12_02118428: ; 0x02118428
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x128
 	ldr r3, _021187fc ; =data_027e0c38
 	add r4, sp, #0xbc
@@ -6735,7 +6735,7 @@ func_ov12_02118428: ; 0x02118428
 	cmp r0, #0
 	addeq sp, sp, #0x128
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, _02118808 ; =data_027e0e60
 	add r1, sp, #0xbc
 	ldr r0, [r0]
@@ -6770,7 +6770,7 @@ _0211857c:
 	add r0, sp, #0x8c
 	mov sb, r1, asr #0x1
 	bl func_01ff9cec
-	mov sl, r0
+	mov r10, r0
 	add r0, sp, #0xa4
 	add r4, sp, #0x20
 	ldmia r0, {r0, r1, r2}
@@ -6782,7 +6782,7 @@ _0211857c:
 	str r0, [sp, #0x1c]
 	add r7, sp, #0x68
 	ldmia r4, {r0, r1, r2}
-	cmp sl, #0
+	cmp r10, #0
 	stmia r7, {r0, r1, r2}
 	ble _0211877c
 	ldr r11, _02118808 ; =data_027e0e60
@@ -6795,8 +6795,8 @@ _021185d8:
 	str r1, [sp, #0x74]
 	str r1, [sp, #0x68]
 	ldr r1, [sp, #0xac]
-	cmp sl, sb
-	movle sb, sl
+	cmp r10, sb
+	movle sb, r10
 	str r0, [sp, #0x78]
 	str r0, [sp, #0x6c]
 	mov r0, sb
@@ -6805,7 +6805,7 @@ _021185d8:
 	add r1, sp, #0x80
 	mov r2, r7
 	mov r3, r7
-	sub sl, sl, sb
+	sub r10, r10, sb
 	bl func_01ff9e64
 	ldr r0, _0211880c ; =0x0000ffff
 	strh r6, [sp, #0xf4]
@@ -6879,7 +6879,7 @@ _021185d8:
 	bl func_01ff9c2c
 	ldr r1, _02118810 ; =0xfffff0f7
 	cmp r0, r1
-	movlt sl, #0
+	movlt r10, #0
 _02118740:
 	ldr r0, [r11]
 	mov r1, r7
@@ -6890,7 +6890,7 @@ _02118740:
 	str r0, [sp, #0xa8]
 	str r0, [sp, #0xb4]
 	ldr r0, [sp, #0x70]
-	cmp sl, #0
+	cmp r10, #0
 	str r1, [sp, #0xa4]
 	str r1, [sp, #0xb0]
 	str r0, [sp, #0xac]
@@ -6913,7 +6913,7 @@ _0211877c:
 	addne sp, sp, #0x128
 	str r1, [r0]
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, _02118800 ; =data_027e0d3c
 	ldr r2, [sp, #0x14]
 	ldr r0, [r0]
@@ -6928,7 +6928,7 @@ _0211877c:
 	ldr r1, [sp, #0x14]
 	str r2, [r1]
 	add sp, sp, #0x128
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov12_02118428
 _021187fc: .word data_027e0c38
@@ -7036,15 +7036,15 @@ func_ov12_021188ec: ; 0x021188ec
 	.global func_ov12_0211893c
 	arm_func_start func_ov12_0211893c
 func_ov12_0211893c: ; 0x0211893c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
-	mov sl, r0
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	mov r10, r0
 	bl func_ov12_021174d4
 	ldr r0, _021189c0 ; =data_ov12_02137d2c
 	ldr r7, _021189c4 ; =data_ov12_02134704
 	ldr r8, _021189c8 ; =data_ov12_02134708
 	ldr sb, _021189cc ; =data_ov12_02134700
 	ldr r4, _021189d0 ; =data_027e0ce0
-	str sl, [r0]
+	str r10, [r0]
 	mov r6, #0
 	mov r5, #0x54
 	mov r11, #4
@@ -7062,15 +7062,15 @@ _0211896c:
 	ldrb r3, [r8]
 	bl func_ov12_02117cc0
 _0211899c:
-	str r0, [sl, r6, lsl #2]
+	str r0, [r10, r6, lsl #2]
 	add r6, r6, #1
 	cmp r6, #3
 	add r7, r7, #1
 	add r8, r8, #1
 	add sb, sb, #1
 	blt _0211896c
-	mov r0, sl
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	mov r0, r10
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov12_0211893c
 _021189c0: .word data_ov12_02137d2c
@@ -9709,26 +9709,26 @@ func_ov12_0211aa94: ; 0x0211aa94
 	.global func_ov12_0211aaa0
 	arm_func_start func_ov12_0211aaa0
 func_ov12_0211aaa0: ; 0x0211aaa0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x10
-	mov sl, r0
+	mov r10, r0
 	blx func_ov04_0210b3f0
 	ldr r1, _0211acf4 ; =data_ov12_02135e80
-	add r0, sl, #0x1a8
-	str r1, [sl]
+	add r0, r10, #0x1a8
+	str r1, [r10]
 	bl func_02035064
 	mov r1, #0
-	str r1, [sl, #0x230]
+	str r1, [r10, #0x230]
 	mov r0, #0x1000
-	str r0, [sl, #0x234]
-	str r1, [sl, #0x23c]
-	str r1, [sl, #0x240]
-	strb r1, [sl, #0x244]
-	strb r1, [sl, #0x245]
-	strb r1, [sl, #0x246]
-	str r1, [sl, #0x144]
+	str r0, [r10, #0x234]
+	str r1, [r10, #0x23c]
+	str r1, [r10, #0x240]
+	strb r1, [r10, #0x244]
+	strb r1, [r10, #0x245]
+	strb r1, [r10, #0x246]
+	str r1, [r10, #0x144]
 	mov r1, #0x2b8
-	str r1, [sl, #4]
+	str r1, [r10, #4]
 	ldr r0, _0211acf8 ; =data_027e0fc4
 	mov r1, #1
 	ldr r0, [r0]
@@ -9740,9 +9740,9 @@ func_ov12_0211aaa0: ; 0x0211aaa0
 	blx func_ov00_020bb378
 	ldr r8, _0211acfc ; =data_ov12_02135e40
 	ldr r4, _0211ad00 ; =data_027e0ce0
-	str r0, [sl, #0x238]
+	str r0, [r10, #0x238]
 	mov sb, #0
-	add r5, sl, #0x40
+	add r5, r10, #0x40
 	add r6, sp, #8
 	mov r11, #0xa4
 _0211ab30:
@@ -9761,18 +9761,18 @@ _0211ab30:
 	ldr r1, [r6, sb, lsl #2]
 	blx func_ov04_0210b2d8
 _0211ab68:
-	add r1, sl, sb, lsl #2
+	add r1, r10, sb, lsl #2
 	add sb, sb, #1
 	str r0, [r1, #0x1a0]
 	str r5, [r0, #0x9c]
 	cmp sb, #2
 	add r8, r8, #0x10
 	blt _0211ab30
-	ldr r0, [sl, #0x1a0]
+	ldr r0, [r10, #0x1a0]
 	mov r1, #4
 	blx func_ov00_020a9938
-	ldr r1, [sl, #0x1a0]
-	ldr r0, [sl, #0x1a4]
+	ldr r1, [r10, #0x1a0]
+	ldr r0, [r10, #0x1a4]
 	ldr r1, [r1, #0x58]
 	bl func_ov00_020a9960
 	ldr r0, _0211acf8 ; =data_027e0fc4
@@ -9795,7 +9795,7 @@ _0211ab68:
 	blx func_ov00_020a99e0
 _0211abe8:
 	ldr r1, _0211ad00 ; =data_027e0ce0
-	str r0, [sl, #0x118]
+	str r0, [r10, #0x118]
 	ldr r1, [r1, #4]
 	mov r0, #0x24
 	mov r2, #4
@@ -9807,7 +9807,7 @@ _0211abe8:
 	blx func_ov00_020a99e0
 _0211ac14:
 	ldr r1, _0211ad00 ; =data_027e0ce0
-	str r0, [sl, #0x138]
+	str r0, [r10, #0x138]
 	ldr r1, [r1, #4]
 	mov r0, #0x24
 	mov r2, #4
@@ -9819,7 +9819,7 @@ _0211ac14:
 	blx func_ov00_020a99e0
 _0211ac40:
 	ldr r1, _0211ad00 ; =data_027e0ce0
-	str r0, [sl, #0x11c]
+	str r0, [r10, #0x11c]
 	ldr r1, [r1, #4]
 	mov r0, #0x24
 	mov r2, #4
@@ -9831,7 +9831,7 @@ _0211ac40:
 	blx func_ov00_020a99e0
 _0211ac6c:
 	ldr r1, _0211ad00 ; =data_027e0ce0
-	str r0, [sl, #0x13c]
+	str r0, [r10, #0x13c]
 	ldr r1, [r1, #4]
 	mov r0, #0x54
 	mov r2, #4
@@ -9844,11 +9844,11 @@ _0211ac6c:
 	ldr r0, _0211ad04 ; =data_ov12_02135e70
 	str r0, [r4]
 _0211aca0:
-	str r4, [sl, #0x140]
+	str r4, [r10, #0x140]
 	blx func_ov04_0210f604
 	mov r3, #0
 	str r3, [sp]
-	add r0, sl, #0x1a8
+	add r0, r10, #0x1a8
 	mov r1, #0x58
 	mov r2, #6
 	str r3, [sp, #4]
@@ -9856,15 +9856,15 @@ _0211aca0:
 	mov r1, #0
 	mov r2, r1
 	mov r3, r1
-	add r0, sl, #0x1a8
+	add r0, r10, #0x1a8
 	str r1, [sp]
 	bl func_020351b8
-	add r0, sl, #0x1a8
+	add r0, r10, #0x1a8
 	mov r1, #0x1000
 	bl func_02035370
-	mov r0, sl
+	mov r0, r10
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov12_0211aaa0
 _0211acf4: .word data_ov12_02135e80
@@ -9995,7 +9995,7 @@ func_ov12_0211ae28: ; 0x0211ae28
 	.global func_ov12_0211ae4c
 	arm_func_start func_ov12_0211ae4c
 func_ov12_0211ae4c: ; 0x0211ae4c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x20
 	mov r4, r1
 	mov r5, #0x19000
@@ -10012,7 +10012,7 @@ func_ov12_0211ae4c: ; 0x0211ae4c
 	mov r5, r0
 	mov r0, #0x800
 	adds r0, r0, r4, lsl #16
-	ldr sl, _0211af54 ; =data_ov12_02134734
+	ldr r10, _0211af54 ; =data_ov12_02134734
 	ldr r7, _0211af58 ; =data_ov12_02134744
 	orr r1, r1, r4, lsr #16
 	mov r6, r0, lsr #0xc
@@ -10022,7 +10022,7 @@ func_ov12_0211ae4c: ; 0x0211ae4c
 	mov lr, r2
 	mov ip, r3
 	orr r6, r6, r0, lsl #20
-	ldmia sl, {r0, r1, r2, r3}
+	ldmia r10, {r0, r1, r2, r3}
 	stmia sb, {r0, r1, r2, r3}
 	ldmia r7, {r0, r1, r2, r3}
 	stmia r11, {r0, r1, r2, r3}
@@ -10038,7 +10038,7 @@ func_ov12_0211ae4c: ; 0x0211ae4c
 	mov r3, #1
 	bl func_ov00_020b45f8
 	add sp, sp, #0x20
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0211aefc:
 	ldr r1, _0211af5c ; =0x00000266
 	cmp r4, r1
@@ -10054,7 +10054,7 @@ _0211aefc:
 	mov r2, r11
 	blx r4
 	add sp, sp, #0x20
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0211af38:
 	mov r0, r5
 	mov r1, r11
@@ -10062,7 +10062,7 @@ _0211af38:
 	mov r3, #1
 	bl func_ov00_020b45f8
 	add sp, sp, #0x20
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov12_0211ae4c
 _0211af54: .word data_ov12_02134734
@@ -11101,61 +11101,61 @@ _0211bcd8:
 	.global func_ov12_0211bce8
 	arm_func_start func_ov12_0211bce8
 func_ov12_0211bce8: ; 0x0211bce8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
-	mov sl, r0
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	mov r10, r0
 	mov r0, #0
-	str r0, [sl]
-	str r0, [sl, #4]
+	str r0, [r10]
+	str r0, [r10, #4]
 	ldr r4, _0211bf00 ; =func_ov12_02118ca4
 	ldr r3, _0211bf04 ; =func_ov12_02118c0c
-	add r0, sl, #8
+	add r0, r10, #8
 	mov r1, #2
 	mov r2, #0x1fc
 	str r4, [sp]
 	bl func_0204f614
-	add r0, sl, #0x400
+	add r0, r10, #0x400
 	bl func_ov12_02118e80
 	mov r5, #0
-	str r5, [sl, #0x6ec]
-	add r0, sl, #0x600
+	str r5, [r10, #0x6ec]
+	add r0, r10, #0x600
 	strh r5, [r0, #0xf4]
-	str r5, [sl, #0x6f0]
+	str r5, [r10, #0x6f0]
 	strh r5, [r0, #0xf6]
 	strh r5, [r0, #0xf4]
-	str r5, [sl, #0x6f0]
+	str r5, [r10, #0x6f0]
 	strh r5, [r0, #0xf6]
-	ldrb r2, [sl, #0x6f8]
-	add r0, sl, #0x700
+	ldrb r2, [r10, #0x6f8]
+	add r0, r10, #0x700
 	mov r1, #1
 	bic r4, r2, #0x3f
 	and r2, r4, #0xff
 	bic r3, r2, #0x40
 	and r2, r3, #0xff
-	strb r4, [sl, #0x6f8]
+	strb r4, [r10, #0x6f8]
 	bic r2, r2, #0x80
-	strb r2, [sl, #0x6f8]
-	strb r5, [sl, #0x702]
-	strb r5, [sl, #0x703]
+	strb r2, [r10, #0x6f8]
+	strb r5, [r10, #0x702]
+	strb r5, [r10, #0x703]
 	strh r5, [r0, #4]
 	strh r5, [r0, #6]
-	strb r5, [sl, #0x708]
-	strb r5, [sl, #0x70b]
-	strb r5, [sl, #0x70c]
-	strb r5, [sl, #0x716]
-	strb r5, [sl, #0x717]
-	strb r1, [sl, #0x718]
-	strb r5, [sl, #0x719]
+	strb r5, [r10, #0x708]
+	strb r5, [r10, #0x70b]
+	strb r5, [r10, #0x70c]
+	strb r5, [r10, #0x716]
+	strb r5, [r10, #0x717]
+	strb r1, [r10, #0x718]
+	strb r5, [r10, #0x719]
 	ldr r0, _0211bf08 ; =data_027e0ce0
-	strb r5, [sl, #0x71a]
+	strb r5, [r10, #0x71a]
 	ldr r1, _0211bf0c ; =data_ov12_0213cc60
 	ldr r0, [r0, #4]
-	str sl, [r1, #0xfe8]
+	str r10, [r1, #0xfe8]
 	mov r1, #0x32000
 	mov r2, #0x20
 	blx func_0201739c
 	mov r1, #0x32000
 	mov r2, #2
-	str r0, [sl]
+	str r0, [r10]
 	blx func_02017374
 	ldr r2, _0211bf0c ; =data_ov12_0213cc60
 	ldr r1, _0211bf10 ; =data_ov00_020ee698
@@ -11172,7 +11172,7 @@ func_ov12_0211bce8: ; 0x0211bce8
 	beq _0211be00
 	bl func_ov61_021796dc
 _0211be00:
-	str r0, [sl, #4]
+	str r0, [r10, #4]
 	b _0211be58
 _0211be08:
 	cmp r0, #1
@@ -11186,7 +11186,7 @@ _0211be08:
 	beq _0211be30
 	bl func_ov60_02145310
 _0211be30:
-	str r0, [sl, #4]
+	str r0, [r10, #4]
 	b _0211be58
 _0211be38:
 	ldr r1, _0211bf08 ; =data_027e0ce0
@@ -11197,9 +11197,9 @@ _0211be38:
 	beq _0211be54
 	bl func_ov12_0212c460
 _0211be54:
-	str r0, [sl, #4]
+	str r0, [r10, #4]
 _0211be58:
-	ldr r0, [sl, #4]
+	ldr r0, [r10, #4]
 	ldr r1, _0211bf18 ; =func_ov12_0211bbdc
 	ldr r3, [r0]
 	ldr r2, _0211bf1c ; =func_ov12_0211bc20
@@ -11210,7 +11210,7 @@ _0211be58:
 	mov r2, #0x88
 	bl func_02007a44
 	mov r8, #0
-	add r7, sl, #8
+	add r7, r10, #8
 	ldr r11, _0211bf24 ; =data_ov12_02139c60
 	mov r4, #0x88
 	b _0211bed0
@@ -11235,16 +11235,16 @@ _0211bebc:
 _0211bed0:
 	cmp r8, #2
 	blo _0211be94
-	ldr r2, [sl, #4]
+	ldr r2, [r10, #4]
 	ldr r1, _0211bf2c ; =func_ov12_0211bc64
 	ldr r0, _0211bf30 ; =func_ov12_0211bc68
 	str r1, [r2, #8]
-	ldr r2, [sl, #4]
+	ldr r2, [r10, #4]
 	mov r1, #0
 	str r0, [r2, #0x10]
-	mov r0, sl
-	strb r1, [sl, #0x70d]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	mov r0, r10
+	strb r1, [r10, #0x70d]
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov12_0211bce8
 _0211bf00: .word func_ov12_02118ca4
@@ -11398,16 +11398,16 @@ func_ov12_0211c0a4: ; 0x0211c0a4
 	.global func_ov12_0211c0cc
 	arm_func_start func_ov12_0211c0cc
 func_ov12_0211c0cc: ; 0x0211c0cc
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
-	mov sl, r0
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	mov r10, r0
 	mov sb, #0
-	add r6, sl, #8
+	add r6, r10, #8
 	mov r8, #0x3b
 	mov r7, sb
 	mov r11, #0x88
 	mov r4, #0x1fc
 _0211c0ec:
-	add r1, sl, sb
+	add r1, r10, sb
 	mul r5, sb, r4
 	strb r8, [r1, #0x709]
 	strb r7, [r1, #0x700]
@@ -11421,7 +11421,7 @@ _0211c0ec:
 	add r0, r6, r5
 	bl func_ov12_02118dc8
 	mov r2, r0
-	ldr r0, [sl, #4]
+	ldr r0, [r10, #4]
 	mov r1, sb
 	mov r3, r11
 	ldr r5, [r0]
@@ -11433,34 +11433,34 @@ _0211c0ec:
 	cmp sb, #2
 	blo _0211c0ec
 	mov r1, #0
-	add r0, sl, #0x400
-	strb r1, [sl, #0x70d]
+	add r0, r10, #0x400
+	strb r1, [r10, #0x70d]
 	bl func_ov12_02118f4c
 	mov r4, #0
-	strb r4, [sl, #0x702]
-	strb r4, [sl, #0x703]
-	add r1, sl, #0x700
+	strb r4, [r10, #0x702]
+	strb r4, [r10, #0x703]
+	add r1, r10, #0x700
 	strh r4, [r1, #4]
-	strb r4, [sl, #0x70b]
-	strb r4, [sl, #0x717]
-	strb r4, [sl, #0x718]
-	strb r4, [sl, #0x708]
-	strb r4, [sl, #0x719]
-	strb r4, [sl, #0x70c]
-	add r0, sl, #0x600
+	strb r4, [r10, #0x70b]
+	strb r4, [r10, #0x717]
+	strb r4, [r10, #0x718]
+	strb r4, [r10, #0x708]
+	strb r4, [r10, #0x719]
+	strb r4, [r10, #0x70c]
+	add r0, r10, #0x600
 	strh r4, [r0, #0xf4]
-	str r4, [sl, #0x6f0]
+	str r4, [r10, #0x6f0]
 	strh r4, [r0, #0xf6]
-	ldrb r0, [sl, #0x6f8]
+	ldrb r0, [r10, #0x6f8]
 	bic r3, r0, #0x3f
 	and r0, r3, #0xff
 	bic r2, r0, #0x40
 	and r0, r2, #0xff
-	strb r3, [sl, #0x6f8]
+	strb r3, [r10, #0x6f8]
 	bic r0, r0, #0x80
-	strb r0, [sl, #0x6f8]
+	strb r0, [r10, #0x6f8]
 	strh r4, [r1, #6]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	arm_func_end func_ov12_0211c0cc
 
 	.global func_ov12_0211c1c4
@@ -11690,12 +11690,12 @@ _0211c4d4:
 	.global func_ov12_0211c4dc
 	arm_func_start func_ov12_0211c4dc
 func_ov12_0211c4dc: ; 0x0211c4dc
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0xc
-	mov sl, r0
+	mov r10, r0
 	mov r6, #0
-	strb r6, [sl, #0x71a]
-	add r2, sl, #0x700
+	strb r6, [r10, #0x71a]
+	add r2, r10, #0x700
 	mov r0, #1
 	mov sb, r1
 	ldrh r7, [r2, #4]
@@ -11706,7 +11706,7 @@ func_ov12_0211c4dc: ; 0x0211c4dc
 _0211c510:
 	tst r7, r5, lsl r6
 	beq _0211c538
-	add r8, sl, r6
+	add r8, r10, r6
 	add r2, r8, #0x700
 	ldrsb r2, [r2, #0x12]
 	cmp r2, #0
@@ -11718,10 +11718,10 @@ _0211c538:
 	add r6, r6, #1
 	cmp r6, #2
 	blt _0211c510
-	ldrb r2, [sl, #0x717]
+	ldrb r2, [r10, #0x717]
 	cmp r2, #0
 	bne _0211c5dc
-	ldr r2, [sl, #0x6ec]
+	ldr r2, [r10, #0x6ec]
 	cmp r2, #1
 	moveq r2, #1
 	movne r2, #0
@@ -11729,10 +11729,10 @@ _0211c538:
 	bne _0211c590
 	mov r0, #1
 	mov r3, #0
-	strb r0, [sl, #0x717]
+	strb r0, [r10, #0x717]
 	mov r2, r3
 _0211c578:
-	add r0, sl, r3
+	add r0, r10, r3
 	add r3, r3, #1
 	strb r2, [r0, #0x712]
 	cmp r3, #2
@@ -11742,15 +11742,15 @@ _0211c590:
 	cmp r0, #0
 	beq _0211c5dc
 	mov r0, #1
-	strb r0, [sl, #0x717]
+	strb r0, [r10, #0x717]
 	mov r5, #0
-	add r2, sl, #0x700
+	add r2, r10, #0x700
 	mov r4, r0
 _0211c5ac:
 	ldrh r0, [r2, #4]
 	tst r0, r4, lsl r5
 	beq _0211c5d0
-	add r3, sl, r5
+	add r3, r10, r5
 	add r0, r3, #0x700
 	ldrsb r0, [r0, #0x12]
 	cmp r0, #0
@@ -11763,7 +11763,7 @@ _0211c5d0:
 _0211c5dc:
 	cmp r1, #0
 	bne _0211c5fc
-	ldr r0, [sl, #0x6ec]
+	ldr r0, [r10, #0x6ec]
 	cmp r0, #1
 	moveq r0, #1
 	movne r0, #0
@@ -11772,16 +11772,16 @@ _0211c5dc:
 _0211c5fc:
 	mov r0, #1
 	mov r2, #0
-	strb r0, [sl, #0x718]
+	strb r0, [r10, #0x718]
 	mov r1, r2
 _0211c60c:
-	add r0, sl, r2
+	add r0, r10, r2
 	add r2, r2, #1
 	strb r1, [r0, #0x714]
 	cmp r2, #2
 	blt _0211c60c
 _0211c620:
-	add r0, sl, #8
+	add r0, r10, #8
 	str r0, [sp]
 	mov r6, #0
 _0211c62c:
@@ -11790,7 +11790,7 @@ _0211c62c:
 	movs r7, r0
 	beq _0211c754
 	ldrb r1, [r7, #4]
-	ldrb r0, [sl, #0x70d]
+	ldrb r0, [r10, #0x70d]
 	mov r1, r1, lsl #0x18
 	mov r1, r1, lsr #0x1f
 	mov r0, r0, lsl #0x18
@@ -11830,12 +11830,12 @@ _0211c6c0:
 	add r8, r8, r0
 	b _0211c668
 _0211c6d0:
-	mov r0, sl
+	mov r0, r10
 	bl func_ov12_0211cc2c
 	cmp r6, r0
 	beq _0211c70c
 	ldrb r1, [r7, #4]
-	add r0, sl, #0x1a
+	add r0, r10, #0x1a
 	mov r1, r1, lsl #0x19
 	movs r1, r1, lsr #0x1f
 	ldrb r1, [r0, #0x700]
@@ -11851,16 +11851,16 @@ _0211c70c:
 	movs r0, r0, lsr #0x1f
 	beq _0211c748
 	ldrb r2, [r7, #1]
-	add r1, sl, r6
-	mov r0, sl
+	add r1, r10, r6
+	mov r0, r10
 	strb r2, [r1, #0x700]
 	bl func_ov12_0211cc2c
 	cmp r6, r0
-	ldrneb r0, [sl, #0x708]
+	ldrneb r0, [r10, #0x708]
 	cmpne r0, #0
 	movne r0, #1
-	strneb r0, [sl, #0x70e]
-	strneb r0, [sl, #0x70f]
+	strneb r0, [r10, #0x70e]
+	strneb r0, [r10, #0x70f]
 _0211c748:
 	ldr r0, [sp]
 	bl func_ov12_02118e54
@@ -11873,7 +11873,7 @@ _0211c754:
 	str r0, [sp]
 	blt _0211c62c
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov12_0211c4dc
 _0211c774: .word data_ov12_0213470c
@@ -14749,7 +14749,7 @@ _0211ed14: .word data_ov12_021347f4
 	.global func_ov12_0211ed18
 	arm_func_start func_ov12_0211ed18
 func_ov12_0211ed18: ; 0x0211ed18
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x2c
 	add r1, sp, #0x20
 	str r1, [sp]
@@ -14764,8 +14764,8 @@ func_ov12_0211ed18: ; 0x0211ed18
 	add r11, sp, #0x14
 	stmia r11, {r0, r1, r2}
 	ldmia r4, {r0, r1, r2}
-	add sl, sp, #8
-	stmia sl, {r0, r1, r2}
+	add r10, sp, #8
+	stmia r10, {r0, r1, r2}
 	mov r0, #0
 	add r5, r3, #0x44
 	add r4, r3, #0x50
@@ -14790,7 +14790,7 @@ _0211ed7c:
 	add r5, r5, #4
 	bl func_02034698
 	ldr r0, _0211ee50 ; =0x0000013b
-	ldr r1, [sl], #4
+	ldr r1, [r10], #4
 	mov r2, sb
 	mov r3, r8
 	add r6, r6, #4
@@ -14824,7 +14824,7 @@ _0211ed7c:
 	sub r3, r2, #1
 	bl func_0203d77c
 	add sp, sp, #0x2c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov12_0211ed18
 _0211ee44: .word data_ov12_021347fc
@@ -14917,10 +14917,10 @@ _0211ef44: .word data_027e0d38
 	.global func_ov12_0211ef48
 	arm_func_start func_ov12_0211ef48
 func_ov12_0211ef48: ; 0x0211ef48
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x30
 	ldr r2, _0211f47c ; =data_027e0d38
-	mov sl, r0
+	mov r10, r0
 	ldr r3, [r2]
 	mov r2, r1
 	ldr r0, [r3, #0x24]
@@ -14928,10 +14928,10 @@ func_ov12_0211ef48: ; 0x0211ef48
 	bl func_ov05_0210274c
 	add r0, sp, #0x10
 	bl func_01ffbe34
-	ldr sb, [sl, #0x38]
-	ldr r8, [sl, #0x34]
+	ldr sb, [r10, #0x38]
+	ldr r8, [r10, #0x34]
 	mov r1, sb, lsl #0xc
-	mov r0, sl
+	mov r0, r10
 	mov r11, r8, lsl #0xc
 	str r1, [sp, #4]
 	bl func_ov12_0211f4b0
@@ -14942,11 +14942,11 @@ func_ov12_0211ef48: ; 0x0211ef48
 	mov r3, r2
 	str r2, [sp]
 	bl func_0203493c
-	mov r0, sl
+	mov r0, r10
 	bl func_ov12_0211f4b0
 	cmp r0, #3
 	bne _0211efe8
-	mov r0, sl
+	mov r0, r10
 	bl func_ov12_0211f4c8
 	cmp r0, #0
 	bne _0211efe8
@@ -14995,7 +14995,7 @@ _0211efe8:
 	str r2, [sp]
 	bl func_0203493c
 _0211f078:
-	ldrh r0, [sl, #0x30]
+	ldrh r0, [r10, #0x30]
 	mov r5, #0
 	mov r6, r5
 	mov r4, r0
@@ -15028,8 +15028,8 @@ _0211f0b8:
 	beq _0211f100
 	mov r0, #0
 	str r0, [sp]
-	ldr r2, [sl, #0x4c]
-	ldr r3, [sl, #0x58]
+	ldr r2, [r10, #0x4c]
+	ldr r3, [r10, #0x58]
 	add r1, r7, r5
 	mov r0, #0x13c
 	bl func_02034984
@@ -15039,16 +15039,16 @@ _0211f100:
 	beq _0211f128
 	mov r0, #0
 	str r0, [sp]
-	ldr r2, [sl, #0x48]
-	ldr r3, [sl, #0x54]
+	ldr r2, [r10, #0x48]
+	ldr r3, [r10, #0x54]
 	add r1, r7, r6
 	mov r0, #0x13c
 	bl func_02034984
 _0211f128:
 	mov r0, #0
 	str r0, [sp]
-	ldr r2, [sl, #0x44]
-	ldr r3, [sl, #0x50]
+	ldr r2, [r10, #0x44]
+	ldr r3, [r10, #0x50]
 	add r1, r7, r4
 	mov r0, #0x13c
 	bl func_02034984
@@ -15066,7 +15066,7 @@ _0211f128:
 	mvneq r2, #0xff
 	moveq r5, #0
 	beq _0211f1f0
-	ldr r0, [sl, #0x40]
+	ldr r0, [r10, #0x40]
 	mul r0, r11, r0
 	add r0, r0, #0x800
 	mov r0, r0, asr #0xc
@@ -15077,7 +15077,7 @@ _0211f128:
 	add r5, r2, #0x100
 	b _0211f1f0
 _0211f1a4:
-	ldr r1, [sl, #0x40]
+	ldr r1, [r10, #0x40]
 	cmp r1, #0
 	mvneq r2, #0xff
 	moveq r5, #0x100
@@ -15131,16 +15131,16 @@ _0211f258:
 	add r5, r5, #1
 	bgt _0211f258
 _0211f268:
-	ldr r1, [sl, #0x5c]
-	ldr r0, [sl, #0x60]
+	ldr r1, [r10, #0x5c]
+	ldr r0, [r10, #0x60]
 	mov r7, #0
 	sub r11, r1, r0
 	cmp r4, #0
 	subeq r7, r7, r11
 	beq _0211f29c
 	str r7, [sp]
-	ldr r2, [sl, #0x64]
-	ldr r3, [sl, #0x70]
+	ldr r2, [r10, #0x64]
+	ldr r3, [r10, #0x70]
 	add r1, r4, #0x41
 	mov r0, #0x13c
 	bl func_02034984
@@ -15151,8 +15151,8 @@ _0211f29c:
 	beq _0211f2cc
 	mov r0, #0
 	str r0, [sp]
-	ldr r0, [sl, #0x60]
-	ldr r3, [sl, #0x6c]
+	ldr r0, [r10, #0x60]
+	ldr r3, [r10, #0x6c]
 	add r2, r0, r7
 	add r1, r5, #0x41
 	mov r0, #0x13c
@@ -15160,8 +15160,8 @@ _0211f29c:
 _0211f2cc:
 	mov r0, #0
 	str r0, [sp]
-	ldr r0, [sl, #0x5c]
-	ldr r3, [sl, #0x68]
+	ldr r0, [r10, #0x5c]
+	ldr r3, [r10, #0x68]
 	add r2, r0, r7
 	add r1, r6, #0x41
 	mov r0, #0x13c
@@ -15220,8 +15220,8 @@ _0211f398:
 	beq _0211f3bc
 	mov r0, #0
 	str r0, [sp]
-	ldr r2, [sl, #0x7c]
-	ldr r3, [sl, #0x88]
+	ldr r2, [r10, #0x7c]
+	ldr r3, [r10, #0x88]
 	add r1, r5, #0x37
 	mov r0, #0x13c
 	bl func_02034984
@@ -15231,16 +15231,16 @@ _0211f3bc:
 	beq _0211f3e4
 	mov r0, #0
 	str r0, [sp]
-	ldr r2, [sl, #0x78]
-	ldr r3, [sl, #0x84]
+	ldr r2, [r10, #0x78]
+	ldr r3, [r10, #0x84]
 	add r1, r6, #0x37
 	mov r0, #0x13c
 	bl func_02034984
 _0211f3e4:
 	mov r0, #0
 	str r0, [sp]
-	ldr r2, [sl, #0x74]
-	ldr r3, [sl, #0x80]
+	ldr r2, [r10, #0x74]
+	ldr r3, [r10, #0x80]
 	add r1, r4, #0x37
 	mov r0, #0x13c
 	bl func_02034984
@@ -15267,7 +15267,7 @@ _0211f43c:
 	str r2, [sp]
 	bl func_0203493c
 	add sp, sp, #0x30
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0211f45c:
 	mov r2, #0
 	ldr r0, _0211f480 ; =0x0000013b
@@ -15276,7 +15276,7 @@ _0211f45c:
 	str r2, [sp]
 	bl func_0203493c
 	add sp, sp, #0x30
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov12_0211ef48
 _0211f47c: .word data_027e0d38
@@ -15777,20 +15777,20 @@ func_ov12_0211fa98: ; 0x0211fa98
 	.global func_ov12_0211fad0
 	arm_func_start func_ov12_0211fad0
 func_ov12_0211fad0: ; 0x0211fad0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #8
 	mov r2, #0
 	mov r6, #1
 	ldr r5, _0211fdf4 ; =data_027e0d54
 	ldr r4, _0211fdf8 ; =data_ov12_02137c64
 	str r2, [sp, #4]
-	mov sl, r0
+	mov r10, r0
 	str r1, [sp]
 	mov r8, r2
 	mov r11, r2
 	mov r7, r6
 _0211fb00:
-	ldrb r0, [sl, #0x89]
+	ldrb r0, [r10, #0x89]
 	mov sb, r7, lsl r8
 	tst r0, r7, lsl r8
 	beq _0211fbb8
@@ -15808,13 +15808,13 @@ _0211fb24:
 	movne r0, r11
 	cmp r0, #0
 	bne _0211fc18
-	ldrb r0, [sl, #0x89]
+	ldrb r0, [r10, #0x89]
 	mvn r1, sb
 	and r0, r0, r1
-	strb r0, [sl, #0x89]
-	ldrb r0, [sl, #0x88]
+	strb r0, [r10, #0x89]
+	ldrb r0, [r10, #0x88]
 	and r0, r0, r1
-	strb r0, [sl, #0x88]
+	strb r0, [r10, #0x88]
 	b _0211fc18
 _0211fb64:
 	ldrb r0, [r5, #0xd]
@@ -15823,24 +15823,24 @@ _0211fb64:
 	movne r0, #0
 	cmp r0, #0
 	beq _0211fc18
-	ldrb r0, [sl, #0x89]
+	ldrb r0, [r10, #0x89]
 	mvn r1, sb
 	and r0, r0, r1
-	strb r0, [sl, #0x89]
-	ldrb r0, [sl, #0x88]
+	strb r0, [r10, #0x89]
+	ldrb r0, [r10, #0x88]
 	and r0, r0, r1
-	strb r0, [sl, #0x88]
+	strb r0, [r10, #0x88]
 	b _0211fc18
 _0211fb9c:
 	mvn r1, sb
 	and r0, r0, r1
-	strb r0, [sl, #0x89]
-	ldrb r0, [sl, #0x88]
+	strb r0, [r10, #0x89]
+	ldrb r0, [r10, #0x88]
 	and r0, r0, r1
-	strb r0, [sl, #0x88]
+	strb r0, [r10, #0x88]
 	b _0211fc18
 _0211fbb8:
-	ldrb r0, [sl, #0x88]
+	ldrb r0, [r10, #0x88]
 	tst r0, sb
 	beq _0211fc18
 	cmp sb, #1
@@ -15851,27 +15851,27 @@ _0211fbb8:
 _0211fbd8:
 	bl func_ov12_0211bc54
 	bl func_ov12_0211c034
-	ldrb r0, [sl, #0x89]
+	ldrb r0, [r10, #0x89]
 	orr r0, r0, sb
-	strb r0, [sl, #0x89]
+	strb r0, [r10, #0x89]
 	b _0211fc18
 _0211fbf0:
 	ldr r0, [r4]
 	bl func_ov12_021134f4
-	ldrb r0, [sl, #0x89]
+	ldrb r0, [r10, #0x89]
 	orr r0, r0, sb
-	strb r0, [sl, #0x89]
+	strb r0, [r10, #0x89]
 	b _0211fc18
 _0211fc08:
 	mov r1, r0
 	mvn r0, sb
 	and r0, r1, r0
-	strb r0, [sl, #0x88]
+	strb r0, [r10, #0x88]
 _0211fc18:
 	add r8, r8, #1
 	cmp r8, #2
 	blt _0211fb00
-	ldr r0, [sl, #0x84]
+	ldr r0, [r10, #0x84]
 	cmp r0, #0
 	beq _0211fc44
 	cmp r0, #1
@@ -15880,18 +15880,18 @@ _0211fc18:
 	beq _0211fd3c
 	b _0211fdbc
 _0211fc44:
-	ldrb r0, [sl, #0x8b]
+	ldrb r0, [r10, #0x8b]
 	cmp r0, #0
 	beq _0211fdbc
-	mov r0, sl
+	mov r0, r10
 	bl func_ov12_021200d8
 	cmp r0, #1
 	beq _0211fdbc
-	mov r0, sl
+	mov r0, r10
 	bl func_ov12_021200b4
 	cmp r0, #0
 	bne _0211fcc8
-	ldr r0, [sl, #0x7c]
+	ldr r0, [r10, #0x7c]
 	cmp r0, #0
 	beq _0211fc90
 	ldr r0, _0211fdfc ; =data_027e0618
@@ -15900,24 +15900,24 @@ _0211fc44:
 	blx func_0202cec8
 	b _0211fcc8
 _0211fc90:
-	ldrb r0, [sl, #0x8c]
+	ldrb r0, [r10, #0x8c]
 	mov r1, #0x20
 	cmp r0, #0
 	movne r0, #1
 	moveq r0, #0
-	strb r0, [sl, #0x48]
-	ldr r2, [sl, #0x80]
-	add r0, sl, #0x28
+	strb r0, [r10, #0x48]
+	ldr r2, [r10, #0x80]
+	add r0, r10, #0x28
 	blx func_0202abf4
 	cmp r0, #0
 	beq _0211fcc8
 	ldr r0, _0211fe00 ; =data_027e071c
-	add r1, sl, #0x28
+	add r1, r10, #0x28
 	bl func_0202d77c
 _0211fcc8:
 	mov r0, #1
-	str r0, [sl, #0x84]
-	ldrb r0, [sl, #0x8a]
+	str r0, [r10, #0x84]
+	ldrb r0, [r10, #0x8a]
 	cmp r0, #0
 	beq _0211fdbc
 	ldr r0, _0211fe04 ; =data_ov00_020eec68
@@ -15929,75 +15929,75 @@ _0211fcc8:
 	bl func_ov00_020d716c
 	b _0211fdbc
 _0211fcfc:
-	mov r0, sl
+	mov r0, r10
 	bl func_ov12_021200b4
 	cmp r0, #0
 	beq _0211fdbc
-	ldrb r0, [sl, #0x8a]
+	ldrb r0, [r10, #0x8a]
 	cmp r0, #0
-	ldrne r0, [sl, #0x78]
+	ldrne r0, [r10, #0x78]
 	cmpne r0, #0xa
 	beq _0211fd28
 	bl func_ov12_0211bc54
 	bl func_ov12_0211ce24
 _0211fd28:
 	mov r0, #0
-	strb r0, [sl, #0x8b]
+	strb r0, [r10, #0x8b]
 	mov r0, #2
-	str r0, [sl, #0x84]
+	str r0, [r10, #0x84]
 	b _0211fdbc
 _0211fd3c:
 	bl func_ov12_0211bc54
 	ldrb r0, [r0, #0x718]
 	cmp r0, #0
 	beq _0211fdbc
-	mov r0, sl
+	mov r0, r10
 	mov r1, #0
 	bl func_ov12_02120064
 	cmp r0, #0
 	beq _0211fdbc
-	ldrb r0, [sl, #0x8a]
+	ldrb r0, [r10, #0x8a]
 	cmp r0, #0
 	beq _0211fd80
-	ldr r1, [sl, #0x78]
-	mov r0, sl
+	ldr r1, [r10, #0x78]
+	mov r0, r10
 	bl func_ov12_0211ff54
 	cmp r0, #0
 	beq _0211fdac
 _0211fd80:
-	ldr r2, [sl, #0x80]
-	add r0, sl, #0x28
+	ldr r2, [r10, #0x80]
+	add r0, r10, #0x28
 	mov r1, #0x20
 	blx func_0202abdc
 	cmp r0, #0
 	beq _0211fda4
 	ldr r0, _0211fe00 ; =data_027e071c
-	add r1, sl, #0x28
+	add r1, r10, #0x28
 	bl func_0202d77c
 _0211fda4:
 	bl func_ov12_0211bc54
 	bl func_ov12_0211cd60
 _0211fdac:
-	ldr r0, [sl, #0x7c]
+	ldr r0, [r10, #0x7c]
 	str r0, [sp, #4]
 	mov r0, #0
-	str r0, [sl, #0x84]
+	str r0, [r10, #0x84]
 _0211fdbc:
-	add r0, sl, #0x4c
+	add r0, r10, #0x4c
 	bl func_ov01_020f8388
-	ldr r0, [sl, #0x74]
+	ldr r0, [r10, #0x74]
 	cmp r0, #0xa
 	bge _0211fde8
-	ldr r0, [sl, #0x74]
+	ldr r0, [r10, #0x74]
 	ldr r1, [sp]
-	ldr r0, [sl, r0, lsl #2]
+	ldr r0, [r10, r0, lsl #2]
 	ldr r2, [r0]
 	ldr r2, [r2, #0x10]
 	blx r2
 _0211fde8:
 	ldr r0, [sp, #4]
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov12_0211fad0
 _0211fdf4: .word data_027e0d54
@@ -17461,14 +17461,14 @@ _02121068: .word 0x00000133
 	.global func_ov12_0212106c
 	arm_func_start func_ov12_0212106c
 func_ov12_0212106c: ; 0x0212106c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #8
-	mov sl, r0
+	mov r10, r0
 	bl func_ov12_02120ff0
-	ldr r0, [sl, #0x14]
+	ldr r0, [r10, #0x14]
 	cmp r0, #0x6a
 	addne sp, sp, #8
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, _02121234 ; =data_ov12_02137c64
 	mov r1, #0
 	ldr r0, [r0]
@@ -17482,10 +17482,10 @@ func_ov12_0212106c: ; 0x0212106c
 	ldr r4, _02121238 ; =0x0000015e
 	str r0, [sp, #4]
 _021210bc:
-	add r0, sl, #0xa8
+	add r0, r10, #0xa8
 	str r0, [sp]
-	ldr r2, [sl, #0x94]
-	ldr r3, [sl, #0x98]
+	ldr r2, [r10, #0x94]
+	ldr r3, [r10, #0x98]
 	mov r0, r4
 	mov r2, r2, asr #0xc
 	mov r3, r3, asr #0xc
@@ -17496,43 +17496,43 @@ _021210bc:
 	mov r8, #0xa
 	mov sb, #9
 	bl func_0203493c
-	add r0, sl, #0xa8
+	add r0, r10, #0xa8
 	str r0, [sp]
-	ldr r0, [sl, #0x94]
-	ldr r3, [sl, #0x98]
+	ldr r0, [r10, #0x94]
+	ldr r3, [r10, #0x98]
 	mov r2, r0, asr #0xc
 	ldr r1, [sp, #4]
 	mov r0, r4
 	mov r3, r3, asr #0xc
 	bl func_0203493c
-	add r0, sl, #0xa8
+	add r0, r10, #0xa8
 	str r0, [sp]
-	ldr r2, [sl, #0x94]
-	ldr r3, [sl, #0x98]
+	ldr r2, [r10, #0x94]
+	ldr r3, [r10, #0x98]
 	mov r1, r11
 	mov r0, r4
 	mov r2, r2, asr #0xc
 	mov r3, r3, asr #0xc
 	bl func_0203493c
-	mov r0, sl
+	mov r0, r10
 	bl func_ov12_0211f4b0
 	sub r0, r0, #1
 	add r1, r5, r0
-	add r0, sl, #0xa8
+	add r0, r10, #0xa8
 	str r0, [sp]
-	ldr r2, [sl, #0x94]
-	ldr r3, [sl, #0x98]
+	ldr r2, [r10, #0x94]
+	ldr r3, [r10, #0x98]
 	mov r0, r4
 	mov r2, r2, asr #0xc
 	mov r3, r3, asr #0xc
 	bl func_0203493c
-	mov r0, sl
+	mov r0, r10
 	bl func_ov12_0211f4c8
 	sub r1, r6, r0
-	add r0, sl, #0xa8
+	add r0, r10, #0xa8
 	str r0, [sp]
-	ldr r2, [sl, #0x94]
-	ldr r3, [sl, #0x98]
+	ldr r2, [r10, #0x94]
+	ldr r3, [r10, #0x98]
 	mov r0, r4
 	mov r2, r2, asr #0xc
 	mov r3, r3, asr #0xc
@@ -17542,42 +17542,42 @@ _021210bc:
 	ldr r1, [r0, #0x994]
 	cmp r1, #1
 	bne _021211d8
-	add r0, sl, #0xdc
+	add r0, r10, #0xdc
 	str r0, [sp]
-	ldr r2, [sl, #0xc8]
-	ldr r3, [sl, #0xcc]
+	ldr r2, [r10, #0xc8]
+	ldr r3, [r10, #0xcc]
 	mov r0, r4
 	mov r1, r7
 	mov r2, r2, asr #0xc
 	mov r3, r3, asr #0xc
 	bl func_0203493c
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _021211d8:
 	bl func_ov12_02113208
 	cmp r0, #0
-	add r0, sl, #0xdc
+	add r0, r10, #0xdc
 	str r0, [sp]
 	bne _02121210
-	ldr r2, [sl, #0xc8]
-	ldr r3, [sl, #0xcc]
+	ldr r2, [r10, #0xc8]
+	ldr r3, [r10, #0xcc]
 	mov r0, r4
 	mov r1, r8
 	mov r2, r2, asr #0xc
 	mov r3, r3, asr #0xc
 	bl func_0203493c
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02121210:
-	ldr r2, [sl, #0xc8]
-	ldr r3, [sl, #0xcc]
+	ldr r2, [r10, #0xc8]
+	ldr r3, [r10, #0xcc]
 	mov r0, r4
 	mov r1, sb
 	mov r2, r2, asr #0xc
 	mov r3, r3, asr #0xc
 	bl func_0203493c
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov12_0212106c
 _02121234: .word data_ov12_02137c64
@@ -17638,14 +17638,14 @@ _021212e4: .word data_ov12_02137c64
 	.global func_ov12_021212e8
 	arm_func_start func_ov12_021212e8
 func_ov12_021212e8: ; 0x021212e8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #4
-	mov sl, r0
+	mov r10, r0
 	bl func_ov12_02120ff0
-	ldr r0, [sl, #0x14]
+	ldr r0, [r10, #0x14]
 	cmp r0, #0x6a
 	addne sp, sp, #4
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	ldr r0, _0212142c ; =data_ov12_02137c64
 	mov sb, #0
 	ldr r0, [r0]
@@ -17654,25 +17654,25 @@ func_ov12_021212e8: ; 0x021212e8
 	mov r6, #0
 	cmp r0, #0
 	moveq r4, #0x7e
-	ldr r0, [sl, #0x150]
+	ldr r0, [r10, #0x150]
 	ldrne r4, _02121430 ; =0x00000161
 	cmp r0, #2
 	cmpne r0, #4
 	mov r7, #2
 	mov r8, #3
 	mov r1, #4
-	ldrne sb, [sl, #0x15c]
+	ldrne sb, [r10, #0x15c]
 	bne _0212136c
-	add r0, sl, #0xa8
+	add r0, r10, #0xa8
 	str r0, [sp]
-	ldr r2, [sl, #0x94]
-	ldr r3, [sl, #0x98]
+	ldr r2, [r10, #0x94]
+	ldr r3, [r10, #0x98]
 	mov r0, r4
 	mov r2, r2, asr #0xc
 	mov r3, r3, asr #0xc
 	bl func_0203493c
 _0212136c:
-	ldr r0, [sl, #0x150]
+	ldr r0, [r10, #0x150]
 	sub r0, r0, #4
 	cmp r0, #1
 	bhi _02121400
@@ -17680,11 +17680,11 @@ _0212136c:
 	ldr r0, [r0]
 	ldr r0, [r0, #0x998]
 	cmp r0, #0
-	add r0, sl, #0xdc
+	add r0, r10, #0xdc
 	str r0, [sp]
 	bne _021213b8
-	ldr r2, [sl, #0xc8]
-	ldr r3, [sl, #0xcc]
+	ldr r2, [r10, #0xc8]
+	ldr r3, [r10, #0xcc]
 	mov r0, r4
 	mov r1, r5
 	mov r2, r2, asr #0xc
@@ -17692,37 +17692,37 @@ _0212136c:
 	bl func_0203493c
 	b _021213d4
 _021213b8:
-	ldr r2, [sl, #0xc8]
-	ldr r3, [sl, #0xcc]
+	ldr r2, [r10, #0xc8]
+	ldr r3, [r10, #0xcc]
 	mov r0, r4
 	mov r1, r6
 	mov r2, r2, asr #0xc
 	add r3, sb, r3, asr #12
 	bl func_0203493c
 _021213d4:
-	add r0, sl, #0xdc
+	add r0, r10, #0xdc
 	str r0, [sp]
-	ldr r2, [sl, #0xc8]
-	ldr r3, [sl, #0xcc]
+	ldr r2, [r10, #0xc8]
+	ldr r3, [r10, #0xcc]
 	mov r0, r4
 	mov r1, r7
 	mov r2, r2, asr #0xc
 	add r3, sb, r3, asr #12
 	bl func_0203493c
 	add sp, sp, #4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 _02121400:
-	add r0, sl, #0xdc
+	add r0, r10, #0xdc
 	str r0, [sp]
-	ldr r2, [sl, #0xc8]
-	ldr r3, [sl, #0xcc]
+	ldr r2, [r10, #0xc8]
+	ldr r3, [r10, #0xcc]
 	mov r0, r4
 	mov r1, r8
 	mov r2, r2, asr #0xc
 	add r3, sb, r3, asr #12
 	bl func_0203493c
 	add sp, sp, #4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov12_021212e8
 _0212142c: .word data_ov12_02137c64
@@ -19030,7 +19030,7 @@ _021224cc: .word 0x00002710
 	.global func_ov12_021224d0
 	arm_func_start func_ov12_021224d0
 func_ov12_021224d0: ; 0x021224d0
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #8
 	mov r6, r0
 	ldr r0, [r6, #0x10]
@@ -19053,15 +19053,15 @@ _02122518:
 	ldr r1, _021226c4 ; =0x00002710
 	mov r0, r5
 	bl func_01ff9b4c
-	mov sl, r0
-	cmp sl, #0
+	mov r10, r0
+	cmp r10, #0
 	ble _02122558
 	ldr r0, [r6, #0x18]
 	mov r2, r7
 	stmia sp, {r0, r4}
 	ldr r3, [r6, #0x1c]
 	ldmib r6, {r0, r1}
-	add r1, r1, sl
+	add r1, r1, r10
 	sub r3, r8, r3
 	bl func_020349cc
 	mov sb, #1
@@ -19073,14 +19073,14 @@ _02122558:
 	subeq r8, r8, r0
 _02122568:
 	ldr r0, _021226c4 ; =0x00002710
-	mul r0, sl, r0
+	mul r0, r10, r0
 	sub r5, r5, r0
 _02122574:
 	mov r0, r5
 	mov r1, #0x3e8
 	bl func_01ff9b4c
-	mov sl, r0
-	cmp sl, #0
+	mov r10, r0
+	cmp r10, #0
 	bgt _02122594
 	cmp sb, #0
 	beq _021225b8
@@ -19090,7 +19090,7 @@ _02122594:
 	stmia sp, {r0, r4}
 	ldmib r6, {r0, r1}
 	mov r3, r8
-	add r1, r1, sl
+	add r1, r1, r10
 	bl func_020349cc
 	mov sb, #1
 	b _021225c8
@@ -19101,15 +19101,15 @@ _021225b8:
 	subeq r8, r8, r0
 _021225c8:
 	mov r0, #0x3e8
-	mul r0, sl, r0
+	mul r0, r10, r0
 	add r7, r7, #1
 	sub r5, r5, r0
 _021225d8:
 	mov r0, r5
 	mov r1, #0x64
 	bl func_01ff9b4c
-	mov sl, r0
-	cmp sl, #0
+	mov r10, r0
+	cmp r10, #0
 	bgt _021225f8
 	cmp sb, #0
 	beq _0212261c
@@ -19119,7 +19119,7 @@ _021225f8:
 	stmia sp, {r0, r4}
 	ldmib r6, {r0, r1}
 	mov r3, r8
-	add r1, r1, sl
+	add r1, r1, r10
 	bl func_020349cc
 	mov sb, #1
 	b _0212262c
@@ -19130,15 +19130,15 @@ _0212261c:
 	subeq r8, r8, r0
 _0212262c:
 	mov r0, #0x64
-	mul r0, sl, r0
+	mul r0, r10, r0
 	add r7, r7, #1
 	sub r5, r5, r0
 _0212263c:
 	mov r0, r5
 	mov r1, #0xa
 	bl func_01ff9b4c
-	mov sl, r0
-	cmp sl, #0
+	mov r10, r0
+	cmp r10, #0
 	bgt _0212265c
 	cmp sb, #0
 	beq _0212267c
@@ -19148,7 +19148,7 @@ _0212265c:
 	stmia sp, {r0, r4}
 	ldmib r6, {r0, r1}
 	mov r3, r8
-	add r1, r1, sl
+	add r1, r1, r10
 	bl func_020349cc
 	b _0212268c
 _0212267c:
@@ -19172,7 +19172,7 @@ _02122690:
 	bl func_020349cc
 _021226bc:
 	add sp, sp, #8
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov12_021224d0
 _021226c4: .word 0x00002710
@@ -19375,9 +19375,9 @@ _02122918: .word func_ov12_021202d8
 	.global func_ov12_0212291c
 	arm_func_start func_ov12_0212291c
 func_ov12_0212291c: ; 0x0212291c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x20
-	mov sl, r0
+	mov r10, r0
 	bl func_ov12_021258e0
 	ldr r0, _02122f28 ; =data_ov00_020ee698
 	ldr r1, _02122f2c ; =data_ov12_02137c64
@@ -19387,7 +19387,7 @@ func_ov12_0212291c: ; 0x0212291c
 	moveq r11, #1
 	movne r11, #0
 	bl func_ov12_02113208
-	str r0, [sl, #0x34c]
+	str r0, [r10, #0x34c]
 	mov r0, #1
 	bl func_02003ce4
 	mov r0, #2
@@ -19406,7 +19406,7 @@ func_ov12_0212291c: ; 0x0212291c
 	bl func_ov12_02123108
 	ldr r0, _02122f30 ; =0x00200010
 	bl func_ov12_021230e4
-	mov r0, sl
+	mov r0, r10
 	mov r1, #0
 	bl func_ov12_02125bfc
 	bl func_ov12_021230d8
@@ -19525,7 +19525,7 @@ func_ov12_0212291c: ; 0x0212291c
 	ldr r5, [r0]
 	ldr r0, [sp, #0xc]
 	bl func_ov12_0211322c
-	ldr r1, [sl, #0x34c]
+	ldr r1, [r10, #0x34c]
 	add r0, r5, r0, lsl #2
 	add r1, r5, r1, lsl #2
 	ldr r0, [r0, #4]
@@ -19533,16 +19533,16 @@ func_ov12_0212291c: ; 0x0212291c
 	sub r0, r1, r0
 	cmp r0, #0
 	movgt r0, #1
-	strgtb r0, [sl, #0x366]
+	strgtb r0, [r10, #0x366]
 	bgt _02122bac
 	moveq r0, #0
-	streqb r0, [sl, #0x366]
+	streqb r0, [r10, #0x366]
 	mvnne r0, #0
-	strneb r0, [sl, #0x366]
+	strneb r0, [r10, #0x366]
 _02122bac:
 	mov r1, #0
 	ldr r0, _02122f28 ; =data_ov00_020ee698
-	strb r1, [sl, #0x364]
+	strb r1, [r10, #0x364]
 	ldr r0, [r0, #0x2c]
 	cmp r0, #0
 	beq _02122cfc
@@ -19564,23 +19564,23 @@ _02122bac:
 _02122c00:
 	tst r6, #1
 	beq _02122c50
-	ldrb r0, [sl, #0x364]
+	ldrb r0, [r10, #0x364]
 	mov r1, #0x64
-	add r0, sl, r0
+	add r0, r10, r0
 	strb r5, [r0, #0x354]
 	ldrb r0, [sb]
 	mul r2, r0, r8
 	mov r0, r2, lsl #0x1
 	bl func_01ff9b4c
 	add r1, r0, #1
-	ldrb r0, [sl, #0x364]
+	ldrb r0, [r10, #0x364]
 	mov r1, r1, asr #0x1
 	strb r1, [r4, r0]
-	ldrb r1, [sl, #0x364]
+	ldrb r1, [r10, #0x364]
 	mov r0, r1
 	ldrb r1, [r4, r1]
 	add r0, r0, #1
-	strb r0, [sl, #0x364]
+	strb r0, [r10, #0x364]
 	add r7, r7, r1
 _02122c50:
 	mov r0, r6, lsl #0xf
@@ -19589,19 +19589,19 @@ _02122c50:
 	mov r6, r0, lsr #0x10
 	add sb, sb, #1
 	blt _02122c00
-	ldrb r0, [sl, #0x364]
+	ldrb r0, [r10, #0x364]
 	cmp r0, #5
 	movlo r0, #0
-	strlob r0, [sl, #0x365]
+	strlob r0, [r10, #0x365]
 	movlo r4, #0x1000
 	blo _02122c94
 	ldr r1, _02122f4c ; =data_ov12_02134864
 	sub r2, r0, #5
 	mov r0, #1
 	ldr r4, [r1, r2, lsl #2]
-	strb r0, [sl, #0x365]
+	strb r0, [r10, #0x365]
 _02122c94:
-	add r0, sl, #0x300
+	add r0, r10, #0x300
 	ldrsb r0, [r0, #0x66]
 	cmp r0, #1
 	bge _02122cc8
@@ -19633,38 +19633,38 @@ _02122cfc:
 	cmp r11, #0
 	moveq r0, #0
 	movne r0, #1
-	strb r0, [sl, #0x36e]
+	strb r0, [r10, #0x36e]
 	mov r1, #0
-	str r1, [sl, #0x330]
+	str r1, [r10, #0x330]
 	mov r0, #0xa
-	str r0, [sl, #0x334]
-	strb r1, [sl, #0x36b]
+	str r0, [r10, #0x334]
+	strb r1, [r10, #0x36b]
 	ldr r0, _02122f50 ; =data_ov12_0213dc6c
-	strb r1, [sl, #0x36c]
+	strb r1, [r10, #0x36c]
 	strb r1, [r0, #0x15]
 	mov r0, #1
-	strb r0, [sl, #0x36d]
+	strb r0, [r10, #0x36d]
 	mov r0, #0xf
-	strb r0, [sl, #0x367]
-	strb r1, [sl, #0x36f]
-	strb r1, [sl, #0x370]
-	strb r1, [sl, #0x371]
-	str r1, [sl, #0x328]
+	strb r0, [r10, #0x367]
+	strb r1, [r10, #0x36f]
+	strb r1, [r10, #0x370]
+	strb r1, [r10, #0x371]
+	str r1, [r10, #0x328]
 	cmp r11, #0
-	strb r1, [sl, #0x368]
+	strb r1, [r10, #0x368]
 	movne r0, #0xd8
 	bne _02122d74
-	ldrb r2, [sl, #0x364]
-	ldrb r1, [sl, #0x365]
+	ldrb r2, [r10, #0x364]
+	ldrb r1, [r10, #0x365]
 	mov r0, #0x1d
 	add r1, r2, r1
 	mul r0, r1, r0
 	add r0, r0, #0x1dc
 _02122d74:
-	str r0, [sl, #0x10]
+	str r0, [r10, #0x10]
 	mov r2, #0
 	ldr r0, _02122f50 ; =data_ov12_0213dc6c
-	str r2, [sl, #0x338]
+	str r2, [r10, #0x338]
 	strb r2, [r0, #0xc]
 	ldr r0, _02122f54 ; =data_ov12_0213dc6c
 	mvn r1, #0
@@ -19675,35 +19675,35 @@ _02122d90:
 	blt _02122d90
 	ldr r0, _02122f58 ; =0x0000016e
 	bl func_ov12_021223a4
-	ldr r1, [sl, #0x10]
-	add r0, sl, #0x168
+	ldr r1, [r10, #0x10]
+	add r0, r10, #0x168
 	mov r2, #1
 	bl func_ov12_02125148
-	ldr r1, [sl, #0x10]
-	add r0, sl, #0x17c
+	ldr r1, [r10, #0x10]
+	add r0, r10, #0x17c
 	mov r2, #0
 	bl func_ov12_02125148
-	add r0, sl, #0x288
+	add r0, r10, #0x288
 	bl func_ov12_02125588
 	ldr r0, _02122f5c ; =0x0000016b
 	bl func_ov12_021223a4
-	ldrb r6, [sl, #0x364]
+	ldrb r6, [r10, #0x364]
 	mov r4, #0
 	cmp r6, #0
 	ble _02122e28
-	add r5, sl, #0x68
+	add r5, r10, #0x68
 _02122dec:
-	add r0, sl, r4
+	add r0, r10, r4
 	ldrb r1, [r0, #0x354]
 	mov r0, r5
 	mov r2, r4
 	str r1, [sp]
-	ldrb r3, [sl, #0x365]
-	ldr r1, [sl, #0x10]
+	ldrb r3, [r10, #0x365]
+	ldr r1, [r10, #0x10]
 	add r3, r6, r3
 	and r3, r3, #0xff
 	bl func_ov12_02124e64
-	ldrb r6, [sl, #0x364]
+	ldrb r6, [r10, #0x364]
 	add r4, r4, #1
 	add r5, r5, #0x10
 	cmp r4, r6
@@ -19719,7 +19719,7 @@ _02122e28:
 	beq _02122e8c
 	stmia sp, {r0, r3}
 	mov r2, r1
-	add r0, sl, #0x190
+	add r0, r10, #0x190
 	rsb r3, r3, #0x138
 	str r1, [sp, #8]
 	bl func_ov01_020f802c
@@ -19729,7 +19729,7 @@ _02122e28:
 	mov r0, #4
 	str r0, [sp, #4]
 	mov r2, r1
-	add r0, sl, #0x1e8
+	add r0, r10, #0x1e8
 	add r3, r4, #0x134
 	str r4, [sp, #8]
 	bl func_ov01_020f802c
@@ -19737,7 +19737,7 @@ _02122e28:
 _02122e8c:
 	stmia sp, {r0, r3}
 	mov r2, r1
-	add r0, sl, #0x190
+	add r0, r10, #0x190
 	add r3, r3, #0x130
 	str r1, [sp, #8]
 	bl func_ov01_020f802c
@@ -19747,27 +19747,27 @@ _02122e8c:
 	mov r0, #4
 	str r0, [sp, #4]
 	mov r2, r1
-	add r0, sl, #0x1e8
+	add r0, r10, #0x1e8
 	rsb r3, r4, #0x134
 	str r4, [sp, #8]
 	bl func_ov01_020f802c
 _02122ecc:
-	ldr r2, [sl, #0x10]
-	add r0, sl, #0x190
+	ldr r2, [r10, #0x10]
+	add r0, r10, #0x190
 	mov r1, #0
 	bl func_ov01_020f7ec8
 	mov r1, #0
-	strb r1, [sl, #0x1e7]
-	ldr r2, [sl, #0x10]
-	add r0, sl, #0x1e8
+	strb r1, [r10, #0x1e7]
+	ldr r2, [r10, #0x10]
+	add r0, r10, #0x1e8
 	bl func_ov01_020f7ec8
 	mov r4, #0
-	strb r4, [sl, #0x23f]
-	add r5, sl, #0x18
+	strb r4, [r10, #0x23f]
+	add r5, r10, #0x18
 _02122efc:
 	mov r0, r5
 	bl func_ov12_021260b8
-	mov r0, sl
+	mov r0, r10
 	mov r1, r5
 	bl func_ov12_02125d14
 	add r4, r4, #1
@@ -19775,7 +19775,7 @@ _02122efc:
 	add r5, r5, #0x28
 	blt _02122efc
 	add sp, sp, #0x20
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov12_0212291c
 _02122f28: .word data_ov00_020ee698
@@ -21093,7 +21093,7 @@ func_ov12_02123f8c: ; 0x02123f8c
 	.global func_ov12_02123fac
 	arm_func_start func_ov12_02123fac
 func_ov12_02123fac: ; 0x02123fac
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #0x48
 	ldr r1, _021243f8 ; =data_ov00_020ee698
 	mov r4, r0
@@ -21198,16 +21198,16 @@ _02124134:
 	mov r6, #0x4c
 _02124138:
 	ldr r1, _021243fc ; =0x0000016b
-	mov sl, #0
+	mov r10, #0
 	mov r2, #8
 	mov lr, #0x2e
 	mov ip, #0xa
 	mov sb, #4
 	mov r0, r4
 	mov r3, r5
-	str sl, [sp, #8]
-	str sl, [sp, #0x1c]
-	str sl, [sp, #0x20]
+	str r10, [sp, #8]
+	str r10, [sp, #0x1c]
+	str r10, [sp, #0x20]
 	str r2, [sp, #0x24]
 	str lr, [sp, #0x10]
 	str ip, [sp, #0x14]
@@ -21221,14 +21221,14 @@ _02124138:
 	str r0, [sp]
 	mov r1, r7
 	mov r0, #0xab
-	mov r3, sl
+	mov r3, r10
 	str sb, [sp, #4]
 	bl func_020349cc
 	mov r7, sb
 	mov r1, r6
 	add r3, r5, #0xd8
 	mov r0, #0xab
-	mov r2, sl
+	mov r2, r10
 	str r7, [sp]
 	bl func_0203493c
 	add r0, r5, #0xd8
@@ -21239,14 +21239,14 @@ _02124138:
 _021241d4:
 	ldr r0, _021243fc ; =0x0000016b
 	mov r1, r7
-	mov r3, sl
+	mov r3, r10
 	stmia sp, {r5, sb}
 	bl func_020349cc
 	mov r7, sb
 	ldr r0, _021243fc ; =0x0000016b
 	mov r1, r6
 	mov r3, r5
-	mov r2, sl
+	mov r2, r10
 	str r7, [sp]
 	bl func_0203493c
 	ldr r0, _021243fc ; =0x0000016b
@@ -21368,7 +21368,7 @@ _021243b8:
 	mov r0, r4
 	bl func_ov12_02124afc
 	add sp, sp, #0x48
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _021243d0:
 	bl func_ov12_021245a8
 	ldr r1, [r4, #0x10]
@@ -21379,7 +21379,7 @@ _021243d0:
 	mov r0, r4
 	bl func_ov12_02124afc
 	add sp, sp, #0x48
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov12_02123fac
 _021243f8: .word data_ov00_020ee698
@@ -25888,14 +25888,14 @@ _02127dc8: .word data_ov00_020eec9c
 	.global func_ov12_02127dcc
 	arm_func_start func_ov12_02127dcc
 func_ov12_02127dcc: ; 0x02127dcc
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0xc
 	mov r4, #5
-	mov sl, r0
+	mov r10, r0
 	str r4, [sp]
 	str r4, [sp, #4]
 	ldr r3, _02127ff8 ; =0x0000015a
-	add r0, sl, #0x1ac
+	add r0, r10, #0x1ac
 	sub r1, r4, #0x25
 	mov r2, #0
 	str r4, [sp, #8]
@@ -25905,10 +25905,10 @@ func_ov12_02127dcc: ; 0x02127dcc
 	stmia sp, {r2, r3}
 	sub r1, r3, #0xe6
 	str r2, [sp, #8]
-	add r0, sl, #0x204
+	add r0, r10, #0x204
 	add r3, r3, #0x154
 	bl func_ov01_020f802c
-	ldr r0, [sl, #0x418]
+	ldr r0, [r10, #0x418]
 	cmp r0, #2
 	beq _02127e50
 	mov r4, #1
@@ -25916,27 +25916,27 @@ func_ov12_02127dcc: ; 0x02127dcc
 	str r4, [sp]
 	mov r0, #7
 	str r0, [sp, #4]
-	add r0, sl, #0x25c
+	add r0, r10, #0x25c
 	add r3, r1, #0x7a
 	mov r2, #0
 	str r4, [sp, #8]
 	bl func_ov01_020f802c
 _02127e50:
-	ldr r0, [sl, #0x418]
+	ldr r0, [r10, #0x418]
 	cmp r0, #3
 	beq _02127e84
 	mov r4, #2
 	mov r1, #8
 	str r4, [sp]
 	str r1, [sp, #4]
-	add r0, sl, #0x2b4
+	add r0, r10, #0x2b4
 	sub r1, r1, #0xe8
 	add r3, r4, #0x158
 	mov r2, #0
 	str r4, [sp, #8]
 	bl func_ov01_020f802c
 _02127e84:
-	ldr r0, [sl, #0x418]
+	ldr r0, [r10, #0x418]
 	cmp r0, #4
 	beq _02127eb8
 	mov r4, #3
@@ -25944,36 +25944,36 @@ _02127e84:
 	str r4, [sp]
 	mov r0, #9
 	str r0, [sp, #4]
-	add r0, sl, #0x30c
+	add r0, r10, #0x30c
 	add r3, r1, #0x7a
 	mov r2, #0
 	str r4, [sp, #8]
 	bl func_ov01_020f802c
 _02127eb8:
-	ldr r0, [sl, #0x418]
+	ldr r0, [r10, #0x418]
 	cmp r0, #5
 	beq _02127eec
 	mov r4, #4
 	mov r2, #0xa
 	str r4, [sp]
 	str r2, [sp, #4]
-	add r0, sl, #0x364
+	add r0, r10, #0x364
 	sub r1, r2, #0xea
 	add r3, r2, #0x150
 	mov r2, #0
 	str r4, [sp, #8]
 	bl func_ov01_020f802c
 _02127eec:
-	add sb, sl, #0x1ac
-	str sb, [sl, #0x414]
-	ldr r0, [sl, #0x418]
+	add sb, r10, #0x1ac
+	str sb, [r10, #0x414]
+	ldr r0, [r10, #0x418]
 	mov r4, #0x58
 	cmp r0, #1
 	cmpne r0, #6
 	bne _02127f5c
-	add sb, sl, #0x1ac
+	add sb, r10, #0x1ac
 	mov r7, #0
-	mov r8, sl
+	mov r8, r10
 	mov r6, sb
 	mov r5, r7
 	mov r11, #0x1000
@@ -25995,7 +25995,7 @@ _02127f20:
 	b _02127fac
 _02127f5c:
 	ldr r8, _02127ffc ; =data_ov12_021348f8
-	mov r7, sl
+	mov r7, r10
 	mov r6, #0
 	mov r5, sb
 	mov r11, #0xc000
@@ -26018,23 +26018,23 @@ _02127f70:
 _02127fac:
 	ldr r1, _02128000 ; =0x0002005b
 	mov r2, #0
-	add r0, sl, #0x3c
-	str r2, [sl, #0x370]
+	add r0, r10, #0x3c
+	str r2, [r10, #0x370]
 	bl func_ov12_0212938c
 	mov r0, #0
 	str r0, [sp]
-	ldr r1, [sl, #0x4c]
-	ldr r2, [sl, #0x50]
-	add r0, sl, #0x3c
+	ldr r1, [r10, #0x4c]
+	ldr r2, [r10, #0x50]
+	add r0, r10, #0x3c
 	mov r3, #0xc000
 	bl func_ov01_020f7f34
-	add r0, sl, #0xd4
+	add r0, r10, #0xd4
 	mov r1, #0x10000
 	bl func_ov12_021292b4
 	mov r0, #0x19
-	str r0, [sl, #0x10]
+	str r0, [r10, #0x10]
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov12_02127dcc
 _02127ff8: .word 0x0000015a
@@ -26044,7 +26044,7 @@ _02128000: .word 0x0002005b
 	.global func_ov12_02128004
 	arm_func_start func_ov12_02128004
 func_ov12_02128004: ; 0x02128004
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #4
 	mov sb, r0
 	bl func_ov12_0211bc54
@@ -26080,7 +26080,7 @@ _0212804c:
 	mov r2, #3
 	bl func_ov12_02128dec
 	add sp, sp, #4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 _02128094:
 	ldr r0, _02128320 ; =data_027e05f8
 	mov r4, #0
@@ -26159,7 +26159,7 @@ _0212819c:
 	mov r1, #0x99
 	bl func_ov00_020d77e4
 	add sp, sp, #4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 _021281b0:
 	bl func_ov61_021792ec
 	sub r1, r4, #1
@@ -26173,13 +26173,13 @@ _021281b0:
 	mov r7, sb
 	strb r5, [r0, #0x203]
 	add r8, sb, #0x1ac
-	mov sl, #0xc000
+	mov r10, #0xc000
 _021281e4:
 	cmp r5, r4
 	beq _02128208
 	ldrb r1, [r6]
 	mov r0, r8
-	mov r3, sl
+	mov r3, r10
 	str r1, [sp]
 	ldr r1, [r7, #0x1c4]
 	ldr r2, [r7, #0x1c8]
@@ -26202,7 +26202,7 @@ _02128208:
 	mov r1, #0xc
 	bl func_ov00_020d716c
 	add sp, sp, #4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 _02128250:
 	mov r0, #7
 	ldr r6, _0212831c ; =data_ov12_021348f8
@@ -26235,7 +26235,7 @@ _0212826c:
 	mov r1, #0xc
 	bl func_ov00_020d716c
 	add sp, sp, #4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 _021282cc:
 	ldr r0, _02128328 ; =data_ov00_020eec68
 	bl func_ov00_020d7180
@@ -26243,20 +26243,20 @@ _021282cc:
 	ldreqb r0, [sb, #0x3a6]
 	cmpeq r0, #0
 	addne sp, sp, #4
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	ldr r0, [sb, #0x10]
 	sub r0, r0, #1
 	cmp r0, #0
 	addgt sp, sp, #4
 	str r0, [sb, #0x10]
-	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	ldr r0, _02128328 ; =data_ov00_020eec68
 	mov r1, #0x27
 	mov r2, #0
 	mov r3, #0x7f
 	bl func_ov00_020d70a4
 	add sp, sp, #4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov12_02128004
 _0212831c: .word data_ov12_021348f8
@@ -27951,7 +27951,7 @@ _021298cc: .word data_ov12_0213dca8
 	.global func_ov12_021298d0
 	arm_func_start func_ov12_021298d0
 func_ov12_021298d0: ; 0x021298d0
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #0x100
 	mov r5, r0
 	add r0, r5, #0x54
@@ -28126,7 +28126,7 @@ _02129ad0:
 _02129b78:
 	cmp r8, r6, lsl #1
 	addge sp, sp, #0x100
-	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	ldrb r0, [r5, #0x258]
 	cmp r0, #0
 	ldreq r0, [r5, #0x234]
@@ -28136,7 +28136,7 @@ _02129b78:
 	ldreq r0, [r4, #0x234]
 	cmpeq r0, #0
 	addne sp, sp, #0x100
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	ldr r0, [r5, #0x250]
 	add sp, sp, #0x100
 	add r0, r0, #1
@@ -28144,7 +28144,7 @@ _02129b78:
 	ldr r0, [r4, #0x250]
 	add r0, r0, #1
 	str r0, [r4, #0x250]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _02129bcc:
 	ldr r1, [r5, #0x48]
 	add r0, sp, #0x44
@@ -28168,7 +28168,7 @@ _02129bcc:
 	bl func_01fffb4c
 	cmp r0, #0
 	addeq sp, sp, #0x100
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	mov r0, r5
 	ldr r1, [r0]
 	ldr r1, [r1, #0xb4]
@@ -28203,7 +28203,7 @@ _02129bcc:
 	mov r8, r0
 	cmp r8, #0
 	addle sp, sp, #0x100
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	add r0, sp, #0x38
 	add r3, sp, #8
 	ldmia r0, {r0, r1, r2}
@@ -28220,11 +28220,11 @@ _02129bcc:
 	add r0, sp, #0xd0
 	mov r1, r0
 	bl func_01ff9c2c
-	mov sl, r0
+	mov r10, r0
 	add r0, sp, #0xdc
 	mov r1, r0
 	bl func_01ff9c2c
-	cmp r0, sl
+	cmp r0, r10
 	movgt r0, #1
 	movle r0, #0
 	cmp r6, r7
@@ -28279,7 +28279,7 @@ _02129d7c:
 	ldr r0, [sp, #0xd8]
 	str r0, [r4, #0x68]
 	add sp, sp, #0x100
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov12_021298d0
 _02129ddc: .word 0x0000099a
@@ -29252,10 +29252,10 @@ _0212aa88: .word data_ov12_0213dc88
 	.global func_ov12_0212aa8c
 	arm_func_start func_ov12_0212aa8c
 func_ov12_0212aa8c: ; 0x0212aa8c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #0x30
 	ldr r1, _0212ad00 ; =data_027e0e60
-	mov sl, r0
+	mov r10, r0
 	ldr r0, [r1]
 	mov r1, #0
 	str r1, [sp, #8]
@@ -29338,7 +29338,7 @@ _0212ab90:
 	mov r1, r8
 	mov r2, sb
 	bl func_ov00_02083e34
-	ldr r1, [sl, #0x18]
+	ldr r1, [r10, #0x18]
 	cmp r0, r1
 	bne _0212acec
 	cmp r5, #0x18
@@ -29350,13 +29350,13 @@ _0212ab90:
 	mov r0, r6
 	bl func_ov00_02083c24
 	str r0, [sp, #0x24]
-	ldr r2, [sl, #0x4c]
+	ldr r2, [r10, #0x4c]
 	mov r1, sb
 	mov r0, r6
 	str r2, [sp, #0x28]
 	bl func_ov00_02083c50
 	str r0, [sp, #0x2c]
-	mov r0, sl
+	mov r0, r10
 	add r1, sp, #0x24
 	bl func_ov12_0212aa10
 	cmp r0, #0
@@ -29388,19 +29388,19 @@ _0212ab90:
 	cmp r0, #0
 	beq _0212acec
 	ldr r1, [sp, #0x24]
-	mov r0, sl
-	str r1, [sl, #0x48]
+	mov r0, r10
+	str r1, [r10, #0x48]
 	ldr r2, [sp, #0x28]
 	mov r1, #0
-	str r2, [sl, #0x4c]
+	str r2, [r10, #0x4c]
 	ldr r2, [sp, #0x2c]
-	str r2, [sl, #0x50]
+	str r2, [r10, #0x50]
 	ldr r2, [sp, #0x24]
-	str r2, [sl, #0x54]
+	str r2, [r10, #0x54]
 	ldr r2, [sp, #0x28]
-	str r2, [sl, #0x58]
+	str r2, [r10, #0x58]
 	ldr r2, [sp, #0x2c]
-	str r2, [sl, #0x5c]
+	str r2, [r10, #0x5c]
 	ldr r2, [r0]
 	ldr r2, [r2, #0xbc]
 	blx r2
@@ -29412,7 +29412,7 @@ _0212acec:
 	cmp r0, #0
 	beq _0212aad4
 	add sp, sp, #0x30
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov12_0212aa8c
 _0212ad00: .word data_027e0e60
@@ -29931,7 +29931,7 @@ func_ov12_0212b350: ; 0x0212b350
 	.global func_ov12_0212b358
 	arm_func_start func_ov12_0212b358
 func_ov12_0212b358: ; 0x0212b358
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	mov sb, r0
 	mov r8, r1
 	mov r7, r2
@@ -29952,11 +29952,11 @@ func_ov12_0212b358: ; 0x0212b358
 	cmp r8, #0
 	mov r5, #0
 	ble _0212b3dc
-	ldr sl, _0212b44c ; =data_027e0ce0
+	ldr r10, _0212b44c ; =data_027e0ce0
 	mov r6, r7, lsl #0x2
 	mov r4, #4
 _0212b3b8:
-	ldr r1, [sl, #4]
+	ldr r1, [r10, #4]
 	mov r0, r6
 	mov r2, r4
 	bl func_0202e9f4
@@ -29996,7 +29996,7 @@ _0212b420:
 	mov r1, #0x60
 	mov r0, sb
 	strh r1, [sb, #0x2e]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov12_0212b358
 _0212b448: .word data_ov12_02136bf4
@@ -30195,20 +30195,20 @@ _0212b680: .word func_ov12_0212b684
 	.global func_ov12_0212b684
 	arm_func_start func_ov12_0212b684
 func_ov12_0212b684: ; 0x0212b684
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x1c
-	mov sl, r0
-	ldr r0, [sl, #0x188]
+	mov r10, r0
+	ldr r0, [r10, #0x188]
 	cmp r0, #0
 	addeq sp, sp, #0x1c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
-	ldrh r0, [sl, #0x28]
-	ldrh sb, [sl, #0x2a]
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldrh r0, [r10, #0x28]
+	ldrh sb, [r10, #0x2a]
 	cmp r0, #0x40
 	str r0, [sp]
 	cmpls sb, #0x30
 	addhi sp, sp, #0x1c
-	ldmhiia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmhiia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	mov r0, #0
 	str r0, [sp, #4]
 	strb r0, [sp, #8]
@@ -30216,7 +30216,7 @@ func_ov12_0212b684: ; 0x0212b684
 	ldr r0, [sp]
 	cmp r0, #0
 	addle sp, sp, #0x1c
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0212b6dc:
 	cmp sb, #0
 	mov r8, #0
@@ -30229,71 +30229,71 @@ _0212b6dc:
 	add r11, sp, #0xe
 _0212b700:
 	mov r0, r6
-	mov r1, sl
+	mov r1, r10
 	mov r2, r5
 	mov r3, #0
 	strb r7, [sp, #8]
 	strb r8, [sp, #9]
 	bl func_ov00_0207f588
-	mov r0, sl
+	mov r0, r10
 	ldr r3, [r0]
 	mov r1, r5
 	ldr r3, [r3, #0x58]
 	mov r2, #0
 	blx r3
 	mov r2, r0
-	mov r0, sl
+	mov r0, r10
 	ldr r3, [r0]
 	mov r1, r6
 	ldr r3, [r3, #0xa8]
 	blx r3
 	mov r0, r4
-	mov r1, sl
+	mov r1, r10
 	mov r2, r5
 	mov r3, #1
 	bl func_ov00_0207f588
-	mov r0, sl
+	mov r0, r10
 	ldr r3, [r0]
 	mov r1, r5
 	ldr r3, [r3, #0x58]
 	mov r2, #1
 	blx r3
 	mov r2, r0
-	mov r0, sl
+	mov r0, r10
 	ldr r3, [r0]
 	mov r1, r4
 	ldr r3, [r3, #0xa8]
 	blx r3
 	mov r0, r11
-	mov r1, sl
+	mov r1, r10
 	mov r2, r5
 	mov r3, #2
 	bl func_ov00_0207f588
-	mov r0, sl
+	mov r0, r10
 	ldr r3, [r0]
 	mov r1, r5
 	ldr r3, [r3, #0x58]
 	mov r2, #2
 	blx r3
 	mov r2, r0
-	mov r0, sl
+	mov r0, r10
 	ldr r3, [r0]
 	mov r1, r11
 	ldr r3, [r3, #0xa8]
 	blx r3
 	add r0, sp, #0xa
-	mov r1, sl
+	mov r1, r10
 	mov r2, r5
 	mov r3, #3
 	bl func_ov00_0207f588
-	mov r0, sl
+	mov r0, r10
 	ldr r3, [r0]
 	mov r1, r5
 	ldr r3, [r3, #0x58]
 	mov r2, #3
 	blx r3
 	mov r2, r0
-	mov r0, sl
+	mov r0, r10
 	ldr r3, [r0]
 	add r1, sp, #0xa
 	ldr r3, [r3, #0xa8]
@@ -30309,7 +30309,7 @@ _0212b824:
 	cmp r1, r0
 	blt _0212b6dc
 	add sp, sp, #0x1c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	arm_func_end func_ov12_0212b684
 
 	.global func_ov12_0212b844
@@ -36158,7 +36158,7 @@ _02130248: .word data_027e0d3c
 	.global func_ov12_0213024c
 	arm_func_start func_ov12_0213024c
 func_ov12_0213024c: ; 0x0213024c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x104
 	ldr r2, _0213069c ; =0x0000ffff
 	mov r1, #0
@@ -36321,7 +36321,7 @@ _02130484:
 	add r2, r4, #0xcc
 	cmp r3, r2
 	addeq sp, sp, #0x104
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _021304a4:
 	ldr r1, [r3]
 	add r3, r3, #0xc
@@ -36332,7 +36332,7 @@ _021304a4:
 	cmp r3, r2
 	bne _021304a4
 	add sp, sp, #0x104
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _021304cc:
 	mov r0, #0x1000
 	mov r1, #0
@@ -36400,7 +36400,7 @@ _02130598:
 	ldr r5, [r2, #8]
 	adds r4, lr, #0x800
 	mla sb, ip, r8, sb
-	ldr sl, [r2]
+	ldr r10, [r2]
 	mov r7, r7, lsl #0xc
 	str r5, [sp, #0x24]
 	mov r5, r7, asr #0x1f
@@ -36409,7 +36409,7 @@ _02130598:
 	adc r8, sb, #0
 	mov r4, r4, lsr #0xc
 	orr r4, r4, r8, lsl #20
-	add sl, sl, r4
+	add r10, r10, r4
 	ldr r4, [sp, #0x14]
 	mov r5, r6, asr #0x1f
 	str r5, [sp, #0x28]
@@ -36437,7 +36437,7 @@ _02130598:
 	orr r6, r6, r4, lsl #20
 	ldr r4, [sp, #0x24]
 	cmp r5, #0
-	strne sl, [r5, #0x58]
+	strne r10, [r5, #0x58]
 	add r6, r4, r6
 	ldr r4, [r3]
 	add r11, r11, #1
@@ -36454,7 +36454,7 @@ _02130598:
 	cmp r11, #2
 	blo _02130598
 	add sp, sp, #0x104
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov12_0213024c
 _0213069c: .word 0x0000ffff
@@ -37728,12 +37728,12 @@ _021316fc:
 	.global func_ov12_02131708
 	arm_func_start func_ov12_02131708
 func_ov12_02131708: ; 0x02131708
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x94
-	mov sl, r0
-	ldr r0, [sl, #0x130]
+	mov r10, r0
+	ldr r0, [r10, #0x130]
 	cmp r0, #3
-	ldreq r0, [sl, #0x750]
+	ldreq r0, [r10, #0x750]
 	subeq r0, r0, #1
 	beq _0213176c
 	ldr r0, _02131a1c ; =data_027e0764
@@ -37754,16 +37754,16 @@ func_ov12_02131708: ; 0x02131708
 	str r2, [r0, #4]
 	add r0, r1, #8
 _0213176c:
-	str r0, [sl, #0x750]
+	str r0, [r10, #0x750]
 	mov r0, #3
-	str r0, [sl, #0x130]
+	str r0, [r10, #0x130]
 	bl func_ov12_0211cfe0
 	cmp r0, #0
 	beq _021319dc
 	mov r0, #1
-	strb r0, [sl, #0x754]
+	strb r0, [r10, #0x754]
 	ldr r1, _02131a1c ; =data_027e0764
-	ldrsh sb, [sl, #0x78]
+	ldrsh sb, [r10, #0x78]
 	ldr r2, [r1]
 	ldmib r1, {r0, r6}
 	umull r3, r4, r6, r2
@@ -37842,49 +37842,49 @@ _021318ac:
 	ldr r7, _02131a20 ; =data_02050f54
 	ldr r6, _02131a24 ; =0x0000ffff
 	strh r0, [sp, #0x1a]
-	add r4, sl, #0x8c
+	add r4, r10, #0x8c
 	add r8, sp, #0x14
 	mov r5, sb
 	mov r11, #0x33
 _021318d0:
 	mov r0, sb, lsl #0x1
-	ldr r1, [sl, #0x48]
+	ldr r1, [r10, #0x48]
 	ldrh r0, [r8, r0]
-	str r1, [sl, #0x73c]
-	ldr r1, [sl, #0x4c]
+	str r1, [r10, #0x73c]
+	ldr r1, [r10, #0x4c]
 	mov r0, r0, asr #0x4
-	str r1, [sl, #0x740]
-	ldr r1, [sl, #0x50]
+	str r1, [r10, #0x740]
+	ldr r1, [r10, #0x50]
 	mov r2, r0, lsl #0x1
 	mov r0, r2, lsl #0x1
-	str r1, [sl, #0x744]
+	str r1, [r10, #0x744]
 	ldrsh r1, [r7, r0]
 	add r0, r7, r2, lsl #1
-	ldr r2, [sl, #0x73c]
+	ldr r2, [r10, #0x73c]
 	mov r1, r1, lsl #0xc
 	add r1, r1, #0x800
 	add r1, r2, r1, asr #12
-	str r1, [sl, #0x73c]
+	str r1, [r10, #0x73c]
 	ldrsh r0, [r0, #2]
-	ldr r2, [sl, #0x744]
+	ldr r2, [r10, #0x744]
 	add r1, sp, #0x34
 	mov r0, r0, lsl #0xc
 	add r0, r0, #0x800
 	add r0, r2, r0, asr #12
-	str r0, [sl, #0x744]
-	ldr r0, [sl, #0x48]
+	str r0, [r10, #0x744]
+	ldr r0, [r10, #0x48]
 	add r2, sp, #0x1c
 	str r0, [sp, #0x28]
-	ldr r0, [sl, #0x4c]
+	ldr r0, [r10, #0x4c]
 	add r3, sp, #0x28
 	str r0, [sp, #0x2c]
-	ldr r0, [sl, #0x50]
+	ldr r0, [r10, #0x50]
 	str r0, [sp, #0x30]
-	ldr r0, [sl, #0x73c]
+	ldr r0, [r10, #0x73c]
 	str r0, [sp, #0x1c]
-	ldr r0, [sl, #0x740]
+	ldr r0, [r10, #0x740]
 	str r0, [sp, #0x20]
-	ldr r0, [sl, #0x744]
+	ldr r0, [r10, #0x744]
 	str r0, [sp, #0x24]
 	strh r6, [sp, #0x58]
 	strh r6, [sp, #0x5a]
@@ -37902,7 +37902,7 @@ _021318d0:
 	strb r5, [sp, #0x90]
 	strb r5, [sp, #0x91]
 	str r4, [sp]
-	ldr r0, [sl, #8]
+	ldr r0, [r10, #8]
 	stmib sp, {r0, r11}
 	str r5, [sp, #0xc]
 	ldr r0, _02131a28 ; =data_027e0e60
@@ -37915,23 +37915,23 @@ _021318d0:
 	cmp sb, #4
 	blt _021318d0
 _021319dc:
-	ldr r0, [sl, #0x238]
+	ldr r0, [r10, #0x238]
 	cmp r0, #1
 	beq _02131a00
-	add r0, sl, #0x224
+	add r0, r10, #0x224
 	mov r1, #1
 	bl func_ov00_020c5d74
-	ldr r0, [sl, #0x234]
+	ldr r0, [r10, #0x234]
 	mov r1, #0x1000
 	str r1, [r0, #0x10]
 _02131a00:
 	ldr r0, _02131a2c ; =data_ov12_02137680
 	ldr r1, [r0, #0x38]
 	ldr r0, [r0, #0x3c]
-	str r1, [sl, #0x21c]
-	str r0, [sl, #0x220]
+	str r1, [r10, #0x21c]
+	str r0, [r10, #0x220]
 	add sp, sp, #0x94
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov12_02131708
 _02131a1c: .word data_027e0764

--- a/asm/ov13.s
+++ b/asm/ov13.s
@@ -1389,7 +1389,7 @@ _02113d44: .word func_ov13_02113c54
 	.global func_ov13_02113d48
 	arm_func_start func_ov13_02113d48
 func_ov13_02113d48: ; 0x02113d48
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	ldr r1, _02113fb8 ; =data_ov13_02116204
 	movs r4, r0
 	ldr r6, [r1, #4]
@@ -1398,16 +1398,16 @@ func_ov13_02113d48: ; 0x02113d48
 	mov r1, r4
 	bl func_ov13_021130b0
 	cmp r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02113d70:
 	cmp r4, #0
-	mov sl, #0
+	mov r10, #0
 	bne _02113e34
 	add r1, r6, #0x5000
 	mov r0, #1
 	str r0, [r1, #0xf0]
 	add r0, r6, #0x1e0
-	str sl, [r1, #0x108]
+	str r10, [r1, #0x108]
 	add r0, r0, #0x5000
 	str r0, [r1, #0x5e0]
 	add r0, r6, #0x5500
@@ -1434,7 +1434,7 @@ _02113d70:
 	add r3, r6, #0x5500
 	mov r1, #1
 	strh r1, [r3, #0xf0]
-	mov r4, sl
+	mov r4, r10
 	add r0, r0, #0x5400
 	mov r1, #0xff
 	mov r2, #0x20
@@ -1448,7 +1448,7 @@ _02113d70:
 	mov r0, r6
 	mov r1, #0x26
 	bl func_ov13_02113074
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02113e34:
 	ldrh r0, [r4]
 	cmp r0, #0x26
@@ -1470,19 +1470,19 @@ _02113e68:
 	mov r0, r6
 	mov r1, #0xb
 	bl func_ov13_02113074
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02113e84:
 	cmp r0, #0xb
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	add r4, r6, #0x5000
 	ldr r0, [r4, #0xf4]
 	cmp r0, #5
 	bne _02113f7c
 	add r0, r6, #0x1e0
-	mov r7, sl
+	mov r7, r10
 	add r8, r0, #0x5000
 	mov r11, #6
-	mov r5, sl
+	mov r5, r10
 	b _02113f14
 _02113eb4:
 	ldrh r0, [r8]
@@ -1490,15 +1490,15 @@ _02113eb4:
 	cmp sb, #0x48
 	blt _02113f04
 	ldr r2, [r4, #0xf8]
-	mov sl, r5
+	mov r10, r5
 	cmp r2, #0
 	beq _02113ee4
 	mov r0, r11
 	mov r1, r8
 	blx r2
-	mov sl, r0
+	mov r10, r0
 _02113ee4:
-	cmp sl, #0
+	cmp r10, #0
 	beq _02113f04
 	add r1, r6, #0x120
 	mov r0, r8
@@ -1516,7 +1516,7 @@ _02113f14:
 	cmp r7, r0
 	blt _02113eb4
 _02113f20:
-	cmp sl, #0
+	cmp r10, #0
 	bne _02113f7c
 	ldr r4, _02113fb8 ; =data_ov13_02116204
 	ldrh r1, [r4]
@@ -1538,13 +1538,13 @@ _02113f20:
 	mov r0, r6
 	mov r1, #0x26
 	bl func_ov13_02113074
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02113f7c:
-	cmp sl, #0
+	cmp r10, #0
 	beq _02113f90
 	mov r0, #0
 	bl func_ov13_02113b2c
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02113f90:
 	add r0, r6, #0x5000
 	ldr r1, [r0, #0xf4]
@@ -1555,7 +1555,7 @@ _02113f90:
 	mov r0, r6
 	mov r1, #3
 	bl func_ov13_021131ac
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov13_02113d48
 _02113fb8: .word data_ov13_02116204
@@ -1734,7 +1734,7 @@ _021141d4: .word data_ov13_0211620c
 	.global func_ov13_021141d8
 	arm_func_start func_ov13_021141d8
 func_ov13_021141d8: ; 0x021141d8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x14
 	mov r4, r1
 	cmp r0, #0xa
@@ -1979,14 +1979,14 @@ _02114554:
 	cmp r7, #0
 	ldrneh r0, [r4, #0x10]
 	ldr r1, _02114794 ; =data_ov13_0211620c
-	mov sl, #0
+	mov r10, #0
 	ldr r2, [r1]
 	moveq r0, #0
 	mov r0, r0, lsl #0x10
 	ldr r1, [r2, #0xd8]
 	mov r8, r0, lsr #0x10
 	add r0, r2, #0x58
-	mov r11, sl
+	mov r11, r10
 	cmp r1, #0
 	add sb, r0, r8, lsl #3
 	bne _02114598
@@ -1996,7 +1996,7 @@ _02114554:
 _02114598:
 	cmp r11, #0
 	cmpne r6, #0
-	movne sl, #1
+	movne r10, #1
 	strh r8, [sb]
 	cmp r7, #0
 	beq _021145c8
@@ -2025,7 +2025,7 @@ _021145ec:
 	add r0, r0, #0x760
 	add r0, r0, #0x5000
 	bl func_ov13_02112dbc
-	cmp sl, #0
+	cmp r10, #0
 	ldrne r0, [r6, #0x10]
 	cmpne r0, #0
 	ldrne r0, [r6, #0x20]
@@ -2051,7 +2051,7 @@ _0211464c:
 	add r0, r0, #0x5000
 	mov r1, r1, lsr #0x10
 	bl func_ov13_02112f1c
-	cmp sl, #0
+	cmp r10, #0
 	beq _02114788
 	ldr r0, _02114794 ; =data_ov13_0211620c
 	mov r1, sb
@@ -2129,7 +2129,7 @@ _02114784:
 _02114788:
 	mov r0, r5
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov13_021141d8
 _02114794: .word data_ov13_0211620c
@@ -2355,7 +2355,7 @@ _02114a30: .word func_ov13_021140d0
 	.global func_ov13_02114a34
 	arm_func_start func_ov13_02114a34
 func_ov13_02114a34: ; 0x02114a34
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #4
 	mov r8, r0
 	mov r7, r1
@@ -2388,14 +2388,14 @@ func_ov13_02114a34: ; 0x02114a34
 _02114aac:
 	ldr r0, [sp, #0x30]
 	bl func_ov13_02112d6c
-	movs sl, r0
+	movs r10, r0
 	bne _02114ac0
 	bl func_0200f248
 _02114ac0:
 	mov r0, sb
 	mov r1, r8
 	mov r2, r7
-	mov r3, sl
+	mov r3, r10
 	bl func_ov13_02112f24
 	ldr r7, [sp, #0x2c]
 	ldr r3, [sp, #0x28]
@@ -2408,7 +2408,7 @@ _02114af0:
 	mov r0, r4
 	bl func_0200ee60
 	add sp, sp, #4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov13_02114a34
 _02114b00: .word data_ov13_0211620c

--- a/asm/ov13.s
+++ b/asm/ov13.s
@@ -1389,7 +1389,7 @@ _02113d44: .word func_ov13_02113c54
 	.global func_ov13_02113d48
 	arm_func_start func_ov13_02113d48
 func_ov13_02113d48: ; 0x02113d48
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	ldr r1, _02113fb8 ; =data_ov13_02116204
 	movs r4, r0
 	ldr r6, [r1, #4]
@@ -1398,7 +1398,7 @@ func_ov13_02113d48: ; 0x02113d48
 	mov r1, r4
 	bl func_ov13_021130b0
 	cmp r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02113d70:
 	cmp r4, #0
 	mov sl, #0
@@ -1448,7 +1448,7 @@ _02113d70:
 	mov r0, r6
 	mov r1, #0x26
 	bl func_ov13_02113074
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02113e34:
 	ldrh r0, [r4]
 	cmp r0, #0x26
@@ -1470,10 +1470,10 @@ _02113e68:
 	mov r0, r6
 	mov r1, #0xb
 	bl func_ov13_02113074
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02113e84:
 	cmp r0, #0xb
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r4, r6, #0x5000
 	ldr r0, [r4, #0xf4]
 	cmp r0, #5
@@ -1481,7 +1481,7 @@ _02113e84:
 	add r0, r6, #0x1e0
 	mov r7, sl
 	add r8, r0, #0x5000
-	mov fp, #6
+	mov r11, #6
 	mov r5, sl
 	b _02113f14
 _02113eb4:
@@ -1493,7 +1493,7 @@ _02113eb4:
 	mov sl, r5
 	cmp r2, #0
 	beq _02113ee4
-	mov r0, fp
+	mov r0, r11
 	mov r1, r8
 	blx r2
 	mov sl, r0
@@ -1538,13 +1538,13 @@ _02113f20:
 	mov r0, r6
 	mov r1, #0x26
 	bl func_ov13_02113074
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02113f7c:
 	cmp sl, #0
 	beq _02113f90
 	mov r0, #0
 	bl func_ov13_02113b2c
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02113f90:
 	add r0, r6, #0x5000
 	ldr r1, [r0, #0xf4]
@@ -1555,7 +1555,7 @@ _02113f90:
 	mov r0, r6
 	mov r1, #3
 	bl func_ov13_021131ac
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov13_02113d48
 _02113fb8: .word data_ov13_02116204
@@ -1734,7 +1734,7 @@ _021141d4: .word data_ov13_0211620c
 	.global func_ov13_021141d8
 	arm_func_start func_ov13_021141d8
 func_ov13_021141d8: ; 0x021141d8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x14
 	mov r4, r1
 	cmp r0, #0xa
@@ -1986,15 +1986,15 @@ _02114554:
 	ldr r1, [r2, #0xd8]
 	mov r8, r0, lsr #0x10
 	add r0, r2, #0x58
-	mov fp, sl
+	mov r11, sl
 	cmp r1, #0
 	add sb, r0, r8, lsl #3
 	bne _02114598
 	bl func_ov13_021149ac
 	cmp r0, #3
-	moveq fp, #1
+	moveq r11, #1
 _02114598:
-	cmp fp, #0
+	cmp r11, #0
 	cmpne r6, #0
 	movne sl, #1
 	strh r8, [sb]
@@ -2129,7 +2129,7 @@ _02114784:
 _02114788:
 	mov r0, r5
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov13_021141d8
 _02114794: .word data_ov13_0211620c

--- a/asm/ov13.s
+++ b/asm/ov13.s
@@ -1389,7 +1389,7 @@ _02113d44: .word func_ov13_02113c54
 	.global func_ov13_02113d48
 	arm_func_start func_ov13_02113d48
 func_ov13_02113d48: ; 0x02113d48
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	ldr r1, _02113fb8 ; =data_ov13_02116204
 	movs r4, r0
 	ldr r6, [r1, #4]
@@ -1398,7 +1398,7 @@ func_ov13_02113d48: ; 0x02113d48
 	mov r1, r4
 	bl func_ov13_021130b0
 	cmp r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02113d70:
 	cmp r4, #0
 	mov r10, #0
@@ -1448,7 +1448,7 @@ _02113d70:
 	mov r0, r6
 	mov r1, #0x26
 	bl func_ov13_02113074
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02113e34:
 	ldrh r0, [r4]
 	cmp r0, #0x26
@@ -1470,10 +1470,10 @@ _02113e68:
 	mov r0, r6
 	mov r1, #0xb
 	bl func_ov13_02113074
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02113e84:
 	cmp r0, #0xb
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r4, r6, #0x5000
 	ldr r0, [r4, #0xf4]
 	cmp r0, #5
@@ -1486,8 +1486,8 @@ _02113e84:
 	b _02113f14
 _02113eb4:
 	ldrh r0, [r8]
-	mov sb, r0, lsl #0x1
-	cmp sb, #0x48
+	mov r9, r0, lsl #0x1
+	cmp r9, #0x48
 	blt _02113f04
 	ldr r2, [r4, #0xf8]
 	mov r10, r5
@@ -1507,7 +1507,7 @@ _02113ee4:
 	bl func_02007ad8
 	b _02113f20
 _02113f04:
-	add r0, sb, #3
+	add r0, r9, #3
 	bic r0, r0, #3
 	add r8, r8, r0
 	add r7, r7, #1
@@ -1538,13 +1538,13 @@ _02113f20:
 	mov r0, r6
 	mov r1, #0x26
 	bl func_ov13_02113074
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02113f7c:
 	cmp r10, #0
 	beq _02113f90
 	mov r0, #0
 	bl func_ov13_02113b2c
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02113f90:
 	add r0, r6, #0x5000
 	ldr r1, [r0, #0xf4]
@@ -1555,7 +1555,7 @@ _02113f90:
 	mov r0, r6
 	mov r1, #3
 	bl func_ov13_021131ac
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov13_02113d48
 _02113fb8: .word data_ov13_02116204
@@ -1734,7 +1734,7 @@ _021141d4: .word data_ov13_0211620c
 	.global func_ov13_021141d8
 	arm_func_start func_ov13_021141d8
 func_ov13_021141d8: ; 0x021141d8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x14
 	mov r4, r1
 	cmp r0, #0xa
@@ -1988,7 +1988,7 @@ _02114554:
 	add r0, r2, #0x58
 	mov r11, r10
 	cmp r1, #0
-	add sb, r0, r8, lsl #3
+	add r9, r0, r8, lsl #3
 	bne _02114598
 	bl func_ov13_021149ac
 	cmp r0, #3
@@ -1997,13 +1997,13 @@ _02114598:
 	cmp r11, #0
 	cmpne r6, #0
 	movne r10, #1
-	strh r8, [sb]
+	strh r8, [r9]
 	cmp r7, #0
 	beq _021145c8
 	ldrh r0, [r4, #0xa]
-	strh r0, [sb, #2]
+	strh r0, [r9, #2]
 	ldrh r0, [r4, #0xc]
-	strh r0, [sb, #4]
+	strh r0, [r9, #4]
 	ldrh r0, [r4, #0xe]
 	b _021145ec
 _021145c8:
@@ -2012,12 +2012,12 @@ _021145c8:
 	add r0, r0, #0x240
 	add r1, r0, #0x5000
 	ldrh r0, [r1, #4]
-	strh r0, [sb, #2]
+	strh r0, [r9, #2]
 	ldrh r0, [r1, #6]
-	strh r0, [sb, #4]
+	strh r0, [r9, #4]
 	ldrh r0, [r1, #8]
 _021145ec:
-	strh r0, [sb, #6]
+	strh r0, [r9, #6]
 	ldr r0, _02114794 ; =data_ov13_0211620c
 	ldr r1, [sp, #8]
 	ldr r0, [r0]
@@ -2054,7 +2054,7 @@ _0211464c:
 	cmp r10, #0
 	beq _02114788
 	ldr r0, _02114794 ; =data_ov13_0211620c
-	mov r1, sb
+	mov r1, r9
 	ldr r2, [r0]
 	mov r0, #4
 	ldr r2, [r2, #4]
@@ -2129,7 +2129,7 @@ _02114784:
 _02114788:
 	mov r0, r5
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov13_021141d8
 _02114794: .word data_ov13_0211620c
@@ -2355,7 +2355,7 @@ _02114a30: .word func_ov13_021140d0
 	.global func_ov13_02114a34
 	arm_func_start func_ov13_02114a34
 func_ov13_02114a34: ; 0x02114a34
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #4
 	mov r8, r0
 	mov r7, r1
@@ -2381,7 +2381,7 @@ func_ov13_02114a34: ; 0x02114a34
 	add r0, r0, #0x5000
 	mov r3, #1
 	bl func_ov13_02112df4
-	movs sb, r0
+	movs r9, r0
 	bne _02114aac
 	bl func_0200f248
 	b _02114af0
@@ -2392,14 +2392,14 @@ _02114aac:
 	bne _02114ac0
 	bl func_0200f248
 _02114ac0:
-	mov r0, sb
+	mov r0, r9
 	mov r1, r8
 	mov r2, r7
 	mov r3, r10
 	bl func_ov13_02112f24
 	ldr r7, [sp, #0x2c]
 	ldr r3, [sp, #0x28]
-	mov r0, sb
+	mov r0, r9
 	mov r1, r6
 	mov r2, r5
 	str r7, [sp]
@@ -2408,7 +2408,7 @@ _02114af0:
 	mov r0, r4
 	bl func_0200ee60
 	add sp, sp, #4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov13_02114a34
 _02114b00: .word data_ov13_0211620c

--- a/asm/ov14/Actor/ActorRupee.s
+++ b/asm/ov14/Actor/ActorRupee.s
@@ -42,7 +42,7 @@ _0213aec8: .word _ZTV10ActorRupee
 	.global _ZN10ActorRupee8vfunc_08Ev
 	arm_func_start _ZN10ActorRupee8vfunc_08Ev
 _ZN10ActorRupee8vfunc_08Ev: ; 0x0213aecc
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x18
 	mov r4, r0
 	ldrh r0, [r4, #0x20]
@@ -113,16 +113,16 @@ _0213afb4:
 	ldr r3, _0213b108 ; =data_027e0764
 	ldr r8, [r3, #0x10]
 	ldr r6, [r3, #0xc]
-	adds sl, r8, sb
+	adds r10, r8, sb
 	ldr r11, [r3, #0x14]
 	mla r0, r6, r5, r0
-	umull r3, lr, r7, sl
+	umull r3, lr, r7, r10
 	adc sb, r11, r0
 	adds r0, r8, r3
 	str r0, [sp, #0x14]
 	ldr r0, _0213b108 ; =data_027e0764
 	mla lr, r7, sb, lr
-	str sl, [r0]
+	str r10, [r0]
 	ldr r3, [sp, #0x14]
 	str sb, [r0, #4]
 	str r3, [r0]
@@ -131,7 +131,7 @@ _0213afb4:
 	umull r0, r5, sb, r0
 	str r0, [sp, #4]
 	mla r5, sb, r2, r5
-	mla lr, r6, sl, lr
+	mla lr, r6, r10, lr
 	ldr r0, [sp, #0x10]
 	mov r3, r2
 	mla r5, r3, r0, r5
@@ -140,14 +140,14 @@ _0213afb4:
 	ldr r5, [sp, #0x14]
 	ldr r0, _0213b108 ; =data_027e0764
 	adc sb, r11, lr
-	umull sl, r5, r7, r5
+	umull r10, r5, r7, r5
 	mla r5, r7, sb, r5
 	ldr r7, [sp, #0x14]
 	rsb r1, r1, #0x334
 	str sb, [r0, #4]
 	umull r0, r3, sb, r1
 	mla r5, r6, r7, r5
-	mov r6, sl
+	mov r6, r10
 	adds r6, r8, r6
 	adc r7, r11, r5
 	ldr r5, _0213b108 ; =data_027e0764
@@ -169,7 +169,7 @@ _0213afb4:
 	mov r0, r4
 	str r2, [r4, #0x64]
 	ldr r2, [sp]
-	str sl, [sp, #0xc]
+	str r10, [sp, #0xc]
 	str r2, [r4, #0x68]
 	bl _ZN10ActorRupee18func_ov14_0213b204Ei
 	b _0213b0f4
@@ -189,7 +189,7 @@ _0213b0e8:
 _0213b0f4:
 	mov r0, #1
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end _ZN10ActorRupee8vfunc_08Ev
 _0213b100: .word data_ov14_021589b4

--- a/asm/ov14/Actor/ActorRupee.s
+++ b/asm/ov14/Actor/ActorRupee.s
@@ -42,7 +42,7 @@ _0213aec8: .word _ZTV10ActorRupee
 	.global _ZN10ActorRupee8vfunc_08Ev
 	arm_func_start _ZN10ActorRupee8vfunc_08Ev
 _ZN10ActorRupee8vfunc_08Ev: ; 0x0213aecc
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x18
 	mov r4, r0
 	ldrh r0, [r4, #0x20]
@@ -114,10 +114,10 @@ _0213afb4:
 	ldr r8, [r3, #0x10]
 	ldr r6, [r3, #0xc]
 	adds sl, r8, sb
-	ldr fp, [r3, #0x14]
+	ldr r11, [r3, #0x14]
 	mla r0, r6, r5, r0
 	umull r3, lr, r7, sl
-	adc sb, fp, r0
+	adc sb, r11, r0
 	adds r0, r8, r3
 	str r0, [sp, #0x14]
 	ldr r0, _0213b108 ; =data_027e0764
@@ -139,7 +139,7 @@ _0213afb4:
 	str r0, [sp]
 	ldr r5, [sp, #0x14]
 	ldr r0, _0213b108 ; =data_027e0764
-	adc sb, fp, lr
+	adc sb, r11, lr
 	umull sl, r5, r7, r5
 	mla r5, r7, sb, r5
 	ldr r7, [sp, #0x14]
@@ -149,7 +149,7 @@ _0213afb4:
 	mla r5, r6, r7, r5
 	mov r6, sl
 	adds r6, r8, r6
-	adc r7, fp, r5
+	adc r7, r11, r5
 	ldr r5, _0213b108 ; =data_027e0764
 	mla r3, sb, r2, r3
 	mov r0, r2
@@ -189,7 +189,7 @@ _0213b0e8:
 _0213b0f4:
 	mov r0, #1
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end _ZN10ActorRupee8vfunc_08Ev
 _0213b100: .word data_ov14_021589b4

--- a/asm/ov14/Actor/ActorRupee.s
+++ b/asm/ov14/Actor/ActorRupee.s
@@ -42,7 +42,7 @@ _0213aec8: .word _ZTV10ActorRupee
 	.global _ZN10ActorRupee8vfunc_08Ev
 	arm_func_start _ZN10ActorRupee8vfunc_08Ev
 _ZN10ActorRupee8vfunc_08Ev: ; 0x0213aecc
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x18
 	mov r4, r0
 	ldrh r0, [r4, #0x20]
@@ -108,29 +108,29 @@ _0213afb4:
 	mvn ip, #0x110
 	ldr r5, [r0]
 	ldmib r0, {r3, r7}
-	umull sb, r0, r7, r5
+	umull r9, r0, r7, r5
 	mla r0, r7, r3, r0
 	ldr r3, _0213b108 ; =data_027e0764
 	ldr r8, [r3, #0x10]
 	ldr r6, [r3, #0xc]
-	adds r10, r8, sb
+	adds r10, r8, r9
 	ldr r11, [r3, #0x14]
 	mla r0, r6, r5, r0
 	umull r3, lr, r7, r10
-	adc sb, r11, r0
+	adc r9, r11, r0
 	adds r0, r8, r3
 	str r0, [sp, #0x14]
 	ldr r0, _0213b108 ; =data_027e0764
-	mla lr, r7, sb, lr
+	mla lr, r7, r9, lr
 	str r10, [r0]
 	ldr r3, [sp, #0x14]
-	str sb, [r0, #4]
+	str r9, [r0, #4]
 	str r3, [r0]
 	rsb r0, r1, #0x224
 	str r0, [sp, #0x10]
-	umull r0, r5, sb, r0
+	umull r0, r5, r9, r0
 	str r0, [sp, #4]
-	mla r5, sb, r2, r5
+	mla r5, r9, r2, r5
 	mla lr, r6, r10, lr
 	ldr r0, [sp, #0x10]
 	mov r3, r2
@@ -139,19 +139,19 @@ _0213afb4:
 	str r0, [sp]
 	ldr r5, [sp, #0x14]
 	ldr r0, _0213b108 ; =data_027e0764
-	adc sb, r11, lr
+	adc r9, r11, lr
 	umull r10, r5, r7, r5
-	mla r5, r7, sb, r5
+	mla r5, r7, r9, r5
 	ldr r7, [sp, #0x14]
 	rsb r1, r1, #0x334
-	str sb, [r0, #4]
-	umull r0, r3, sb, r1
+	str r9, [r0, #4]
+	umull r0, r3, r9, r1
 	mla r5, r6, r7, r5
 	mov r6, r10
 	adds r6, r8, r6
 	adc r7, r11, r5
 	ldr r5, _0213b108 ; =data_027e0764
-	mla r3, sb, r2, r3
+	mla r3, r9, r2, r3
 	mov r0, r2
 	mla r3, r0, r1, r3
 	add r0, r3, #0x55
@@ -189,7 +189,7 @@ _0213b0e8:
 _0213b0f4:
 	mov r0, #1
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end _ZN10ActorRupee8vfunc_08Ev
 _0213b100: .word data_ov14_021589b4

--- a/asm/ov14/ov14_0211f640.s
+++ b/asm/ov14/ov14_0211f640.s
@@ -308,7 +308,7 @@ _0211f97c: .word 0x424d5459
 	.global func_ov14_0211f980
 	arm_func_start func_ov14_0211f980
 func_ov14_0211f980: ; 0x0211f980
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x20
 	mov r4, r0
 	bl func_ov00_02079b78
@@ -318,7 +318,7 @@ func_ov14_0211f980: ; 0x0211f980
 	bl func_ov14_0211f8d0
 	cmp r0, #0
 	addeq sp, sp, #0x20
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, _0211faa4 ; =gItemManager
 	mvn r5, #0
 	ldr r3, _0211faa8 ; =data_027e0d3c
@@ -328,14 +328,14 @@ func_ov14_0211f980: ; 0x0211f980
 	str r5, [sp, #4]
 	str r5, [sp, #8]
 	ldr r8, [r3]
-	ldr sb, [r2]
+	ldr r9, [r2]
 	bl _ZN11ItemManager12GetEquipItemEi
 	ldr r1, [sp, #0xc]
 	mov r10, r0
 	cmp r1, #0
 	mov r7, #0
 	addle sp, sp, #0x20
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	mov r11, #3
 	add r5, sp, #4
 _0211f9f8:
@@ -344,11 +344,11 @@ _0211f9f8:
 	bl func_ov14_0213ed94
 	ldrb r6, [r0]
 	ldrb r1, [r0, #1]
-	mov r0, sb
+	mov r0, r9
 	bl func_ov00_02083c50
 	mov r1, r6
 	mov r6, r0
-	mov r0, sb
+	mov r0, r9
 	bl func_ov00_02083c24
 	str r0, [sp, #0x14]
 	mov r0, #0
@@ -384,7 +384,7 @@ _0211fa8c:
 	cmp r7, r0
 	blt _0211f9f8
 	add sp, sp, #0x20
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_0211f980
 _0211faa4: .word gItemManager
@@ -1406,7 +1406,7 @@ func_ov14_021207a0: ; 0x021207a0
 	.global func_ov14_021207b8
 	arm_func_start func_ov14_021207b8
 func_ov14_021207b8: ; 0x021207b8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x28
 	mov r5, r0
 	ldr r7, [r5, #0x130]
@@ -1414,7 +1414,7 @@ func_ov14_021207b8: ; 0x021207b8
 	cmp r7, #1
 	mov r6, r3
 	addeq sp, sp, #0x28
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	ldr r2, [r1]
 	str r2, [r5, #0x164]
 	ldr r2, [r1, #4]
@@ -1452,7 +1452,7 @@ func_ov14_021207b8: ; 0x021207b8
 	add r3, r3, r2
 	add r1, sp, #0x18
 	mov r2, r0
-	add sb, r6, r3
+	add r9, r6, r3
 	bl func_01ff9bf8
 	add r0, sp, #0
 	mov r1, r0
@@ -1465,10 +1465,10 @@ func_ov14_021207b8: ; 0x021207b8
 	add r0, sp, #0xc
 	mov r1, r0
 	bl func_01ff9c2c
-	smull r3, r2, sb, sb
-	smull sb, r1, r6, r6
-	adds ip, sb, #0x800
-	adc sb, r1, #0
+	smull r3, r2, r9, r9
+	smull r9, r1, r6, r6
+	adds ip, r9, #0x800
+	adc r9, r1, #0
 	adds r3, r3, #0x800
 	mov r1, ip, lsr #0xc
 	adc r2, r2, #0
@@ -1479,7 +1479,7 @@ func_ov14_021207b8: ; 0x021207b8
 	adds r2, r2, #0x800
 	adc r0, r0, #0
 	mov r2, r2, lsr #0xc
-	orr r1, r1, sb, lsl #20
+	orr r1, r1, r9, lsl #20
 	orr r2, r2, r0, lsl #20
 	subs r0, r1, r2
 	bmi _02120914
@@ -1525,7 +1525,7 @@ _0212094c:
 	ldr r0, [r0, #8]
 	str r0, [r5, #0x68]
 	add sp, sp, #0x28
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov14_021207b8
 _0212098c: .word data_027e0fe4
@@ -2879,7 +2879,7 @@ _02121bd4:
 	.global func_ov14_02121be4
 	arm_func_start func_ov14_02121be4
 func_ov14_02121be4: ; 0x02121be4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	mov r4, r0
 	bl _ZN5ActorC2Ev
 	ldr r1, _02121cc0 ; =data_ov14_02155bf0
@@ -2902,14 +2902,14 @@ func_ov14_02121be4: ; 0x02121be4
 	ldr r7, _02121cd0 ; =0x0000059a
 	str r3, [r4, #0x244]
 	ldr r0, _02121cd4 ; =data_027e0d0c
-	add sb, r4, #0x254
+	add r9, r4, #0x254
 	mov r8, #0x1000
 	add r6, r7, #0x1000
 	mov r5, #0x22c
 	mov lr, #2
 	add ip, r5, #1
 	ldmia r0, {r0, r1, r2}
-	stmia sb, {r0, r1, r2}
+	stmia r9, {r0, r1, r2}
 	str r8, [r4, #0x260]
 	strb r3, [r4, #0x26a]
 	str r3, [r4, #0x7c]
@@ -2933,7 +2933,7 @@ func_ov14_02121be4: ; 0x02121be4
 	str lr, [r4, #0x234]
 	str ip, [r4, #0x23c]
 	str lr, [r4, #0x240]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov14_02121be4
 _02121cc0: .word data_ov14_02155bf0
@@ -3099,7 +3099,7 @@ _02121eb0: .word data_ov14_02153bc4
 	.global func_ov14_02121eb4
 	arm_func_start func_ov14_02121eb4
 func_ov14_02121eb4: ; 0x02121eb4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x104
 	mov r5, r0
 	mov r11, r1
@@ -3221,32 +3221,32 @@ _0212204c:
 	str r3, [r5, #0x68]
 	add r7, r5, #0x200
 	ldrh r0, [r7, #0x68]
-	ldr sb, _02122ac4 ; =data_02050f54
+	ldr r9, _02122ac4 ; =data_02050f54
 	ldr r6, _02122ac8 ; =0x000004cd
 	mov r0, r0, asr #0x4
 	mov r1, r0, lsl #0x1
 	mov r0, r1, lsl #0x1
-	ldrsh r0, [sb, r0]
+	ldrsh r0, [r9, r0]
 	add r1, r1, #1
 	mov r8, r1, lsl #0x1
 	umull r2, r1, r0, r6
-	ldrsh r8, [sb, r8]
+	ldrsh r8, [r9, r8]
 	mla r1, r0, r3, r1
-	umull r10, sb, r8, r6
+	umull r10, r9, r8, r6
 	mov r0, r0, asr #0x1f
 	adds ip, r2, #0x800
 	mla r1, r0, r6, r1
 	adc r2, r1, #0
 	mov ip, ip, lsr #0xc
 	adds r1, r10, #0x800
-	mla sb, r8, r3, sb
+	mla r9, r8, r3, r9
 	mov r0, r8, asr #0x1f
-	mla sb, r0, r6, sb
+	mla r9, r0, r6, r9
 	ldr r0, [r5, #0x60]
 	orr ip, ip, r2, lsl #20
 	add r0, r0, ip
 	str r0, [r5, #0x60]
-	adc r0, sb, #0
+	adc r0, r9, #0
 	mov r1, r1, lsr #0xc
 	ldr r2, [r5, #0x68]
 	orr r1, r1, r0, lsl #20
@@ -3396,9 +3396,9 @@ _021222b4:
 	mla r7, r6, r3, r7
 	ldr r10, [r1, #0x10]
 	mla r7, lr, ip, r7
-	ldr sb, [r1, #0x14]
+	ldr r9, [r1, #0x14]
 	adds r3, r10, r8
-	adc r6, sb, r7
+	adc r6, r9, r7
 	stmia r1, {r3, r6}
 	umull r1, r3, r6, r0
 	mla r3, r6, r2, r3
@@ -3898,7 +3898,7 @@ _02122a84:
 	add r2, r5, #0x48
 	bl func_ov00_0207a1c8
 	add sp, sp, #0x104
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_02121eb4
 _02122a9c: .word data_027e0ffc
@@ -4240,7 +4240,7 @@ func_ov14_02122eb8: ; 0x02122eb8
 	.global func_ov14_02122ed4
 	arm_func_start func_ov14_02122ed4
 func_ov14_02122ed4: ; 0x02122ed4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x54
 	mov r10, r0
 	ldr r4, [r10, #0x98]
@@ -4265,7 +4265,7 @@ func_ov14_02122ed4: ; 0x02122ed4
 	add r0, sp, #0x30
 	bl func_01ff9cec
 	add r1, sp, #0x3c
-	mov sb, r0
+	mov r9, r0
 	add r11, sp, #0
 	ldmia r1, {r0, r1, r2}
 	stmia r11, {r0, r1, r2}
@@ -4282,28 +4282,28 @@ func_ov14_02122ed4: ; 0x02122ed4
 	mov r0, r3
 	bl func_01fffb4c
 	cmp r0, #0
-	cmpne sb, #0
+	cmpne r9, #0
 	beq _02123038
 	add r6, sp, #0xc
 	mov r4, r7
 	mov r11, r7
 _02122f90:
-	cmp sb, r8
+	cmp r9, r8
 	ble _02122fb4
 	mov r0, r8
 	mov r1, r6
 	mov r2, r5
 	mov r3, r5
 	bl func_01ff9e64
-	sub sb, sb, r8
+	sub r9, r9, r8
 	b _02122fcc
 _02122fb4:
-	mov r0, sb
+	mov r0, r9
 	mov r1, r6
 	mov r2, r5
 	mov r3, r5
 	bl func_01ff9e64
-	mov sb, r4
+	mov r9, r4
 _02122fcc:
 	ldr r1, [sp, #0x18]
 	mov r0, r10
@@ -4330,7 +4330,7 @@ _02122fcc:
 	str r2, [sp, #0x24]
 	str r1, [sp, #0x28]
 	str r0, [sp, #0x2c]
-	cmp sb, #0
+	cmp r9, #0
 	bne _02122f90
 _02123038:
 	ldr r1, [r10, #0x48]
@@ -4341,7 +4341,7 @@ _02123038:
 	ldr r1, [r10, #0x50]
 	str r1, [r10, #0x5c]
 	add sp, sp, #0x54
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	arm_func_end func_ov14_02122ed4
 
 	.global func_ov14_0212305c
@@ -10227,7 +10227,7 @@ _02127b58:
 	.global func_ov14_02127bb0
 	arm_func_start func_ov14_02127bb0
 func_ov14_02127bb0: ; 0x02127bb0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #8
 	mov r10, r0
 	cmp r2, #0
@@ -10238,12 +10238,12 @@ func_ov14_02127bb0: ; 0x02127bb0
 	streq r0, [sp]
 	ldrb r11, [r10, #0x14]
 	ldr r0, [sp]
-	mov sb, r1
+	mov r9, r1
 	add r0, r11, r0
 	moveq r8, r3
 	cmp r11, r0
 	addge sp, sp, #8
-	ldmgeia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmgeia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r4, _02127c5c ; =data_027e0e60
 	add r5, sp, #4
 _02127bfc:
@@ -10255,7 +10255,7 @@ _02127bfc:
 _02127c10:
 	ldr r0, [r4]
 	mov r1, r5
-	mov r2, sb
+	mov r2, r9
 	strb r6, [sp, #4]
 	strb r7, [sp, #5]
 	bl func_ov00_02082680
@@ -10272,7 +10272,7 @@ _02127c3c:
 	cmp r11, r0
 	blt _02127bfc
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_02127bb0
 _02127c5c: .word data_027e0e60
@@ -11313,7 +11313,7 @@ _021289a0: .word data_027e0f90
 	.global func_ov14_021289a4
 	arm_func_start func_ov14_021289a4
 func_ov14_021289a4: ; 0x021289a4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x118
 	mov r4, r0
 	bl func_ov14_02127188
@@ -11415,7 +11415,7 @@ _02128a84:
 	ldr r7, [sp]
 	ldr r6, [sp, #4]
 	ldr r5, [sp, #8]
-	ldr sb, [sp, #0x24]
+	ldr r9, [sp, #0x24]
 	ldr r8, [sp, #0x28]
 	str r7, [sp, #0x94]
 	ldr r7, [sp, #0x2c]
@@ -11423,8 +11423,8 @@ _02128a84:
 	ldr r6, [sp, #0x30]
 	str r5, [sp, #0x9c]
 	ldr r5, [sp, #0x34]
-	str sb, [sp, #0xb8]
-	ldr sb, [sp, #0x38]
+	str r9, [sp, #0xb8]
+	ldr r9, [sp, #0x38]
 	str r8, [sp, #0xbc]
 	ldr r8, [sp, #0x3c]
 	str r7, [sp, #0xc0]
@@ -11433,8 +11433,8 @@ _02128a84:
 	ldr r6, [sp, #0x44]
 	str r5, [sp, #0xc8]
 	ldr r5, [sp, #0x48]
-	str sb, [sp, #0xcc]
-	ldr sb, [sp, #0x4c]
+	str r9, [sp, #0xcc]
+	ldr r9, [sp, #0x4c]
 	str r8, [sp, #0xd0]
 	ldr r8, [sp, #0x50]
 	str r7, [sp, #0xd4]
@@ -11443,7 +11443,7 @@ _02128a84:
 	ldr r6, [sp, #0x58]
 	str r5, [sp, #0xdc]
 	ldr r5, [sp, #0x5c]
-	str sb, [sp, #0xe0]
+	str r9, [sp, #0xe0]
 	str lr, [sp, #0xc]
 	str ip, [sp, #0x10]
 	str r3, [sp, #0x14]
@@ -11571,7 +11571,7 @@ _02128d40:
 _02128d64:
 	mov r0, #1
 	add sp, sp, #0x118
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov14_021289a4
 _02128d70: .word data_027e0f90
@@ -12321,7 +12321,7 @@ _02129800: .word 0x00000547
 	.global func_ov14_02129804
 	arm_func_start func_ov14_02129804
 func_ov14_02129804: ; 0x02129804
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0xc
 	mov r8, #0
 	mov r10, r0
@@ -12330,7 +12330,7 @@ func_ov14_02129804: ; 0x02129804
 	ldr r7, _02129908 ; =data_ov14_02153c4c
 	str r8, [sp, #4]
 	ldr r0, [r7, r2, lsl #2]
-	mov sb, r8
+	mov r9, r8
 	cmp r0, #0
 	bls _021298bc
 	ldr r11, _0212990c ; =data_ov14_02153c64
@@ -12340,7 +12340,7 @@ func_ov14_02129804: ; 0x02129804
 _02129844:
 	add r0, r5, r2, lsl #2
 	str r6, [sp]
-	ldr r1, [r0, sb, lsl #2]
+	ldr r1, [r0, r9, lsl #2]
 	ldr r0, _02129918 ; =data_027e104c
 	ldr r2, [r4, r2, lsl #2]
 	ldr r0, [r0]
@@ -12366,15 +12366,15 @@ _021298a4:
 	mov r8, #1
 _021298a8:
 	ldr r2, [r10, #0xb0]
-	add sb, sb, #1
+	add r9, r9, #1
 	ldr r0, [r7, r2, lsl #2]
-	cmp sb, r0
+	cmp r9, r0
 	blo _02129844
 _021298bc:
 	ldr r0, [sp, #4]
 	cmp r0, #0
 	addne sp, sp, #0xc
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	mov r0, r10
 	cmp r8, #0
 	mov r2, #0
@@ -12384,13 +12384,13 @@ _021298bc:
 	mov r1, #0x14
 	blx r3
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _021298f4:
 	ldr r3, [r3, #0x80]
 	mov r1, #0x13
 	blx r3
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_02129804
 _02129908: .word data_ov14_02153c4c
@@ -12402,11 +12402,11 @@ _02129918: .word data_027e104c
 	.global func_ov14_0212991c
 	arm_func_start func_ov14_0212991c
 func_ov14_0212991c: ; 0x0212991c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	movs r10, r2
-	mov sb, r3
+	mov r9, r3
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, _021299a4 ; =data_ov14_02153c4c
 	mov r11, #0
 	ldr r7, [r0, r1, lsl #2]
@@ -12425,10 +12425,10 @@ _02129960:
 	bl strcmp
 	cmp r0, #0
 	bne _02129988
-	cmp sb, r5
+	cmp r9, r5
 	movge r0, #2
-	ldmgeia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
-	cmp sb, r4
+	ldmgeia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
+	cmp r9, r4
 	movge r11, #1
 _02129988:
 	add r8, r8, #1
@@ -12438,7 +12438,7 @@ _02129994:
 	cmp r11, #0
 	movne r0, #1
 	moveq r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_0212991c
 _021299a4: .word data_ov14_02153c4c
@@ -14811,7 +14811,7 @@ func_ov14_0212b7ec: ; 0x0212b7ec
 	.global func_ov14_0212b81c
 	arm_func_start func_ov14_0212b81c
 func_ov14_0212b81c: ; 0x0212b81c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #0x60
 	mov r7, r0
 	ldr r1, [r7, #4]
@@ -14896,7 +14896,7 @@ func_ov14_0212b81c: ; 0x0212b81c
 	ldr r8, _0212b9c8 ; =data_027e0e60
 	strb r0, [r7, #0x3c]
 	add r10, sp, #4
-	mov sb, r0
+	mov r9, r0
 	mov r4, r5
 _0212b978:
 	mov r6, r4
@@ -14907,7 +14907,7 @@ _0212b97c:
 	sub ip, r2, r6
 	add r3, r1, r5
 	mov r1, r10
-	mov r2, sb
+	mov r2, r9
 	strb r3, [sp, #4]
 	strb ip, [sp, #5]
 	bl func_ov00_02082680
@@ -14918,7 +14918,7 @@ _0212b97c:
 	cmp r5, #2
 	blt _0212b978
 	add sp, sp, #0x60
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov14_0212b81c
 _0212b9c4: .word 0x00000b34
@@ -15074,7 +15074,7 @@ func_ov14_0212bb50: ; 0x0212bb50
 	.global func_ov14_0212bb6c
 	arm_func_start func_ov14_0212bb6c
 func_ov14_0212bb6c: ; 0x0212bb6c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x1c
 	ldr r2, _0212bc94 ; =data_027e0764
 	mov r3, #0
@@ -15112,9 +15112,9 @@ func_ov14_0212bb6c: ; 0x0212bb6c
 	ldr r5, [r2, #0xc]
 	ldr r10, [r2, #0x10]
 	mla r7, r5, lr, r7
-	ldr sb, [r2, #0x14]
+	ldr r9, [r2, #0x14]
 	adds r5, r10, r8
-	adc r7, sb, r7
+	adc r7, r9, r7
 	stmia r2, {r5, r7}
 	umull r2, r5, r7, r1
 	mla r5, r7, r3, r5
@@ -15147,7 +15147,7 @@ func_ov14_0212bb6c: ; 0x0212bb6c
 	mov r0, r4
 	bl func_ov14_02146d48
 	add sp, sp, #0x1c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_0212bb6c
 _0212bc94: .word data_027e0764
@@ -19799,7 +19799,7 @@ _0212f7ac: .word func_ov14_02121cd8 - 1
 	.global func_ov14_0212f7b0
 	arm_func_start func_ov14_0212f7b0
 func_ov14_0212f7b0: ; 0x0212f7b0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x68
 	mov r4, r0
 	ldr r1, [r4, #4]
@@ -19957,7 +19957,7 @@ _0212f964:
 	ble _0212fac8
 _0212f9fc:
 	ldrh r0, [r4, #0x26]
-	mov sb, #0
+	mov r9, #0
 	add r0, r0, #1
 	cmp r0, #0
 	ble _0212fab4
@@ -19967,7 +19967,7 @@ _0212f9fc:
 	add r7, sp, #0x24
 _0212fa20:
 	cmp r8, #0
-	cmpeq sb, #0
+	cmpeq r9, #0
 	beq _0212faa0
 	ldrb r1, [r4, #0x14]
 	mov r0, r4
@@ -19975,7 +19975,7 @@ _0212fa20:
 	add r1, r8, r1
 	strb r1, [sp, #4]
 	ldrb r1, [r4, #0x15]
-	add r1, sb, r1
+	add r1, r9, r1
 	strb r1, [sp, #5]
 	ldr r1, [r0]
 	ldr r1, [r1, #0x1c]
@@ -19991,7 +19991,7 @@ _0212fa20:
 	ldrh r0, [r4, #0x24]
 	cmp r8, r0
 	ldreqh r0, [r4, #0x26]
-	cmpeq sb, r0
+	cmpeq r9, r0
 	bne _0212faa0
 	ldr r0, [r5]
 	mov r1, r6
@@ -20000,9 +20000,9 @@ _0212fa20:
 	strneb r11, [r0, #0xa9]
 _0212faa0:
 	ldrh r0, [r4, #0x26]
-	add sb, sb, #1
+	add r9, r9, #1
 	add r0, r0, #1
-	cmp sb, r0
+	cmp r9, r0
 	blt _0212fa20
 _0212fab4:
 	ldrh r0, [r4, #0x24]
@@ -20032,7 +20032,7 @@ _0212fb04:
 	strh r0, [r4, #0x66]
 	strh r0, [r4, #0x68]
 	add sp, sp, #0x68
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_0212f7b0
 _0212fb18: .word 0x00001333
@@ -21169,7 +21169,7 @@ _021309b8: .word 0x00001334
 	.global func_ov14_021309bc
 	arm_func_start func_ov14_021309bc
 func_ov14_021309bc: ; 0x021309bc
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #8
 	mov r10, r0
 	ldrb r0, [r10, #0x79]
@@ -21190,7 +21190,7 @@ func_ov14_021309bc: ; 0x021309bc
 	ldr r4, _02130be0 ; =data_027e0e60
 	add r6, sp, #6
 _02130a0c:
-	mov sb, #0
+	mov r9, #0
 	cmp r8, #0
 	ble _02130a60
 	and r7, r11, #0xff
@@ -21198,7 +21198,7 @@ _02130a1c:
 	ldr r0, [r4]
 	mov r1, r6
 	strb r7, [sp, #6]
-	strb sb, [sp, #7]
+	strb r9, [sp, #7]
 	bl func_ov00_020840c4
 	movs r5, r0
 	beq _02130a54
@@ -21210,8 +21210,8 @@ _02130a1c:
 	mov r0, r5
 	bl func_ov14_021314b8
 _02130a54:
-	add sb, sb, #1
-	cmp sb, r8
+	add r9, r9, #1
+	cmp r9, r8
 	blt _02130a1c
 _02130a60:
 	ldr r0, [sp]
@@ -21255,11 +21255,11 @@ _02130ae8:
 	add r0, r8, r0
 	cmp r8, r0
 	bgt _02130b7c
-	ldr sb, _02130be0 ; =data_027e0e60
+	ldr r9, _02130be0 ; =data_027e0e60
 	and r6, r7, #0xff
 	add r5, sp, #4
 _02130b08:
-	ldr r0, [sb]
+	ldr r0, [r9]
 	mov r1, r5
 	strb r6, [sp, #4]
 	strb r8, [sp, #5]
@@ -21309,14 +21309,14 @@ _02130b94:
 	mov r2, #1
 	blx r3
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02130bc8:
 	mov r1, #1
 	ldr r3, [r3, #0x80]
 	mov r2, r1
 	blx r3
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_021309bc
 _02130be0: .word data_027e0e60
@@ -21577,7 +21577,7 @@ _02130f84: .word data_027e0f74
 	.global func_ov14_02130f88
 	arm_func_start func_ov14_02130f88
 func_ov14_02130f88: ; 0x02130f88
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0xe4
 	mov r4, r0
 	str r1, [r4, #8]
@@ -21632,10 +21632,10 @@ _02130ff8:
 	umull r8, r7, r3, r2
 	mla r7, r3, r0, r7
 	ldr r0, [r6, #0xc]
-	ldr sb, [r6, #0x10]
+	ldr r9, [r6, #0x10]
 	mla r7, r0, r2, r7
 	ldr r3, [r6, #0x14]
-	adds r8, sb, r8
+	adds r8, r9, r8
 	mov r1, #0
 	adc r3, r3, r7
 	mov r0, #3
@@ -21724,7 +21724,7 @@ _02131100:
 	ble _02131240
 	add r6, sp, #0x12
 _021311bc:
-	mov sb, #0
+	mov r9, #0
 	cmp r10, #0
 	ble _02131230
 	ldr r11, _02131410 ; =data_027e0e60
@@ -21733,12 +21733,12 @@ _021311d0:
 	ldrb r0, [r4, #0x14]
 	cmp r8, r0
 	ldreqb r0, [r4, #0x15]
-	cmpeq sb, r0
+	cmpeq r9, r0
 	beq _02131224
 	ldr r0, [r11]
 	mov r1, r6
 	strb r7, [sp, #0x12]
-	strb sb, [sp, #0x13]
+	strb r9, [sp, #0x13]
 	bl func_ov00_020840c4
 	movs r5, r0
 	beq _02131224
@@ -21752,8 +21752,8 @@ _021311d0:
 	ldreq r0, [r4, #0x70]
 	streq r0, [r5, #0x70]
 _02131224:
-	add sb, sb, #1
-	cmp sb, r10
+	add r9, r9, #1
+	cmp r9, r10
 	blt _021311d0
 _02131230:
 	ldr r0, [sp, #0xc]
@@ -21789,7 +21789,7 @@ _02131298:
 	cmp r0, #0
 	bne _02131374
 	ldrh r0, [r4, #0x24]
-	mov sb, #1
+	mov r9, #1
 	cmp r0, #0
 	bne _02131360
 	ldrb r0, [r4, #0x7a]
@@ -21824,7 +21824,7 @@ _021312f4:
 	cmp r0, #0x45
 	ldreqh r0, [r6, #0x28]
 	cmpeq r0, #1
-	moveq sb, r5
+	moveq r9, r5
 _02131330:
 	ldrb r1, [r4, #0x15]
 	ldrb r0, [r4, #0x7d]
@@ -21840,7 +21840,7 @@ _02131348:
 	cmp r11, r0
 	ble _021312dc
 _02131360:
-	cmp sb, #0
+	cmp r9, #0
 	beq _02131374
 	mov r0, r4
 	mov r1, #1
@@ -21880,7 +21880,7 @@ _021313e4:
 	mov r0, #1
 	str r1, [r4, #0x44]
 	add sp, sp, #0xe4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_02130f88
 _021313f8: .word data_027e0f64
@@ -21961,13 +21961,13 @@ _0213149c:
 	.global func_ov14_021314b8
 	arm_func_start func_ov14_021314b8
 func_ov14_021314b8: ; 0x021314b8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x10
 	mov r10, r0
 	ldrb r0, [r10, #0x79]
 	cmp r0, #0
 	addne sp, sp, #0x10
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldrb r0, [r10, #0x14]
 	ldr r1, _021316c0 ; =data_027e0e60
 	str r0, [sp, #4]
@@ -22002,12 +22002,12 @@ _02131544:
 	mov r0, r8
 	cmp r0, r7
 	bge _021315cc
-	ldr sb, _021316c0 ; =data_027e0e60
+	ldr r9, _021316c0 ; =data_027e0e60
 	mov r4, #0
 	add r6, sp, #0xe
 _02131560:
 	ldrb r2, [r10, #0x14]
-	ldr r0, [sb]
+	ldr r0, [r9]
 	mov r1, r6
 	strb r2, [sp, #0xe]
 	strb r8, [sp, #0xf]
@@ -22050,9 +22050,9 @@ _021315f4:
 	ldr r0, [sp, #4]
 	cmp r0, r1
 	beq _02131698
-	ldr sb, [sp]
+	ldr r9, [sp]
 	mov r7, #0
-	mov r0, sb
+	mov r0, r9
 	cmp r0, r8
 	bge _02131684
 	ldr r0, [sp, #4]
@@ -22062,7 +22062,7 @@ _02131620:
 	mov r1, r11
 	ldr r0, [r0]
 	strb r6, [sp, #0xc]
-	strb sb, [sp, #0xd]
+	strb r9, [sp, #0xd]
 	bl func_ov00_020840c4
 	mov r5, r0
 	cmp r5, r10
@@ -22081,8 +22081,8 @@ _02131620:
 	mov r7, #1
 	strb r4, [r5, #0x79]
 _02131678:
-	add sb, sb, #1
-	cmp sb, r8
+	add r9, r9, #1
+	cmp r9, r8
 	blt _02131620
 _02131684:
 	cmp r7, #0
@@ -22101,7 +22101,7 @@ _021316b0:
 	mov r0, #1
 	strb r0, [r10, #0x79]
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_021314b8
 _021316c0: .word data_027e0e60
@@ -26004,7 +26004,7 @@ func_ov14_02134954: ; 0x02134954
 	.global func_ov14_0213497c
 	arm_func_start func_ov14_0213497c
 func_ov14_0213497c: ; 0x0213497c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x24
 	mov r10, r0
 	ldr r0, _02134be4 ; =data_027e0e60
@@ -26109,10 +26109,10 @@ _02134ad4:
 	add r5, sp, #4
 	mov r11, r6
 _02134b00:
-	ldrb sb, [r10, #0x15]
+	ldrb r9, [r10, #0x15]
 	ldrb r0, [r10, #0x3a]
-	add r0, sb, r0
-	cmp sb, r0
+	add r0, r9, r0
+	cmp r9, r0
 	bge _02134b64
 	ldr r0, [sp]
 	and r8, r0, #0xff
@@ -26121,19 +26121,19 @@ _02134b1c:
 	mov r1, r7
 	mov r2, r6
 	strb r8, [sp, #6]
-	strb sb, [sp, #7]
+	strb r9, [sp, #7]
 	bl func_ov00_02082680
 	ldr r0, [r4]
 	mov r1, r5
 	strb r8, [sp, #4]
-	strb sb, [sp, #5]
+	strb r9, [sp, #5]
 	mov r2, r11
 	bl func_ov00_020826a0
 	ldrb r1, [r10, #0x15]
 	ldrb r0, [r10, #0x3a]
-	add sb, sb, #1
+	add r9, r9, #1
 	add r0, r1, r0
-	cmp sb, r0
+	cmp r9, r0
 	blt _02134b1c
 _02134b64:
 	ldrb r8, [r10, #0x39]
@@ -26168,7 +26168,7 @@ _02134b84:
 	str r0, [r10, #0x68]
 	str r5, [r10, #0x6c]
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_0213497c
 _02134be4: .word data_027e0e60
@@ -26203,7 +26203,7 @@ func_ov14_02134c0c: ; 0x02134c0c
 	.global func_ov14_02134c14
 	arm_func_start func_ov14_02134c14
 func_ov14_02134c14: ; 0x02134c14
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x48
 	ldr r2, [r0]
 	mov r10, r0
@@ -26211,7 +26211,7 @@ func_ov14_02134c14: ; 0x02134c14
 	blx r2
 	cmp r0, #0
 	addeq sp, sp, #0x48
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldrh r1, [r10, #0xc]
 	ldr r3, _02134e04 ; =data_02050f54
 	add r0, sp, #0x24
@@ -26246,12 +26246,12 @@ _02134c9c:
 	ldrb r0, [r10, #0x3a]
 	cmp r0, #0
 	ble _02134d14
-	mov sb, r8
+	mov r9, r8
 _02134cc0:
 	ldr r0, [r10, #0x4c]
 	cmp r8, #0
 	streq r0, [sp, #0x20]
-	addne r0, r0, sb
+	addne r0, r0, r9
 	strne r0, [sp, #0x20]
 	cmp r7, #0
 	cmpeq r8, #0
@@ -26266,7 +26266,7 @@ _02134cc0:
 	blx ip
 	ldrb r0, [r10, #0x3a]
 	add r8, r8, #1
-	add sb, sb, #0x1000
+	add r9, r9, #0x1000
 	cmp r8, r0
 	blt _02134cc0
 _02134d14:
@@ -26278,7 +26278,7 @@ _02134d24:
 	ldrb r0, [r10, #0x38]
 	cmp r0, #0
 	addeq sp, sp, #0x48
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldrsh r0, [r10, #0xc]
 	cmp r0, #0x4000
 	bne _02134d64
@@ -26332,7 +26332,7 @@ _02134d7c:
 	orr r3, r3, r4, lsl #20
 	bl func_ov05_02102c2c
 	add sp, sp, #0x48
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_02134c14
 _02134e04: .word data_02050f54
@@ -28194,7 +28194,7 @@ _02136508: .word data_ov00_020e9370
 	.global func_ov14_0213650c
 	arm_func_start func_ov14_0213650c
 func_ov14_0213650c: ; 0x0213650c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x18
 	mov r10, r0
 	ldr r0, [r10, #0x48]
@@ -28221,7 +28221,7 @@ func_ov14_0213650c: ; 0x0213650c
 	cmpne r0, #3
 	moveq r1, #0x4000
 	mov r0, r1, lsl #0x10
-	mov sb, r0, lsr #0x10
+	mov r9, r0, lsr #0x10
 _0213657c:
 	ldr r1, [r10, #0x1a0]
 	mov r0, r6
@@ -28254,14 +28254,14 @@ _021365e8:
 	ldr r0, [r8]
 	add r5, r5, #1
 	cmp r0, #0
-	strneh sb, [r0, #0xa4]
+	strneh r9, [r0, #0xa4]
 	cmp r5, #2
 	add r6, r6, #0xc
 	add r7, r7, #0xc
 	add r8, r8, #4
 	blo _0213657c
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_0213650c
 _02136614: .word data_ov14_02157d70
@@ -28860,7 +28860,7 @@ _02136e2c: .word data_027e0ffc
 	.global func_ov14_02136e30
 	arm_func_start func_ov14_02136e30
 func_ov14_02136e30: ; 0x02136e30
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0xe4
 	mov r4, r0
 	ldr r0, [r4, #0x4c]
@@ -29101,7 +29101,7 @@ _0213716c:
 	bge _021371b8
 	cmp r3, r2
 	addeq sp, sp, #0xe4
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02137190:
 	ldr r1, [r3]
 	add r3, r3, #0xc
@@ -29112,7 +29112,7 @@ _02137190:
 	cmp r3, r2
 	bne _02137190
 	add sp, sp, #0xe4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _021371b8:
 	cmp r3, r2
 	beq _021371e0
@@ -29186,7 +29186,7 @@ _021372a4:
 	bl Divide
 	ldr r7, _021373d0 ; =data_ov14_02157ecc
 	ldr r8, _021373d4 ; =data_ov14_02157eb4
-	add sb, r4, #0x210
+	add r9, r4, #0x210
 	mov r10, r0, asr #0x1f
 	mov r6, #0
 _021372c8:
@@ -29230,17 +29230,17 @@ _021372c8:
 	mla r3, r10, r2, r3
 	adds r5, r5, #0x800
 	adc r2, r3, #0
-	ldr r1, [sb]
+	ldr r1, [r9]
 	mov r3, r5, lsr #0xc
 	orr r3, r3, r2, lsl #20
 	ldr r2, [sp, #0x1c]
 	cmp r1, #0
 	strne r4, [r1, #0x58]
-	ldr r1, [sb]
+	ldr r1, [r9]
 	add r3, r2, r3
 	cmp r1, #0
 	strneh r11, [r1, #0x74]
-	ldr r2, [sb]
+	ldr r2, [r9]
 	mov r1, r3, lsl #0x10
 	mov r1, r1, asr #0x10
 	cmp r2, #0
@@ -29249,10 +29249,10 @@ _021372c8:
 	cmp r6, #2
 	add r7, r7, #0xc
 	add r8, r8, #0xc
-	add sb, sb, #0xc
+	add r9, r9, #0xc
 	blo _021372c8
 	add sp, sp, #0xe4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_02136e30
 _021373c4: .word 0x0000ffff

--- a/asm/ov14/ov14_0211f640.s
+++ b/asm/ov14/ov14_0211f640.s
@@ -308,7 +308,7 @@ _0211f97c: .word 0x424d5459
 	.global func_ov14_0211f980
 	arm_func_start func_ov14_0211f980
 func_ov14_0211f980: ; 0x0211f980
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x20
 	mov r4, r0
 	bl func_ov00_02079b78
@@ -318,7 +318,7 @@ func_ov14_0211f980: ; 0x0211f980
 	bl func_ov14_0211f8d0
 	cmp r0, #0
 	addeq sp, sp, #0x20
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, _0211faa4 ; =gItemManager
 	mvn r5, #0
 	ldr r3, _0211faa8 ; =data_027e0d3c
@@ -331,15 +331,15 @@ func_ov14_0211f980: ; 0x0211f980
 	ldr sb, [r2]
 	bl _ZN11ItemManager12GetEquipItemEi
 	ldr r1, [sp, #0xc]
-	mov sl, r0
+	mov r10, r0
 	cmp r1, #0
 	mov r7, #0
 	addle sp, sp, #0x20
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	mov r11, #3
 	add r5, sp, #4
 _0211f9f8:
-	mov r0, sl
+	mov r0, r10
 	mov r1, r7
 	bl func_ov14_0213ed94
 	ldrb r6, [r0]
@@ -384,7 +384,7 @@ _0211fa8c:
 	cmp r7, r0
 	blt _0211f9f8
 	add sp, sp, #0x20
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_0211f980
 _0211faa4: .word gItemManager
@@ -3099,7 +3099,7 @@ _02121eb0: .word data_ov14_02153bc4
 	.global func_ov14_02121eb4
 	arm_func_start func_ov14_02121eb4
 func_ov14_02121eb4: ; 0x02121eb4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x104
 	mov r5, r0
 	mov r11, r1
@@ -3232,13 +3232,13 @@ _0212204c:
 	umull r2, r1, r0, r6
 	ldrsh r8, [sb, r8]
 	mla r1, r0, r3, r1
-	umull sl, sb, r8, r6
+	umull r10, sb, r8, r6
 	mov r0, r0, asr #0x1f
 	adds ip, r2, #0x800
 	mla r1, r0, r6, r1
 	adc r2, r1, #0
 	mov ip, ip, lsr #0xc
-	adds r1, sl, #0x800
+	adds r1, r10, #0x800
 	mla sb, r8, r3, sb
 	mov r0, r8, asr #0x1f
 	mla sb, r0, r6, sb
@@ -3394,10 +3394,10 @@ _021222b4:
 	ldmib r1, {r3, r6, lr}
 	umull r8, r7, r6, ip
 	mla r7, r6, r3, r7
-	ldr sl, [r1, #0x10]
+	ldr r10, [r1, #0x10]
 	mla r7, lr, ip, r7
 	ldr sb, [r1, #0x14]
-	adds r3, sl, r8
+	adds r3, r10, r8
 	adc r6, sb, r7
 	stmia r1, {r3, r6}
 	umull r1, r3, r6, r0
@@ -3898,7 +3898,7 @@ _02122a84:
 	add r2, r5, #0x48
 	bl func_ov00_0207a1c8
 	add sp, sp, #0x104
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_02121eb4
 _02122a9c: .word data_027e0ffc
@@ -4240,26 +4240,26 @@ func_ov14_02122eb8: ; 0x02122eb8
 	.global func_ov14_02122ed4
 	arm_func_start func_ov14_02122ed4
 func_ov14_02122ed4: ; 0x02122ed4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x54
-	mov sl, r0
-	ldr r4, [sl, #0x98]
-	ldr r1, [sl, #0x48]
+	mov r10, r0
+	ldr r4, [r10, #0x98]
+	ldr r1, [r10, #0x48]
 	add r0, sp, #0x48
 	str r1, [sp, #0x48]
-	ldr r2, [sl, #0x4c]
+	ldr r2, [r10, #0x4c]
 	add r1, sp, #0x3c
 	str r2, [sp, #0x4c]
-	ldr r3, [sl, #0x50]
+	ldr r3, [r10, #0x50]
 	add r2, sp, #0x30
 	str r3, [sp, #0x50]
-	ldr r3, [sl, #0x54]
+	ldr r3, [r10, #0x54]
 	sub r8, r4, #0x40
 	str r3, [sp, #0x3c]
-	ldr r3, [sl, #0x58]
+	ldr r3, [r10, #0x58]
 	mov r7, #0
 	str r3, [sp, #0x40]
-	ldr r3, [sl, #0x5c]
+	ldr r3, [r10, #0x5c]
 	str r3, [sp, #0x44]
 	bl func_01ff9bf8
 	add r0, sp, #0x30
@@ -4306,22 +4306,22 @@ _02122fb4:
 	mov sb, r4
 _02122fcc:
 	ldr r1, [sp, #0x18]
-	mov r0, sl
-	str r1, [sl, #0x48]
+	mov r0, r10
+	str r1, [r10, #0x48]
 	ldr r2, [sp, #0x1c]
 	mov r1, r11
-	str r2, [sl, #0x4c]
+	str r2, [r10, #0x4c]
 	ldr r2, [sp, #0x20]
-	str r2, [sl, #0x50]
+	str r2, [r10, #0x50]
 	ldr r2, [sp, #0x24]
-	str r2, [sl, #0x54]
+	str r2, [r10, #0x54]
 	ldr r2, [sp, #0x28]
-	str r2, [sl, #0x58]
+	str r2, [r10, #0x58]
 	ldr r2, [sp, #0x2c]
-	str r2, [sl, #0x5c]
+	str r2, [r10, #0x5c]
 	bl func_01fffd04
 	movs r7, r0
-	ldreqb r0, [sl, #0x111]
+	ldreqb r0, [r10, #0x111]
 	cmpeq r0, #0
 	bne _02123038
 	ldr r2, [sp, #0x18]
@@ -4333,15 +4333,15 @@ _02122fcc:
 	cmp sb, #0
 	bne _02122f90
 _02123038:
-	ldr r1, [sl, #0x48]
+	ldr r1, [r10, #0x48]
 	mov r0, r7
-	str r1, [sl, #0x54]
-	ldr r1, [sl, #0x4c]
-	str r1, [sl, #0x58]
-	ldr r1, [sl, #0x50]
-	str r1, [sl, #0x5c]
+	str r1, [r10, #0x54]
+	ldr r1, [r10, #0x4c]
+	str r1, [r10, #0x58]
+	ldr r1, [r10, #0x50]
+	str r1, [r10, #0x5c]
 	add sp, sp, #0x54
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	arm_func_end func_ov14_02122ed4
 
 	.global func_ov14_0212305c
@@ -10227,27 +10227,27 @@ _02127b58:
 	.global func_ov14_02127bb0
 	arm_func_start func_ov14_02127bb0
 func_ov14_02127bb0: ; 0x02127bb0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #8
-	mov sl, r0
+	mov r10, r0
 	cmp r2, #0
 	cmpne r2, #1
 	ldr r8, [sp, #0x30]
 	ldreq r0, [sp, #0x30]
 	str r3, [sp]
 	streq r0, [sp]
-	ldrb r11, [sl, #0x14]
+	ldrb r11, [r10, #0x14]
 	ldr r0, [sp]
 	mov sb, r1
 	add r0, r11, r0
 	moveq r8, r3
 	cmp r11, r0
 	addge sp, sp, #8
-	ldmgeia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmgeia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r4, _02127c5c ; =data_027e0e60
 	add r5, sp, #4
 _02127bfc:
-	ldrb r7, [sl, #0x15]
+	ldrb r7, [r10, #0x15]
 	add r0, r7, r8
 	cmp r7, r0
 	bge _02127c3c
@@ -10259,20 +10259,20 @@ _02127c10:
 	strb r6, [sp, #4]
 	strb r7, [sp, #5]
 	bl func_ov00_02082680
-	ldrb r0, [sl, #0x15]
+	ldrb r0, [r10, #0x15]
 	add r7, r7, #1
 	add r0, r0, r8
 	cmp r7, r0
 	blt _02127c10
 _02127c3c:
-	ldrb r1, [sl, #0x14]
+	ldrb r1, [r10, #0x14]
 	ldr r0, [sp]
 	add r11, r11, #1
 	add r0, r1, r0
 	cmp r11, r0
 	blt _02127bfc
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_02127bb0
 _02127c5c: .word data_027e0e60
@@ -12321,12 +12321,12 @@ _02129800: .word 0x00000547
 	.global func_ov14_02129804
 	arm_func_start func_ov14_02129804
 func_ov14_02129804: ; 0x02129804
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0xc
 	mov r8, #0
-	mov sl, r0
+	mov r10, r0
 	str r8, [sp, #8]
-	ldr r2, [sl, #0xb0]
+	ldr r2, [r10, #0xb0]
 	ldr r7, _02129908 ; =data_ov14_02153c4c
 	str r8, [sp, #4]
 	ldr r0, [r7, r2, lsl #2]
@@ -12348,12 +12348,12 @@ _02129844:
 	bl func_ov09_0211a69c
 	cmp r0, #0
 	beq _021298a8
-	ldr r0, [sl, #0xb0]
+	ldr r0, [r10, #0xb0]
 	ldr r1, [sp, #8]
 	ldr r0, [r11, r0, lsl #2]
 	cmp r1, r0
 	blt _021298a4
-	mov r0, sl
+	mov r0, r10
 	ldr r3, [r0]
 	mov r1, #0x12
 	ldr r3, [r3, #0x80]
@@ -12365,7 +12365,7 @@ _02129844:
 _021298a4:
 	mov r8, #1
 _021298a8:
-	ldr r2, [sl, #0xb0]
+	ldr r2, [r10, #0xb0]
 	add sb, sb, #1
 	ldr r0, [r7, r2, lsl #2]
 	cmp sb, r0
@@ -12374,8 +12374,8 @@ _021298bc:
 	ldr r0, [sp, #4]
 	cmp r0, #0
 	addne sp, sp, #0xc
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
-	mov r0, sl
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	mov r0, r10
 	cmp r8, #0
 	mov r2, #0
 	ldr r3, [r0]
@@ -12384,13 +12384,13 @@ _021298bc:
 	mov r1, #0x14
 	blx r3
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _021298f4:
 	ldr r3, [r3, #0x80]
 	mov r1, #0x13
 	blx r3
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_02129804
 _02129908: .word data_ov14_02153c4c
@@ -12402,11 +12402,11 @@ _02129918: .word data_027e104c
 	.global func_ov14_0212991c
 	arm_func_start func_ov14_0212991c
 func_ov14_0212991c: ; 0x0212991c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
-	movs sl, r2
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	movs r10, r2
 	mov sb, r3
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, _021299a4 ; =data_ov14_02153c4c
 	mov r11, #0
 	ldr r7, [r0, r1, lsl #2]
@@ -12421,13 +12421,13 @@ func_ov14_0212991c: ; 0x0212991c
 	add r6, r3, r1, lsl #2
 _02129960:
 	ldr r0, [r6, r8, lsl #2]
-	mov r1, sl
+	mov r1, r10
 	bl strcmp
 	cmp r0, #0
 	bne _02129988
 	cmp sb, r5
 	movge r0, #2
-	ldmgeia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmgeia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	cmp sb, r4
 	movge r11, #1
 _02129988:
@@ -12438,7 +12438,7 @@ _02129994:
 	cmp r11, #0
 	movne r0, #1
 	moveq r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_0212991c
 _021299a4: .word data_ov14_02153c4c
@@ -14811,7 +14811,7 @@ func_ov14_0212b7ec: ; 0x0212b7ec
 	.global func_ov14_0212b81c
 	arm_func_start func_ov14_0212b81c
 func_ov14_0212b81c: ; 0x0212b81c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #0x60
 	mov r7, r0
 	ldr r1, [r7, #4]
@@ -14895,7 +14895,7 @@ func_ov14_0212b81c: ; 0x0212b81c
 	mov r5, #0
 	ldr r8, _0212b9c8 ; =data_027e0e60
 	strb r0, [r7, #0x3c]
-	add sl, sp, #4
+	add r10, sp, #4
 	mov sb, r0
 	mov r4, r5
 _0212b978:
@@ -14906,7 +14906,7 @@ _0212b97c:
 	ldr r0, [r8]
 	sub ip, r2, r6
 	add r3, r1, r5
-	mov r1, sl
+	mov r1, r10
 	mov r2, sb
 	strb r3, [sp, #4]
 	strb ip, [sp, #5]
@@ -14918,7 +14918,7 @@ _0212b97c:
 	cmp r5, #2
 	blt _0212b978
 	add sp, sp, #0x60
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov14_0212b81c
 _0212b9c4: .word 0x00000b34
@@ -15074,7 +15074,7 @@ func_ov14_0212bb50: ; 0x0212bb50
 	.global func_ov14_0212bb6c
 	arm_func_start func_ov14_0212bb6c
 func_ov14_0212bb6c: ; 0x0212bb6c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x1c
 	ldr r2, _0212bc94 ; =data_027e0764
 	mov r3, #0
@@ -15110,10 +15110,10 @@ func_ov14_0212bb6c: ; 0x0212bb6c
 	umull r8, r7, r6, lr
 	mla r7, r6, ip, r7
 	ldr r5, [r2, #0xc]
-	ldr sl, [r2, #0x10]
+	ldr r10, [r2, #0x10]
 	mla r7, r5, lr, r7
 	ldr sb, [r2, #0x14]
-	adds r5, sl, r8
+	adds r5, r10, r8
 	adc r7, sb, r7
 	stmia r2, {r5, r7}
 	umull r2, r5, r7, r1
@@ -15147,7 +15147,7 @@ func_ov14_0212bb6c: ; 0x0212bb6c
 	mov r0, r4
 	bl func_ov14_02146d48
 	add sp, sp, #0x1c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_0212bb6c
 _0212bc94: .word data_027e0764
@@ -19799,7 +19799,7 @@ _0212f7ac: .word func_ov14_02121cd8 - 1
 	.global func_ov14_0212f7b0
 	arm_func_start func_ov14_0212f7b0
 func_ov14_0212f7b0: ; 0x0212f7b0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x68
 	mov r4, r0
 	ldr r1, [r4, #4]
@@ -19971,7 +19971,7 @@ _0212fa20:
 	beq _0212faa0
 	ldrb r1, [r4, #0x14]
 	mov r0, r4
-	ldr sl, [r5]
+	ldr r10, [r5]
 	add r1, r8, r1
 	strb r1, [sp, #4]
 	ldrb r1, [r4, #0x15]
@@ -19982,7 +19982,7 @@ _0212fa20:
 	blx r1
 	str r7, [sp]
 	mov r1, r0
-	mov r0, sl
+	mov r0, r10
 	mov r2, r6
 	ldrsh r3, [r4, #0xc]
 	bl func_ov00_020828c0
@@ -20032,7 +20032,7 @@ _0212fb04:
 	strh r0, [r4, #0x66]
 	strh r0, [r4, #0x68]
 	add sp, sp, #0x68
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_0212f7b0
 _0212fb18: .word 0x00001333
@@ -21169,10 +21169,10 @@ _021309b8: .word 0x00001334
 	.global func_ov14_021309bc
 	arm_func_start func_ov14_021309bc
 func_ov14_021309bc: ; 0x021309bc
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #8
-	mov sl, r0
-	ldrb r0, [sl, #0x79]
+	mov r10, r0
+	ldrb r0, [r10, #0x79]
 	cmp r0, #0
 	bne _02130a70
 	ldr r0, _02130be0 ; =data_027e0e60
@@ -21219,39 +21219,39 @@ _02130a60:
 	cmp r11, r0
 	blt _02130a0c
 _02130a70:
-	ldrb r0, [sl, #0x7a]
+	ldrb r0, [r10, #0x7a]
 	cmp r0, #0
 	beq _02130b94
-	ldrb r1, [sl, #0x7c]
-	ldr r2, [sl, #0x18]
+	ldrb r1, [r10, #0x7c]
+	ldr r2, [r10, #0x18]
 	ldr r0, _02130be4 ; =data_ov14_0215aecc
 	mov r1, r1, lsl #0xc
 	add r1, r2, r1, asr #1
-	str r1, [sl, #0x80]
-	ldrb r1, [sl, #0x7d]
-	ldr r2, [sl, #0x20]
+	str r1, [r10, #0x80]
+	ldrb r1, [r10, #0x7d]
+	ldr r2, [r10, #0x20]
 	mov r1, r1, lsl #0xc
 	add r1, r2, r1, asr #1
-	str r1, [sl, #0x88]
+	str r1, [r10, #0x88]
 	ldr r1, [r0, #0x38]
-	str r1, [sl, #0x6c]
+	str r1, [r10, #0x6c]
 	ldr r1, [r0, #0x38]
 	add r1, r1, #1
 	str r1, [r0, #0x38]
-	ldrb r1, [sl, #0x7c]
-	ldrb r0, [sl, #0x7d]
+	ldrb r1, [r10, #0x7c]
+	ldrb r0, [r10, #0x7d]
 	cmp r1, r0
 	movhi r0, #0
 	movls r0, #1
-	strb r0, [sl, #0x7b]
-	ldrb r7, [sl, #0x14]
-	ldrb r0, [sl, #0x7c]
+	strb r0, [r10, #0x7b]
+	ldrb r7, [r10, #0x14]
+	ldrb r0, [r10, #0x7c]
 	add r0, r7, r0
 	cmp r7, r0
 	bgt _02130b94
 _02130ae8:
-	ldrb r8, [sl, #0x15]
-	ldrb r0, [sl, #0x7d]
+	ldrb r8, [r10, #0x15]
+	ldrb r0, [r10, #0x7d]
 	add r0, r8, r0
 	cmp r8, r0
 	bgt _02130b7c
@@ -21265,43 +21265,43 @@ _02130b08:
 	strb r8, [sp, #5]
 	bl func_ov00_020840c4
 	movs r4, r0
-	cmpne r4, sl
+	cmpne r4, r10
 	beq _02130b64
 	ldr r1, [r0]
 	ldr r1, [r1, #0x1c]
 	blx r1
 	cmp r0, #0x45
 	bne _02130b64
-	ldr r0, [sl, #0x80]
+	ldr r0, [r10, #0x80]
 	str r0, [r4, #0x80]
-	ldr r0, [sl, #0x84]
+	ldr r0, [r10, #0x84]
 	str r0, [r4, #0x84]
-	ldr r0, [sl, #0x88]
+	ldr r0, [r10, #0x88]
 	str r0, [r4, #0x88]
-	ldr r0, [sl, #0x6c]
+	ldr r0, [r10, #0x6c]
 	str r0, [r4, #0x6c]
-	ldrb r0, [sl, #0x7b]
+	ldrb r0, [r10, #0x7b]
 	strb r0, [r4, #0x7b]
 _02130b64:
-	ldrb r1, [sl, #0x15]
-	ldrb r0, [sl, #0x7d]
+	ldrb r1, [r10, #0x15]
+	ldrb r0, [r10, #0x7d]
 	add r8, r8, #1
 	add r0, r1, r0
 	cmp r8, r0
 	ble _02130b08
 _02130b7c:
-	ldrb r1, [sl, #0x14]
-	ldrb r0, [sl, #0x7c]
+	ldrb r1, [r10, #0x14]
+	ldrb r0, [r10, #0x7c]
 	add r7, r7, #1
 	add r0, r1, r0
 	cmp r7, r0
 	ble _02130ae8
 _02130b94:
-	mov r0, sl
+	mov r0, r10
 	mov r1, #0
 	bl func_ov00_0208b9e4
 	cmp r0, #0
-	mov r0, sl
+	mov r0, r10
 	ldr r3, [r0]
 	beq _02130bc8
 	ldr r3, [r3, #0x80]
@@ -21309,14 +21309,14 @@ _02130b94:
 	mov r2, #1
 	blx r3
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02130bc8:
 	mov r1, #1
 	ldr r3, [r3, #0x80]
 	mov r2, r1
 	blx r3
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_021309bc
 _02130be0: .word data_027e0e60
@@ -21577,7 +21577,7 @@ _02130f84: .word data_027e0f74
 	.global func_ov14_02130f88
 	arm_func_start func_ov14_02130f88
 func_ov14_02130f88: ; 0x02130f88
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0xe4
 	mov r4, r0
 	str r1, [r4, #8]
@@ -21717,7 +21717,7 @@ _02131100:
 	str r0, [sp, #0xc]
 	ldr r0, [r1]
 	bl func_ov00_02083368
-	mov sl, r0
+	mov r10, r0
 	ldr r0, [sp, #0xc]
 	mov r8, #0
 	cmp r0, #0
@@ -21725,7 +21725,7 @@ _02131100:
 	add r6, sp, #0x12
 _021311bc:
 	mov sb, #0
-	cmp sl, #0
+	cmp r10, #0
 	ble _02131230
 	ldr r11, _02131410 ; =data_027e0e60
 	and r7, r8, #0xff
@@ -21753,7 +21753,7 @@ _021311d0:
 	streq r0, [r5, #0x70]
 _02131224:
 	add sb, sb, #1
-	cmp sb, sl
+	cmp sb, r10
 	blt _021311d0
 _02131230:
 	ldr r0, [sp, #0xc]
@@ -21803,10 +21803,10 @@ _02131298:
 	mov r5, #0
 	add r7, sp, #0x10
 _021312dc:
-	ldrb sl, [r4, #0x15]
+	ldrb r10, [r4, #0x15]
 	ldrb r0, [r4, #0x7d]
-	add r0, sl, r0
-	cmp sl, r0
+	add r0, r10, r0
+	cmp r10, r0
 	bgt _02131348
 	and r8, r11, #0xff
 _021312f4:
@@ -21814,7 +21814,7 @@ _021312f4:
 	mov r1, r7
 	ldr r0, [r0]
 	strb r8, [sp, #0x10]
-	strb sl, [sp, #0x11]
+	strb r10, [sp, #0x11]
 	bl func_ov00_020840c4
 	movs r6, r0
 	beq _02131330
@@ -21828,9 +21828,9 @@ _021312f4:
 _02131330:
 	ldrb r1, [r4, #0x15]
 	ldrb r0, [r4, #0x7d]
-	add sl, sl, #1
+	add r10, r10, #1
 	add r0, r1, r0
-	cmp sl, r0
+	cmp r10, r0
 	ble _021312f4
 _02131348:
 	ldrb r1, [r4, #0x14]
@@ -21880,7 +21880,7 @@ _021313e4:
 	mov r0, #1
 	str r1, [r4, #0x44]
 	add sp, sp, #0xe4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_02130f88
 _021313f8: .word data_027e0f64
@@ -21961,17 +21961,17 @@ _0213149c:
 	.global func_ov14_021314b8
 	arm_func_start func_ov14_021314b8
 func_ov14_021314b8: ; 0x021314b8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x10
-	mov sl, r0
-	ldrb r0, [sl, #0x79]
+	mov r10, r0
+	ldrb r0, [r10, #0x79]
 	cmp r0, #0
 	addne sp, sp, #0x10
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
-	ldrb r0, [sl, #0x14]
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldrb r0, [r10, #0x14]
 	ldr r1, _021316c0 ; =data_027e0e60
 	str r0, [sp, #4]
-	ldrb r0, [sl, #0x15]
+	ldrb r0, [r10, #0x15]
 	str r0, [sp]
 	ldr r0, [r1]
 	ldr r1, [sp, #4]
@@ -22006,14 +22006,14 @@ _02131544:
 	mov r4, #0
 	add r6, sp, #0xe
 _02131560:
-	ldrb r2, [sl, #0x14]
+	ldrb r2, [r10, #0x14]
 	ldr r0, [sb]
 	mov r1, r6
 	strb r2, [sp, #0xe]
 	strb r8, [sp, #0xf]
 	bl func_ov00_020840c4
 	mov r5, r0
-	cmp r5, sl
+	cmp r5, r10
 	beq _021315c0
 	cmp r5, #0
 	beq _021315cc
@@ -22022,14 +22022,14 @@ _02131560:
 	blx r1
 	cmp r0, #0x45
 	ldreqh r1, [r5, #0x26]
-	ldreqh r0, [sl, #0x26]
+	ldreqh r0, [r10, #0x26]
 	cmpeq r1, r0
 	bne _021315cc
 	strb r4, [r5, #0x7a]
 	strb r4, [r5, #0x79]
-	ldrb r0, [sl, #0x7d]
+	ldrb r0, [r10, #0x7d]
 	add r0, r0, #1
-	strb r0, [sl, #0x7d]
+	strb r0, [r10, #0x7d]
 _021315c0:
 	add r8, r8, #1
 	cmp r8, r7
@@ -22037,7 +22037,7 @@ _021315c0:
 _021315cc:
 	ldr r1, [sp, #4]
 	ldr r0, [sp, #8]
-	ldrb r2, [sl, #0x7d]
+	ldrb r2, [r10, #0x7d]
 	cmp r1, r0
 	ldr r0, [sp]
 	add r0, r0, r2
@@ -22046,7 +22046,7 @@ _021315cc:
 	mov r4, #0
 	add r11, sp, #0xc
 _021315f4:
-	ldrb r1, [sl, #0x14]
+	ldrb r1, [r10, #0x14]
 	ldr r0, [sp, #4]
 	cmp r0, r1
 	beq _02131698
@@ -22065,7 +22065,7 @@ _02131620:
 	strb sb, [sp, #0xd]
 	bl func_ov00_020840c4
 	mov r5, r0
-	cmp r5, sl
+	cmp r5, r10
 	beq _02131678
 	cmp r5, #0
 	beq _02131684
@@ -22074,7 +22074,7 @@ _02131620:
 	blx r1
 	cmp r0, #0x45
 	ldreqh r1, [r5, #0x26]
-	ldreqh r0, [sl, #0x26]
+	ldreqh r0, [r10, #0x26]
 	cmpeq r1, r0
 	bne _02131684
 	strb r4, [r5, #0x7a]
@@ -22087,9 +22087,9 @@ _02131678:
 _02131684:
 	cmp r7, #0
 	beq _021316b0
-	ldrb r0, [sl, #0x7c]
+	ldrb r0, [r10, #0x7c]
 	add r0, r0, #1
-	strb r0, [sl, #0x7c]
+	strb r0, [r10, #0x7c]
 _02131698:
 	ldr r0, [sp, #4]
 	add r1, r0, #1
@@ -22099,9 +22099,9 @@ _02131698:
 	blt _021315f4
 _021316b0:
 	mov r0, #1
-	strb r0, [sl, #0x79]
+	strb r0, [r10, #0x79]
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_021314b8
 _021316c0: .word data_027e0e60
@@ -26004,12 +26004,12 @@ func_ov14_02134954: ; 0x02134954
 	.global func_ov14_0213497c
 	arm_func_start func_ov14_0213497c
 func_ov14_0213497c: ; 0x0213497c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x24
-	mov sl, r0
+	mov r10, r0
 	ldr r0, _02134be4 ; =data_027e0e60
-	ldrb r3, [sl, #0x15]
-	ldrb r2, [sl, #0x14]
+	ldrb r3, [r10, #0x15]
+	ldrb r2, [r10, #0x14]
 	ldr r0, [r0]
 	add r1, sp, #8
 	strb r2, [sp, #8]
@@ -26030,38 +26030,38 @@ _021349d0:
 	bne _021349e0
 _021349d8:
 	mov r0, #0
-	strb r0, [sl, #0x38]
+	strb r0, [r10, #0x38]
 _021349e0:
-	ldr r0, [sl, #0x18]
-	str r0, [sl, #0x44]
-	ldr r0, [sl, #0x1c]
-	str r0, [sl, #0x48]
-	ldr r0, [sl, #0x20]
-	str r0, [sl, #0x4c]
-	ldrh r0, [sl, #0x24]
+	ldr r0, [r10, #0x18]
+	str r0, [r10, #0x44]
+	ldr r0, [r10, #0x1c]
+	str r0, [r10, #0x48]
+	ldr r0, [r10, #0x20]
+	str r0, [r10, #0x4c]
+	ldrh r0, [r10, #0x24]
 	cmp r0, #0
 	bne _02134a28
 	mov r0, #0
-	strh r0, [sl, #0xc]
-	ldrb r1, [sl, #0x14]
+	strh r0, [r10, #0xc]
+	ldrb r1, [r10, #0x14]
 	ldr r0, _02134be4 ; =data_027e0e60
-	ldrb r2, [sl, #0x15]
+	ldrb r2, [r10, #0x15]
 	ldr r0, [r0]
 	sub r1, r1, #1
 	bl func_ov00_02083e34
 	b _02134a48
 _02134a28:
 	mov r0, #0x4000
-	strh r0, [sl, #0xc]
-	ldrb r2, [sl, #0x15]
+	strh r0, [r10, #0xc]
+	ldrb r2, [r10, #0x15]
 	ldr r0, _02134be4 ; =data_027e0e60
-	ldrb r1, [sl, #0x14]
+	ldrb r1, [r10, #0x14]
 	ldr r0, [r0]
 	sub r2, r2, #1
 	bl func_ov00_02083e34
 _02134a48:
-	str r0, [sl, #0x1c]
-	ldrh r5, [sl, #0x26]
+	str r0, [r10, #0x1c]
+	ldrh r5, [r10, #0x26]
 	cmp r5, #0
 	beq _02134a90
 	and r0, r5, #0xff
@@ -26075,11 +26075,11 @@ _02134a48:
 	mla r3, r1, r0, r3
 	adc r0, r3, #0
 	mov r1, r2, lsr #0xc
-	strb r5, [sl, #0x39]
+	strb r5, [r10, #0x39]
 	orr r1, r1, r0, lsl #20
-	str r1, [sl, #0x3c]
+	str r1, [r10, #0x3c]
 _02134a90:
-	ldrh r5, [sl, #0x28]
+	ldrh r5, [r10, #0x28]
 	cmp r5, #0
 	beq _02134ad4
 	and r0, r5, #0xff
@@ -26093,12 +26093,12 @@ _02134a90:
 	mla r3, r1, r0, r3
 	adc r0, r3, #0
 	mov r1, r2, lsr #0xc
-	strb r5, [sl, #0x3a]
+	strb r5, [r10, #0x3a]
 	orr r1, r1, r0, lsl #20
-	str r1, [sl, #0x40]
+	str r1, [r10, #0x40]
 _02134ad4:
-	ldrb r0, [sl, #0x14]
-	ldrb r8, [sl, #0x39]
+	ldrb r0, [r10, #0x14]
+	ldrb r8, [r10, #0x39]
 	str r0, [sp]
 	add r1, r0, r8
 	cmp r0, r1
@@ -26109,8 +26109,8 @@ _02134ad4:
 	add r5, sp, #4
 	mov r11, r6
 _02134b00:
-	ldrb sb, [sl, #0x15]
-	ldrb r0, [sl, #0x3a]
+	ldrb sb, [r10, #0x15]
+	ldrb r0, [r10, #0x3a]
 	add r0, sb, r0
 	cmp sb, r0
 	bge _02134b64
@@ -26129,15 +26129,15 @@ _02134b1c:
 	strb sb, [sp, #5]
 	mov r2, r11
 	bl func_ov00_020826a0
-	ldrb r1, [sl, #0x15]
-	ldrb r0, [sl, #0x3a]
+	ldrb r1, [r10, #0x15]
+	ldrb r0, [r10, #0x3a]
 	add sb, sb, #1
 	add r0, r1, r0
 	cmp sb, r0
 	blt _02134b1c
 _02134b64:
-	ldrb r8, [sl, #0x39]
-	ldrb r1, [sl, #0x14]
+	ldrb r8, [r10, #0x39]
+	ldrb r1, [r10, #0x14]
 	ldr r0, [sp]
 	add r0, r0, #1
 	add r1, r1, r8
@@ -26145,14 +26145,14 @@ _02134b64:
 	cmp r0, r1
 	blt _02134b00
 _02134b84:
-	ldrb r0, [sl, #0x3a]
+	ldrb r0, [r10, #0x3a]
 	mov r5, r8, lsl #0xc
 	mov r1, r5, asr #0x1
 	mov r4, r0, lsl #0xc
 	mov r0, r4, asr #0x1
 	sub r3, r0, #0x800
 	sub r7, r1, #0x800
-	add r0, sl, #0x18
+	add r0, r10, #0x18
 	mov r6, #0
 	add r1, sp, #0x18
 	mov r2, r0
@@ -26161,14 +26161,14 @@ _02134b84:
 	str r3, [sp, #0x20]
 	bl func_01ff9bc4
 	mov r0, #0
-	str r0, [sl, #0x60]
-	str r0, [sl, #0x64]
+	str r0, [r10, #0x60]
+	str r0, [r10, #0x64]
 	cmp r4, r8, lsl #12
 	movgt r5, r4
-	str r0, [sl, #0x68]
-	str r5, [sl, #0x6c]
+	str r0, [r10, #0x68]
+	str r5, [r10, #0x6c]
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_0213497c
 _02134be4: .word data_027e0e60
@@ -26203,16 +26203,16 @@ func_ov14_02134c0c: ; 0x02134c0c
 	.global func_ov14_02134c14
 	arm_func_start func_ov14_02134c14
 func_ov14_02134c14: ; 0x02134c14
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x48
 	ldr r2, [r0]
-	mov sl, r0
+	mov r10, r0
 	ldr r2, [r2, #0x88]
 	blx r2
 	cmp r0, #0
 	addeq sp, sp, #0x48
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
-	ldrh r1, [sl, #0xc]
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldrh r1, [r10, #0xc]
 	ldr r3, _02134e04 ; =data_02050f54
 	add r0, sp, #0x24
 	mov r1, r1, asr #0x4
@@ -26223,14 +26223,14 @@ func_ov14_02134c14: ; 0x02134c14
 	ldrsh r1, [r3, r4]
 	ldrsh r2, [r3, r2]
 	blx func_01ff8214
-	ldr r2, [sl, #0x4c]
-	ldr r1, [sl, #0x1c]
-	ldr r0, [sl, #0x44]
+	ldr r2, [r10, #0x4c]
+	ldr r1, [r10, #0x1c]
+	ldr r0, [r10, #0x44]
 	mov r7, #0
 	str r1, [sp, #0x1c]
 	str r2, [sp, #0x20]
 	str r0, [sp, #0x18]
-	ldrb r0, [sl, #0x39]
+	ldrb r0, [r10, #0x39]
 	cmp r0, #0
 	ble _02134d24
 	ldr r4, _02134e08 ; =data_ov14_02153e10
@@ -26243,48 +26243,48 @@ _02134c9c:
 	mov r8, #0
 	addne r0, r0, #0x1000
 	strne r0, [sp, #0x18]
-	ldrb r0, [sl, #0x3a]
+	ldrb r0, [r10, #0x3a]
 	cmp r0, #0
 	ble _02134d14
 	mov sb, r8
 _02134cc0:
-	ldr r0, [sl, #0x4c]
+	ldr r0, [r10, #0x4c]
 	cmp r8, #0
 	streq r0, [sp, #0x20]
 	addne r0, r0, sb
 	strne r0, [sp, #0x20]
 	cmp r7, #0
 	cmpeq r8, #0
-	streqh r6, [sl, #0x5a]
-	strneh r5, [sl, #0x5a]
-	add r0, sl, #0x50
+	streqh r6, [r10, #0x5a]
+	strneh r5, [r10, #0x5a]
+	add r0, r10, #0x50
 	ldr ip, [r0]
 	mov r1, r4
 	ldr ip, [ip, #0x10]
 	mov r2, r11
 	add r3, sp, #0x18
 	blx ip
-	ldrb r0, [sl, #0x3a]
+	ldrb r0, [r10, #0x3a]
 	add r8, r8, #1
 	add sb, sb, #0x1000
 	cmp r8, r0
 	blt _02134cc0
 _02134d14:
-	ldrb r0, [sl, #0x39]
+	ldrb r0, [r10, #0x39]
 	add r7, r7, #1
 	cmp r7, r0
 	blt _02134c9c
 _02134d24:
-	ldrb r0, [sl, #0x38]
+	ldrb r0, [r10, #0x38]
 	cmp r0, #0
 	addeq sp, sp, #0x48
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
-	ldrsh r0, [sl, #0xc]
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldrsh r0, [r10, #0xc]
 	cmp r0, #0x4000
 	bne _02134d64
-	ldr r0, [sl, #0x18]
-	ldr r2, [sl, #0x20]
-	ldr r1, [sl, #0x48]
+	ldr r0, [r10, #0x18]
+	ldr r2, [r10, #0x20]
+	ldr r1, [r10, #0x48]
 	add r0, r0, #0x66
 	add r0, r0, #0x600
 	str r0, [sp, #0x18]
@@ -26292,14 +26292,14 @@ _02134d24:
 	str r2, [sp, #0x20]
 	b _02134d7c
 _02134d64:
-	ldr r2, [sl, #0x20]
-	ldr r1, [sl, #0x48]
-	ldr r0, [sl, #0x18]
+	ldr r2, [r10, #0x20]
+	ldr r1, [r10, #0x48]
+	ldr r0, [r10, #0x18]
 	str r0, [sp, #0x18]
 	str r1, [sp, #0x1c]
 	str r2, [sp, #0x20]
 _02134d7c:
-	ldrb r0, [sl, #0x3a]
+	ldrb r0, [r10, #0x3a]
 	ldr r3, _02134e0c ; =0x0000099a
 	mov r7, #0
 	mov r0, r0, lsl #0xc
@@ -26318,7 +26318,7 @@ _02134d7c:
 	str r1, [sp, #0xc]
 	str r1, [sp, #0x10]
 	str r1, [sp, #0x14]
-	ldrb r4, [sl, #0x39]
+	ldrb r4, [r10, #0x39]
 	ldr r0, _02134e10 ; =data_ov00_020e9370
 	add r2, sp, #0x18
 	mov r4, r4, lsl #0xc
@@ -26332,7 +26332,7 @@ _02134d7c:
 	orr r3, r3, r4, lsl #20
 	bl func_ov05_02102c2c
 	add sp, sp, #0x48
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_02134c14
 _02134e04: .word data_02050f54
@@ -28194,28 +28194,28 @@ _02136508: .word data_ov00_020e9370
 	.global func_ov14_0213650c
 	arm_func_start func_ov14_0213650c
 func_ov14_0213650c: ; 0x0213650c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x18
-	mov sl, r0
-	ldr r0, [sl, #0x48]
+	mov r10, r0
+	ldr r0, [r10, #0x48]
 	mov r5, #0
 	str r0, [sp]
-	ldr r0, [sl, #0x4c]
+	ldr r0, [r10, #0x4c]
 	mov r1, #0
 	str r0, [sp, #4]
-	ldr r0, [sl, #0x50]
+	ldr r0, [r10, #0x50]
 	ldr r4, _02136614 ; =data_ov14_02157d70
 	str r0, [sp, #8]
-	ldr r0, [sl, #0x48]
+	ldr r0, [r10, #0x48]
 	add r6, sp, #0
 	str r0, [sp, #0xc]
-	ldr r0, [sl, #0x4c]
+	ldr r0, [r10, #0x4c]
 	mov r7, r5
 	str r0, [sp, #0x10]
-	ldr r0, [sl, #0x50]
-	add r8, sl, #0x1ac
+	ldr r0, [r10, #0x50]
+	add r8, r10, #0x1ac
 	str r0, [sp, #0x14]
-	ldr r0, [sl, #0x1a0]
+	ldr r0, [r10, #0x1a0]
 	mov r11, #0x18
 	cmp r0, #2
 	cmpne r0, #3
@@ -28223,7 +28223,7 @@ func_ov14_0213650c: ; 0x0213650c
 	mov r0, r1, lsl #0x10
 	mov sb, r0, lsr #0x10
 _0213657c:
-	ldr r1, [sl, #0x1a0]
+	ldr r1, [r10, #0x1a0]
 	mov r0, r6
 	mla r3, r1, r11, r4
 	mov r2, r6
@@ -28261,7 +28261,7 @@ _021365e8:
 	add r8, r8, #4
 	blo _0213657c
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_0213650c
 _02136614: .word data_ov14_02157d70
@@ -28860,7 +28860,7 @@ _02136e2c: .word data_027e0ffc
 	.global func_ov14_02136e30
 	arm_func_start func_ov14_02136e30
 func_ov14_02136e30: ; 0x02136e30
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0xe4
 	mov r4, r0
 	ldr r0, [r4, #0x4c]
@@ -29101,7 +29101,7 @@ _0213716c:
 	bge _021371b8
 	cmp r3, r2
 	addeq sp, sp, #0xe4
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02137190:
 	ldr r1, [r3]
 	add r3, r3, #0xc
@@ -29112,7 +29112,7 @@ _02137190:
 	cmp r3, r2
 	bne _02137190
 	add sp, sp, #0xe4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _021371b8:
 	cmp r3, r2
 	beq _021371e0
@@ -29187,7 +29187,7 @@ _021372a4:
 	ldr r7, _021373d0 ; =data_ov14_02157ecc
 	ldr r8, _021373d4 ; =data_ov14_02157eb4
 	add sb, r4, #0x210
-	mov sl, r0, asr #0x1f
+	mov r10, r0, asr #0x1f
 	mov r6, #0
 _021372c8:
 	ldr ip, [r7]
@@ -29201,7 +29201,7 @@ _021372c8:
 	mov r3, r1, lsl #0xc
 	ldrh r1, [r8, #4]
 	adds r4, r4, #0x800
-	mla lr, sl, ip, lr
+	mla lr, r10, ip, lr
 	str r1, [sp, #0x14]
 	mov r1, r3, asr #0x1f
 	str r1, [sp, #0x18]
@@ -29215,7 +29215,7 @@ _021372c8:
 	ldr ip, [sp, #0x18]
 	str r1, [sp, #0x1c]
 	mla r5, r0, ip, r5
-	mla r5, sl, r3, r5
+	mla r5, r10, r3, r5
 	adds r11, r11, #0x800
 	adc r3, r5, #0
 	mov r5, r11, lsr #0xc
@@ -29227,7 +29227,7 @@ _021372c8:
 	mov r11, r3, lsr #0x10
 	umull r5, r3, r0, r2
 	mla r3, r0, ip, r3
-	mla r3, sl, r2, r3
+	mla r3, r10, r2, r3
 	adds r5, r5, #0x800
 	adc r2, r3, #0
 	ldr r1, [sb]
@@ -29252,7 +29252,7 @@ _021372c8:
 	add sb, sb, #0xc
 	blo _021372c8
 	add sp, sp, #0xe4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_02136e30
 _021373c4: .word 0x0000ffff

--- a/asm/ov14/ov14_0211f640.s
+++ b/asm/ov14/ov14_0211f640.s
@@ -308,7 +308,7 @@ _0211f97c: .word 0x424d5459
 	.global func_ov14_0211f980
 	arm_func_start func_ov14_0211f980
 func_ov14_0211f980: ; 0x0211f980
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x20
 	mov r4, r0
 	bl func_ov00_02079b78
@@ -318,7 +318,7 @@ func_ov14_0211f980: ; 0x0211f980
 	bl func_ov14_0211f8d0
 	cmp r0, #0
 	addeq sp, sp, #0x20
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, _0211faa4 ; =gItemManager
 	mvn r5, #0
 	ldr r3, _0211faa8 ; =data_027e0d3c
@@ -335,8 +335,8 @@ func_ov14_0211f980: ; 0x0211f980
 	cmp r1, #0
 	mov r7, #0
 	addle sp, sp, #0x20
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
-	mov fp, #3
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	mov r11, #3
 	add r5, sp, #4
 _0211f9f8:
 	mov r0, sl
@@ -363,7 +363,7 @@ _0211f9f8:
 	cmp r7, r0
 	bgt _0211fa80
 	bne _0211fa70
-	str fp, [sp]
+	str r11, [sp]
 	ldr r1, [sp, #4]
 	ldr r2, [sp, #8]
 	mov r0, r4
@@ -384,7 +384,7 @@ _0211fa8c:
 	cmp r7, r0
 	blt _0211f9f8
 	add sp, sp, #0x20
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_0211f980
 _0211faa4: .word gItemManager
@@ -3099,10 +3099,10 @@ _02121eb0: .word data_ov14_02153bc4
 	.global func_ov14_02121eb4
 	arm_func_start func_ov14_02121eb4
 func_ov14_02121eb4: ; 0x02121eb4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x104
 	mov r5, r0
-	mov fp, r1
+	mov r11, r1
 	bl _ZN5Actor18func_ov00_020c313cEj
 	cmp r0, #0
 	beq _02122a84
@@ -3893,12 +3893,12 @@ _02122a70:
 	cmp r6, r4
 	bne _02122a70
 _02122a84:
-	mov r1, fp
+	mov r1, r11
 	add r0, r5, #0xa4
 	add r2, r5, #0x48
 	bl func_ov00_0207a1c8
 	add sp, sp, #0x104
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_02121eb4
 _02122a9c: .word data_027e0ffc
@@ -4240,7 +4240,7 @@ func_ov14_02122eb8: ; 0x02122eb8
 	.global func_ov14_02122ed4
 	arm_func_start func_ov14_02122ed4
 func_ov14_02122ed4: ; 0x02122ed4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x54
 	mov sl, r0
 	ldr r4, [sl, #0x98]
@@ -4266,14 +4266,14 @@ func_ov14_02122ed4: ; 0x02122ed4
 	bl func_01ff9cec
 	add r1, sp, #0x3c
 	mov sb, r0
-	add fp, sp, #0
+	add r11, sp, #0
 	ldmia r1, {r0, r1, r2}
-	stmia fp, {r0, r1, r2}
+	stmia r11, {r0, r1, r2}
 	add r6, sp, #0x24
-	ldmia fp, {r0, r1, r2}
+	ldmia r11, {r0, r1, r2}
 	stmia r6, {r0, r1, r2}
 	add r5, sp, #0x18
-	ldmia fp, {r0, r1, r2}
+	ldmia r11, {r0, r1, r2}
 	add r4, sp, #0x30
 	stmia r5, {r0, r1, r2}
 	add r3, sp, #0xc
@@ -4286,7 +4286,7 @@ func_ov14_02122ed4: ; 0x02122ed4
 	beq _02123038
 	add r6, sp, #0xc
 	mov r4, r7
-	mov fp, r7
+	mov r11, r7
 _02122f90:
 	cmp sb, r8
 	ble _02122fb4
@@ -4309,7 +4309,7 @@ _02122fcc:
 	mov r0, sl
 	str r1, [sl, #0x48]
 	ldr r2, [sp, #0x1c]
-	mov r1, fp
+	mov r1, r11
 	str r2, [sl, #0x4c]
 	ldr r2, [sp, #0x20]
 	str r2, [sl, #0x50]
@@ -4341,7 +4341,7 @@ _02123038:
 	ldr r1, [sl, #0x50]
 	str r1, [sl, #0x5c]
 	add sp, sp, #0x54
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	arm_func_end func_ov14_02122ed4
 
 	.global func_ov14_0212305c
@@ -10227,7 +10227,7 @@ _02127b58:
 	.global func_ov14_02127bb0
 	arm_func_start func_ov14_02127bb0
 func_ov14_02127bb0: ; 0x02127bb0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #8
 	mov sl, r0
 	cmp r2, #0
@@ -10236,14 +10236,14 @@ func_ov14_02127bb0: ; 0x02127bb0
 	ldreq r0, [sp, #0x30]
 	str r3, [sp]
 	streq r0, [sp]
-	ldrb fp, [sl, #0x14]
+	ldrb r11, [sl, #0x14]
 	ldr r0, [sp]
 	mov sb, r1
-	add r0, fp, r0
+	add r0, r11, r0
 	moveq r8, r3
-	cmp fp, r0
+	cmp r11, r0
 	addge sp, sp, #8
-	ldmgeia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmgeia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r4, _02127c5c ; =data_027e0e60
 	add r5, sp, #4
 _02127bfc:
@@ -10251,7 +10251,7 @@ _02127bfc:
 	add r0, r7, r8
 	cmp r7, r0
 	bge _02127c3c
-	and r6, fp, #0xff
+	and r6, r11, #0xff
 _02127c10:
 	ldr r0, [r4]
 	mov r1, r5
@@ -10267,12 +10267,12 @@ _02127c10:
 _02127c3c:
 	ldrb r1, [sl, #0x14]
 	ldr r0, [sp]
-	add fp, fp, #1
+	add r11, r11, #1
 	add r0, r1, r0
-	cmp fp, r0
+	cmp r11, r0
 	blt _02127bfc
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_02127bb0
 _02127c5c: .word data_027e0e60
@@ -12321,7 +12321,7 @@ _02129800: .word 0x00000547
 	.global func_ov14_02129804
 	arm_func_start func_ov14_02129804
 func_ov14_02129804: ; 0x02129804
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0xc
 	mov r8, #0
 	mov sl, r0
@@ -12333,7 +12333,7 @@ func_ov14_02129804: ; 0x02129804
 	mov sb, r8
 	cmp r0, #0
 	bls _021298bc
-	ldr fp, _0212990c ; =data_ov14_02153c64
+	ldr r11, _0212990c ; =data_ov14_02153c64
 	ldr r5, _02129910 ; =data_ov14_02156770
 	ldr r4, _02129914 ; =data_ov14_02153c74
 	add r6, sp, #8
@@ -12350,7 +12350,7 @@ _02129844:
 	beq _021298a8
 	ldr r0, [sl, #0xb0]
 	ldr r1, [sp, #8]
-	ldr r0, [fp, r0, lsl #2]
+	ldr r0, [r11, r0, lsl #2]
 	cmp r1, r0
 	blt _021298a4
 	mov r0, sl
@@ -12374,7 +12374,7 @@ _021298bc:
 	ldr r0, [sp, #4]
 	cmp r0, #0
 	addne sp, sp, #0xc
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	mov r0, sl
 	cmp r8, #0
 	mov r2, #0
@@ -12384,13 +12384,13 @@ _021298bc:
 	mov r1, #0x14
 	blx r3
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _021298f4:
 	ldr r3, [r3, #0x80]
 	mov r1, #0x13
 	blx r3
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_02129804
 _02129908: .word data_ov14_02153c4c
@@ -12402,15 +12402,15 @@ _02129918: .word data_027e104c
 	.global func_ov14_0212991c
 	arm_func_start func_ov14_0212991c
 func_ov14_0212991c: ; 0x0212991c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	movs sl, r2
 	mov sb, r3
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, _021299a4 ; =data_ov14_02153c4c
-	mov fp, #0
+	mov r11, #0
 	ldr r7, [r0, r1, lsl #2]
-	mov r8, fp
+	mov r8, r11
 	cmp r7, #0
 	bls _02129994
 	ldr r2, _021299a8 ; =data_ov14_02153c64
@@ -12427,18 +12427,18 @@ _02129960:
 	bne _02129988
 	cmp sb, r5
 	movge r0, #2
-	ldmgeia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmgeia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	cmp sb, r4
-	movge fp, #1
+	movge r11, #1
 _02129988:
 	add r8, r8, #1
 	cmp r8, r7
 	blo _02129960
 _02129994:
-	cmp fp, #0
+	cmp r11, #0
 	movne r0, #1
 	moveq r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_0212991c
 _021299a4: .word data_ov14_02153c4c
@@ -15074,7 +15074,7 @@ func_ov14_0212bb50: ; 0x0212bb50
 	.global func_ov14_0212bb6c
 	arm_func_start func_ov14_0212bb6c
 func_ov14_0212bb6c: ; 0x0212bb6c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x1c
 	ldr r2, _0212bc94 ; =data_027e0764
 	mov r3, #0
@@ -15092,8 +15092,8 @@ func_ov14_0212bb6c: ; 0x0212bb6c
 	umull r4, r5, r6, r1
 	str r7, [r2]
 	mla r5, r6, r3, r5
-	mov fp, r3
-	mla r5, fp, r1, r5
+	mov r11, r3
+	mla r5, r11, r1, r5
 	str r6, [r2, #4]
 	mov r4, r0
 	sub r6, r5, #0xa
@@ -15118,7 +15118,7 @@ func_ov14_0212bb6c: ; 0x0212bb6c
 	stmia r2, {r5, r7}
 	umull r2, r5, r7, r1
 	mla r5, r7, r3, r5
-	mla r5, fp, r1, r5
+	mla r5, r11, r1, r5
 	ldr r6, [r4, #0x20]
 	sub r2, r5, #0xa
 	mov r1, #0x29
@@ -15135,7 +15135,7 @@ func_ov14_0212bb6c: ; 0x0212bb6c
 	mov r1, #0x1000
 	str r1, [sp, #0x18]
 	bl func_ov00_0208b9cc
-	mov r1, fp
+	mov r1, r11
 	str r1, [sp]
 	mov r2, r0
 	add r0, r4, #0x38
@@ -15147,7 +15147,7 @@ func_ov14_0212bb6c: ; 0x0212bb6c
 	mov r0, r4
 	bl func_ov14_02146d48
 	add sp, sp, #0x1c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_0212bb6c
 _0212bc94: .word data_027e0764
@@ -19799,7 +19799,7 @@ _0212f7ac: .word func_ov14_02121cd8 - 1
 	.global func_ov14_0212f7b0
 	arm_func_start func_ov14_0212f7b0
 func_ov14_0212f7b0: ; 0x0212f7b0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x68
 	mov r4, r0
 	ldr r1, [r4, #4]
@@ -19962,7 +19962,7 @@ _0212f9fc:
 	cmp r0, #0
 	ble _0212fab4
 	ldr r5, _0212fb20 ; =data_027e0e60
-	mov fp, #1
+	mov r11, #1
 	add r6, sp, #4
 	add r7, sp, #0x24
 _0212fa20:
@@ -19997,7 +19997,7 @@ _0212fa20:
 	mov r1, r6
 	bl func_ov00_020840c4
 	cmp r0, #0
-	strneb fp, [r0, #0xa9]
+	strneb r11, [r0, #0xa9]
 _0212faa0:
 	ldrh r0, [r4, #0x26]
 	add sb, sb, #1
@@ -20032,7 +20032,7 @@ _0212fb04:
 	strh r0, [r4, #0x66]
 	strh r0, [r4, #0x68]
 	add sp, sp, #0x68
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_0212f7b0
 _0212fb18: .word 0x00001333
@@ -21169,7 +21169,7 @@ _021309b8: .word 0x00001334
 	.global func_ov14_021309bc
 	arm_func_start func_ov14_021309bc
 func_ov14_021309bc: ; 0x021309bc
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #8
 	mov sl, r0
 	ldrb r0, [sl, #0x79]
@@ -21184,7 +21184,7 @@ func_ov14_021309bc: ; 0x021309bc
 	bl func_ov00_02083368
 	mov r8, r0
 	ldr r0, [sp]
-	mov fp, #0
+	mov r11, #0
 	cmp r0, #0
 	ble _02130a70
 	ldr r4, _02130be0 ; =data_027e0e60
@@ -21193,7 +21193,7 @@ _02130a0c:
 	mov sb, #0
 	cmp r8, #0
 	ble _02130a60
-	and r7, fp, #0xff
+	and r7, r11, #0xff
 _02130a1c:
 	ldr r0, [r4]
 	mov r1, r6
@@ -21215,8 +21215,8 @@ _02130a54:
 	blt _02130a1c
 _02130a60:
 	ldr r0, [sp]
-	add fp, fp, #1
-	cmp fp, r0
+	add r11, r11, #1
+	cmp r11, r0
 	blt _02130a0c
 _02130a70:
 	ldrb r0, [sl, #0x7a]
@@ -21309,14 +21309,14 @@ _02130b94:
 	mov r2, #1
 	blx r3
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02130bc8:
 	mov r1, #1
 	ldr r3, [r3, #0x80]
 	mov r2, r1
 	blx r3
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_021309bc
 _02130be0: .word data_027e0e60
@@ -21577,7 +21577,7 @@ _02130f84: .word data_027e0f74
 	.global func_ov14_02130f88
 	arm_func_start func_ov14_02130f88
 func_ov14_02130f88: ; 0x02130f88
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0xe4
 	mov r4, r0
 	str r1, [r4, #8]
@@ -21727,7 +21727,7 @@ _021311bc:
 	mov sb, #0
 	cmp sl, #0
 	ble _02131230
-	ldr fp, _02131410 ; =data_027e0e60
+	ldr r11, _02131410 ; =data_027e0e60
 	and r7, r8, #0xff
 _021311d0:
 	ldrb r0, [r4, #0x14]
@@ -21735,7 +21735,7 @@ _021311d0:
 	ldreqb r0, [r4, #0x15]
 	cmpeq sb, r0
 	beq _02131224
-	ldr r0, [fp]
+	ldr r0, [r11]
 	mov r1, r6
 	strb r7, [sp, #0x12]
 	strb sb, [sp, #0x13]
@@ -21795,10 +21795,10 @@ _02131298:
 	ldrb r0, [r4, #0x7a]
 	cmp r0, #0
 	beq _02131360
-	ldrb fp, [r4, #0x14]
+	ldrb r11, [r4, #0x14]
 	ldrb r0, [r4, #0x7c]
-	add r0, fp, r0
-	cmp fp, r0
+	add r0, r11, r0
+	cmp r11, r0
 	bgt _02131360
 	mov r5, #0
 	add r7, sp, #0x10
@@ -21808,7 +21808,7 @@ _021312dc:
 	add r0, sl, r0
 	cmp sl, r0
 	bgt _02131348
-	and r8, fp, #0xff
+	and r8, r11, #0xff
 _021312f4:
 	ldr r0, _02131410 ; =data_027e0e60
 	mov r1, r7
@@ -21835,9 +21835,9 @@ _02131330:
 _02131348:
 	ldrb r1, [r4, #0x14]
 	ldrb r0, [r4, #0x7c]
-	add fp, fp, #1
+	add r11, r11, #1
 	add r0, r1, r0
-	cmp fp, r0
+	cmp r11, r0
 	ble _021312dc
 _02131360:
 	cmp sb, #0
@@ -21880,7 +21880,7 @@ _021313e4:
 	mov r0, #1
 	str r1, [r4, #0x44]
 	add sp, sp, #0xe4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_02130f88
 _021313f8: .word data_027e0f64
@@ -21961,13 +21961,13 @@ _0213149c:
 	.global func_ov14_021314b8
 	arm_func_start func_ov14_021314b8
 func_ov14_021314b8: ; 0x021314b8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x10
 	mov sl, r0
 	ldrb r0, [sl, #0x79]
 	cmp r0, #0
 	addne sp, sp, #0x10
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldrb r0, [sl, #0x14]
 	ldr r1, _021316c0 ; =data_027e0e60
 	str r0, [sp, #4]
@@ -22044,7 +22044,7 @@ _021315cc:
 	add r8, r0, #1
 	bge _021316b0
 	mov r4, #0
-	add fp, sp, #0xc
+	add r11, sp, #0xc
 _021315f4:
 	ldrb r1, [sl, #0x14]
 	ldr r0, [sp, #4]
@@ -22059,7 +22059,7 @@ _021315f4:
 	and r6, r0, #0xff
 _02131620:
 	ldr r0, _021316c0 ; =data_027e0e60
-	mov r1, fp
+	mov r1, r11
 	ldr r0, [r0]
 	strb r6, [sp, #0xc]
 	strb sb, [sp, #0xd]
@@ -22101,7 +22101,7 @@ _021316b0:
 	mov r0, #1
 	strb r0, [sl, #0x79]
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_021314b8
 _021316c0: .word data_027e0e60
@@ -26004,7 +26004,7 @@ func_ov14_02134954: ; 0x02134954
 	.global func_ov14_0213497c
 	arm_func_start func_ov14_0213497c
 func_ov14_0213497c: ; 0x0213497c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x24
 	mov sl, r0
 	ldr r0, _02134be4 ; =data_027e0e60
@@ -26107,7 +26107,7 @@ _02134ad4:
 	ldr r4, _02134be4 ; =data_027e0e60
 	add r7, sp, #6
 	add r5, sp, #4
-	mov fp, r6
+	mov r11, r6
 _02134b00:
 	ldrb sb, [sl, #0x15]
 	ldrb r0, [sl, #0x3a]
@@ -26127,7 +26127,7 @@ _02134b1c:
 	mov r1, r5
 	strb r8, [sp, #4]
 	strb sb, [sp, #5]
-	mov r2, fp
+	mov r2, r11
 	bl func_ov00_020826a0
 	ldrb r1, [sl, #0x15]
 	ldrb r0, [sl, #0x3a]
@@ -26168,7 +26168,7 @@ _02134b84:
 	str r0, [sl, #0x68]
 	str r5, [sl, #0x6c]
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_0213497c
 _02134be4: .word data_027e0e60
@@ -26203,7 +26203,7 @@ func_ov14_02134c0c: ; 0x02134c0c
 	.global func_ov14_02134c14
 	arm_func_start func_ov14_02134c14
 func_ov14_02134c14: ; 0x02134c14
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x48
 	ldr r2, [r0]
 	mov sl, r0
@@ -26211,7 +26211,7 @@ func_ov14_02134c14: ; 0x02134c14
 	blx r2
 	cmp r0, #0
 	addeq sp, sp, #0x48
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldrh r1, [sl, #0xc]
 	ldr r3, _02134e04 ; =data_02050f54
 	add r0, sp, #0x24
@@ -26236,7 +26236,7 @@ func_ov14_02134c14: ; 0x02134c14
 	ldr r4, _02134e08 ; =data_ov14_02153e10
 	mvn r5, #0
 	mov r6, r7
-	add fp, sp, #0x24
+	add r11, sp, #0x24
 _02134c9c:
 	cmp r7, #0
 	ldrne r0, [sp, #0x18]
@@ -26261,7 +26261,7 @@ _02134cc0:
 	ldr ip, [r0]
 	mov r1, r4
 	ldr ip, [ip, #0x10]
-	mov r2, fp
+	mov r2, r11
 	add r3, sp, #0x18
 	blx ip
 	ldrb r0, [sl, #0x3a]
@@ -26278,7 +26278,7 @@ _02134d24:
 	ldrb r0, [sl, #0x38]
 	cmp r0, #0
 	addeq sp, sp, #0x48
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldrsh r0, [sl, #0xc]
 	cmp r0, #0x4000
 	bne _02134d64
@@ -26332,7 +26332,7 @@ _02134d7c:
 	orr r3, r3, r4, lsl #20
 	bl func_ov05_02102c2c
 	add sp, sp, #0x48
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_02134c14
 _02134e04: .word data_02050f54
@@ -28194,7 +28194,7 @@ _02136508: .word data_ov00_020e9370
 	.global func_ov14_0213650c
 	arm_func_start func_ov14_0213650c
 func_ov14_0213650c: ; 0x0213650c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x18
 	mov sl, r0
 	ldr r0, [sl, #0x48]
@@ -28216,7 +28216,7 @@ func_ov14_0213650c: ; 0x0213650c
 	add r8, sl, #0x1ac
 	str r0, [sp, #0x14]
 	ldr r0, [sl, #0x1a0]
-	mov fp, #0x18
+	mov r11, #0x18
 	cmp r0, #2
 	cmpne r0, #3
 	moveq r1, #0x4000
@@ -28225,7 +28225,7 @@ func_ov14_0213650c: ; 0x0213650c
 _0213657c:
 	ldr r1, [sl, #0x1a0]
 	mov r0, r6
-	mla r3, r1, fp, r4
+	mla r3, r1, r11, r4
 	mov r2, r6
 	add r1, r3, r7
 	bl func_01ff9bc4
@@ -28261,7 +28261,7 @@ _021365e8:
 	add r8, r8, #4
 	blo _0213657c
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_0213650c
 _02136614: .word data_ov14_02157d70
@@ -28860,7 +28860,7 @@ _02136e2c: .word data_027e0ffc
 	.global func_ov14_02136e30
 	arm_func_start func_ov14_02136e30
 func_ov14_02136e30: ; 0x02136e30
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0xe4
 	mov r4, r0
 	ldr r0, [r4, #0x4c]
@@ -29101,7 +29101,7 @@ _0213716c:
 	bge _021371b8
 	cmp r3, r2
 	addeq sp, sp, #0xe4
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02137190:
 	ldr r1, [r3]
 	add r3, r3, #0xc
@@ -29112,7 +29112,7 @@ _02137190:
 	cmp r3, r2
 	bne _02137190
 	add sp, sp, #0xe4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _021371b8:
 	cmp r3, r2
 	beq _021371e0
@@ -29192,12 +29192,12 @@ _021372a4:
 _021372c8:
 	ldr ip, [r7]
 	ldr r2, [r7, #8]
-	mov fp, ip, asr #0x1f
+	mov r11, ip, asr #0x1f
 	mov r4, r2, asr #0x1f
 	str r4, [sp, #0x20]
 	umull r4, lr, r0, ip
 	ldrh r1, [r7, #4]
-	mla lr, r0, fp, lr
+	mla lr, r0, r11, lr
 	mov r3, r1, lsl #0xc
 	ldrh r1, [r8, #4]
 	adds r4, r4, #0x800
@@ -29206,25 +29206,25 @@ _021372c8:
 	mov r1, r3, asr #0x1f
 	str r1, [sp, #0x18]
 	ldr r5, [r8]
-	adc fp, lr, #0
+	adc r11, lr, #0
 	mov r4, r4, lsr #0xc
-	orr r4, r4, fp, lsl #20
+	orr r4, r4, r11, lsl #20
 	add r4, r5, r4
-	umull fp, r5, r0, r3
+	umull r11, r5, r0, r3
 	ldr r1, [r8, #8]
 	ldr ip, [sp, #0x18]
 	str r1, [sp, #0x1c]
 	mla r5, r0, ip, r5
 	mla r5, sl, r3, r5
-	adds fp, fp, #0x800
+	adds r11, r11, #0x800
 	adc r3, r5, #0
-	mov r5, fp, lsr #0xc
+	mov r5, r11, lsr #0xc
 	orr r5, r5, r3, lsl #20
 	ldr r3, [sp, #0x14]
 	ldr ip, [sp, #0x20]
 	add r3, r3, r5, asr #12
 	mov r3, r3, lsl #0x10
-	mov fp, r3, lsr #0x10
+	mov r11, r3, lsr #0x10
 	umull r5, r3, r0, r2
 	mla r3, r0, ip, r3
 	mla r3, sl, r2, r3
@@ -29239,7 +29239,7 @@ _021372c8:
 	ldr r1, [sb]
 	add r3, r2, r3
 	cmp r1, #0
-	strneh fp, [r1, #0x74]
+	strneh r11, [r1, #0x74]
 	ldr r2, [sb]
 	mov r1, r3, lsl #0x10
 	mov r1, r1, asr #0x10
@@ -29252,7 +29252,7 @@ _021372c8:
 	add sb, sb, #0xc
 	blo _021372c8
 	add sp, sp, #0xe4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_02136e30
 _021373c4: .word 0x0000ffff

--- a/asm/ov14/ov14_0213b778.s
+++ b/asm/ov14/ov14_0213b778.s
@@ -5,7 +5,7 @@
 	.global func_ov14_0213b778
 	arm_func_start func_ov14_0213b778
 func_ov14_0213b778: ; 0x0213b778
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0xd4
 	mov r8, r0
 	add r3, sp, #0x54
@@ -44,18 +44,18 @@ _0213b794:
 	bl _ZN12ActorManager12FilterActorsEP15ActorFilterBaseP9ActorList
 	mov r6, r0
 	cmp r6, #0
-	mov fp, #0
+	mov r11, #0
 	ble _0213b8f0
 	smull r1, r0, r4, r4
 	adds r1, r1, #0x800
-	adc r0, r0, fp
+	adc r0, r0, r11
 	mov r4, r1, lsr #0xc
 	cmp r6, #0x10
 	orr r4, r4, r0, lsl #20
 	movgt r6, r7
 	bgt _0213b840
 	cmp r6, #0
-	movlt r6, fp
+	movlt r6, r11
 _0213b840:
 	cmp r6, #0
 	mov r5, #0
@@ -96,7 +96,7 @@ _0213b850:
 	add r1, r1, r3
 	add r1, sb, r1
 	cmp r1, r4
-	movlt fp, r0
+	movlt r11, r0
 	movlt r4, r1
 _0213b8e0:
 	add r5, r5, #1
@@ -104,9 +104,9 @@ _0213b8e0:
 	add r7, r7, #8
 	blt _0213b850
 _0213b8f0:
-	mov r0, fp
+	mov r0, r11
 	add sp, sp, #0xd4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_0213b778
 _0213b8fc: .word data_027e0fe4
@@ -3004,7 +3004,7 @@ _0213d9a8: .word data_027e0e60
 	.global func_ov14_0213d9ac
 	arm_func_start func_ov14_0213d9ac
 func_ov14_0213d9ac: ; 0x0213d9ac
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x18
 	mov sl, r0
 	bl func_ov14_0213dda0
@@ -3017,7 +3017,7 @@ func_ov14_0213d9ac: ; 0x0213d9ac
 	add r8, sl, #0x2c
 	add sb, sl, #0x24
 	mov r4, #2
-	mov fp, #3
+	mov r11, #3
 _0213d9e4:
 	ldrsh r0, [r7, #0x2e]
 	cmp r0, #4
@@ -3059,14 +3059,14 @@ _0213d9fc:
 	mov r0, #0
 	strh r0, [r1, #0x2e]
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0213da84:
 	ldr r0, _0213dad8 ; =data_027e0fe4
 	mov r1, sb
 	ldr r0, [r0]
 	bl _ZN12ActorManager8GetActorEP8ActorRef
 	cmp r0, #0
-	strneh fp, [r7, #0x2e]
+	strneh r11, [r7, #0x2e]
 	moveq r0, #0
 	streqh r0, [r7, #0x2e]
 _0213daa4:
@@ -3082,7 +3082,7 @@ _0213dac0:
 	str r0, [sl, #0x74]
 	mov r0, #1
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_0213d9ac
 _0213dad4: .word data_027e0e60
@@ -3703,17 +3703,17 @@ _0213e324: .word data_027e0e60
 	.global func_ov14_0213e328
 	arm_func_start func_ov14_0213e328
 func_ov14_0213e328: ; 0x0213e328
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x18
 	mov sl, r0
 	ldrsh r0, [sl, #0xa]
 	cmp r0, #0
 	addlt sp, sp, #0x18
 	movlt r0, #0
-	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldrsh r1, [sl, #0xa]
 	mov r4, #0
-	mov fp, r4
+	mov r11, r4
 	cmp r1, #0
 	blt _0213e42c
 	mov r5, sl
@@ -3762,17 +3762,17 @@ _0213e3f0:
 _0213e3f8:
 	add sp, sp, #0x18
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0213e404:
 	ldrsh r1, [sl, #0xa]
 	add r0, sp, #4
-	str r8, [r0, fp, lsl #2]
-	add fp, fp, #1
+	str r8, [r0, r11, lsl #2]
+	add r11, r11, #1
 	add r5, r5, #0x1c
 	add r6, r6, #0x1c
 	add r7, r7, #0x1c
 	add r8, r8, #0x1c
-	cmp fp, r1
+	cmp r11, r1
 	ble _0213e36c
 _0213e42c:
 	cmp r1, #0
@@ -3797,7 +3797,7 @@ _0213e44c:
 	strb r0, [sl, #0x69]
 	add sp, sp, #0x18
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0213e484:
 	mov r5, #0
 	cmp r0, #0
@@ -3848,7 +3848,7 @@ _0213e518:
 _0213e52c:
 	mov r0, #1
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_0213e328
 _0213e538: .word data_027e0fe4
@@ -3869,13 +3869,13 @@ func_ov14_0213e544: ; 0x0213e544
 	.global func_ov14_0213e55c
 	arm_func_start func_ov14_0213e55c
 func_ov14_0213e55c: ; 0x0213e55c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0xb4
 	mov r6, r0
 	ldr r0, [r6, #0x20]
 	cmp r0, #2
 	addlo sp, sp, #0xb4
-	ldmloia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmloia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r2, [r6]
 	ldr r0, _0213eaa0 ; =data_027e0f64
 	ldr r1, [r2]
@@ -3900,7 +3900,7 @@ func_ov14_0213e55c: ; 0x0213e55c
 	bls _0213e670
 	mov r7, r4
 	ldr r4, _0213eaa0 ; =data_027e0f64
-	add fp, sp, #0x5c
+	add r11, sp, #0x5c
 	add r5, sp, #0xa4
 _0213e5e0:
 	ldr r0, [r6, #0x20]
@@ -3917,7 +3917,7 @@ _0213e5e0:
 	ldr r1, [r2, #8]
 	str r1, [sp, #0x64]
 	bl func_ov00_0208b180
-	mov r1, fp
+	mov r1, r11
 	add r2, sp, #0x44
 	add r3, sp, #0x40
 	str r7, [sp]
@@ -4051,9 +4051,9 @@ _0213e788:
 	adc r7, r8, #0
 	mov r8, sb, lsr #0xc
 	orr r8, r8, r7, lsl #20
-	ldr fp, [sp, #0x78]
+	ldr r11, [sp, #0x78]
 	str r8, [sp, #0x74]
-	smull sb, r8, fp, r0
+	smull sb, r8, r11, r0
 	ldr sl, [sp, #8]
 	add r1, sp, #0x8c
 	smull r7, r0, sl, r0
@@ -4211,7 +4211,7 @@ _0213ea6c:
 	str r3, [sp, #0xc]
 	bl func_01ffa9fc
 	add sp, sp, #0xb4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_0213e55c
 _0213eaa0: .word data_027e0f64
@@ -6357,7 +6357,7 @@ func_ov14_0213ff88: ; 0x0213ff88
 	.global func_ov14_0213ffac
 	arm_func_start func_ov14_0213ffac
 func_ov14_0213ffac: ; 0x0213ffac
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x20
 	mov r4, r1
 	mov r5, #0x19000
@@ -6380,14 +6380,14 @@ func_ov14_0213ffac: ; 0x0213ffac
 	mov r6, r0, lsr #0xc
 	adc r0, r1, #0
 	add sb, sp, #0x10
-	add fp, sp, #0
+	add r11, sp, #0
 	mov lr, r2
 	mov ip, r3
 	orr r6, r6, r0, lsl #20
 	ldmia sl, {r0, r1, r2, r3}
 	stmia sb, {r0, r1, r2, r3}
 	ldmia r7, {r0, r1, r2, r3}
-	stmia fp, {r0, r1, r2, r3}
+	stmia r11, {r0, r1, r2, r3}
 	cmp r4, #0xa4
 	str lr, [sp, #0x10]
 	str r8, [sp, #0x14]
@@ -6400,7 +6400,7 @@ func_ov14_0213ffac: ; 0x0213ffac
 	mov r3, #1
 	bl func_ov00_020b45f8
 	add sp, sp, #0x20
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0214005c:
 	ldr r1, _021400bc ; =0x00000266
 	cmp r4, r1
@@ -6413,18 +6413,18 @@ _0214005c:
 	ldr r4, [r0]
 	mov r1, sb
 	ldr r4, [r4, #0x60]
-	mov r2, fp
+	mov r2, r11
 	blx r4
 	add sp, sp, #0x20
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02140098:
 	mov r0, r5
-	mov r1, fp
+	mov r1, r11
 	mov r2, #0
 	mov r3, #1
 	bl func_ov00_020b45f8
 	add sp, sp, #0x20
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_0213ffac
 _021400b4: .word data_ov14_02153e50
@@ -6950,7 +6950,7 @@ _021407b4: .word data_027e0f64
 	.global func_ov14_021407b8
 	arm_func_start func_ov14_021407b8
 func_ov14_021407b8: ; 0x021407b8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x38
 	ldrh r1, [r1]
 	mov sl, r0
@@ -6959,7 +6959,7 @@ func_ov14_021407b8: ; 0x021407b8
 	bne _021407e0
 	tst r1, #8
 	addeq sp, sp, #0x38
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _021407e0:
 	add r0, sp, #0x18
 	bl func_01ffbe34
@@ -6980,7 +6980,7 @@ _021407e0:
 	cmp r4, #0x28
 	movlt r8, #1
 	ldr r7, [r1]
-	ldr fp, [r0]
+	ldr r11, [r0]
 	mov r0, r7
 	movge r8, #0
 	bl func_ov00_02078b40
@@ -7034,7 +7034,7 @@ _021408e0:
 	ldrb r1, [r0, #0x95]
 	cmp r1, #0
 	beq _02140c4c
-	mov r0, fp
+	mov r0, r11
 	bl func_ov00_020849dc
 	cmp r0, #0
 	beq _021409d0
@@ -7063,7 +7063,7 @@ _021408e0:
 _02140960:
 	cmp r8, #0
 	addeq sp, sp, #0x38
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r1, sp, #0x14
 	str r1, [sp]
 	add r0, sp, #0x10
@@ -7079,7 +7079,7 @@ _02140960:
 	bl func_ov00_02079470
 	cmp r0, #0
 	addeq sp, sp, #0x38
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r1, sp, #0x18
 	str r1, [sp]
 	ldr r0, _02141144 ; =data_02063e4c
@@ -7088,9 +7088,9 @@ _02140960:
 	mov r3, #0x6b
 	bl func_020313c8
 	add sp, sp, #0x38
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _021409d0:
-	mov r0, fp
+	mov r0, r11
 	bl func_ov00_020849c0
 	cmp r0, #0
 	beq _02140bdc
@@ -7157,7 +7157,7 @@ _02140aac:
 _02140ac4:
 	cmp r8, #0
 	addeq sp, sp, #0x38
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r1, sp, #0x14
 	str r1, [sp]
 	add r0, sp, #0x10
@@ -7173,7 +7173,7 @@ _02140ac4:
 	bl func_ov00_02079470
 	cmp r0, #0
 	addeq sp, sp, #0x38
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r0, r7, #0xc
 	bl func_ov00_020a5e9c
 	cmp r0, #4
@@ -7184,7 +7184,7 @@ _02140ac4:
 	bl func_ov00_02097760
 	cmp r0, #0
 	addne sp, sp, #0x38
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, _0214114c ; =data_027e0f74
 	mov r1, #0x81
 	ldr r0, [r0]
@@ -7199,7 +7199,7 @@ _02140ac4:
 	mov r3, #0x70
 	bl func_020313c8
 	add sp, sp, #0x38
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02140b78:
 	ldr r0, _0214114c ; =data_027e0f74
 	mov r1, #0x62
@@ -7207,7 +7207,7 @@ _02140b78:
 	bl func_ov00_02097760
 	cmp r0, #0
 	addeq sp, sp, #0x38
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r1, sp, #0x18
 	str r1, [sp]
 	ldr r0, _02141144 ; =data_02063e4c
@@ -7216,7 +7216,7 @@ _02140b78:
 	mov r3, #0x6f
 	bl func_020313c8
 	add sp, sp, #0x38
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02140bb8:
 	add r1, sp, #0x18
 	str r1, [sp]
@@ -7226,11 +7226,11 @@ _02140bb8:
 	mov r3, #0x6b
 	bl func_020313c8
 	add sp, sp, #0x38
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02140bdc:
 	cmp r8, #0
 	addeq sp, sp, #0x38
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r1, sp, #0x14
 	str r1, [sp]
 	add r0, sp, #0x10
@@ -7246,7 +7246,7 @@ _02140bdc:
 	bl func_ov00_02079470
 	cmp r0, #0
 	addeq sp, sp, #0x38
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r1, sp, #0x18
 	str r1, [sp]
 	ldr r0, _02141144 ; =data_02063e4c
@@ -7255,11 +7255,11 @@ _02140bdc:
 	mov r3, #0x6b
 	bl func_020313c8
 	add sp, sp, #0x38
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02140c4c:
 	bl func_ov03_020f4b7c
 	cmp r0, #0
-	mov r0, fp
+	mov r0, r11
 	beq _02140db0
 	bl func_ov00_020849dc
 	cmp r0, #0
@@ -7304,7 +7304,7 @@ _02140cc8:
 	bl func_ov00_02079470
 	cmp r0, #0
 	addeq sp, sp, #0x38
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r1, sp, #0x18
 	str r1, [sp]
 	ldr r0, _02141144 ; =data_02063e4c
@@ -7313,16 +7313,16 @@ _02140cc8:
 	mov r3, #0x5d
 	bl func_020313c8
 	add sp, sp, #0x38
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02140d2c:
-	mov r0, fp
+	mov r0, r11
 	bl func_ov00_020849c0
 	cmp r0, #0
 	addne sp, sp, #0x38
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	cmp r8, #0
 	addeq sp, sp, #0x38
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r1, sp, #0x14
 	str r1, [sp]
 	add r0, sp, #0x10
@@ -7338,7 +7338,7 @@ _02140d2c:
 	bl func_ov00_02079470
 	cmp r0, #0
 	addeq sp, sp, #0x38
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r1, sp, #0x18
 	str r1, [sp]
 	ldr r0, _02141144 ; =data_02063e4c
@@ -7347,7 +7347,7 @@ _02140d2c:
 	mov r3, #2
 	bl func_020313c8
 	add sp, sp, #0x38
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02140db0:
 	bl func_ov00_020849c0
 	cmp r0, #0
@@ -7432,7 +7432,7 @@ _02140eb4:
 	bl func_ov00_02079470
 	cmp r0, #0
 	addeq sp, sp, #0x38
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r0, r7, #0xc
 	bl func_ov00_020a5e9c
 	cmp r0, #5
@@ -7450,7 +7450,7 @@ _02140eb4:
 	mov r3, #0x5a
 	bl func_020313c8
 	add sp, sp, #0x38
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02140f3c:
 	str r1, [sp]
 	ldr r0, _02141144 ; =data_02063e4c
@@ -7459,7 +7459,7 @@ _02140f3c:
 	mov r3, #0x59
 	bl func_020313c8
 	add sp, sp, #0x38
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02140f5c:
 	add r0, r7, #0xc
 	bl func_ov00_020a5e9c
@@ -7473,7 +7473,7 @@ _02140f5c:
 	mov r3, #0x42
 	bl func_020313c8
 	add sp, sp, #0x38
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02140f90:
 	str r1, [sp]
 	ldr r0, _02141144 ; =data_02063e4c
@@ -7482,7 +7482,7 @@ _02140f90:
 	mov r3, #0x58
 	bl func_020313c8
 	add sp, sp, #0x38
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02140fb0:
 	add r1, sp, #0x14
 	str r1, [sp]
@@ -7514,7 +7514,7 @@ _02140fb0:
 	add r0, sl, #0x1a8
 	bl func_02034a1c
 	add sp, sp, #0x38
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0214102c:
 	ldrb r0, [sl, #0x14d]
 	cmp r0, #0
@@ -7526,7 +7526,7 @@ _0214102c:
 	add r0, r1, r0, ror #28
 	cmp r0, #8
 	addge sp, sp, #0x38
-	ldmgeia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmgeia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02141058:
 	add r1, sp, #0x18
 	str r1, [sp]
@@ -7536,12 +7536,12 @@ _02141058:
 	mov r3, #1
 	bl func_020313c8
 	add sp, sp, #0x38
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0214107c:
 	cmp r8, #0
 	addeq sp, sp, #0x38
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
-	mov r0, fp
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	mov r0, r11
 	bl func_ov00_02084990
 	cmp r0, #0
 	add r3, sp, #0x10
@@ -7557,7 +7557,7 @@ _0214107c:
 	bl func_ov00_0207977c
 	cmp r0, #0
 	addeq sp, sp, #0x38
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldrb r0, [sp, #0x60]
 	cmp r0, #0
 	beq _0214110c
@@ -7573,7 +7573,7 @@ _0214107c:
 	add r0, sl, #0x1a8
 	bl func_02034a1c
 	add sp, sp, #0x38
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0214110c:
 	add r1, sp, #0x18
 	str r1, [sp]
@@ -7583,7 +7583,7 @@ _0214110c:
 	mov r3, r4
 	bl func_020313c8
 	add sp, sp, #0x38
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_021407b8
 _02141130: .word 0x88888889
@@ -7599,7 +7599,7 @@ _02141150: .word 0x00000186
 	.global func_ov14_02141154
 	arm_func_start func_ov14_02141154
 func_ov14_02141154: ; 0x02141154
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x1e8
 	ldr r3, _021415b4 ; =data_027e0c54
 	mov sl, r0
@@ -7610,7 +7610,7 @@ func_ov14_02141154: ; 0x02141154
 	cmp r1, r3
 	mov r5, r2
 	addne sp, sp, #0x1e8
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r1, _021415b8 ; =data_027e0d38
 	str r4, [sl, #0x18c]
 	ldr r1, [r1]
@@ -7622,7 +7622,7 @@ func_ov14_02141154: ; 0x02141154
 	ldr r2, [r2, #0x84]
 	blx r2
 	add sp, sp, #0x1e8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _021411b4:
 	mov r0, r4
 	ldr r1, [r0]
@@ -7689,7 +7689,7 @@ _0214128c:
 	bl func_ov14_021415d4
 	bl _ZN15LinkStateDamage18func_ov00_020aca94Ev
 	add sp, sp, #0x1e8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _021412a8:
 	mov r0, r5, lsl #0x10
 	mov r0, r0, lsr #0x10
@@ -7702,7 +7702,7 @@ _021412a8:
 	mov r5, r2, lsl #0x1
 	mov r2, r1, lsl #0x1
 	mov r1, #0x25
-	ldrsh fp, [r3, r5]
+	ldrsh r11, [r3, r5]
 	ldrsh r5, [r3, r2]
 	bl _ZNK11ItemManager7HasItemEi
 	mov r7, #0
@@ -7809,7 +7809,7 @@ _02141418:
 	ldr r1, [r0, #0x54]
 	smull r3, r6, r2, r5
 	adds r7, r3, #0x800
-	smull r3, r2, r1, fp
+	smull r3, r2, r1, r11
 	adc r6, r6, #0
 	adds r3, r3, #0x800
 	mov r7, r7, lsr #0xc
@@ -7825,7 +7825,7 @@ _02141418:
 	ldr r1, [r0, #0x4c]
 	smull r3, r5, r2, r5
 	adds r6, r3, #0x800
-	smull r3, r2, r1, fp
+	smull r3, r2, r1, r11
 	adc r5, r5, #0
 	adds r3, r3, #0x800
 	mov r6, r6, lsr #0xc
@@ -7895,7 +7895,7 @@ _0214159c:
 	mov r0, r4
 	bl func_ov00_020a9c14
 	add sp, sp, #0x1e8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_02141154
 _021415b4: .word data_027e0c54
@@ -8432,7 +8432,7 @@ func_ov14_02141c38: ; 0x02141c38
 	.global func_ov14_02141c60
 	arm_func_start func_ov14_02141c60
 func_ov14_02141c60: ; 0x02141c60
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x4c
 	mov sb, r0
 	ldr r0, [sb, #0x18]
@@ -8530,7 +8530,7 @@ _02141d88:
 	ldr r4, _02142040 ; =data_027e0e60
 	add r6, sp, #0xe
 	add sl, sp, #0xc
-	mov fp, r5
+	mov r11, r5
 _02141dd4:
 	ldrb r8, [sb, #0x15]
 	ldrb r0, [sb, #0x39]
@@ -8550,7 +8550,7 @@ _02141df0:
 	mov r1, sl
 	strb r7, [sp, #0xc]
 	strb r8, [sp, #0xd]
-	mov r2, fp
+	mov r2, r11
 	bl func_ov00_020826a0
 	ldrb r1, [sb, #0x15]
 	ldrb r0, [sb, #0x39]
@@ -8579,7 +8579,7 @@ _02141e5c:
 	ldr r4, _02142040 ; =data_027e0e60
 	add r6, sp, #0xa
 	add sl, sp, #8
-	mov fp, r5
+	mov r11, r5
 _02141e88:
 	ldrb r8, [sb, #0x15]
 	ldrb r0, [sb, #0x39]
@@ -8599,7 +8599,7 @@ _02141ea4:
 	mov r1, sl
 	strb r7, [sp, #8]
 	strb r8, [sp, #9]
-	mov r2, fp
+	mov r2, r11
 	bl func_ov00_020826a0
 	ldrb r1, [sb, #0x15]
 	ldrb r0, [sb, #0x39]
@@ -8699,7 +8699,7 @@ _02142004:
 	add r0, r0, #0x2d
 	str r0, [sb, #0x4c]
 	add sp, sp, #0x4c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_02141c60
 _02142040: .word data_027e0e60
@@ -9231,21 +9231,21 @@ func_ov14_02142784: ; 0x02142784
 	.global func_ov14_0214278c
 	arm_func_start func_ov14_0214278c
 func_ov14_0214278c: ; 0x0214278c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x20
 	mov sl, r0
 	ldr r0, [sl, #4]
 	str r1, [sp, #0x10]
 	tst r0, #0x10
 	addeq sp, sp, #0x20
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, _02142904 ; =data_027e0d38
 	ldr r0, [r0]
 	add r0, r0, #0xc
 	bl func_ov00_020a5e9c
 	cmp r0, #0x1a
 	addeq sp, sp, #0x20
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldrb r0, [sl, #0x38]
 	ldr r1, _02142904 ; =data_027e0d38
 	ldrb r7, [sl, #0x39]
@@ -9273,9 +9273,9 @@ _02142818:
 	mov r0, #0
 	str r0, [sp, #0x1c]
 	addle sp, sp, #0x20
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	str r0, [sp, #0x14]
-	mvn fp, #0
+	mvn r11, #0
 _02142838:
 	ldr r0, [sl, #0x40]
 	cmp r0, #0
@@ -9311,7 +9311,7 @@ _02142898:
 _021428a0:
 	mov r1, sb
 _021428a4:
-	str fp, [sp]
+	str r11, [sp]
 	mov r0, #0
 	stmib sp, {r0, r6}
 	str r1, [sp, #0xc]
@@ -9335,7 +9335,7 @@ _021428d8:
 	str r0, [sp, #0x14]
 	blt _02142838
 	add sp, sp, #0x20
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_0214278c
 _02142904: .word data_027e0d38
@@ -9344,7 +9344,7 @@ _02142908: .word data_027e0e60
 	.global func_ov14_0214290c
 	arm_func_start func_ov14_0214290c
 func_ov14_0214290c: ; 0x0214290c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x30
 	ldr r2, [r0]
 	mov sl, r0
@@ -9352,7 +9352,7 @@ func_ov14_0214290c: ; 0x0214290c
 	blx r2
 	cmp r0, #0
 	addeq sp, sp, #0x30
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldrsh r1, [sl, #0xc]
 	ldr r3, _02142b58 ; =data_02050f54
 	add r0, sp, #0xc
@@ -9377,7 +9377,7 @@ func_ov14_0214290c: ; 0x0214290c
 	ldrb r0, [sl, #0x38]
 	cmp r0, #0
 	addle sp, sp, #0x30
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	mov r8, r6
 _02142998:
 	ldr r0, [sl, #0x40]
@@ -9431,7 +9431,7 @@ _02142a3c:
 	mov sb, r7
 	mvn r4, #0
 	mov r5, r7
-	add fp, sp, #0xc
+	add r11, sp, #0xc
 _02142a5c:
 	ldr r0, [sl, #0x40]
 	cmp r0, #2
@@ -9483,7 +9483,7 @@ _02142b00:
 	strneh r4, [sl, #0x6e]
 	add r0, sl, #0x64
 	ldr r3, [r0]
-	mov r1, fp
+	mov r1, r11
 	ldr r3, [r3, #0x14]
 	add r2, sp, #0
 	blx r3
@@ -9499,7 +9499,7 @@ _02142b3c:
 	cmp r6, r0
 	blt _02142998
 	add sp, sp, #0x30
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_0214290c
 _02142b58: .word data_02050f54
@@ -10258,28 +10258,28 @@ _021434b4: .word data_027e0f64
 	.global func_ov14_021434b8
 	arm_func_start func_ov14_021434b8
 func_ov14_021434b8: ; 0x021434b8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #8
 	mov sl, r0
 	ldr r0, [sl, #4]
 	tst r0, #0x10
 	addeq sp, sp, #8
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldrh r0, [r1]
 	tst r0, #4
 	bne _021434ec
 	tst r0, #8
 	addeq sp, sp, #8
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _021434ec:
 	ldr r0, [sl, #0x138]
 	mov r8, #0
 	cmp r0, #0
 	addle sp, sp, #8
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r4, _02143584 ; =data_027e0d3c
 	mov sb, sl
-	mov fp, r8
+	mov r11, r8
 	add r7, sp, #4
 	add r6, sp, #0
 	mov r5, r8
@@ -10301,7 +10301,7 @@ _02143518:
 	beq _02143568
 	ldr r1, [sp, #4]
 	ldr r2, [sp]
-	mov r3, fp
+	mov r3, r11
 	add r0, sl, #0x200
 	bl func_02034a1c
 _02143568:
@@ -10311,7 +10311,7 @@ _02143568:
 	add sb, sb, #6
 	blt _02143518
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_021434b8
 _02143584: .word data_027e0d3c
@@ -14717,7 +14717,7 @@ _021467b4: .word 0x55555556
 	.global func_ov14_021467b8
 	arm_func_start func_ov14_021467b8
 func_ov14_021467b8: ; 0x021467b8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x48
 	mov sl, r0
 	cmp r1, #0
@@ -14727,7 +14727,7 @@ func_ov14_021467b8: ; 0x021467b8
 	ldrne r0, [sl, #0x130]
 	cmpne r0, #2
 	addeq sp, sp, #0x48
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r0, sl, #0x100
 	ldrsh r1, [r0, #0x58]
 	ldrh r0, [sl, #0x20]
@@ -14819,16 +14819,16 @@ func_ov14_021467b8: ; 0x021467b8
 	add r4, sl, #0x100
 	ldrsh r0, [r4, #0x82]
 	adc r1, r1, #0
-	mov fp, r2, lsr #0xc
+	mov r11, r2, lsr #0xc
 	cmp r0, #0
-	orr fp, fp, r1, lsl #20
+	orr r11, r11, r1, lsl #20
 	mov r8, #0
 	addle sp, sp, #0x48
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add sb, sl, #0x15c
 _0214696c:
 	ldr r0, [sp, #0xc]
-	add r1, r6, fp
+	add r1, r6, r11
 	add r0, r7, r0
 	mov r1, r1, lsl #0x10
 	mov r0, r0, lsl #0x10
@@ -14850,7 +14850,7 @@ _0214696c:
 	cmp r8, r0
 	blt _0214696c
 	add sp, sp, #0x48
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_021467b8
 _021469cc: .word data_02050f54
@@ -16917,7 +16917,7 @@ func_ov14_02148334: ; 0x02148334
 	.global func_ov14_02148364
 	arm_func_start func_ov14_02148364
 func_ov14_02148364: ; 0x02148364
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x128
 	ldr r2, _02148644 ; =data_027e0e60
 	mov sl, r0
@@ -16929,7 +16929,7 @@ func_ov14_02148364: ; 0x02148364
 	cmp r1, r0
 	addlt sp, sp, #0x128
 	movlt r0, #0
-	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r1, _02148644 ; =data_027e0e60
 	add r0, sp, #0x14
 	ldr r1, [r1]
@@ -16955,7 +16955,7 @@ _021483e4:
 _021483ec:
 	add sp, sp, #0x128
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _021483f8:
 	ldr r1, _02148648 ; =0x0000ffff
 	mov r0, #0
@@ -16998,7 +16998,7 @@ _021483f8:
 	cmp r0, #0
 	addne sp, sp, #0x128
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, _0214864c ; =data_ov14_02153ed8
 	add r4, sp, #0xb8
 	ldmia r0, {r0, r1, r2, r3}
@@ -17054,7 +17054,7 @@ _021483f8:
 	cmp r6, #0
 	mov r7, #0
 	ble _02148638
-	ldr fp, _02148650 ; =data_027e0fe4
+	ldr r11, _02148650 ; =data_027e0fe4
 	mov r8, r7
 	add r5, sp, #0x38
 	mvn r4, #0
@@ -17067,7 +17067,7 @@ _0214858c:
 	ldr r0, [r1, #4]
 	str r0, [sp, #0x1c]
 	beq _02148628
-	ldr r0, [fp]
+	ldr r0, [r11]
 	add r1, sp, #0x18
 	bl _ZN12ActorManager8GetActorEP8ActorRef
 	cmp r0, #0
@@ -17088,7 +17088,7 @@ _0214858c:
 	cmp r0, #0
 	addne sp, sp, #0x128
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r3, [sl, #0x98]
 	mov r0, r5
 	add r1, sp, #0xac
@@ -17097,7 +17097,7 @@ _0214858c:
 	cmp r0, #0
 	addne sp, sp, #0x128
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02148628:
 	add r7, r7, #1
 	cmp r7, r6
@@ -17106,7 +17106,7 @@ _02148628:
 _02148638:
 	mov r0, #1
 	add sp, sp, #0x128
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_02148364
 _02148644: .word data_027e0e60
@@ -19541,7 +19541,7 @@ _0214a71c: .word data_02050f54
 	.global func_ov14_0214a720
 	arm_func_start func_ov14_0214a720
 func_ov14_0214a720: ; 0x0214a720
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x10
 	movs sb, r1
 	mov sl, r0
@@ -19575,7 +19575,7 @@ _0214a77c:
 	cmp r0, #0
 	addeq sp, sp, #0x10
 	moveq r0, r8
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldrsh r4, [sl, #0x6c]
 	ldr r5, [sp, #4]
 	ldr r0, [r6]
@@ -19607,17 +19607,17 @@ _0214a7ec:
 	mov r8, r0, asr #0x10
 _0214a808:
 	ldrsh r5, [sl, #0x6e]
-	ldr fp, [sp, #8]
+	ldr r11, [sp, #8]
 	ldr r3, [r6, #4]
 	rsb r0, r5, #0
 	mov r2, r0, lsl #0x10
 	mov r0, r6
 	add r1, sp, #4
-	sub fp, fp, r3
+	sub r11, r11, r3
 	mov r6, r2, asr #0x10
 	bl func_ov00_020ce2f0
 	mov r1, r0
-	mov r0, fp
+	mov r0, r11
 	bl func_01ffa0f4
 	mov r0, r0, lsl #0x10
 	cmp sb, #0
@@ -19681,7 +19681,7 @@ _0214a8e8:
 _0214a918:
 	mov r0, r8
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_0214a720
 _0214a924: .word 0x00000222
@@ -21985,7 +21985,7 @@ _0214c674: .word func_0202b2e8
 	.global func_ov14_0214c678
 	arm_func_start func_ov14_0214c678
 func_ov14_0214c678: ; 0x0214c678
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x94
 	mov sl, r0
 	mov sb, r1
@@ -22014,7 +22014,7 @@ func_ov14_0214c678: ; 0x0214c678
 	ldrh r8, [r6, #0x9c]
 	adc r6, r4, r0
 	mov r0, #0x64
-	mov fp, r1, lsr #0x10
+	mov r11, r1, lsr #0x10
 	umull ip, r1, r6, r0
 	mov ip, #0
 	mla r1, r6, ip, r1
@@ -22033,15 +22033,15 @@ func_ov14_0214c678: ; 0x0214c678
 	mla r2, r6, r1, r2
 	mla r2, r1, r0, r2
 	cmp r2, #0x32
-	addge r0, fp, #0x4000
+	addge r0, r11, #0x4000
 	str r7, [lr]
 	movge r0, r0, lsl #0x10
 	str r6, [lr, #4]
-	movge fp, r0, lsr #0x10
+	movge r11, r0, lsr #0x10
 	bge _0214c75c
-	sub r0, fp, #0x4000
+	sub r0, r11, #0x4000
 	mov r0, r0, lsl #0x10
-	mov fp, r0, lsr #0x10
+	mov r11, r0, lsr #0x10
 _0214c75c:
 	ldr r2, _0214c938 ; =data_027e0764
 	mov r1, #0
@@ -22059,27 +22059,27 @@ _0214c75c:
 	mla r4, r5, r1, r4
 	mla r4, r1, r0, r4
 	str r6, [r2]
-	strh fp, [sp, #0x14]
+	strh r11, [sp, #0x14]
 	str r5, [r2, #4]
 	cmp r4, #0x32
 	bge _0214c7c0
-	sub r1, fp, #0x4000
-	add r0, fp, #0x4000
+	sub r1, r11, #0x4000
+	add r0, r11, #0x4000
 	strh r1, [sp, #0x16]
 	strh r0, [sp, #0x18]
 	b _0214c7d0
 _0214c7c0:
-	add r1, fp, #0x4000
-	sub r0, fp, #0x4000
+	add r1, r11, #0x4000
+	sub r0, r11, #0x4000
 	strh r1, [sp, #0x16]
 	strh r0, [sp, #0x18]
 _0214c7d0:
-	sub r0, fp, #0x8000
+	sub r0, r11, #0x8000
 	mov r7, #0
 	ldr r6, _0214c93c ; =data_02050f54
 	ldr r4, _0214c940 ; =data_027e0e60
 	strh r0, [sp, #0x1a]
-	add fp, sp, #0x1c
+	add r11, sp, #0x1c
 	mov r5, r7
 _0214c7ec:
 	ldr r0, [sb]
@@ -22110,7 +22110,7 @@ _0214c7ec:
 	add r0, r2, r0, asr #12
 	str r0, [sl, #8]
 	ldr r0, [sb]
-	mov r2, fp
+	mov r2, r11
 	str r0, [sp, #0x28]
 	ldr r0, [sb, #4]
 	str r0, [sp, #0x2c]
@@ -22151,7 +22151,7 @@ _0214c7ec:
 	bne _0214c910
 	ldrb r1, [sl, #0x11]
 	ldr r0, [r4]
-	mov r2, fp
+	mov r2, r11
 	bl func_ov00_02083770
 	cmp r0, #0
 	bne _0214c92c
@@ -22163,11 +22163,11 @@ _0214c910:
 _0214c920:
 	add sp, sp, #0x94
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0214c92c:
 	mov r0, #0
 	add sp, sp, #0x94
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_0214c678
 _0214c938: .word data_027e0764
@@ -23658,7 +23658,7 @@ _0214dc78: .word data_02050f54
 	.global func_ov14_0214dc7c
 	arm_func_start func_ov14_0214dc7c
 func_ov14_0214dc7c: ; 0x0214dc7c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0xf8
 	ldr r2, _0214e120 ; =0x0000ffff
 	mov r1, #0
@@ -23858,7 +23858,7 @@ _0214df30:
 	bge _0214df78
 	cmp r3, r2
 	addeq sp, sp, #0xf8
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0214df50:
 	ldr r1, [r3]
 	add r3, r3, #0xc
@@ -23869,7 +23869,7 @@ _0214df50:
 	cmp r3, r2
 	bne _0214df50
 	add sp, sp, #0xf8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0214df78:
 	cmp r3, r2
 	beq _0214dfa0
@@ -23900,9 +23900,9 @@ _0214dfcc:
 	mov r1, #0x5800
 	bl Divide
 	ldr r1, _0214e128 ; =0x00000d9a
-	mov fp, #0
+	mov r11, #0
 	umull r3, r2, r0, r1
-	mla r2, r0, fp, r2
+	mla r2, r0, r11, r2
 	mov ip, r0, asr #0x1f
 	mla r2, ip, r1, r2
 	adds r3, r3, #0x800
@@ -23967,7 +23967,7 @@ _0214e01c:
 	strne sl, [r5, #0x58]
 	add r6, r4, r6
 	ldr r4, [r3]
-	add fp, fp, #1
+	add r11, r11, #1
 	cmp r4, #0
 	strneh r8, [r4, #0x74]
 	mov r4, r6, lsl #0x10
@@ -23978,10 +23978,10 @@ _0214e01c:
 	strne r5, [r4, #0x70]
 	add r2, r2, #0xc
 	add r3, r3, #0xc
-	cmp fp, #2
+	cmp r11, #2
 	blo _0214e01c
 	add sp, sp, #0xf8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_0214dc7c
 _0214e120: .word 0x0000ffff
@@ -23993,7 +23993,7 @@ _0214e130: .word data_ov14_0215a1a0
 	.global func_ov14_0214e134
 	arm_func_start func_ov14_0214e134
 func_ov14_0214e134: ; 0x0214e134
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0xc
 	ldr r2, _0214e268 ; =data_027e0e60
 	mov r5, r0
@@ -24046,9 +24046,9 @@ _0214e1e4:
 	ldr r0, [sp, #4]
 	cmp sb, r0
 	addgt sp, sp, #0xc
-	ldmgtia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmgtia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r6, _0214e268 ; =data_027e0e60
-	add fp, sp, #8
+	add r11, sp, #8
 _0214e1fc:
 	ldr sl, [sp]
 	mov r0, sl
@@ -24064,7 +24064,7 @@ _0214e210:
 	cmp r1, r0
 	bne _0214e244
 	ldr r0, [r6]
-	mov r1, fp
+	mov r1, r11
 	mov r2, r4
 	strb r7, [sp, #8]
 	strb sl, [sp, #9]
@@ -24079,7 +24079,7 @@ _0214e250:
 	cmp sb, r0
 	ble _0214e1fc
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_0214e134
 _0214e268: .word data_027e0e60
@@ -26264,7 +26264,7 @@ func_ov14_0214fe70: ; 0x0214fe70
 	.global func_ov14_0214fe98
 	arm_func_start func_ov14_0214fe98
 func_ov14_0214fe98: ; 0x0214fe98
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x20
 	mov r4, r0
 	ldr r0, [r4, #0x18]
@@ -26354,7 +26354,7 @@ _0214ffc0:
 	ldr r5, _021500d0 ; =data_027e0e60
 	add r8, sp, #6
 	add r6, sp, #4
-	mov fp, r7
+	mov r11, r7
 _0214ffec:
 	ldrb sl, [r4, #0x15]
 	ldrb r0, [r4, #0x39]
@@ -26374,7 +26374,7 @@ _02150008:
 	mov r1, r6
 	strb sb, [sp, #4]
 	strb sl, [sp, #5]
-	mov r2, fp
+	mov r2, r11
 	bl func_ov00_020826a0
 	ldrb r1, [r4, #0x15]
 	ldrb r0, [r4, #0x39]
@@ -26415,7 +26415,7 @@ _02150070:
 	str r0, [r4, #0x68]
 	str r6, [r4, #0x6c]
 	add sp, sp, #0x20
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_0214fe98
 _021500d0: .word data_027e0e60
@@ -26484,7 +26484,7 @@ _02150160:
 	.global func_ov14_02150168
 	arm_func_start func_ov14_02150168
 func_ov14_02150168: ; 0x02150168
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x30
 	mov sl, r0
 	ldr r2, [sl, #0x4c]
@@ -26497,7 +26497,7 @@ func_ov14_02150168: ; 0x02150168
 	ldrb r0, [sl, #0x39]
 	cmp r0, #0
 	addle sp, sp, #0x30
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _021501a0:
 	cmp r8, #0
 	subne r0, r0, #1
@@ -26566,7 +26566,7 @@ _0215026c:
 	mvn r5, #0
 	mov r6, r7
 	add r4, sp, #0xc
-	add fp, sp, #0
+	add r11, sp, #0
 _021502a0:
 	ldr r0, [sl, #0x44]
 	cmp r7, #0
@@ -26580,7 +26580,7 @@ _021502a0:
 	ldr r3, [r0]
 	mov r1, r4
 	ldr r3, [r3, #0x14]
-	mov r2, fp
+	mov r2, r11
 	blx r3
 	ldrb r0, [sl, #0x38]
 	add r7, r7, #1
@@ -26593,7 +26593,7 @@ _021502ec:
 	cmp r8, r0
 	blt _021501a0
 	add sp, sp, #0x30
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_02150168
 _02150304: .word data_027e0f68
@@ -26602,7 +26602,7 @@ _02150308: .word data_02050f54
 	.global func_ov14_0215030c
 	arm_func_start func_ov14_0215030c
 func_ov14_0215030c: ; 0x0215030c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x30
 	mov sl, r0
 	ldrh r1, [sl, #0xc]
@@ -26626,7 +26626,7 @@ func_ov14_0215030c: ; 0x0215030c
 	ldrb r0, [sl, #0x38]
 	cmp r0, #0
 	addle sp, sp, #0x30
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02150370:
 	cmp r7, #0
 	subne r0, r0, #1
@@ -26695,7 +26695,7 @@ _0215043c:
 	mvn r5, #0
 	mov r6, r8
 	add r4, sp, #0xc
-	add fp, sp, #0
+	add r11, sp, #0
 _02150470:
 	ldr r0, [sl, #0x4c]
 	cmp r8, #0
@@ -26709,7 +26709,7 @@ _02150470:
 	ldr r3, [r0]
 	mov r1, r4
 	ldr r3, [r3, #0x14]
-	mov r2, fp
+	mov r2, r11
 	blx r3
 	ldrb r0, [sl, #0x39]
 	add r8, r8, #1
@@ -26722,7 +26722,7 @@ _021504bc:
 	cmp r7, r0
 	blt _02150370
 	add sp, sp, #0x30
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_0215030c
 _021504d4: .word data_02050f54
@@ -26731,7 +26731,7 @@ _021504d8: .word data_027e0f68
 	.global func_ov14_021504dc
 	arm_func_start func_ov14_021504dc
 func_ov14_021504dc: ; 0x021504dc
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x30
 	mov sl, r0
 	ldrh r1, [sl, #0xc]
@@ -26765,11 +26765,11 @@ func_ov14_021504dc: ; 0x021504dc
 	ldrb r0, [sl, #0x38]
 	cmp r0, #0
 	addle sp, sp, #0x30
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	mvn r5, #0
 	mov r6, r7
 	add r4, sp, #0xc
-	add fp, sp, #0
+	add r11, sp, #0
 _02150578:
 	cmp r7, #0
 	ldrne r0, [sp]
@@ -26794,7 +26794,7 @@ _0215059c:
 	ldr r3, [r0]
 	mov r1, r4
 	ldr r3, [r3, #0x14]
-	mov r2, fp
+	mov r2, r11
 	blx r3
 	ldrb r0, [sl, #0x39]
 	add r8, r8, #1
@@ -26807,7 +26807,7 @@ _021505ec:
 	cmp r7, r0
 	blt _02150578
 	add sp, sp, #0x30
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_021504dc
 _02150604: .word data_02050f54
@@ -28693,7 +28693,7 @@ _0215193c: .word func_ov03_020f23b4
 	.global func_ov14_02151940
 	arm_func_start func_ov14_02151940
 func_ov14_02151940: ; 0x02151940
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x24
 	mov sl, r0
 	mov sb, r1
@@ -28704,7 +28704,7 @@ func_ov14_02151940: ; 0x02151940
 	ldrnesb r0, [sl, #0x14]
 	cmpne r0, #0
 	addeq sp, sp, #0x24
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r0, sp, #4
 	bl func_01ffbe34
 	mov r0, sl
@@ -28723,11 +28723,11 @@ func_ov14_02151940: ; 0x02151940
 	mov r7, #0
 	cmp r0, #0
 	addle sp, sp, #0x24
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r4, _02151a28 ; =gItemManager
 	mov r8, r7
 	mov r5, r7
-	add fp, sp, #4
+	add r11, sp, #4
 	mov r6, #0x21
 _021519d0:
 	cmp r7, #3
@@ -28742,7 +28742,7 @@ _021519ec:
 	ldr r0, [sl, #0x20]
 	mov r1, sb
 	mov r2, r5
-	mov r3, fp
+	mov r3, r11
 	add r0, r0, r8
 	bl func_ov00_020d00c4
 _02151a08:
@@ -28752,7 +28752,7 @@ _02151a08:
 	cmp r7, r0
 	blt _021519d0
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_02151940
 _02151a24: .word data_027e0cbc
@@ -29467,34 +29467,34 @@ _02152258: .word data_027e077c
 	.global func_ov14_0215225c
 	arm_func_start func_ov14_0215225c
 func_ov14_0215225c: ; 0x0215225c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	mov sb, r0
 	ldr r0, [sb, #0x84]
 	cmp r0, #0
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, _021523b4 ; =data_027e077c
 	ldr r0, [r0]
 	cmp r0, #0x37
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, _021523b8 ; =data_027e0c68
 	bl func_020366c4
 	add r0, r0, #0x100
 	ldrsh r0, [r0, #0x5c]
 	cmp r0, #0
 	movgt r0, #0
-	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldrsh r1, [sb, #4]
 	ldrsh r0, [sb, #6]
 	cmp r1, r0
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	mov r8, #0
 	mov r5, r8
 	mov r7, sb
 	add r6, sb, #0x20
-	mov fp, r8
+	mov r11, r8
 	mov sl, #1
 	mov r4, r8
 _021522d4:
@@ -29555,7 +29555,7 @@ _0215238c:
 	mov r8, sl
 	b _02152398
 _02152394:
-	mov r8, fp
+	mov r8, r11
 _02152398:
 	add r5, r5, #1
 	cmp r5, #4
@@ -29563,7 +29563,7 @@ _02152398:
 	add r7, r7, #0x18
 	blt _021522d4
 	mov r0, r8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_0215225c
 _021523b4: .word data_027e077c
@@ -29605,15 +29605,15 @@ _0215240c: .word data_027e077c
 	.global func_ov14_02152410
 	arm_func_start func_ov14_02152410
 func_ov14_02152410: ; 0x02152410
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	mov sb, r0
 	ldr r0, [sb, #0x84]
 	cmp r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, _02152650 ; =data_027e0618
 	ldrb r0, [r0, #0x101]
 	cmp r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, [sb, #0x84]
 	cmp r0, #3
 	bne _0215244c
@@ -29624,7 +29624,7 @@ _0215244c:
 	ldr r0, _02152654 ; =data_027e077c
 	ldr r0, [r0]
 	cmp r0, #0x37
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0215245c:
 	ldrsh r0, [sb, #4]
 	ldrsh r2, [sb, #6]
@@ -29671,7 +29671,7 @@ _021524ec:
 	ldrb r0, [r1, r0]
 	mov r8, #0
 	tst r0, #1
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, _0215265c ; =data_027e0cbc
 	mov r1, #0x14
 	bl func_0203d7e0
@@ -29681,30 +29681,30 @@ _021524ec:
 	mov r1, #0x15
 	bl func_0203d7e0
 	cmp r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02152534:
 	mov ip, #0x3c000
-	umull r0, fp, r7, ip
+	umull r0, r11, r7, ip
 	mov r5, #0
 	mov r2, #0x50000
 	umull sl, r3, r7, r2
 	adds r0, r0, #0x800
-	mla fp, r7, r5, fp
+	mla r11, r7, r5, r11
 	mov r1, r7, asr #0x1f
 	mla r3, r7, r5, r3
-	mla fp, r1, ip, fp
+	mla r11, r1, ip, r11
 	mla r3, r1, r2, r3
-	adc fp, fp, #0
+	adc r11, r11, #0
 	adds r2, sl, #0x800
 	mov r0, r0, lsr #0xc
-	orr r0, r0, fp, lsl #20
+	orr r0, r0, r11, lsl #20
 	add r0, r0, #0x800
 	adc r1, r3, #0
 	mov r2, r2, lsr #0xc
 	orr r2, r2, r1, lsl #20
 	add r1, r2, #0x800
 	add r7, sb, #0x20
-	mov fp, r1, asr #0xc
+	mov r11, r1, asr #0xc
 	mov sl, r0, asr #0xc
 _02152590:
 	ldr r1, [sb, #0x88]
@@ -29746,7 +29746,7 @@ _02152604:
 	beq _0215263c
 	cmp r1, #2
 	movne r8, r6
-	moveq r8, fp
+	moveq r8, r11
 _02152618:
 	mov r2, #0
 	cmp r5, #0
@@ -29762,7 +29762,7 @@ _0215263c:
 	cmp r5, #4
 	add r7, r7, #0x18
 	blt _02152590
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_02152410
 _02152650: .word data_027e0618
@@ -30787,7 +30787,7 @@ _02153320: .word data_027e109c
 	.global func_ov14_02153324
 	arm_func_start func_ov14_02153324
 func_ov14_02153324: ; 0x02153324
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	mov r7, r3
 	mov r5, r7, lsr #0x1
 	mov sl, r0
@@ -30808,18 +30808,18 @@ _02153358:
 _02153368:
 	cmp r0, #0
 	movge r6, r0, lsl #0x1
-	ldrgesh fp, [sb, r6]
+	ldrgesh r11, [sb, r6]
 	ldrgesh r6, [r8, r6]
 	bge _02153394
-	ldr fp, [sl, #0xc]
+	ldr r11, [sl, #0xc]
 	ldr r6, [sl, #0x10]
-	add fp, fp, r0, lsl #1
+	add r11, r11, r0, lsl #1
 	add r6, r6, r0, lsl #1
-	ldrsh fp, [fp, #0x10]
+	ldrsh r11, [r11, #0x10]
 	ldrsh r6, [r6, #0x10]
 _02153394:
 	add r0, r0, #1
-	add r3, r3, fp
+	add r3, r3, r11
 	add r2, r2, r6
 	cmp r0, r4
 	blt _02153368
@@ -30880,17 +30880,17 @@ _02153474:
 	rsb r4, r6, #0x1000
 	sub r3, r1, #0x1000
 	ldr r0, [sl, #4]
-	mov fp, r4, lsl #0x1
+	mov r11, r4, lsl #0x1
 	mov r3, r3, lsl #0x1
 	mov r1, sb
-	mov r2, fp
+	mov r2, r11
 	add r0, r0, r6, lsl #1
 	str r3, [sp]
 	bl func_02007984
 	ldr r0, [sl, #8]
 	mov r1, r8
 	add r0, r0, r6, lsl #1
-	mov r2, fp
+	mov r2, r11
 	bl func_02007984
 	ldr r0, [sl, #4]
 	ldr r2, [sp]
@@ -30914,7 +30914,7 @@ _021534d0:
 	mov r0, r8
 	mov r1, r7
 	bl func_0200e2c0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	arm_func_end func_ov14_02153324
 
 	.global func_ov14_02153508

--- a/asm/ov14/ov14_0213b778.s
+++ b/asm/ov14/ov14_0213b778.s
@@ -5,7 +5,7 @@
 	.global func_ov14_0213b778
 	arm_func_start func_ov14_0213b778
 func_ov14_0213b778: ; 0x0213b778
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0xd4
 	mov r8, r0
 	add r3, sp, #0x54
@@ -23,12 +23,12 @@ _0213b794:
 	ldr r5, _0213b900 ; =_ZTV11FilterActor
 	add r3, sp, #0x40
 	str r1, [sp, #0x10]
-	add sb, sp, #0x54
+	add r9, sp, #0x54
 	mov r7, #0x10
 	ldr r0, [r0]
 	add r1, sp, #0xc
 	add r2, sp, #0
-	str sb, [sp]
+	str r9, [sp]
 	str r7, [sp, #4]
 	str r6, [sp, #8]
 	str r5, [sp, #0xc]
@@ -75,16 +75,16 @@ _0213b850:
 	sub r1, r2, r1
 	smull r3, r2, r1, r1
 	ldr r1, [r8, #0x48]
-	ldr sb, [r0, #0x50]
+	ldr r9, [r0, #0x50]
 	sub r1, r10, r1
 	smull lr, ip, r1, r1
 	ldr r1, [r8, #0x50]
-	sub r1, sb, r1
-	smull r10, sb, r1, r1
+	sub r1, r9, r1
+	smull r10, r9, r1, r1
 	adds r10, r10, #0x800
-	adc r1, sb, #0
-	mov sb, r10, lsr #0xc
-	orr sb, sb, r1, lsl #20
+	adc r1, r9, #0
+	mov r9, r10, lsr #0xc
+	orr r9, r9, r1, lsl #20
 	adds r1, lr, #0x800
 	adc r10, ip, #0
 	mov r1, r1, lsr #0xc
@@ -94,7 +94,7 @@ _0213b850:
 	mov r3, r10, lsr #0xc
 	orr r3, r3, r2, lsl #20
 	add r1, r1, r3
-	add r1, sb, r1
+	add r1, r9, r1
 	cmp r1, r4
 	movlt r11, r0
 	movlt r4, r1
@@ -106,7 +106,7 @@ _0213b8e0:
 _0213b8f0:
 	mov r0, r11
 	add sp, sp, #0xd4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_0213b778
 _0213b8fc: .word data_027e0fe4
@@ -680,15 +680,15 @@ func_ov14_0213bf94: ; 0x0213bf94
 	.global func_ov14_0213bfd0
 	arm_func_start func_ov14_0213bfd0
 func_ov14_0213bfd0: ; 0x0213bfd0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #0x14
 	mov r7, r0
-	ldr sb, [r7, #0x18]
+	ldr r9, [r7, #0x18]
 	mov r6, r1
-	cmp sb, #9
+	cmp r9, #9
 	mov r5, r2
 	mov r4, r3
-	cmpne sb, #0xa
+	cmpne r9, #0xa
 	bne _0213c000
 	mov r10, #1
 	b _0213c004
@@ -697,29 +697,29 @@ _0213c000:
 _0213c004:
 	mov r8, #0
 	bl func_ov14_0215364c
-	cmp sb, r0
+	cmp r9, r0
 	moveq r8, #1
 	beq _0213c034
 	ldr r0, _0213c0f4 ; =gItemManager
-	mov r1, sb
+	mov r1, r9
 	ldr r0, [r0]
 	bl _ZNK11ItemManager7HasItemEi
 	cmp r0, #0
 	addeq sp, sp, #0x14
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 _0213c034:
 	ldr r0, _0213c0f8 ; =data_027e103c
 	ldr r0, [r0]
-	ldrsh sb, [r0, #0x1e]
+	ldrsh r9, [r0, #0x1e]
 	bl func_ov00_020ceffc
 	add r0, r0, #0x100
 	cmp r8, #0
 	ldrsb r1, [r0, #0x4c]
 	cmpne r4, #0
 	beq _0213c074
-	cmp sb, #0x10
+	cmp r9, #0x10
 	blt _0213c068
-	cmp sb, #0x16
+	cmp r9, #0x16
 	ble _0213c074
 _0213c068:
 	mvn r0, #0
@@ -727,7 +727,7 @@ _0213c068:
 	beq _0213c088
 _0213c074:
 	ldrh r0, [r7, #0xa]
-	cmp sb, r0
+	cmp r9, r0
 	ldrne r0, [r7, #0x18]
 	cmpne r1, r0
 	bne _0213c0b8
@@ -759,7 +759,7 @@ _0213c0b8:
 	add r1, r1, r5
 	bl func_ov14_02153924
 	add sp, sp, #0x14
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov14_0213bfd0
 _0213c0f4: .word gItemManager
@@ -768,7 +768,7 @@ _0213c0f8: .word data_027e103c
 	.global func_ov14_0213c0fc
 	arm_func_start func_ov14_0213c0fc
 func_ov14_0213c0fc: ; 0x0213c0fc
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x18
 	ldr r4, _0213c214 ; =gItemManager
 	mov r8, r0
@@ -789,17 +789,17 @@ func_ov14_0213c0fc: ; 0x0213c0fc
 	cmp r0, #9
 	cmpne r0, #0xa
 	bne _0213c158
-	mov sb, #1
+	mov r9, #1
 	b _0213c15c
 _0213c158:
-	mov sb, #0
+	mov r9, #0
 _0213c15c:
-	cmp sb, #0
+	cmp r9, #0
 	bne _0213c16c
 	ldr r0, [r8, #0x18]
 	blx func_ov14_021537c8
 _0213c16c:
-	cmp sb, #0
+	cmp r9, #0
 	bne _0213c1fc
 	ldr r1, _0213c214 ; =gItemManager
 	ldr r0, _0213c21c ; =data_ov14_0215b494
@@ -838,11 +838,11 @@ _0213c16c:
 _0213c1fc:
 	add sp, sp, #0x18
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _0213c208:
 	mov r0, #0
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov14_0213c0fc
 _0213c214: .word gItemManager
@@ -1245,7 +1245,7 @@ _0213c5b8: .word data_ov14_02158cf0
 	.global func_ov14_0213c5bc
 	arm_func_start func_ov14_0213c5bc
 func_ov14_0213c5bc: ; 0x0213c5bc
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	ldr r3, _0213c8bc ; =data_027e0d78
 	ldr r2, _0213c8c0 ; =data_ov14_02158cb0
 	ldr r6, [r3, #0x2c]
@@ -1280,14 +1280,14 @@ _0213c614:
 _0213c634:
 	cmp r1, #0
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	ldr r0, _0213c8c4 ; =data_027e103c
 	ldr r1, _0213c8c8 ; =0x000002ff
 	ldr r0, [r0]
 	bl func_ov00_020cf8fc
 	cmp r0, #0
 	movne r0, #0
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	ldrsb r0, [r4, #0x14]
 	mov r1, #1
 	cmp r0, #1
@@ -1295,11 +1295,11 @@ _0213c634:
 	movne r1, #0
 	cmp r1, #0
 	movne r0, #0
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	bl func_ov14_0213ccd8
 	cmp r0, #0
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	ldr r0, _0213c8cc ; =data_027e077c
 	ldr r0, [r0]
 	cmp r0, #1
@@ -1307,37 +1307,37 @@ _0213c634:
 	ldreqb r0, [r0, #4]
 	cmpeq r0, #0
 	movne r0, #0
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	ldr r0, _0213c8d4 ; =data_027e0fb8
 	ldr r0, [r0]
 	ldrb r0, [r0, #0x79]
 	cmp r0, #0
 	movne r0, #0
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	ldr r0, _0213c8c4 ; =data_027e103c
 	ldr r0, [r0]
 	bl func_ov00_020cf03c
 	ldrsb r0, [r0, #0x14]
 	cmp r0, #0
 	movne r0, #0
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	ldr r0, [r4, #0x1c]
 	ldrh r0, [r0]
 	cmp r0, #0
 	movne r0, #0
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	ldrsb r0, [r4, #0x14]
 	ldrsh r6, [r4, #0xe]
 	cmp r0, #2
 	bne _0213c868
 	mov r7, #0
-	mov sb, r4
+	mov r9, r4
 	add r10, r4, #0x20
 	mov r5, r7
 _0213c714:
 	mov r0, r10
 	ldr ip, [r0]
-	ldrh r8, [sb, #0x2a]
+	ldrh r8, [r9, #0x2a]
 	ldr ip, [ip]
 	mov r1, r6
 	mov r2, r5
@@ -1402,11 +1402,11 @@ _0213c7d4:
 	blx r2
 _0213c808:
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _0213c810:
 	add r7, r7, #1
 	cmp r7, #9
-	add sb, sb, #0x1c
+	add r9, r9, #0x1c
 	add r10, r10, #0x1c
 	blt _0213c714
 	add r0, r4, #0x134
@@ -1425,7 +1425,7 @@ _0213c810:
 	cmp r0, #0
 	beq _0213c8b4
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _0213c868:
 	ldrsb r0, [r4, #0x14]
 	cmp r0, #0
@@ -1445,10 +1445,10 @@ _0213c868:
 	bl func_ov14_0213c910
 	cmp r0, #0
 	movne r0, #1
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _0213c8b4:
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov14_0213c5bc
 _0213c8bc: .word data_027e0d78
@@ -1623,13 +1623,13 @@ _0213cae0: .word data_027e103c
 	.global func_ov14_0213cae4
 	arm_func_start func_ov14_0213cae4
 func_ov14_0213cae4: ; 0x0213cae4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x24
 	mov r5, r0
 	bl func_ov14_0213ccd8
 	cmp r0, #0
 	addeq sp, sp, #0x24
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	ldr r0, _0213ccd0 ; =data_027e103c
 	ldr r1, _0213ccd4 ; =0x000002ff
 	ldr r0, [r0]
@@ -1637,7 +1637,7 @@ func_ov14_0213cae4: ; 0x0213cae4
 	mov r2, r0
 	cmp r2, #0x1000
 	addeq sp, sp, #0x24
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	mov r0, #0
 	mov r1, #0x3c000
 	bl func_ov00_020d03f8
@@ -1668,11 +1668,11 @@ func_ov14_0213cae4: ; 0x0213cae4
 	str r6, [sp]
 	bl func_0203493c
 	mov r8, #0
-	add sb, r5, #0x20
+	add r9, r5, #0x20
 	mov r7, #1
 	mov r6, r8
 _0213cba4:
-	mov r0, sb
+	mov r0, r9
 	mov r1, r4
 	mov r2, r6
 	mov r3, r7
@@ -1680,7 +1680,7 @@ _0213cba4:
 	bl func_ov14_0213bfd0
 	add r8, r8, #1
 	cmp r8, #9
-	add sb, sb, #0x1c
+	add r9, r9, #0x1c
 	blt _0213cba4
 	add r3, sp, #4
 	mov r1, r4
@@ -1707,7 +1707,7 @@ _0213cc20:
 	ldrsb r0, [r5, #0x14]
 	cmp r0, #2
 	addeq sp, sp, #0x24
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	ldr r0, _0213ccd0 ; =data_027e103c
 	ldr r0, [r0]
 	bl func_ov00_020cf03c
@@ -1716,7 +1716,7 @@ _0213cc20:
 	ldreqsb r0, [r5, #0x14]
 	cmpeq r0, #1
 	addeq sp, sp, #0x24
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	ldr r0, _0213ccd0 ; =data_027e103c
 	ldr r0, [r0]
 	bl func_ov00_020cf03c
@@ -1725,14 +1725,14 @@ _0213cc20:
 	ldreqsb r0, [r5, #0x14]
 	cmpeq r0, #4
 	addeq sp, sp, #0x24
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	ldr r0, _0213ccd0 ; =data_027e103c
 	ldr r0, [r0]
 	bl func_ov00_020cf03c
 	ldrsb r0, [r0, #0x14]
 	cmp r0, #2
 	addeq sp, sp, #0x24
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	ldr r0, _0213ccd0 ; =data_027e103c
 	ldr r0, [r0]
 	bl func_ov00_020cf03c
@@ -1747,7 +1747,7 @@ _0213cc20:
 	add r1, r4, r1
 	bl func_ov00_020d00c4
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov14_0213cae4
 _0213ccd0: .word data_027e103c
@@ -1756,12 +1756,12 @@ _0213ccd4: .word 0x000002ff
 	.global func_ov14_0213ccd8
 	arm_func_start func_ov14_0213ccd8
 func_ov14_0213ccd8: ; 0x0213ccd8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	ldr r0, _0213cdb0 ; =data_027e0c68
 	ldr r0, [r0, #0x28]
 	cmp r0, #0
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	ldr r0, _0213cdb4 ; =data_027e077c
 	mov r5, #0
 	ldr r0, [r0]
@@ -1770,31 +1770,31 @@ func_ov14_0213ccd8: ; 0x0213ccd8
 	cmpne r0, #0x37
 	ldr r6, _0213cdb8 ; =gItemManager
 	moveq r4, #0
-	mov sb, r5
+	mov r9, r5
 	mov r7, r5
 	mov r8, #1
 _0213cd1c:
 	ldr r0, [r6]
-	mov r1, sb
+	mov r1, r9
 	bl _ZNK11ItemManager9HasPotionEj
 	orrs r0, r5, r0
 	movne r5, r8
-	add sb, sb, #1
+	add r9, r9, #1
 	moveq r5, r7
-	cmp sb, #2
+	cmp r9, #2
 	blt _0213cd1c
 	mov r6, #0
-	mov sb, #1
+	mov r9, #1
 	mov r7, r6
 	mov r8, r6
 	bl func_ov14_0215364c
 	cmp r0, #0
-	movge r0, sb
+	movge r0, r9
 	movlt r0, r6
 	cmp r0, #0
 	cmpeq r5, #0
-	moveq sb, #0
-	cmp sb, #0
+	moveq r9, #0
+	cmp r9, #0
 	beq _0213cd84
 	ldr r0, _0213cdb0 ; =data_027e0c68
 	ldrb r0, [r0, #4]
@@ -1812,7 +1812,7 @@ _0213cd84:
 	moveq r6, #1
 _0213cda8:
 	mov r0, r6
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov14_0213ccd8
 _0213cdb0: .word data_027e0c68
@@ -3004,7 +3004,7 @@ _0213d9a8: .word data_027e0e60
 	.global func_ov14_0213d9ac
 	arm_func_start func_ov14_0213d9ac
 func_ov14_0213d9ac: ; 0x0213d9ac
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x18
 	mov r10, r0
 	bl func_ov14_0213dda0
@@ -3015,7 +3015,7 @@ func_ov14_0213d9ac: ; 0x0213d9ac
 	blt _0213dac0
 	mov r7, r10
 	add r8, r10, #0x2c
-	add sb, r10, #0x24
+	add r9, r10, #0x24
 	mov r4, #2
 	mov r11, #3
 _0213d9e4:
@@ -3059,10 +3059,10 @@ _0213d9fc:
 	mov r0, #0
 	strh r0, [r1, #0x2e]
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0213da84:
 	ldr r0, _0213dad8 ; =data_027e0fe4
-	mov r1, sb
+	mov r1, r9
 	ldr r0, [r0]
 	bl _ZN12ActorManager8GetActorEP8ActorRef
 	cmp r0, #0
@@ -3072,7 +3072,7 @@ _0213da84:
 _0213daa4:
 	add r7, r7, #0x1c
 	add r8, r8, #0x1c
-	add sb, sb, #0x1c
+	add r9, r9, #0x1c
 	add r6, r6, #1
 	ldrsh r0, [r10, #0xa]
 	cmp r6, r0
@@ -3082,7 +3082,7 @@ _0213dac0:
 	str r0, [r10, #0x74]
 	mov r0, #1
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_0213d9ac
 _0213dad4: .word data_027e0e60
@@ -3623,7 +3623,7 @@ _0213e208: .word 0x0000019a
 	.global func_ov14_0213e20c
 	arm_func_start func_ov14_0213e20c
 func_ov14_0213e20c: ; 0x0213e20c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x18
 	mov r3, #0x1c
 	mul r6, r1, r3
@@ -3643,8 +3643,8 @@ func_ov14_0213e20c: ; 0x0213e20c
 	bl func_ov14_0213d248
 	cmp r0, #0
 	beq _0213e318
-	add sb, r8, #0x30
-	ldrb r0, [sb, r6]
+	add r9, r8, #0x30
+	ldrb r0, [r9, r6]
 	cmp r0, #0
 	bne _0213e2f0
 	mov r0, r5
@@ -3680,7 +3680,7 @@ _0213e2d0:
 	mov r0, r5
 	bl func_ov14_0214bd08
 	mov r4, #1
-	strb r4, [sb, r6]
+	strb r4, [r9, r6]
 _0213e2f0:
 	mov r0, r5
 	ldr r2, [r0]
@@ -3695,7 +3695,7 @@ _0213e2f0:
 _0213e318:
 	mov r0, r4
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov14_0213e20c
 _0213e324: .word data_027e0e60
@@ -3703,14 +3703,14 @@ _0213e324: .word data_027e0e60
 	.global func_ov14_0213e328
 	arm_func_start func_ov14_0213e328
 func_ov14_0213e328: ; 0x0213e328
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x18
 	mov r10, r0
 	ldrsh r0, [r10, #0xa]
 	cmp r0, #0
 	addlt sp, sp, #0x18
 	movlt r0, #0
-	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmltia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldrsh r1, [r10, #0xa]
 	mov r4, #0
 	mov r11, r4
@@ -3724,13 +3724,13 @@ _0213e36c:
 	ldrsh r0, [r5, #0x2e]
 	cmp r0, #3
 	str r0, [sp]
-	movne sb, #0
+	movne r9, #0
 	bne _0213e394
 	ldr r0, _0213e538 ; =data_027e0fe4
 	mov r1, r6
 	ldr r0, [r0]
 	bl _ZN12ActorManager8GetActorEP8ActorRef
-	mov sb, r0
+	mov r9, r0
 _0213e394:
 	ldr r0, [sp]
 	cmp r0, #2
@@ -3741,8 +3741,8 @@ _0213e394:
 	ldr r0, [r0]
 	bl func_ov00_020840c4
 _0213e3b4:
-	cmp sb, #0
-	ldrne r0, [sb, #0x88]
+	cmp r9, #0
+	ldrne r0, [r9, #0x88]
 	addne r4, r4, r0
 	bne _0213e404
 	cmp r0, #0
@@ -3762,7 +3762,7 @@ _0213e3f0:
 _0213e3f8:
 	add sp, sp, #0x18
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0213e404:
 	ldrsh r1, [r10, #0xa]
 	add r0, sp, #4
@@ -3797,7 +3797,7 @@ _0213e44c:
 	strb r0, [r10, #0x69]
 	add sp, sp, #0x18
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0213e484:
 	mov r5, #0
 	cmp r0, #0
@@ -3848,7 +3848,7 @@ _0213e518:
 _0213e52c:
 	mov r0, #1
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_0213e328
 _0213e538: .word data_027e0fe4
@@ -3869,13 +3869,13 @@ func_ov14_0213e544: ; 0x0213e544
 	.global func_ov14_0213e55c
 	arm_func_start func_ov14_0213e55c
 func_ov14_0213e55c: ; 0x0213e55c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0xb4
 	mov r6, r0
 	ldr r0, [r6, #0x20]
 	cmp r0, #2
 	addlo sp, sp, #0xb4
-	ldmloia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmloia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r2, [r6]
 	ldr r0, _0213eaa0 ; =data_027e0f64
 	ldr r1, [r2]
@@ -3895,7 +3895,7 @@ func_ov14_0213e55c: ; 0x0213e55c
 	ldr r0, [r6, #0x20]
 	ldr r8, [sp, #0x4c]
 	cmp r0, #0
-	ldr sb, [sp, #0x48]
+	ldr r9, [sp, #0x48]
 	mov r10, r4
 	bls _0213e670
 	mov r7, r4
@@ -3926,13 +3926,13 @@ _0213e62c:
 	ldr r0, [sp, #0x44]
 	ldr r1, [sp, #0x40]
 	sub r0, r0, r8
-	sub r1, r1, sb
+	sub r1, r1, r9
 	bl func_01ffa0f4
 	mov r2, r10, lsl #0x1
 	ldr r8, [sp, #0x4c]
 	ldr r1, [sp, #0x44]
 	strh r0, [r5, r2]
-	ldr sb, [sp, #0x48]
+	ldr r9, [sp, #0x48]
 	ldr r0, [sp, #0x40]
 	str r1, [sp, #0x4c]
 	str r0, [sp, #0x48]
@@ -4035,50 +4035,50 @@ _0213e788:
 	mov r0, ip, asr #0x1f
 	str r0, [sp, #4]
 	mov r0, #0xf6
-	umull r10, sb, r8, r0
+	umull r10, r9, r8, r0
 	mov r0, #0
-	mla sb, r8, r0, sb
+	mla r9, r8, r0, r9
 	mov r0, #0xf6
-	mla sb, r7, r0, sb
+	mla r9, r7, r0, r9
 	mov r0, #0x800
 	adds r8, r10, r0
 	mov r0, #0
-	adc r7, sb, r0
+	adc r7, r9, r0
 	mov r0, r8, lsr #0xc
 	orr r0, r0, r7, lsl #20
-	smull sb, r8, lr, r0
-	adds sb, sb, #0x800
+	smull r9, r8, lr, r0
+	adds r9, r9, #0x800
 	adc r7, r8, #0
-	mov r8, sb, lsr #0xc
+	mov r8, r9, lsr #0xc
 	orr r8, r8, r7, lsl #20
 	ldr r11, [sp, #0x78]
 	str r8, [sp, #0x74]
-	smull sb, r8, r11, r0
+	smull r9, r8, r11, r0
 	ldr r10, [sp, #8]
 	add r1, sp, #0x8c
 	smull r7, r0, r10, r0
-	adds r10, sb, #0x800
+	adds r10, r9, #0x800
 	adc r8, r8, #0
-	mov sb, r10, lsr #0xc
-	orr sb, sb, r8, lsl #20
+	mov r9, r10, lsr #0xc
+	orr r9, r9, r8, lsl #20
 	adds r8, r7, #0x800
 	adc r0, r0, #0
 	mov r7, r8, lsr #0xc
 	orr r7, r7, r0, lsl #20
 	str r7, [sp, #0x7c]
 	mov r0, #0xf6
-	str sb, [sp, #0x78]
-	umull sb, r8, ip, r0
+	str r9, [sp, #0x78]
+	umull r9, r8, ip, r0
 	mov r0, #0
 	mla r8, ip, r0, r8
 	ldr r7, [sp, #4]
 	mov r0, #0xf6
 	mla r8, r7, r0, r8
 	mov r0, #0x800
-	adds sb, sb, r0
+	adds r9, r9, r0
 	mov r0, #0
 	adc r7, r8, r0
-	mov r0, sb, lsr #0xc
+	mov r0, r9, lsr #0xc
 	mov r2, r3
 	orr r0, r0, r7, lsl #20
 	bl func_01ff9e64
@@ -4211,7 +4211,7 @@ _0213ea6c:
 	str r3, [sp, #0xc]
 	bl func_01ffa9fc
 	add sp, sp, #0xb4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_0213e55c
 _0213eaa0: .word data_027e0f64
@@ -6357,17 +6357,17 @@ func_ov14_0213ff88: ; 0x0213ff88
 	.global func_ov14_0213ffac
 	arm_func_start func_ov14_0213ffac
 func_ov14_0213ffac: ; 0x0213ffac
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x20
 	mov r4, r1
 	mov r5, #0x19000
 	umull r7, r6, r4, r5
 	mov r1, #0
 	mla r6, r4, r1, r6
-	mov sb, r4, asr #0x1f
+	mov r9, r4, asr #0x1f
 	adds r8, r7, #0x800
-	mla r6, sb, r5, r6
-	mov r1, sb, lsl #0x10
+	mla r6, r9, r5, r6
+	mov r1, r9, lsl #0x10
 	adc r5, r6, #0
 	mov r8, r8, lsr #0xc
 	orr r8, r8, r5, lsl #20
@@ -6379,13 +6379,13 @@ func_ov14_0213ffac: ; 0x0213ffac
 	orr r1, r1, r4, lsr #16
 	mov r6, r0, lsr #0xc
 	adc r0, r1, #0
-	add sb, sp, #0x10
+	add r9, sp, #0x10
 	add r11, sp, #0
 	mov lr, r2
 	mov ip, r3
 	orr r6, r6, r0, lsl #20
 	ldmia r10, {r0, r1, r2, r3}
-	stmia sb, {r0, r1, r2, r3}
+	stmia r9, {r0, r1, r2, r3}
 	ldmia r7, {r0, r1, r2, r3}
 	stmia r11, {r0, r1, r2, r3}
 	cmp r4, #0xa4
@@ -6395,12 +6395,12 @@ func_ov14_0213ffac: ; 0x0213ffac
 	str r6, [sp, #4]
 	bgt _0214005c
 	mov r0, r5
-	mov r1, sb
+	mov r1, r9
 	mov r2, #0
 	mov r3, #1
 	bl func_ov00_020b45f8
 	add sp, sp, #0x20
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0214005c:
 	ldr r1, _021400bc ; =0x00000266
 	cmp r4, r1
@@ -6411,12 +6411,12 @@ _0214005c:
 	mov r3, r0
 	mov r0, r5
 	ldr r4, [r0]
-	mov r1, sb
+	mov r1, r9
 	ldr r4, [r4, #0x60]
 	mov r2, r11
 	blx r4
 	add sp, sp, #0x20
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02140098:
 	mov r0, r5
 	mov r1, r11
@@ -6424,7 +6424,7 @@ _02140098:
 	mov r3, #1
 	bl func_ov00_020b45f8
 	add sp, sp, #0x20
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_0213ffac
 _021400b4: .word data_ov14_02153e50
@@ -6434,7 +6434,7 @@ _021400bc: .word 0x00000266
 	.global func_ov14_021400c0
 	arm_func_start func_ov14_021400c0
 func_ov14_021400c0: ; 0x021400c0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	mov r5, r0
 	add r0, r5, #0x1a8
 	bl func_0203516c
@@ -6456,7 +6456,7 @@ _021400ec:
 	ldr r1, [r0]
 	ldr r1, [r1, #0x80]
 	blx r1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _02140118:
 	bl func_ov00_020b46dc
 	ldr r0, [r5, #0x498]
@@ -6512,14 +6512,14 @@ _021401dc:
 	mov r6, #0
 	ldr r2, [r4]
 	ldmib r4, {r0, r7, r8}
-	umull r3, sb, r7, r2
-	mla sb, r7, r0, sb
+	umull r3, r9, r7, r2
+	mla r9, r7, r0, r9
 	ldr r1, [r4, #0x10]
-	mla sb, r8, r2, sb
+	mla r9, r8, r2, r9
 	adds r3, r1, r3
 	ldr r0, [r4, #0x14]
 	umull lr, ip, r7, r3
-	adc r2, r0, sb
+	adc r2, r0, r9
 	mla ip, r7, r2, ip
 	mov r7, r6, lsl #0x4
 	mla ip, r8, r3, ip
@@ -6564,7 +6564,7 @@ _02140294:
 	add r2, r2, #1
 	strh r2, [r0, #0xa0]
 	strh r1, [r0, #0xa2]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov14_021400c0
 _021402b0: .word data_027e0d38
@@ -6950,16 +6950,16 @@ _021407b4: .word data_027e0f64
 	.global func_ov14_021407b8
 	arm_func_start func_ov14_021407b8
 func_ov14_021407b8: ; 0x021407b8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x38
 	ldrh r1, [r1]
 	mov r10, r0
-	mov sb, r2
+	mov r9, r2
 	tst r1, #4
 	bne _021407e0
 	tst r1, #8
 	addeq sp, sp, #0x38
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _021407e0:
 	add r0, sp, #0x18
 	bl func_01ffbe34
@@ -7048,7 +7048,7 @@ _021408e0:
 	ldr r0, _02141140 ; =data_027e0d3c
 	str r2, [sp, #0xc]
 	ldr r0, [r0]
-	mov r1, sb
+	mov r1, r9
 	mov r3, r2
 	bl func_ov00_02079470
 	cmp r0, #0
@@ -7063,7 +7063,7 @@ _021408e0:
 _02140960:
 	cmp r8, #0
 	addeq sp, sp, #0x38
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r1, sp, #0x14
 	str r1, [sp]
 	add r0, sp, #0x10
@@ -7074,12 +7074,12 @@ _02140960:
 	ldr r0, _02141140 ; =data_027e0d3c
 	str r2, [sp, #0xc]
 	ldr r0, [r0]
-	mov r1, sb
+	mov r1, r9
 	sub r3, r2, #0xc
 	bl func_ov00_02079470
 	cmp r0, #0
 	addeq sp, sp, #0x38
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r1, sp, #0x18
 	str r1, [sp]
 	ldr r0, _02141144 ; =data_02063e4c
@@ -7088,7 +7088,7 @@ _02140960:
 	mov r3, #0x6b
 	bl func_020313c8
 	add sp, sp, #0x38
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _021409d0:
 	mov r0, r11
 	bl func_ov00_020849c0
@@ -7104,7 +7104,7 @@ _021409d0:
 	ldr r0, _02141140 ; =data_027e0d3c
 	str r2, [sp, #0xc]
 	ldr r0, [r0]
-	mov r1, sb
+	mov r1, r9
 	mov r3, r2
 	bl func_ov00_02079470
 	cmp r0, #0
@@ -7157,7 +7157,7 @@ _02140aac:
 _02140ac4:
 	cmp r8, #0
 	addeq sp, sp, #0x38
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r1, sp, #0x14
 	str r1, [sp]
 	add r0, sp, #0x10
@@ -7168,12 +7168,12 @@ _02140ac4:
 	ldr r0, _02141140 ; =data_027e0d3c
 	str r2, [sp, #0xc]
 	ldr r0, [r0]
-	mov r1, sb
+	mov r1, r9
 	sub r3, r2, #0xc
 	bl func_ov00_02079470
 	cmp r0, #0
 	addeq sp, sp, #0x38
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r0, r7, #0xc
 	bl func_ov00_020a5e9c
 	cmp r0, #4
@@ -7184,7 +7184,7 @@ _02140ac4:
 	bl func_ov00_02097760
 	cmp r0, #0
 	addne sp, sp, #0x38
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, _0214114c ; =data_027e0f74
 	mov r1, #0x81
 	ldr r0, [r0]
@@ -7199,7 +7199,7 @@ _02140ac4:
 	mov r3, #0x70
 	bl func_020313c8
 	add sp, sp, #0x38
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02140b78:
 	ldr r0, _0214114c ; =data_027e0f74
 	mov r1, #0x62
@@ -7207,7 +7207,7 @@ _02140b78:
 	bl func_ov00_02097760
 	cmp r0, #0
 	addeq sp, sp, #0x38
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r1, sp, #0x18
 	str r1, [sp]
 	ldr r0, _02141144 ; =data_02063e4c
@@ -7216,7 +7216,7 @@ _02140b78:
 	mov r3, #0x6f
 	bl func_020313c8
 	add sp, sp, #0x38
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02140bb8:
 	add r1, sp, #0x18
 	str r1, [sp]
@@ -7226,11 +7226,11 @@ _02140bb8:
 	mov r3, #0x6b
 	bl func_020313c8
 	add sp, sp, #0x38
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02140bdc:
 	cmp r8, #0
 	addeq sp, sp, #0x38
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r1, sp, #0x14
 	str r1, [sp]
 	add r0, sp, #0x10
@@ -7241,12 +7241,12 @@ _02140bdc:
 	ldr r0, _02141140 ; =data_027e0d3c
 	str r2, [sp, #0xc]
 	ldr r0, [r0]
-	mov r1, sb
+	mov r1, r9
 	sub r3, r2, #8
 	bl func_ov00_02079470
 	cmp r0, #0
 	addeq sp, sp, #0x38
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r1, sp, #0x18
 	str r1, [sp]
 	ldr r0, _02141144 ; =data_02063e4c
@@ -7255,7 +7255,7 @@ _02140bdc:
 	mov r3, #0x6b
 	bl func_020313c8
 	add sp, sp, #0x38
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02140c4c:
 	bl func_ov03_020f4b7c
 	cmp r0, #0
@@ -7276,7 +7276,7 @@ _02140c4c:
 	ldr r0, _02141140 ; =data_027e0d3c
 	str r2, [sp, #0xc]
 	ldr r0, [r0]
-	mov r1, sb
+	mov r1, r9
 	sub r3, r2, #0xc
 	bl func_ov00_02079470
 	cmp r0, #0
@@ -7299,12 +7299,12 @@ _02140cc8:
 	ldr r0, _02141140 ; =data_027e0d3c
 	str r2, [sp, #0xc]
 	ldr r0, [r0]
-	mov r1, sb
+	mov r1, r9
 	mov r3, r2
 	bl func_ov00_02079470
 	cmp r0, #0
 	addeq sp, sp, #0x38
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r1, sp, #0x18
 	str r1, [sp]
 	ldr r0, _02141144 ; =data_02063e4c
@@ -7313,16 +7313,16 @@ _02140cc8:
 	mov r3, #0x5d
 	bl func_020313c8
 	add sp, sp, #0x38
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02140d2c:
 	mov r0, r11
 	bl func_ov00_020849c0
 	cmp r0, #0
 	addne sp, sp, #0x38
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	cmp r8, #0
 	addeq sp, sp, #0x38
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r1, sp, #0x14
 	str r1, [sp]
 	add r0, sp, #0x10
@@ -7333,12 +7333,12 @@ _02140d2c:
 	ldr r0, _02141140 ; =data_027e0d3c
 	str r2, [sp, #0xc]
 	ldr r0, [r0]
-	mov r1, sb
+	mov r1, r9
 	sub r3, r2, #0xc
 	bl func_ov00_02079470
 	cmp r0, #0
 	addeq sp, sp, #0x38
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r1, sp, #0x18
 	str r1, [sp]
 	ldr r0, _02141144 ; =data_02063e4c
@@ -7347,7 +7347,7 @@ _02140d2c:
 	mov r3, #2
 	bl func_020313c8
 	add sp, sp, #0x38
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02140db0:
 	bl func_ov00_020849c0
 	cmp r0, #0
@@ -7364,7 +7364,7 @@ _02140db0:
 	ldr r0, _02141140 ; =data_027e0d3c
 	str r2, [sp, #0xc]
 	ldr r0, [r0]
-	mov r1, sb
+	mov r1, r9
 	sub r3, r2, #0xc
 	bl func_ov00_02079470
 	cmp r0, #0
@@ -7427,12 +7427,12 @@ _02140eb4:
 	ldr r0, _02141140 ; =data_027e0d3c
 	str r2, [sp, #0xc]
 	ldr r0, [r0]
-	mov r1, sb
+	mov r1, r9
 	mov r3, r2
 	bl func_ov00_02079470
 	cmp r0, #0
 	addeq sp, sp, #0x38
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r0, r7, #0xc
 	bl func_ov00_020a5e9c
 	cmp r0, #5
@@ -7450,7 +7450,7 @@ _02140eb4:
 	mov r3, #0x5a
 	bl func_020313c8
 	add sp, sp, #0x38
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02140f3c:
 	str r1, [sp]
 	ldr r0, _02141144 ; =data_02063e4c
@@ -7459,7 +7459,7 @@ _02140f3c:
 	mov r3, #0x59
 	bl func_020313c8
 	add sp, sp, #0x38
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02140f5c:
 	add r0, r7, #0xc
 	bl func_ov00_020a5e9c
@@ -7473,7 +7473,7 @@ _02140f5c:
 	mov r3, #0x42
 	bl func_020313c8
 	add sp, sp, #0x38
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02140f90:
 	str r1, [sp]
 	ldr r0, _02141144 ; =data_02063e4c
@@ -7482,7 +7482,7 @@ _02140f90:
 	mov r3, #0x58
 	bl func_020313c8
 	add sp, sp, #0x38
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02140fb0:
 	add r1, sp, #0x14
 	str r1, [sp]
@@ -7494,7 +7494,7 @@ _02140fb0:
 	ldr r0, _02141140 ; =data_027e0d3c
 	str r2, [sp, #0xc]
 	ldr r0, [r0]
-	mov r1, sb
+	mov r1, r9
 	mov r3, r2
 	bl func_ov00_02079470
 	cmp r0, #0
@@ -7514,7 +7514,7 @@ _02140fb0:
 	add r0, r10, #0x1a8
 	bl func_02034a1c
 	add sp, sp, #0x38
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0214102c:
 	ldrb r0, [r10, #0x14d]
 	cmp r0, #0
@@ -7526,7 +7526,7 @@ _0214102c:
 	add r0, r1, r0, ror #28
 	cmp r0, #8
 	addge sp, sp, #0x38
-	ldmgeia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmgeia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02141058:
 	add r1, sp, #0x18
 	str r1, [sp]
@@ -7536,11 +7536,11 @@ _02141058:
 	mov r3, #1
 	bl func_020313c8
 	add sp, sp, #0x38
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0214107c:
 	cmp r8, #0
 	addeq sp, sp, #0x38
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	mov r0, r11
 	bl func_ov00_02084990
 	cmp r0, #0
@@ -7557,7 +7557,7 @@ _0214107c:
 	bl func_ov00_0207977c
 	cmp r0, #0
 	addeq sp, sp, #0x38
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldrb r0, [sp, #0x60]
 	cmp r0, #0
 	beq _0214110c
@@ -7573,7 +7573,7 @@ _0214107c:
 	add r0, r10, #0x1a8
 	bl func_02034a1c
 	add sp, sp, #0x38
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0214110c:
 	add r1, sp, #0x18
 	str r1, [sp]
@@ -7583,7 +7583,7 @@ _0214110c:
 	mov r3, r4
 	bl func_020313c8
 	add sp, sp, #0x38
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_021407b8
 _02141130: .word 0x88888889
@@ -7599,7 +7599,7 @@ _02141150: .word 0x00000186
 	.global func_ov14_02141154
 	arm_func_start func_ov14_02141154
 func_ov14_02141154: ; 0x02141154
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x1e8
 	ldr r3, _021415b4 ; =data_027e0c54
 	mov r10, r0
@@ -7610,7 +7610,7 @@ func_ov14_02141154: ; 0x02141154
 	cmp r1, r3
 	mov r5, r2
 	addne sp, sp, #0x1e8
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r1, _021415b8 ; =data_027e0d38
 	str r4, [r10, #0x18c]
 	ldr r1, [r1]
@@ -7622,7 +7622,7 @@ func_ov14_02141154: ; 0x02141154
 	ldr r2, [r2, #0x84]
 	blx r2
 	add sp, sp, #0x1e8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _021411b4:
 	mov r0, r4
 	ldr r1, [r0]
@@ -7689,7 +7689,7 @@ _0214128c:
 	bl func_ov14_021415d4
 	bl _ZN15LinkStateDamage18func_ov00_020aca94Ev
 	add sp, sp, #0x1e8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _021412a8:
 	mov r0, r5, lsl #0x10
 	mov r0, r0, lsr #0x10
@@ -7732,7 +7732,7 @@ _02141338:
 	add r0, r10, #0x400
 	ldrsh r8, [r0, #0xa2]
 	mov r0, r4
-	mov sb, #0x1f
+	mov r9, #0x1f
 	cmp r8, #0
 	ldr r1, [r0]
 	blt _02141370
@@ -7741,12 +7741,12 @@ _02141338:
 	mov r1, r8
 	bl func_020197fc
 	add r0, r10, #0x400
-	ldrsh sb, [r0, #0xa2]
+	ldrsh r9, [r0, #0xa2]
 	b _02141380
 _02141370:
 	ldr r1, [r1, #8]
 	blx r1
-	mov r1, sb
+	mov r1, r9
 	bl func_020197fc
 _02141380:
 	ldr r0, [sp, #4]
@@ -7765,28 +7765,28 @@ _021413ac:
 _021413b0:
 	cmp r7, #0
 	cmpne r8, #0
-	movne r2, sb
+	movne r2, r9
 	moveq r2, #0
 	mov r0, r4
 	mov r1, #0
 	bl func_ov00_020aa0f0
 	cmp r7, #0
-	movne r2, sb
+	movne r2, r9
 	moveq r2, #0
 	mov r0, r4
 	mov r1, #1
 	bl func_ov00_020aa0f0
 	cmp r6, #0
 	cmpne r8, #0
-	movne r2, sb
+	movne r2, r9
 	moveq r2, #0
 	mov r0, r4
 	mov r1, #2
 	bl func_ov00_020aa0f0
 	cmp r6, #0
-	moveq sb, #0
+	moveq r9, #0
 	mov r0, r4
-	mov r2, sb
+	mov r2, r9
 	mov r1, #3
 	bl func_ov00_020aa0f0
 _02141418:
@@ -7895,7 +7895,7 @@ _0214159c:
 	mov r0, r4
 	bl func_ov00_020a9c14
 	add sp, sp, #0x1e8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_02141154
 _021415b4: .word data_027e0c54
@@ -8061,15 +8061,15 @@ _02141788: .word 0x00000266
 	.global func_ov14_0214178c
 	arm_func_start func_ov14_0214178c
 func_ov14_0214178c: ; 0x0214178c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #0xc
 	mov r10, r0
 	ldrb r0, [r10, #0x14c]
-	mov sb, r2
+	mov r9, r2
 	cmp r0, #0
 	addeq sp, sp, #0xc
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	mov r0, #0xc
 	mul r8, r1, r0
 	add r7, r10, #0xd4
@@ -8079,7 +8079,7 @@ func_ov14_0214178c: ; 0x0214178c
 	cmp r1, r0
 	addge sp, sp, #0xc
 	movge r0, #0
-	ldmgeia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmgeia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	add r5, r10, #0xd0
 	ldr r1, [r5, r8]
 	ldr r0, _021418e8 ; =data_027e0e60
@@ -8099,7 +8099,7 @@ func_ov14_0214178c: ; 0x0214178c
 	cmp r3, r0
 	addge sp, sp, #0xc
 	movge r0, #0
-	ldmgeia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmgeia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	ldr r0, [r6, r8]
 	add r2, r3, #0xf6
 	cmp r0, r2
@@ -8107,16 +8107,16 @@ func_ov14_0214178c: ; 0x0214178c
 	add r1, r10, #0xe8
 	ldr ip, [r1, r8]
 	add r0, r10, #0xf0
-	str ip, [sb]
+	str ip, [r9]
 	ldr r6, [r6, r8]
-	str r6, [sb, #4]
+	str r6, [r9, #4]
 	ldr r6, [r0, r8]
-	stmib sb, {r3, r6}
+	stmib r9, {r3, r6}
 	ldr r3, [r7, r8]
 	cmp r3, r2
 	addgt sp, sp, #0xc
 	movgt r0, #1
-	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	ldr r2, [r1, r8]
 	ldr r3, [r5, r8]
 	ldr r1, [r4, r8]
@@ -8135,7 +8135,7 @@ func_ov14_0214178c: ; 0x0214178c
 _021418a8:
 	add sp, sp, #0xc
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 _021418b4:
 	mul r0, r1, r1
 	mul r1, r2, r2
@@ -8146,11 +8146,11 @@ _021418b4:
 	cmp r0, #0x45
 	addgt sp, sp, #0xc
 	movgt r0, #1
-	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 _021418dc:
 	mov r0, #0
 	add sp, sp, #0xc
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov14_0214178c
 _021418e8: .word data_027e0e60
@@ -8432,30 +8432,30 @@ func_ov14_02141c38: ; 0x02141c38
 	.global func_ov14_02141c60
 	arm_func_start func_ov14_02141c60
 func_ov14_02141c60: ; 0x02141c60
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x4c
-	mov sb, r0
-	ldr r0, [sb, #0x18]
+	mov r9, r0
+	ldr r0, [r9, #0x18]
 	mov r4, #0
-	str r0, [sb, #0x58]
-	ldr r0, [sb, #0x1c]
-	str r0, [sb, #0x5c]
-	ldr r0, [sb, #0x20]
-	str r0, [sb, #0x60]
-	ldrsh r0, [sb, #0xc]
+	str r0, [r9, #0x58]
+	ldr r0, [r9, #0x1c]
+	str r0, [r9, #0x5c]
+	ldr r0, [r9, #0x20]
+	str r0, [r9, #0x60]
+	ldrsh r0, [r9, #0xc]
 	bl func_0202bbbc
-	str r0, [sb, #0x40]
+	str r0, [r9, #0x40]
 	mov r1, r0
-	mov r0, sb
+	mov r0, r9
 	mov r2, #1
 	bl func_ov14_02142b6c
-	strb r0, [sb, #0x38]
-	ldr r1, [sb, #0x40]
-	mov r0, sb
+	strb r0, [r9, #0x38]
+	ldr r1, [r9, #0x40]
+	mov r0, r9
 	mov r2, #1
 	bl func_ov14_02142bbc
-	strb r0, [sb, #0x39]
-	ldr r0, [sb, #0x40]
+	strb r0, [r9, #0x39]
+	ldr r0, [r9, #0x40]
 	cmp r0, #3
 	addls pc, pc, r0, lsl #2
 	b _02141d88
@@ -8467,61 +8467,61 @@ _02141ccc: ; jump table
 _02141cdc:
 	mov r0, #0x8000
 	rsb r0, r0, #0
-	strh r0, [sb, #0xc]
-	ldrb r2, [sb, #0x15]
+	strh r0, [r9, #0xc]
+	ldrb r2, [r9, #0x15]
 	ldr r0, _02142040 ; =data_027e0e60
-	ldrb r1, [sb, #0x14]
+	ldrb r1, [r9, #0x14]
 	ldr r0, [r0]
 	add r2, r2, #1
 	bl func_ov00_02083e34
-	str r0, [sb, #0x1c]
+	str r0, [r9, #0x1c]
 	mov r4, #1
 	b _02141d88
 _02141d0c:
 	mov r0, r4
-	strh r0, [sb, #0xc]
-	ldrb r2, [sb, #0x15]
+	strh r0, [r9, #0xc]
+	ldrb r2, [r9, #0x15]
 	ldr r0, _02142040 ; =data_027e0e60
-	ldrb r1, [sb, #0x14]
+	ldrb r1, [r9, #0x14]
 	ldr r0, [r0]
 	sub r2, r2, #1
 	bl func_ov00_02083e34
-	str r0, [sb, #0x1c]
+	str r0, [r9, #0x1c]
 	b _02141d88
 _02141d34:
 	mov r0, #0x4000
 	rsb r0, r0, #0
-	strh r0, [sb, #0xc]
-	ldrb r1, [sb, #0x14]
+	strh r0, [r9, #0xc]
+	ldrb r1, [r9, #0x14]
 	ldr r0, _02142040 ; =data_027e0e60
-	ldrb r2, [sb, #0x15]
+	ldrb r2, [r9, #0x15]
 	ldr r0, [r0]
 	add r1, r1, #1
 	bl func_ov00_02083e34
-	str r0, [sb, #0x1c]
+	str r0, [r9, #0x1c]
 	mov r4, #1
 	b _02141d88
 _02141d64:
 	mov r0, #0x4000
-	strh r0, [sb, #0xc]
-	ldrb r1, [sb, #0x14]
+	strh r0, [r9, #0xc]
+	ldrb r1, [r9, #0x14]
 	ldr r0, _02142040 ; =data_027e0e60
-	ldrb r2, [sb, #0x15]
+	ldrb r2, [r9, #0x15]
 	ldr r0, [r0]
 	sub r1, r1, #1
 	bl func_ov00_02083e34
-	str r0, [sb, #0x1c]
+	str r0, [r9, #0x1c]
 _02141d88:
-	ldr r1, [sb, #4]
-	mov r0, sb
+	ldr r1, [r9, #4]
+	mov r0, r9
 	orr r1, r1, #0x10
-	str r1, [sb, #4]
+	str r1, [r9, #4]
 	bl func_ov00_0208c214
 	cmp r4, #0
-	ldrb r0, [sb, #0x14]
+	ldrb r0, [r9, #0x14]
 	beq _02141e5c
 	str r0, [sp, #4]
-	ldrb r0, [sb, #0x38]
+	ldrb r0, [r9, #0x38]
 	ldr r1, [sp, #4]
 	sub r2, r1, r0
 	cmp r1, r2
@@ -8532,8 +8532,8 @@ _02141d88:
 	add r10, sp, #0xc
 	mov r11, r5
 _02141dd4:
-	ldrb r8, [sb, #0x15]
-	ldrb r0, [sb, #0x39]
+	ldrb r8, [r9, #0x15]
+	ldrb r0, [r9, #0x39]
 	sub r0, r8, r0
 	cmp r8, r0
 	ble _02141e38
@@ -8552,15 +8552,15 @@ _02141df0:
 	strb r8, [sp, #0xd]
 	mov r2, r11
 	bl func_ov00_020826a0
-	ldrb r1, [sb, #0x15]
-	ldrb r0, [sb, #0x39]
+	ldrb r1, [r9, #0x15]
+	ldrb r0, [r9, #0x39]
 	sub r8, r8, #1
 	sub r0, r1, r0
 	cmp r8, r0
 	bgt _02141df0
 _02141e38:
-	ldrb r0, [sb, #0x38]
-	ldrb r2, [sb, #0x14]
+	ldrb r0, [r9, #0x38]
+	ldrb r2, [r9, #0x14]
 	ldr r1, [sp, #4]
 	sub r1, r1, #1
 	sub r2, r2, r0
@@ -8570,7 +8570,7 @@ _02141e38:
 	b _02141f0c
 _02141e5c:
 	str r0, [sp]
-	ldrb r0, [sb, #0x38]
+	ldrb r0, [r9, #0x38]
 	ldr r1, [sp]
 	add r2, r1, r0
 	cmp r1, r2
@@ -8581,8 +8581,8 @@ _02141e5c:
 	add r10, sp, #8
 	mov r11, r5
 _02141e88:
-	ldrb r8, [sb, #0x15]
-	ldrb r0, [sb, #0x39]
+	ldrb r8, [r9, #0x15]
+	ldrb r0, [r9, #0x39]
 	add r0, r8, r0
 	cmp r8, r0
 	bge _02141eec
@@ -8601,15 +8601,15 @@ _02141ea4:
 	strb r8, [sp, #9]
 	mov r2, r11
 	bl func_ov00_020826a0
-	ldrb r1, [sb, #0x15]
-	ldrb r0, [sb, #0x39]
+	ldrb r1, [r9, #0x15]
+	ldrb r0, [r9, #0x39]
 	add r8, r8, #1
 	add r0, r1, r0
 	cmp r8, r0
 	blt _02141ea4
 _02141eec:
-	ldrb r0, [sb, #0x38]
-	ldrb r2, [sb, #0x14]
+	ldrb r0, [r9, #0x38]
+	ldrb r2, [r9, #0x14]
 	ldr r1, [sp]
 	add r1, r1, #1
 	add r2, r2, r0
@@ -8617,8 +8617,8 @@ _02141eec:
 	cmp r1, r2
 	blt _02141e88
 _02141f0c:
-	ldrb r2, [sb, #0x39]
-	ldr r1, [sb, #0x40]
+	ldrb r2, [r9, #0x39]
+	ldr r1, [r9, #0x40]
 	mov r5, r0, lsl #0xc
 	cmp r1, #3
 	mov r4, r2, lsl #0xc
@@ -8634,7 +8634,7 @@ _02141f38:
 	rsb r3, r0, #0x800
 	mov r1, r5, asr #0x1
 	sub r7, r1, #0x800
-	add r0, sb, #0x18
+	add r0, r9, #0x18
 	mov r6, #0
 	add r1, sp, #0x40
 	mov r2, r0
@@ -8648,7 +8648,7 @@ _02141f6c:
 	sub r3, r0, #0x800
 	mov r1, r5, asr #0x1
 	sub r7, r1, #0x800
-	add r0, sb, #0x18
+	add r0, r9, #0x18
 	mov r6, #0
 	add r1, sp, #0x34
 	mov r2, r0
@@ -8662,7 +8662,7 @@ _02141fa0:
 	sub r3, r0, #0x800
 	mov r1, r5, asr #0x1
 	rsb r7, r1, #0x800
-	add r0, sb, #0x18
+	add r0, r9, #0x18
 	mov r6, #0
 	add r1, sp, #0x28
 	mov r2, r0
@@ -8676,7 +8676,7 @@ _02141fd4:
 	sub r3, r0, #0x800
 	mov r1, r5, asr #0x1
 	sub r7, r1, #0x800
-	add r0, sb, #0x18
+	add r0, r9, #0x18
 	mov r6, #0
 	add r1, sp, #0x1c
 	mov r2, r0
@@ -8686,20 +8686,20 @@ _02141fd4:
 	bl func_01ff9bc4
 _02142004:
 	mov r0, #0
-	str r0, [sb, #0x74]
-	str r0, [sb, #0x78]
+	str r0, [r9, #0x74]
+	str r0, [r9, #0x78]
 	cmp r4, r5
-	str r0, [sb, #0x7c]
+	str r0, [r9, #0x7c]
 	movgt r5, r4
-	str r5, [sb, #0x80]
-	ldrh r1, [sb, #0x24]
+	str r5, [r9, #0x80]
+	ldrh r1, [r9, #0x24]
 	mov r0, #0xa
 	add r1, r1, #1
 	mul r0, r1, r0
 	add r0, r0, #0x2d
-	str r0, [sb, #0x4c]
+	str r0, [r9, #0x4c]
 	add sp, sp, #0x4c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_02141c60
 _02142040: .word data_027e0e60
@@ -9231,21 +9231,21 @@ func_ov14_02142784: ; 0x02142784
 	.global func_ov14_0214278c
 	arm_func_start func_ov14_0214278c
 func_ov14_0214278c: ; 0x0214278c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x20
 	mov r10, r0
 	ldr r0, [r10, #4]
 	str r1, [sp, #0x10]
 	tst r0, #0x10
 	addeq sp, sp, #0x20
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, _02142904 ; =data_027e0d38
 	ldr r0, [r0]
 	add r0, r0, #0xc
 	bl func_ov00_020a5e9c
 	cmp r0, #0x1a
 	addeq sp, sp, #0x20
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldrb r0, [r10, #0x38]
 	ldr r1, _02142904 ; =data_027e0d38
 	ldrb r7, [r10, #0x39]
@@ -9273,7 +9273,7 @@ _02142818:
 	mov r0, #0
 	str r0, [sp, #0x1c]
 	addle sp, sp, #0x20
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	str r0, [sp, #0x14]
 	mvn r11, #0
 _02142838:
@@ -9295,7 +9295,7 @@ _02142868:
 	mov r5, #0
 	cmp r7, #0
 	ble _021428d8
-	mov sb, r5
+	mov r9, r5
 	mvn r4, #0
 _0214287c:
 	ldr r0, [r10, #0x40]
@@ -9303,13 +9303,13 @@ _0214287c:
 	beq _02142898
 	cmp r0, #3
 	bne _021428a0
-	sub r1, r4, sb
+	sub r1, r4, r9
 	b _021428a4
 _02142898:
-	mov r1, sb
+	mov r1, r9
 	b _021428a4
 _021428a0:
-	mov r1, sb
+	mov r1, r9
 _021428a4:
 	str r11, [sp]
 	mov r0, #0
@@ -9321,7 +9321,7 @@ _021428a4:
 	mov r2, #0xa
 	bl func_ov00_0208c0dc
 	add r5, r5, #1
-	add sb, sb, r8
+	add r9, r9, r8
 	cmp r5, r7
 	blt _0214287c
 _021428d8:
@@ -9335,7 +9335,7 @@ _021428d8:
 	str r0, [sp, #0x14]
 	blt _02142838
 	add sp, sp, #0x20
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_0214278c
 _02142904: .word data_027e0d38
@@ -9344,7 +9344,7 @@ _02142908: .word data_027e0e60
 	.global func_ov14_0214290c
 	arm_func_start func_ov14_0214290c
 func_ov14_0214290c: ; 0x0214290c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x30
 	ldr r2, [r0]
 	mov r10, r0
@@ -9352,7 +9352,7 @@ func_ov14_0214290c: ; 0x0214290c
 	blx r2
 	cmp r0, #0
 	addeq sp, sp, #0x30
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldrsh r1, [r10, #0xc]
 	ldr r3, _02142b58 ; =data_02050f54
 	add r0, sp, #0xc
@@ -9377,7 +9377,7 @@ func_ov14_0214290c: ; 0x0214290c
 	ldrb r0, [r10, #0x38]
 	cmp r0, #0
 	addle sp, sp, #0x30
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	mov r8, r6
 _02142998:
 	ldr r0, [r10, #0x40]
@@ -9428,7 +9428,7 @@ _02142a3c:
 	mov r7, #0
 	cmp r0, #0
 	ble _02142b3c
-	mov sb, r7
+	mov r9, r7
 	mvn r4, #0
 	mov r5, r7
 	add r11, sp, #0xc
@@ -9439,7 +9439,7 @@ _02142a5c:
 	cmp r0, #3
 	ldr r0, [r10, #0x60]
 	bne _02142af8
-	sub r0, r0, sb
+	sub r0, r0, r9
 	str r0, [sp, #8]
 	ldrb r1, [r10, #0x39]
 	sub r1, r1, #1
@@ -9457,7 +9457,7 @@ _02142a5c:
 	b _02142b00
 _02142ab4:
 	ldr r0, [r10, #0x60]
-	add r0, r0, sb
+	add r0, r0, r9
 	str r0, [sp, #8]
 	ldrb r1, [r10, #0x39]
 	sub r1, r1, #1
@@ -9474,7 +9474,7 @@ _02142ab4:
 	str r0, [sp, #4]
 	b _02142b00
 _02142af8:
-	add r0, r0, sb
+	add r0, r0, r9
 	str r0, [sp, #8]
 _02142b00:
 	cmp r6, #0
@@ -9489,7 +9489,7 @@ _02142b00:
 	blx r3
 	ldrb r0, [r10, #0x39]
 	add r7, r7, #1
-	add sb, sb, #0x1000
+	add r9, r9, #0x1000
 	cmp r7, r0
 	blt _02142a5c
 _02142b3c:
@@ -9499,7 +9499,7 @@ _02142b3c:
 	cmp r6, r0
 	blt _02142998
 	add sp, sp, #0x30
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_0214290c
 _02142b58: .word data_02050f54
@@ -10258,36 +10258,36 @@ _021434b4: .word data_027e0f64
 	.global func_ov14_021434b8
 	arm_func_start func_ov14_021434b8
 func_ov14_021434b8: ; 0x021434b8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #8
 	mov r10, r0
 	ldr r0, [r10, #4]
 	tst r0, #0x10
 	addeq sp, sp, #8
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldrh r0, [r1]
 	tst r0, #4
 	bne _021434ec
 	tst r0, #8
 	addeq sp, sp, #8
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _021434ec:
 	ldr r0, [r10, #0x138]
 	mov r8, #0
 	cmp r0, #0
 	addle sp, sp, #8
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r4, _02143584 ; =data_027e0d3c
-	mov sb, r10
+	mov r9, r10
 	mov r11, r8
 	add r7, sp, #4
 	add r6, sp, #0
 	mov r5, r8
 _02143518:
-	ldrb r0, [sb, #0x145]
+	ldrb r0, [r9, #0x145]
 	cmp r0, #0
 	bne _02143568
-	add r2, sb, #0x100
+	add r2, r9, #0x100
 	ldrsh r3, [r2, #0x40]
 	ldr r0, [r4]
 	mov r1, r7
@@ -10308,10 +10308,10 @@ _02143568:
 	ldr r0, [r10, #0x138]
 	add r8, r8, #1
 	cmp r8, r0
-	add sb, sb, #6
+	add r9, r9, #6
 	blt _02143518
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_021434b8
 _02143584: .word data_027e0d3c
@@ -14717,7 +14717,7 @@ _021467b4: .word 0x55555556
 	.global func_ov14_021467b8
 	arm_func_start func_ov14_021467b8
 func_ov14_021467b8: ; 0x021467b8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x48
 	mov r10, r0
 	cmp r1, #0
@@ -14727,7 +14727,7 @@ func_ov14_021467b8: ; 0x021467b8
 	ldrne r0, [r10, #0x130]
 	cmpne r0, #2
 	addeq sp, sp, #0x48
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r0, r10, #0x100
 	ldrsh r1, [r0, #0x58]
 	ldrh r0, [r10, #0x20]
@@ -14824,8 +14824,8 @@ func_ov14_021467b8: ; 0x021467b8
 	orr r11, r11, r1, lsl #20
 	mov r8, #0
 	addle sp, sp, #0x48
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
-	add sb, r10, #0x15c
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
+	add r9, r10, #0x15c
 _0214696c:
 	ldr r0, [sp, #0xc]
 	add r1, r6, r11
@@ -14840,17 +14840,17 @@ _0214696c:
 	sub r5, r5, #5
 	mov r0, r10
 	str r1, [sp, #8]
-	mov r1, sb
+	mov r1, r9
 	add r2, sp, #0x24
 	mov r3, r5
 	bl func_ov14_021469e4
 	ldrsh r0, [r4, #0x82]
 	add r8, r8, #1
-	add sb, sb, #0xc
+	add r9, r9, #0xc
 	cmp r8, r0
 	blt _0214696c
 	add sp, sp, #0x48
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_021467b8
 _021469cc: .word data_02050f54
@@ -15734,12 +15734,12 @@ _02147580: .word data_027e0f74
 	.global func_ov14_02147584
 	arm_func_start func_ov14_02147584
 func_ov14_02147584: ; 0x02147584
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x24
 	ldr r2, _02147678 ; =data_027e0fa0
 	ldr ip, _0214767c ; =data_027e0f94
 	ldr r5, [r2, #8]
-	ldmia ip, {r3, sb}
+	ldmia ip, {r3, r9}
 	ldr r8, [ip, #8]
 	ldr r7, [r2]
 	ldr r6, [r2, #4]
@@ -15750,7 +15750,7 @@ func_ov14_02147584: ; 0x02147584
 	stmia lr, {r0, r1, r2}
 	ldr r0, [ip]
 	str r3, [sp, #0x18]
-	str sb, [sp, #0x1c]
+	str r9, [sp, #0x1c]
 	str r8, [sp, #0x20]
 	str r7, [sp, #0xc]
 	str r6, [sp, #0x10]
@@ -15759,7 +15759,7 @@ func_ov14_02147584: ; 0x02147584
 	cmp r0, #0
 	addne sp, sp, #0x24
 	movne r0, #1
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	ldr r0, _02147680 ; =data_027e0fc8
 	ldr r0, [r0]
 	bl func_ov00_020bc500
@@ -15773,20 +15773,20 @@ func_ov14_02147584: ; 0x02147584
 	cmp r0, #0
 	addeq sp, sp, #0x24
 	moveq r0, #1
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _02147624:
 	ldr r1, [sp, #0x1c]
 	ldr r0, [r4, #0x1c]
 	cmp r1, r0
 	addlt sp, sp, #0x24
 	movlt r0, #1
-	ldmltia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmltia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	ldr r1, [sp, #4]
 	ldr r0, _02147688 ; =0xfffffe66
 	cmp r1, r0
 	addge sp, sp, #0x24
 	movge r0, #1
-	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmgeia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	mov r0, r4
 	ldr r3, [r0]
 	mov r1, #1
@@ -15795,7 +15795,7 @@ _02147624:
 	blx r3
 	mov r0, #0
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov14_02147584
 _02147678: .word data_027e0fa0
@@ -16917,23 +16917,23 @@ func_ov14_02148334: ; 0x02148334
 	.global func_ov14_02148364
 	arm_func_start func_ov14_02148364
 func_ov14_02148364: ; 0x02148364
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x128
 	ldr r2, _02148644 ; =data_027e0e60
 	mov r10, r0
 	ldr r0, [r2]
 	mov r2, #0
-	mov sb, r1
+	mov r9, r1
 	bl func_ov00_02083ee0
 	ldr r1, [r10, #0x4c]
 	cmp r1, r0
 	addlt sp, sp, #0x128
 	movlt r0, #0
-	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmltia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r1, _02148644 ; =data_027e0e60
 	add r0, sp, #0x14
 	ldr r1, [r1]
-	mov r2, sb
+	mov r2, r9
 	bl func_ov00_02083a1c
 	ldr r0, _02148644 ; =data_027e0e60
 	add r1, sp, #0x14
@@ -16955,7 +16955,7 @@ _021483e4:
 _021483ec:
 	add sp, sp, #0x128
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _021483f8:
 	ldr r1, _02148648 ; =0x0000ffff
 	mov r0, #0
@@ -16989,7 +16989,7 @@ _021483f8:
 	str r3, [sp, #4]
 	ldrh r5, [r2, #0x5a]
 	add r3, sp, #0x2c
-	mov r2, sb
+	mov r2, r9
 	str r5, [sp, #8]
 	str r0, [sp, #0xc]
 	str r0, [sp, #0x10]
@@ -16998,7 +16998,7 @@ _021483f8:
 	cmp r0, #0
 	addne sp, sp, #0x128
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, _0214864c ; =data_ov14_02153ed8
 	add r4, sp, #0xb8
 	ldmia r0, {r0, r1, r2, r3}
@@ -17012,7 +17012,7 @@ _021483f8:
 	ldr r0, [r10, #0x50]
 	ldr r5, _02148650 ; =data_027e0fe4
 	str r0, [sp, #0xb4]
-	ldmia sb, {r0, r1, r2}
+	ldmia r9, {r0, r1, r2}
 	sub r6, r7, #5
 	stmia r8, {r0, r1, r2}
 	ldr r0, _02148654 ; =data_ov14_02159a44
@@ -17081,14 +17081,14 @@ _0214858c:
 	add r1, sp, #0x20
 	str r2, [sp, #0x24]
 	ldr r3, [r10, #0x50]
-	mov r2, sb
+	mov r2, r9
 	str r3, [sp, #0x28]
 	ldr r3, [r10, #0x98]
 	bl func_ov00_0208f030
 	cmp r0, #0
 	addne sp, sp, #0x128
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r3, [r10, #0x98]
 	mov r0, r5
 	add r1, sp, #0xac
@@ -17097,7 +17097,7 @@ _0214858c:
 	cmp r0, #0
 	addne sp, sp, #0x128
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02148628:
 	add r7, r7, #1
 	cmp r7, r6
@@ -17106,7 +17106,7 @@ _02148628:
 _02148638:
 	mov r0, #1
 	add sp, sp, #0x128
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_02148364
 _02148644: .word data_027e0e60
@@ -19541,16 +19541,16 @@ _0214a71c: .word data_02050f54
 	.global func_ov14_0214a720
 	arm_func_start func_ov14_0214a720
 func_ov14_0214a720: ; 0x0214a720
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x10
-	movs sb, r1
+	movs r9, r1
 	mov r10, r0
 	mov r6, r2
 	mov r8, r3
 	beq _0214a750
-	cmp sb, #1
+	cmp r9, #1
 	beq _0214a758
-	cmp sb, #2
+	cmp r9, #2
 	ldreq r7, _0214a924 ; =0x00000222
 	b _0214a75c
 _0214a750:
@@ -19559,14 +19559,14 @@ _0214a750:
 _0214a758:
 	ldr r7, _0214a928 ; =0x000004fa
 _0214a75c:
-	cmp sb, #2
+	cmp r9, #2
 	beq _0214a770
 	ldrb r0, [r10, #0x8e]
 	cmp r0, #0
 	beq _0214a77c
 _0214a770:
 	mov r4, #0
-	mov sb, r4
+	mov r9, r4
 	b _0214a868
 _0214a77c:
 	add r1, sp, #4
@@ -19575,7 +19575,7 @@ _0214a77c:
 	cmp r0, #0
 	addeq sp, sp, #0x10
 	moveq r0, r8
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldrsh r4, [r10, #0x6c]
 	ldr r5, [sp, #4]
 	ldr r0, [r6]
@@ -19620,22 +19620,22 @@ _0214a808:
 	mov r0, r11
 	bl func_01ffa0f4
 	mov r0, r0, lsl #0x10
-	cmp sb, #0
-	mov sb, r0, asr #0x10
-	addeq r0, sb, sb, lsr #31
+	cmp r9, #0
+	mov r9, r0, asr #0x10
+	addeq r0, r9, r9, lsr #31
 	moveq r0, r0, lsl #0xf
-	moveq sb, r0, asr #0x10
-	cmp sb, r5
-	movgt sb, r5
+	moveq r9, r0, asr #0x10
+	cmp r9, r5
+	movgt r9, r5
 	bgt _0214a868
-	cmp sb, r6
-	movlt sb, r6
+	cmp r9, r6
+	movlt r9, r6
 _0214a868:
 	ldrb r0, [r10, #0x8f]
 	cmp r0, #0
 	beq _0214a888
 	strh r4, [r10, #0x68]
-	strh sb, [r10, #0x6a]
+	strh r9, [r10, #0x6a]
 	mov r0, #0
 	strb r0, [r10, #0x8f]
 	b _0214a918
@@ -19646,7 +19646,7 @@ _0214a888:
 	subs r1, r4, r0
 	rsbmi r1, r1, #0
 	strh r2, [sp]
-	subs r2, sb, r2
+	subs r2, r9, r2
 	rsbmi r2, r2, #0
 	cmp r1, r2
 	ble _0214a8c4
@@ -19671,7 +19671,7 @@ _0214a8e8:
 	mov r2, r7
 	bl func_0202b154
 	add r0, sp, #0
-	mov r1, sb
+	mov r1, r9
 	mov r2, r5
 	bl func_0202b154
 	ldrsh r0, [sp, #2]
@@ -19681,7 +19681,7 @@ _0214a8e8:
 _0214a918:
 	mov r0, r8
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_0214a720
 _0214a924: .word 0x00000222
@@ -21985,10 +21985,10 @@ _0214c674: .word func_0202b2e8
 	.global func_ov14_0214c678
 	arm_func_start func_ov14_0214c678
 func_ov14_0214c678: ; 0x0214c678
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x94
 	mov r10, r0
-	mov sb, r1
+	mov r9, r1
 	bl func_ov14_0214c660
 	cmp r0, #0
 	beq _0214c92c
@@ -22082,16 +22082,16 @@ _0214c7d0:
 	add r11, sp, #0x1c
 	mov r5, r7
 _0214c7ec:
-	ldr r0, [sb]
+	ldr r0, [r9]
 	mov r1, r7, lsl #0x1
 	str r0, [r10]
 	add r0, sp, #0x14
 	ldrh r0, [r0, r1]
-	ldr r2, [sb, #4]
+	ldr r2, [r9, #4]
 	add r3, sp, #0x28
 	str r2, [r10, #4]
 	mov r0, r0, asr #0x4
-	ldr r1, [sb, #8]
+	ldr r1, [r9, #8]
 	mov r2, r0, lsl #0x1
 	mov r0, r2, lsl #0x1
 	str r1, [r10, #8]
@@ -22109,12 +22109,12 @@ _0214c7ec:
 	add r0, r0, #0x800
 	add r0, r2, r0, asr #12
 	str r0, [r10, #8]
-	ldr r0, [sb]
+	ldr r0, [r9]
 	mov r2, r11
 	str r0, [sp, #0x28]
-	ldr r0, [sb, #4]
+	ldr r0, [r9, #4]
 	str r0, [sp, #0x2c]
-	ldr r0, [sb, #8]
+	ldr r0, [r9, #8]
 	str r0, [sp, #0x30]
 	ldr r0, [r10]
 	str r0, [sp, #0x1c]
@@ -22163,11 +22163,11 @@ _0214c910:
 _0214c920:
 	add sp, sp, #0x94
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0214c92c:
 	mov r0, #0
 	add sp, sp, #0x94
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_0214c678
 _0214c938: .word data_027e0764
@@ -23658,7 +23658,7 @@ _0214dc78: .word data_02050f54
 	.global func_ov14_0214dc7c
 	arm_func_start func_ov14_0214dc7c
 func_ov14_0214dc7c: ; 0x0214dc7c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0xf8
 	ldr r2, _0214e120 ; =0x0000ffff
 	mov r1, #0
@@ -23858,7 +23858,7 @@ _0214df30:
 	bge _0214df78
 	cmp r3, r2
 	addeq sp, sp, #0xf8
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0214df50:
 	ldr r1, [r3]
 	add r3, r3, #0xc
@@ -23869,7 +23869,7 @@ _0214df50:
 	cmp r3, r2
 	bne _0214df50
 	add sp, sp, #0xf8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0214df78:
 	cmp r3, r2
 	beq _0214dfa0
@@ -23922,18 +23922,18 @@ _0214e01c:
 	ldrh r7, [r1, #4]
 	str r4, [sp, #0x1c]
 	mov r4, r8, asr #0x1f
-	umull lr, sb, r0, r8
-	mla sb, r0, r4, sb
+	umull lr, r9, r0, r8
+	mla r9, r0, r4, r9
 	ldr r5, [r2, #8]
 	adds r4, lr, #0x800
-	mla sb, ip, r8, sb
+	mla r9, ip, r8, r9
 	ldr r10, [r2]
 	mov r7, r7, lsl #0xc
 	str r5, [sp, #0x24]
 	mov r5, r7, asr #0x1f
 	str r5, [sp, #0x20]
 	ldr r6, [r1, #8]
-	adc r8, sb, #0
+	adc r8, r9, #0
 	mov r4, r4, lsr #0xc
 	orr r4, r4, r8, lsl #20
 	add r10, r10, r4
@@ -23941,22 +23941,22 @@ _0214e01c:
 	mov r5, r6, asr #0x1f
 	str r5, [sp, #0x28]
 	ldr lr, [sp, #0x20]
-	umull sb, r8, r4, r7
+	umull r9, r8, r4, r7
 	mla r8, r4, lr, r8
 	ldr r4, [sp, #0x18]
 	ldr r5, [r3]
 	mla r8, r4, r7, r8
-	adds r7, sb, #0x800
+	adds r7, r9, #0x800
 	adc r4, r8, #0
 	mov r7, r7, lsr #0xc
 	orr r7, r7, r4, lsl #20
 	ldr r4, [sp, #0x1c]
-	ldr sb, [sp, #0x28]
+	ldr r9, [sp, #0x28]
 	add r4, r4, r7, asr #12
 	mov r4, r4, lsl #0x10
 	mov r8, r4, lsr #0x10
 	umull r7, r4, r0, r6
-	mla r4, r0, sb, r4
+	mla r4, r0, r9, r4
 	mla r4, ip, r6, r4
 	adds r7, r7, #0x800
 	adc r4, r4, #0
@@ -23981,7 +23981,7 @@ _0214e01c:
 	cmp r11, #2
 	blo _0214e01c
 	add sp, sp, #0xf8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_0214dc7c
 _0214e120: .word 0x0000ffff
@@ -23993,7 +23993,7 @@ _0214e130: .word data_ov14_0215a1a0
 	.global func_ov14_0214e134
 	arm_func_start func_ov14_0214e134
 func_ov14_0214e134: ; 0x0214e134
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0xc
 	ldr r2, _0214e268 ; =data_027e0e60
 	mov r5, r0
@@ -24006,10 +24006,10 @@ func_ov14_0214e134: ; 0x0214e134
 	bl func_ov00_02083368
 	mov r7, r0
 	ldrb r0, [r5, #0x15]
-	ldrb sb, [r5, #0x14]
+	ldrb r9, [r5, #0x14]
 	str r0, [sp]
 	ldrsh r0, [r5, #0xc]
-	str sb, [sp, #4]
+	str r9, [sp, #4]
 	ldr r8, [sp]
 	bl func_0202bbbc
 	cmp r0, #3
@@ -24021,11 +24021,11 @@ _0214e18c: ; jump table
 	b _0214e1d8 ; case 2
 	b _0214e1c0 ; case 3
 _0214e19c:
-	subs sb, sb, #5
-	movmi sb, #0
+	subs r9, r9, #5
+	movmi r9, #0
 	b _0214e1e4
 _0214e1a8:
-	mov r0, sb
+	mov r0, r9
 	add r0, r0, #5
 	str r0, [sp, #4]
 	cmp r0, r6
@@ -24044,9 +24044,9 @@ _0214e1d8:
 	movge r8, r7
 _0214e1e4:
 	ldr r0, [sp, #4]
-	cmp sb, r0
+	cmp r9, r0
 	addgt sp, sp, #0xc
-	ldmgtia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmgtia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r6, _0214e268 ; =data_027e0e60
 	add r11, sp, #8
 _0214e1fc:
@@ -24054,10 +24054,10 @@ _0214e1fc:
 	mov r0, r10
 	cmp r0, r8
 	bgt _0214e250
-	and r7, sb, #0xff
+	and r7, r9, #0xff
 _0214e210:
 	ldr r0, [r6]
-	mov r1, sb
+	mov r1, r9
 	mov r2, r10
 	bl func_ov00_02083e34
 	ldr r1, [r5, #0x1c]
@@ -24075,11 +24075,11 @@ _0214e244:
 	ble _0214e210
 _0214e250:
 	ldr r0, [sp, #4]
-	add sb, sb, #1
-	cmp sb, r0
+	add r9, r9, #1
+	cmp r9, r0
 	ble _0214e1fc
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_0214e134
 _0214e268: .word data_027e0e60
@@ -26264,7 +26264,7 @@ func_ov14_0214fe70: ; 0x0214fe70
 	.global func_ov14_0214fe98
 	arm_func_start func_ov14_0214fe98
 func_ov14_0214fe98: ; 0x0214fe98
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x20
 	mov r4, r0
 	ldr r0, [r4, #0x18]
@@ -26345,9 +26345,9 @@ _0214ff7c:
 	str r1, [r4, #0x40]
 _0214ffc0:
 	ldrb r0, [r4, #0x14]
-	ldrb sb, [r4, #0x38]
+	ldrb r9, [r4, #0x38]
 	str r0, [sp]
-	add r1, r0, sb
+	add r1, r0, r9
 	cmp r0, r1
 	bge _02150070
 	mov r7, #1
@@ -26362,17 +26362,17 @@ _0214ffec:
 	cmp r10, r0
 	bge _02150050
 	ldr r0, [sp]
-	and sb, r0, #0xff
+	and r9, r0, #0xff
 _02150008:
 	ldr r0, [r5]
 	mov r1, r8
 	mov r2, r7
-	strb sb, [sp, #6]
+	strb r9, [sp, #6]
 	strb r10, [sp, #7]
 	bl func_ov00_02082680
 	ldr r0, [r5]
 	mov r1, r6
-	strb sb, [sp, #4]
+	strb r9, [sp, #4]
 	strb r10, [sp, #5]
 	mov r2, r11
 	bl func_ov00_020826a0
@@ -26383,17 +26383,17 @@ _02150008:
 	cmp r10, r0
 	blt _02150008
 _02150050:
-	ldrb sb, [r4, #0x38]
+	ldrb r9, [r4, #0x38]
 	ldrb r1, [r4, #0x14]
 	ldr r0, [sp]
 	add r0, r0, #1
-	add r1, r1, sb
+	add r1, r1, r9
 	str r0, [sp]
 	cmp r0, r1
 	blt _0214ffec
 _02150070:
 	ldrb r0, [r4, #0x39]
-	mov r6, sb, lsl #0xc
+	mov r6, r9, lsl #0xc
 	mov r1, r6, asr #0x1
 	mov r5, r0, lsl #0xc
 	mov r0, r5, asr #0x1
@@ -26410,12 +26410,12 @@ _02150070:
 	mov r0, #0
 	str r0, [r4, #0x60]
 	str r0, [r4, #0x64]
-	cmp r5, sb, lsl #12
+	cmp r5, r9, lsl #12
 	movgt r6, r5
 	str r0, [r4, #0x68]
 	str r6, [r4, #0x6c]
 	add sp, sp, #0x20
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_0214fe98
 _021500d0: .word data_027e0e60
@@ -26484,7 +26484,7 @@ _02150160:
 	.global func_ov14_02150168
 	arm_func_start func_ov14_02150168
 func_ov14_02150168: ; 0x02150168
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x30
 	mov r10, r0
 	ldr r2, [r10, #0x4c]
@@ -26497,7 +26497,7 @@ func_ov14_02150168: ; 0x02150168
 	ldrb r0, [r10, #0x39]
 	cmp r0, #0
 	addle sp, sp, #0x30
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _021501a0:
 	cmp r8, #0
 	subne r0, r0, #1
@@ -26562,7 +26562,7 @@ _0215026c:
 	ldrb r0, [r10, #0x38]
 	cmp r0, #0
 	ble _021502ec
-	mov sb, r7
+	mov r9, r7
 	mvn r5, #0
 	mov r6, r7
 	add r4, sp, #0xc
@@ -26571,7 +26571,7 @@ _021502a0:
 	ldr r0, [r10, #0x44]
 	cmp r7, #0
 	streq r0, [sp]
-	addne r0, r0, sb
+	addne r0, r0, r9
 	strne r0, [sp]
 	cmp r7, #0
 	streqh r6, [r10, #0x5a]
@@ -26584,7 +26584,7 @@ _021502a0:
 	blx r3
 	ldrb r0, [r10, #0x38]
 	add r7, r7, #1
-	add sb, sb, #0x1000
+	add r9, r9, #0x1000
 	cmp r7, r0
 	blt _021502a0
 _021502ec:
@@ -26593,7 +26593,7 @@ _021502ec:
 	cmp r8, r0
 	blt _021501a0
 	add sp, sp, #0x30
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_02150168
 _02150304: .word data_027e0f68
@@ -26602,7 +26602,7 @@ _02150308: .word data_02050f54
 	.global func_ov14_0215030c
 	arm_func_start func_ov14_0215030c
 func_ov14_0215030c: ; 0x0215030c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x30
 	mov r10, r0
 	ldrh r1, [r10, #0xc]
@@ -26626,7 +26626,7 @@ func_ov14_0215030c: ; 0x0215030c
 	ldrb r0, [r10, #0x38]
 	cmp r0, #0
 	addle sp, sp, #0x30
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02150370:
 	cmp r7, #0
 	subne r0, r0, #1
@@ -26691,7 +26691,7 @@ _0215043c:
 	ldrb r0, [r10, #0x39]
 	cmp r0, #0
 	ble _021504bc
-	mov sb, r8
+	mov r9, r8
 	mvn r5, #0
 	mov r6, r8
 	add r4, sp, #0xc
@@ -26700,7 +26700,7 @@ _02150470:
 	ldr r0, [r10, #0x4c]
 	cmp r8, #0
 	streq r0, [sp, #8]
-	addne r0, r0, sb
+	addne r0, r0, r9
 	strne r0, [sp, #8]
 	cmp r8, #0
 	streqh r6, [r10, #0x5a]
@@ -26713,7 +26713,7 @@ _02150470:
 	blx r3
 	ldrb r0, [r10, #0x39]
 	add r8, r8, #1
-	add sb, sb, #0x1000
+	add r9, r9, #0x1000
 	cmp r8, r0
 	blt _02150470
 _021504bc:
@@ -26722,7 +26722,7 @@ _021504bc:
 	cmp r7, r0
 	blt _02150370
 	add sp, sp, #0x30
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_0215030c
 _021504d4: .word data_02050f54
@@ -26731,7 +26731,7 @@ _021504d8: .word data_027e0f68
 	.global func_ov14_021504dc
 	arm_func_start func_ov14_021504dc
 func_ov14_021504dc: ; 0x021504dc
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x30
 	mov r10, r0
 	ldrh r1, [r10, #0xc]
@@ -26765,7 +26765,7 @@ func_ov14_021504dc: ; 0x021504dc
 	ldrb r0, [r10, #0x38]
 	cmp r0, #0
 	addle sp, sp, #0x30
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	mvn r5, #0
 	mov r6, r7
 	add r4, sp, #0xc
@@ -26779,12 +26779,12 @@ _02150578:
 	ldrb r0, [r10, #0x39]
 	cmp r0, #0
 	ble _021505ec
-	mov sb, r8
+	mov r9, r8
 _0215059c:
 	ldr r0, [r10, #0x4c]
 	cmp r8, #0
 	streq r0, [sp, #8]
-	addne r0, r0, sb
+	addne r0, r0, r9
 	strne r0, [sp, #8]
 	cmp r7, #0
 	cmpeq r8, #0
@@ -26798,7 +26798,7 @@ _0215059c:
 	blx r3
 	ldrb r0, [r10, #0x39]
 	add r8, r8, #1
-	add sb, sb, #0x1000
+	add r9, r9, #0x1000
 	cmp r8, r0
 	blt _0215059c
 _021505ec:
@@ -26807,7 +26807,7 @@ _021505ec:
 	cmp r7, r0
 	blt _02150578
 	add sp, sp, #0x30
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_021504dc
 _02150604: .word data_02050f54
@@ -28693,10 +28693,10 @@ _0215193c: .word func_ov03_020f23b4
 	.global func_ov14_02151940
 	arm_func_start func_ov14_02151940
 func_ov14_02151940: ; 0x02151940
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x24
 	mov r10, r0
-	mov sb, r1
+	mov r9, r1
 	ldr r0, _02151a24 ; =data_027e0cbc
 	mov r1, #1
 	bl func_0203d7e0
@@ -28704,7 +28704,7 @@ func_ov14_02151940: ; 0x02151940
 	ldrnesb r0, [r10, #0x14]
 	cmpne r0, #0
 	addeq sp, sp, #0x24
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r0, sp, #4
 	bl func_01ffbe34
 	mov r0, r10
@@ -28715,7 +28715,7 @@ func_ov14_02151940: ; 0x02151940
 	add r0, sp, #4
 	mov r1, #0
 	str r0, [sp]
-	mov r2, sb
+	mov r2, r9
 	mov r3, r1
 	mov r0, #4
 	bl func_0203493c
@@ -28723,7 +28723,7 @@ func_ov14_02151940: ; 0x02151940
 	mov r7, #0
 	cmp r0, #0
 	addle sp, sp, #0x24
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r4, _02151a28 ; =gItemManager
 	mov r8, r7
 	mov r5, r7
@@ -28740,7 +28740,7 @@ _021519d0:
 _021519ec:
 	str r10, [sp]
 	ldr r0, [r10, #0x20]
-	mov r1, sb
+	mov r1, r9
 	mov r2, r5
 	mov r3, r11
 	add r0, r0, r8
@@ -28752,7 +28752,7 @@ _02151a08:
 	cmp r7, r0
 	blt _021519d0
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_02151940
 _02151a24: .word data_027e0cbc
@@ -29467,38 +29467,38 @@ _02152258: .word data_027e077c
 	.global func_ov14_0215225c
 	arm_func_start func_ov14_0215225c
 func_ov14_0215225c: ; 0x0215225c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
-	mov sb, r0
-	ldr r0, [sb, #0x84]
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
+	mov r9, r0
+	ldr r0, [r9, #0x84]
 	cmp r0, #0
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, _021523b4 ; =data_027e077c
 	ldr r0, [r0]
 	cmp r0, #0x37
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, _021523b8 ; =data_027e0c68
 	bl func_020366c4
 	add r0, r0, #0x100
 	ldrsh r0, [r0, #0x5c]
 	cmp r0, #0
 	movgt r0, #0
-	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
-	ldrsh r1, [sb, #4]
-	ldrsh r0, [sb, #6]
+	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
+	ldrsh r1, [r9, #4]
+	ldrsh r0, [r9, #6]
 	cmp r1, r0
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	mov r8, #0
 	mov r5, r8
-	mov r7, sb
-	add r6, sb, #0x20
+	mov r7, r9
+	add r6, r9, #0x20
 	mov r11, r8
 	mov r10, #1
 	mov r4, r8
 _021522d4:
-	ldr r0, [sb, #0x88]
+	ldr r0, [r9, #0x88]
 	cmp r0, #2
 	beq _021522e8
 	cmp r5, #2
@@ -29510,7 +29510,7 @@ _021522e8:
 	cmpne r5, #2
 	beq _02152398
 _021522fc:
-	ldr r0, [sb, #0x84]
+	ldr r0, [r9, #0x84]
 	cmp r0, #4
 	addls pc, pc, r0, lsl #2
 	b _0215234c
@@ -29547,7 +29547,7 @@ _0215234c:
 	cmp r8, #0
 	bne _0215238c
 	ldrh r1, [r7, #0x2a]
-	mov r0, sb
+	mov r0, r9
 	bl func_ov14_02152660
 	cmp r0, #0
 	beq _02152394
@@ -29563,7 +29563,7 @@ _02152398:
 	add r7, r7, #0x18
 	blt _021522d4
 	mov r0, r8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_0215225c
 _021523b4: .word data_027e077c
@@ -29605,33 +29605,33 @@ _0215240c: .word data_027e077c
 	.global func_ov14_02152410
 	arm_func_start func_ov14_02152410
 func_ov14_02152410: ; 0x02152410
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
-	mov sb, r0
-	ldr r0, [sb, #0x84]
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
+	mov r9, r0
+	ldr r0, [r9, #0x84]
 	cmp r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, _02152650 ; =data_027e0618
 	ldrb r0, [r0, #0x101]
 	cmp r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
-	ldr r0, [sb, #0x84]
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
+	ldr r0, [r9, #0x84]
 	cmp r0, #3
 	bne _0215244c
-	ldr r0, [sb, #0x80]
+	ldr r0, [r9, #0x80]
 	bl func_ov26_021778e8
 	b _0215245c
 _0215244c:
 	ldr r0, _02152654 ; =data_027e077c
 	ldr r0, [r0]
 	cmp r0, #0x37
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0215245c:
-	ldrsh r0, [sb, #4]
-	ldrsh r2, [sb, #6]
+	ldrsh r0, [r9, #4]
+	ldrsh r2, [r9, #6]
 	cmp r0, r2
 	moveq r3, #0
 	beq _02152498
-	ldrsh r1, [sb, #8]
+	ldrsh r1, [r9, #8]
 	cmp r0, r1
 	moveq r3, #0x1000
 	beq _02152498
@@ -29642,18 +29642,18 @@ _0215245c:
 	bl Divide
 	mov r3, r0
 _02152498:
-	ldrb r0, [sb, #0x14]
-	ldr r1, [sb, #0xc]
-	ldr r2, [sb, #0x10]
+	ldrb r0, [r9, #0x14]
+	ldr r1, [r9, #0xc]
+	ldr r2, [r9, #0x10]
 	bl func_ov00_020d02bc
 	add r1, r0, #0x800
-	ldrsh r0, [sb, #4]
-	ldrsh r2, [sb, #6]
+	ldrsh r0, [r9, #4]
+	ldrsh r2, [r9, #6]
 	mov r6, r1, asr #0xc
 	cmp r0, r2
 	moveq r7, #0
 	beq _021524ec
-	ldrsh r1, [sb, #8]
+	ldrsh r1, [r9, #8]
 	cmp r0, r1
 	moveq r7, #0x1000
 	beq _021524ec
@@ -29671,7 +29671,7 @@ _021524ec:
 	ldrb r0, [r1, r0]
 	mov r8, #0
 	tst r0, #1
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, _0215265c ; =data_027e0cbc
 	mov r1, #0x14
 	bl func_0203d7e0
@@ -29681,7 +29681,7 @@ _021524ec:
 	mov r1, #0x15
 	bl func_0203d7e0
 	cmp r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02152534:
 	mov ip, #0x3c000
 	umull r0, r11, r7, ip
@@ -29703,11 +29703,11 @@ _02152534:
 	mov r2, r2, lsr #0xc
 	orr r2, r2, r1, lsl #20
 	add r1, r2, #0x800
-	add r7, sb, #0x20
+	add r7, r9, #0x20
 	mov r11, r1, asr #0xc
 	mov r10, r0, asr #0xc
 _02152590:
-	ldr r1, [sb, #0x88]
+	ldr r1, [r9, #0x88]
 	cmp r1, #2
 	beq _021525a4
 	cmp r5, #2
@@ -29719,7 +29719,7 @@ _021525a4:
 	cmpne r5, #2
 	beq _0215263c
 _021525b8:
-	ldr r0, [sb, #0x84]
+	ldr r0, [r9, #0x84]
 	cmp r0, #4
 	addls pc, pc, r0, lsl #2
 	b _02152618
@@ -29762,7 +29762,7 @@ _0215263c:
 	cmp r5, #4
 	add r7, r7, #0x18
 	blt _02152590
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_02152410
 _02152650: .word data_027e0618
@@ -30787,13 +30787,13 @@ _02153320: .word data_027e109c
 	.global func_ov14_02153324
 	arm_func_start func_ov14_02153324
 func_ov14_02153324: ; 0x02153324
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	mov r7, r3
 	mov r5, r7, lsr #0x1
 	mov r10, r0
 	add r0, r5, #1
 	mov r3, #0
-	mov sb, r1
+	mov r9, r1
 	mov r8, r2
 	mov r2, r3
 	cmp r0, #1
@@ -30808,7 +30808,7 @@ _02153358:
 _02153368:
 	cmp r0, #0
 	movge r6, r0, lsl #0x1
-	ldrgesh r11, [sb, r6]
+	ldrgesh r11, [r9, r6]
 	ldrgesh r6, [r8, r6]
 	bge _02153394
 	ldr r11, [r10, #0xc]
@@ -30851,7 +30851,7 @@ _021533a8:
 _02153408:
 	sub r4, r5, #8
 	ldr r1, [r10, #0xc]
-	add r0, sb, r4, lsl #1
+	add r0, r9, r4, lsl #1
 	mov r2, #0x10
 	bl func_02007908
 	ldr r1, [r10, #0x10]
@@ -30866,7 +30866,7 @@ _02153408:
 	cmp r1, #0x1000
 	bhs _02153474
 	ldr r0, [r10, #4]
-	mov r1, sb
+	mov r1, r9
 	mov r2, r7
 	add r0, r0, r6, lsl #1
 	bl func_02007984
@@ -30882,7 +30882,7 @@ _02153474:
 	ldr r0, [r10, #4]
 	mov r11, r4, lsl #0x1
 	mov r3, r3, lsl #0x1
-	mov r1, sb
+	mov r1, r9
 	mov r2, r11
 	add r0, r0, r6, lsl #1
 	str r3, [sp]
@@ -30894,7 +30894,7 @@ _02153474:
 	bl func_02007984
 	ldr r0, [r10, #4]
 	ldr r2, [sp]
-	add r1, sb, r4, lsl #1
+	add r1, r9, r4, lsl #1
 	bl func_02007984
 	ldr r2, [sp]
 	ldr r0, [r10, #8]
@@ -30909,12 +30909,12 @@ _021534d0:
 	ldrhs r0, [r10, #0x14]
 	subhs r0, r0, #0x1000
 	strhs r0, [r10, #0x14]
-	mov r0, sb
+	mov r0, r9
 	bl func_0200e2c0
 	mov r0, r8
 	mov r1, r7
 	bl func_0200e2c0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	arm_func_end func_ov14_02153324
 
 	.global func_ov14_02153508

--- a/asm/ov14/ov14_0213b778.s
+++ b/asm/ov14/ov14_0213b778.s
@@ -5,16 +5,16 @@
 	.global func_ov14_0213b778
 	arm_func_start func_ov14_0213b778
 func_ov14_0213b778: ; 0x0213b778
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0xd4
 	mov r8, r0
 	add r3, sp, #0x54
 	mov r4, r2
-	mvn sl, #0
+	mvn r10, #0
 	add r0, sp, #0xd4
 _0213b794:
-	str sl, [r3]
-	str sl, [r3, #4]
+	str r10, [r3]
+	str r10, [r3, #4]
 	add r3, r3, #8
 	cmp r3, r0
 	blo _0213b794
@@ -32,8 +32,8 @@ _0213b794:
 	str r7, [sp, #4]
 	str r6, [sp, #8]
 	str r5, [sp, #0xc]
-	str sl, [sp, #0x14]
-	str sl, [sp, #0x18]
+	str r10, [sp, #0x14]
+	str r10, [sp, #0x18]
 	str r6, [sp, #0x1c]
 	strb r6, [sp, #0x20]
 	strb r6, [sp, #0x3c]
@@ -71,27 +71,27 @@ _0213b850:
 	beq _0213b8e0
 	ldr r2, [r0, #0x4c]
 	ldr r1, [r8, #0x4c]
-	ldr sl, [r0, #0x48]
+	ldr r10, [r0, #0x48]
 	sub r1, r2, r1
 	smull r3, r2, r1, r1
 	ldr r1, [r8, #0x48]
 	ldr sb, [r0, #0x50]
-	sub r1, sl, r1
+	sub r1, r10, r1
 	smull lr, ip, r1, r1
 	ldr r1, [r8, #0x50]
 	sub r1, sb, r1
-	smull sl, sb, r1, r1
-	adds sl, sl, #0x800
+	smull r10, sb, r1, r1
+	adds r10, r10, #0x800
 	adc r1, sb, #0
-	mov sb, sl, lsr #0xc
+	mov sb, r10, lsr #0xc
 	orr sb, sb, r1, lsl #20
 	adds r1, lr, #0x800
-	adc sl, ip, #0
+	adc r10, ip, #0
 	mov r1, r1, lsr #0xc
-	orr r1, r1, sl, lsl #20
-	adds sl, r3, #0x800
+	orr r1, r1, r10, lsl #20
+	adds r10, r3, #0x800
 	adc r2, r2, #0
-	mov r3, sl, lsr #0xc
+	mov r3, r10, lsr #0xc
 	orr r3, r3, r2, lsl #20
 	add r1, r1, r3
 	add r1, sb, r1
@@ -106,7 +106,7 @@ _0213b8e0:
 _0213b8f0:
 	mov r0, r11
 	add sp, sp, #0xd4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_0213b778
 _0213b8fc: .word data_027e0fe4
@@ -680,7 +680,7 @@ func_ov14_0213bf94: ; 0x0213bf94
 	.global func_ov14_0213bfd0
 	arm_func_start func_ov14_0213bfd0
 func_ov14_0213bfd0: ; 0x0213bfd0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #0x14
 	mov r7, r0
 	ldr sb, [r7, #0x18]
@@ -690,10 +690,10 @@ func_ov14_0213bfd0: ; 0x0213bfd0
 	mov r4, r3
 	cmpne sb, #0xa
 	bne _0213c000
-	mov sl, #1
+	mov r10, #1
 	b _0213c004
 _0213c000:
-	mov sl, #0
+	mov r10, #0
 _0213c004:
 	mov r8, #0
 	bl func_ov14_0215364c
@@ -706,7 +706,7 @@ _0213c004:
 	bl _ZNK11ItemManager7HasItemEi
 	cmp r0, #0
 	addeq sp, sp, #0x14
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 _0213c034:
 	ldr r0, _0213c0f8 ; =data_027e103c
 	ldr r0, [r0]
@@ -740,7 +740,7 @@ _0213c088:
 	ldr r0, [sp, #0x10]
 	ldr r1, [sp, #0xc]
 	ldrb r2, [sp, #0x38]
-	mov r3, sl
+	mov r3, r10
 	add r0, r0, r6
 	add r1, r1, r5
 	bl func_ov14_021536a0
@@ -759,7 +759,7 @@ _0213c0b8:
 	add r1, r1, r5
 	bl func_ov14_02153924
 	add sp, sp, #0x14
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov14_0213bfd0
 _0213c0f4: .word gItemManager
@@ -1245,7 +1245,7 @@ _0213c5b8: .word data_ov14_02158cf0
 	.global func_ov14_0213c5bc
 	arm_func_start func_ov14_0213c5bc
 func_ov14_0213c5bc: ; 0x0213c5bc
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	ldr r3, _0213c8bc ; =data_027e0d78
 	ldr r2, _0213c8c0 ; =data_ov14_02158cb0
 	ldr r6, [r3, #0x2c]
@@ -1280,14 +1280,14 @@ _0213c614:
 _0213c634:
 	cmp r1, #0
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	ldr r0, _0213c8c4 ; =data_027e103c
 	ldr r1, _0213c8c8 ; =0x000002ff
 	ldr r0, [r0]
 	bl func_ov00_020cf8fc
 	cmp r0, #0
 	movne r0, #0
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	ldrsb r0, [r4, #0x14]
 	mov r1, #1
 	cmp r0, #1
@@ -1295,11 +1295,11 @@ _0213c634:
 	movne r1, #0
 	cmp r1, #0
 	movne r0, #0
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	bl func_ov14_0213ccd8
 	cmp r0, #0
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	ldr r0, _0213c8cc ; =data_027e077c
 	ldr r0, [r0]
 	cmp r0, #1
@@ -1307,35 +1307,35 @@ _0213c634:
 	ldreqb r0, [r0, #4]
 	cmpeq r0, #0
 	movne r0, #0
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	ldr r0, _0213c8d4 ; =data_027e0fb8
 	ldr r0, [r0]
 	ldrb r0, [r0, #0x79]
 	cmp r0, #0
 	movne r0, #0
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	ldr r0, _0213c8c4 ; =data_027e103c
 	ldr r0, [r0]
 	bl func_ov00_020cf03c
 	ldrsb r0, [r0, #0x14]
 	cmp r0, #0
 	movne r0, #0
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	ldr r0, [r4, #0x1c]
 	ldrh r0, [r0]
 	cmp r0, #0
 	movne r0, #0
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	ldrsb r0, [r4, #0x14]
 	ldrsh r6, [r4, #0xe]
 	cmp r0, #2
 	bne _0213c868
 	mov r7, #0
 	mov sb, r4
-	add sl, r4, #0x20
+	add r10, r4, #0x20
 	mov r5, r7
 _0213c714:
-	mov r0, sl
+	mov r0, r10
 	ldr ip, [r0]
 	ldrh r8, [sb, #0x2a]
 	ldr ip, [ip]
@@ -1402,12 +1402,12 @@ _0213c7d4:
 	blx r2
 _0213c808:
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _0213c810:
 	add r7, r7, #1
 	cmp r7, #9
 	add sb, sb, #0x1c
-	add sl, sl, #0x1c
+	add r10, r10, #0x1c
 	blt _0213c714
 	add r0, r4, #0x134
 	add r2, r4, #0x100
@@ -1425,7 +1425,7 @@ _0213c810:
 	cmp r0, #0
 	beq _0213c8b4
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _0213c868:
 	ldrsb r0, [r4, #0x14]
 	cmp r0, #0
@@ -1445,10 +1445,10 @@ _0213c868:
 	bl func_ov14_0213c910
 	cmp r0, #0
 	movne r0, #1
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _0213c8b4:
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov14_0213c5bc
 _0213c8bc: .word data_027e0d78
@@ -3004,18 +3004,18 @@ _0213d9a8: .word data_027e0e60
 	.global func_ov14_0213d9ac
 	arm_func_start func_ov14_0213d9ac
 func_ov14_0213d9ac: ; 0x0213d9ac
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x18
-	mov sl, r0
+	mov r10, r0
 	bl func_ov14_0213dda0
-	strh r0, [sl, #0xa]
-	ldrsh r0, [sl, #0xa]
+	strh r0, [r10, #0xa]
+	ldrsh r0, [r10, #0xa]
 	mov r6, #0
 	cmp r0, #0
 	blt _0213dac0
-	mov r7, sl
-	add r8, sl, #0x2c
-	add sb, sl, #0x24
+	mov r7, r10
+	add r8, r10, #0x2c
+	add sb, r10, #0x24
 	mov r4, #2
 	mov r11, #3
 _0213d9e4:
@@ -3032,7 +3032,7 @@ _0213d9fc:
 	bl func_ov00_020840c4
 	movs r5, r0
 	beq _0213daa4
-	mov r0, sl
+	mov r0, r10
 	add r1, sp, #0xc
 	mov r2, r6
 	bl func_ov14_0213d5d0
@@ -3055,11 +3055,11 @@ _0213d9fc:
 	cmp r0, #0
 	bne _0213daa4
 	mov r0, #0x1c
-	mla r1, r6, r0, sl
+	mla r1, r6, r0, r10
 	mov r0, #0
 	strh r0, [r1, #0x2e]
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0213da84:
 	ldr r0, _0213dad8 ; =data_027e0fe4
 	mov r1, sb
@@ -3074,15 +3074,15 @@ _0213daa4:
 	add r8, r8, #0x1c
 	add sb, sb, #0x1c
 	add r6, r6, #1
-	ldrsh r0, [sl, #0xa]
+	ldrsh r0, [r10, #0xa]
 	cmp r6, r0
 	ble _0213d9e4
 _0213dac0:
 	mov r0, #0
-	str r0, [sl, #0x74]
+	str r0, [r10, #0x74]
 	mov r0, #1
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_0213d9ac
 _0213dad4: .word data_027e0e60
@@ -3703,23 +3703,23 @@ _0213e324: .word data_027e0e60
 	.global func_ov14_0213e328
 	arm_func_start func_ov14_0213e328
 func_ov14_0213e328: ; 0x0213e328
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x18
-	mov sl, r0
-	ldrsh r0, [sl, #0xa]
+	mov r10, r0
+	ldrsh r0, [r10, #0xa]
 	cmp r0, #0
 	addlt sp, sp, #0x18
 	movlt r0, #0
-	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
-	ldrsh r1, [sl, #0xa]
+	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldrsh r1, [r10, #0xa]
 	mov r4, #0
 	mov r11, r4
 	cmp r1, #0
 	blt _0213e42c
-	mov r5, sl
-	add r6, sl, #0x24
-	add r7, sl, #0x2c
-	add r8, sl, #0x18
+	mov r5, r10
+	add r6, r10, #0x24
+	add r7, r10, #0x2c
+	add r8, r10, #0x18
 _0213e36c:
 	ldrsh r0, [r5, #0x2e]
 	cmp r0, #3
@@ -3762,9 +3762,9 @@ _0213e3f0:
 _0213e3f8:
 	add sp, sp, #0x18
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0213e404:
-	ldrsh r1, [sl, #0xa]
+	ldrsh r1, [r10, #0xa]
 	add r0, sp, #4
 	str r8, [r0, r11, lsl #2]
 	add r11, r11, #1
@@ -3778,7 +3778,7 @@ _0213e42c:
 	cmp r1, #0
 	bne _0213e44c
 	ldr r0, _0213e540 ; =data_027e0fd4
-	add r1, sl, #0x78
+	add r1, r10, #0x78
 	ldr r0, [r0]
 	str r1, [sp, #8]
 	ldr r0, [r0, #0x2c]
@@ -3788,59 +3788,59 @@ _0213e44c:
 	ldr r1, [sp, #8]
 	bl func_01ff9ec0
 	cmp r0, r4
-	ldrsh r0, [sl, #0xa]
+	ldrsh r0, [r10, #0xa]
 	bge _0213e484
 	cmp r0, #0
 	moveq r0, #1
-	streqb r0, [sl, #0x6a]
+	streqb r0, [r10, #0x6a]
 	mov r0, #1
-	strb r0, [sl, #0x69]
+	strb r0, [r10, #0x69]
 	add sp, sp, #0x18
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0213e484:
 	mov r5, #0
 	cmp r0, #0
 	blt _0213e52c
-	mov r6, sl
+	mov r6, r10
 	add r4, sp, #0xc
 	mov r7, #0x1c
 _0213e49c:
 	ldrsh r0, [r6, #0x2e]
 	cmp r0, #2
 	bne _0213e518
-	mov r0, sl
+	mov r0, r10
 	mov r1, r4
 	mov r2, r5
 	bl func_ov14_0213d5d0
-	ldrsh r0, [sl, #0xa]
+	ldrsh r0, [r10, #0xa]
 	cmp r0, #0
 	beq _0213e4d8
 	rsb r1, r5, #1
-	mla r0, r1, r7, sl
+	mla r0, r1, r7, r10
 	ldrsb r0, [r0, #0x31]
 	cmp r0, #2
 	bne _0213e518
 _0213e4d8:
-	mov r0, sl
+	mov r0, r10
 	mov r1, r5
 	mov r2, r4
 	bl func_ov14_0213e20c
 	cmp r0, #0
 	beq _0213e508
-	ldrsh r0, [sl, #0xa]
+	ldrsh r0, [r10, #0xa]
 	cmp r0, #0
 	bne _0213e508
-	mov r0, sl
+	mov r0, r10
 	bl func_ov57_02199e24
 	b _0213e518
 _0213e508:
-	mov r0, sl
+	mov r0, r10
 	bl func_ov14_0213d420
 	mov r1, r5
 	bl func_ov14_02123c54
 _0213e518:
-	ldrsh r0, [sl, #0xa]
+	ldrsh r0, [r10, #0xa]
 	add r5, r5, #1
 	add r6, r6, #0x1c
 	cmp r5, r0
@@ -3848,7 +3848,7 @@ _0213e518:
 _0213e52c:
 	mov r0, #1
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_0213e328
 _0213e538: .word data_027e0fe4
@@ -3869,13 +3869,13 @@ func_ov14_0213e544: ; 0x0213e544
 	.global func_ov14_0213e55c
 	arm_func_start func_ov14_0213e55c
 func_ov14_0213e55c: ; 0x0213e55c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0xb4
 	mov r6, r0
 	ldr r0, [r6, #0x20]
 	cmp r0, #2
 	addlo sp, sp, #0xb4
-	ldmloia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmloia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r2, [r6]
 	ldr r0, _0213eaa0 ; =data_027e0f64
 	ldr r1, [r2]
@@ -3896,7 +3896,7 @@ func_ov14_0213e55c: ; 0x0213e55c
 	ldr r8, [sp, #0x4c]
 	cmp r0, #0
 	ldr sb, [sp, #0x48]
-	mov sl, r4
+	mov r10, r4
 	bls _0213e670
 	mov r7, r4
 	ldr r4, _0213eaa0 ; =data_027e0f64
@@ -3905,9 +3905,9 @@ func_ov14_0213e55c: ; 0x0213e55c
 _0213e5e0:
 	ldr r0, [r6, #0x20]
 	sub r0, r0, #1
-	cmp sl, r0
+	cmp r10, r0
 	bhs _0213e62c
-	add r0, r6, sl, lsl #2
+	add r0, r6, r10, lsl #2
 	ldr r2, [r0, #4]
 	ldr r0, [r4]
 	ldr r1, [r2]
@@ -3928,7 +3928,7 @@ _0213e62c:
 	sub r0, r0, r8
 	sub r1, r1, sb
 	bl func_01ffa0f4
-	mov r2, sl, lsl #0x1
+	mov r2, r10, lsl #0x1
 	ldr r8, [sp, #0x4c]
 	ldr r1, [sp, #0x44]
 	strh r0, [r5, r2]
@@ -3937,8 +3937,8 @@ _0213e62c:
 	str r1, [sp, #0x4c]
 	str r0, [sp, #0x48]
 	ldr r0, [r6, #0x20]
-	add sl, sl, #1
-	cmp sl, r0
+	add r10, r10, #1
+	cmp r10, r0
 	blo _0213e5e0
 _0213e670:
 	bl func_02018450
@@ -4035,13 +4035,13 @@ _0213e788:
 	mov r0, ip, asr #0x1f
 	str r0, [sp, #4]
 	mov r0, #0xf6
-	umull sl, sb, r8, r0
+	umull r10, sb, r8, r0
 	mov r0, #0
 	mla sb, r8, r0, sb
 	mov r0, #0xf6
 	mla sb, r7, r0, sb
 	mov r0, #0x800
-	adds r8, sl, r0
+	adds r8, r10, r0
 	mov r0, #0
 	adc r7, sb, r0
 	mov r0, r8, lsr #0xc
@@ -4054,12 +4054,12 @@ _0213e788:
 	ldr r11, [sp, #0x78]
 	str r8, [sp, #0x74]
 	smull sb, r8, r11, r0
-	ldr sl, [sp, #8]
+	ldr r10, [sp, #8]
 	add r1, sp, #0x8c
-	smull r7, r0, sl, r0
-	adds sl, sb, #0x800
+	smull r7, r0, r10, r0
+	adds r10, sb, #0x800
 	adc r8, r8, #0
-	mov sb, sl, lsr #0xc
+	mov sb, r10, lsr #0xc
 	orr sb, sb, r8, lsl #20
 	adds r8, r7, #0x800
 	adc r0, r0, #0
@@ -4211,7 +4211,7 @@ _0213ea6c:
 	str r3, [sp, #0xc]
 	bl func_01ffa9fc
 	add sp, sp, #0xb4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_0213e55c
 _0213eaa0: .word data_027e0f64
@@ -6357,7 +6357,7 @@ func_ov14_0213ff88: ; 0x0213ff88
 	.global func_ov14_0213ffac
 	arm_func_start func_ov14_0213ffac
 func_ov14_0213ffac: ; 0x0213ffac
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x20
 	mov r4, r1
 	mov r5, #0x19000
@@ -6374,7 +6374,7 @@ func_ov14_0213ffac: ; 0x0213ffac
 	mov r5, r0
 	mov r0, #0x800
 	adds r0, r0, r4, lsl #16
-	ldr sl, _021400b4 ; =data_ov14_02153e50
+	ldr r10, _021400b4 ; =data_ov14_02153e50
 	ldr r7, _021400b8 ; =data_ov14_02153e60
 	orr r1, r1, r4, lsr #16
 	mov r6, r0, lsr #0xc
@@ -6384,7 +6384,7 @@ func_ov14_0213ffac: ; 0x0213ffac
 	mov lr, r2
 	mov ip, r3
 	orr r6, r6, r0, lsl #20
-	ldmia sl, {r0, r1, r2, r3}
+	ldmia r10, {r0, r1, r2, r3}
 	stmia sb, {r0, r1, r2, r3}
 	ldmia r7, {r0, r1, r2, r3}
 	stmia r11, {r0, r1, r2, r3}
@@ -6400,7 +6400,7 @@ func_ov14_0213ffac: ; 0x0213ffac
 	mov r3, #1
 	bl func_ov00_020b45f8
 	add sp, sp, #0x20
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0214005c:
 	ldr r1, _021400bc ; =0x00000266
 	cmp r4, r1
@@ -6416,7 +6416,7 @@ _0214005c:
 	mov r2, r11
 	blx r4
 	add sp, sp, #0x20
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02140098:
 	mov r0, r5
 	mov r1, r11
@@ -6424,7 +6424,7 @@ _02140098:
 	mov r3, #1
 	bl func_ov00_020b45f8
 	add sp, sp, #0x20
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_0213ffac
 _021400b4: .word data_ov14_02153e50
@@ -6950,22 +6950,22 @@ _021407b4: .word data_027e0f64
 	.global func_ov14_021407b8
 	arm_func_start func_ov14_021407b8
 func_ov14_021407b8: ; 0x021407b8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x38
 	ldrh r1, [r1]
-	mov sl, r0
+	mov r10, r0
 	mov sb, r2
 	tst r1, #4
 	bne _021407e0
 	tst r1, #8
 	addeq sp, sp, #0x38
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _021407e0:
 	add r0, sp, #0x18
 	bl func_01ffbe34
 	mov r0, #2
 	str r0, [sp, #0x1c]
-	add r0, sl, #0x400
+	add r0, r10, #0x400
 	ldrsh r3, [r0, #0xa0]
 	ldr r1, _02141130 ; =0x88888889
 	mov r2, #0x3c
@@ -6992,11 +6992,11 @@ _021407e0:
 	bl func_ov03_020f4b7c
 	cmp r0, #0
 	bne _021408e0
-	add r5, sl, #0x450
-	add r6, sl, #0x230
+	add r5, r10, #0x450
+	add r6, r10, #0x230
 	mov r4, #0
 _02140868:
-	add r0, sl, r4, lsl #2
+	add r0, r10, r4, lsl #2
 	ldr r0, [r0, #0x480]
 	cmp r0, #0
 	ble _021408cc
@@ -7063,7 +7063,7 @@ _021408e0:
 _02140960:
 	cmp r8, #0
 	addeq sp, sp, #0x38
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	add r1, sp, #0x14
 	str r1, [sp]
 	add r0, sp, #0x10
@@ -7079,7 +7079,7 @@ _02140960:
 	bl func_ov00_02079470
 	cmp r0, #0
 	addeq sp, sp, #0x38
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	add r1, sp, #0x18
 	str r1, [sp]
 	ldr r0, _02141144 ; =data_02063e4c
@@ -7088,7 +7088,7 @@ _02140960:
 	mov r3, #0x6b
 	bl func_020313c8
 	add sp, sp, #0x38
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _021409d0:
 	mov r0, r11
 	bl func_ov00_020849c0
@@ -7157,7 +7157,7 @@ _02140aac:
 _02140ac4:
 	cmp r8, #0
 	addeq sp, sp, #0x38
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	add r1, sp, #0x14
 	str r1, [sp]
 	add r0, sp, #0x10
@@ -7173,7 +7173,7 @@ _02140ac4:
 	bl func_ov00_02079470
 	cmp r0, #0
 	addeq sp, sp, #0x38
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	add r0, r7, #0xc
 	bl func_ov00_020a5e9c
 	cmp r0, #4
@@ -7184,7 +7184,7 @@ _02140ac4:
 	bl func_ov00_02097760
 	cmp r0, #0
 	addne sp, sp, #0x38
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, _0214114c ; =data_027e0f74
 	mov r1, #0x81
 	ldr r0, [r0]
@@ -7199,7 +7199,7 @@ _02140ac4:
 	mov r3, #0x70
 	bl func_020313c8
 	add sp, sp, #0x38
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02140b78:
 	ldr r0, _0214114c ; =data_027e0f74
 	mov r1, #0x62
@@ -7207,7 +7207,7 @@ _02140b78:
 	bl func_ov00_02097760
 	cmp r0, #0
 	addeq sp, sp, #0x38
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	add r1, sp, #0x18
 	str r1, [sp]
 	ldr r0, _02141144 ; =data_02063e4c
@@ -7216,7 +7216,7 @@ _02140b78:
 	mov r3, #0x6f
 	bl func_020313c8
 	add sp, sp, #0x38
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02140bb8:
 	add r1, sp, #0x18
 	str r1, [sp]
@@ -7226,11 +7226,11 @@ _02140bb8:
 	mov r3, #0x6b
 	bl func_020313c8
 	add sp, sp, #0x38
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02140bdc:
 	cmp r8, #0
 	addeq sp, sp, #0x38
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	add r1, sp, #0x14
 	str r1, [sp]
 	add r0, sp, #0x10
@@ -7246,7 +7246,7 @@ _02140bdc:
 	bl func_ov00_02079470
 	cmp r0, #0
 	addeq sp, sp, #0x38
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	add r1, sp, #0x18
 	str r1, [sp]
 	ldr r0, _02141144 ; =data_02063e4c
@@ -7255,7 +7255,7 @@ _02140bdc:
 	mov r3, #0x6b
 	bl func_020313c8
 	add sp, sp, #0x38
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02140c4c:
 	bl func_ov03_020f4b7c
 	cmp r0, #0
@@ -7304,7 +7304,7 @@ _02140cc8:
 	bl func_ov00_02079470
 	cmp r0, #0
 	addeq sp, sp, #0x38
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	add r1, sp, #0x18
 	str r1, [sp]
 	ldr r0, _02141144 ; =data_02063e4c
@@ -7313,16 +7313,16 @@ _02140cc8:
 	mov r3, #0x5d
 	bl func_020313c8
 	add sp, sp, #0x38
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02140d2c:
 	mov r0, r11
 	bl func_ov00_020849c0
 	cmp r0, #0
 	addne sp, sp, #0x38
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	cmp r8, #0
 	addeq sp, sp, #0x38
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	add r1, sp, #0x14
 	str r1, [sp]
 	add r0, sp, #0x10
@@ -7338,7 +7338,7 @@ _02140d2c:
 	bl func_ov00_02079470
 	cmp r0, #0
 	addeq sp, sp, #0x38
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	add r1, sp, #0x18
 	str r1, [sp]
 	ldr r0, _02141144 ; =data_02063e4c
@@ -7347,7 +7347,7 @@ _02140d2c:
 	mov r3, #2
 	bl func_020313c8
 	add sp, sp, #0x38
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02140db0:
 	bl func_ov00_020849c0
 	cmp r0, #0
@@ -7432,7 +7432,7 @@ _02140eb4:
 	bl func_ov00_02079470
 	cmp r0, #0
 	addeq sp, sp, #0x38
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	add r0, r7, #0xc
 	bl func_ov00_020a5e9c
 	cmp r0, #5
@@ -7450,7 +7450,7 @@ _02140eb4:
 	mov r3, #0x5a
 	bl func_020313c8
 	add sp, sp, #0x38
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02140f3c:
 	str r1, [sp]
 	ldr r0, _02141144 ; =data_02063e4c
@@ -7459,7 +7459,7 @@ _02140f3c:
 	mov r3, #0x59
 	bl func_020313c8
 	add sp, sp, #0x38
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02140f5c:
 	add r0, r7, #0xc
 	bl func_ov00_020a5e9c
@@ -7473,7 +7473,7 @@ _02140f5c:
 	mov r3, #0x42
 	bl func_020313c8
 	add sp, sp, #0x38
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02140f90:
 	str r1, [sp]
 	ldr r0, _02141144 ; =data_02063e4c
@@ -7482,7 +7482,7 @@ _02140f90:
 	mov r3, #0x58
 	bl func_020313c8
 	add sp, sp, #0x38
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02140fb0:
 	add r1, sp, #0x14
 	str r1, [sp]
@@ -7511,22 +7511,22 @@ _02140fb0:
 	ldr r1, [sp, #0x14]
 	ldr r2, [sp, #0x10]
 	add r3, sp, #0x18
-	add r0, sl, #0x1a8
+	add r0, r10, #0x1a8
 	bl func_02034a1c
 	add sp, sp, #0x38
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0214102c:
-	ldrb r0, [sl, #0x14d]
+	ldrb r0, [r10, #0x14d]
 	cmp r0, #0
 	beq _02141058
-	add r0, sl, #0x400
+	add r0, r10, #0x400
 	ldrsh r0, [r0, #0xa0]
 	mov r1, r0, lsr #0x1f
 	rsb r0, r1, r0, lsl #28
 	add r0, r1, r0, ror #28
 	cmp r0, #8
 	addge sp, sp, #0x38
-	ldmgeia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmgeia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02141058:
 	add r1, sp, #0x18
 	str r1, [sp]
@@ -7536,11 +7536,11 @@ _02141058:
 	mov r3, #1
 	bl func_020313c8
 	add sp, sp, #0x38
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0214107c:
 	cmp r8, #0
 	addeq sp, sp, #0x38
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	mov r0, r11
 	bl func_ov00_02084990
 	cmp r0, #0
@@ -7557,7 +7557,7 @@ _0214107c:
 	bl func_ov00_0207977c
 	cmp r0, #0
 	addeq sp, sp, #0x38
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldrb r0, [sp, #0x60]
 	cmp r0, #0
 	beq _0214110c
@@ -7570,10 +7570,10 @@ _0214107c:
 	ldr r1, [sp, #0x14]
 	ldr r2, [sp, #0x10]
 	add r3, sp, #0x18
-	add r0, sl, #0x1a8
+	add r0, r10, #0x1a8
 	bl func_02034a1c
 	add sp, sp, #0x38
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0214110c:
 	add r1, sp, #0x18
 	str r1, [sp]
@@ -7583,7 +7583,7 @@ _0214110c:
 	mov r3, r4
 	bl func_020313c8
 	add sp, sp, #0x38
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_021407b8
 _02141130: .word 0x88888889
@@ -7599,20 +7599,20 @@ _02141150: .word 0x00000186
 	.global func_ov14_02141154
 	arm_func_start func_ov14_02141154
 func_ov14_02141154: ; 0x02141154
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x1e8
 	ldr r3, _021415b4 ; =data_027e0c54
-	mov sl, r0
-	ldr r4, [sl, #0x490]
+	mov r10, r0
+	ldr r4, [r10, #0x490]
 	ldrb r3, [r3]
-	add r4, sl, r4, lsl #2
+	add r4, r10, r4, lsl #2
 	ldr r4, [r4, #0x1a0]
 	cmp r1, r3
 	mov r5, r2
 	addne sp, sp, #0x1e8
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r1, _021415b8 ; =data_027e0d38
-	str r4, [sl, #0x18c]
+	str r4, [r10, #0x18c]
 	ldr r1, [r1]
 	ldr r1, [r1, #0x14]
 	cmp r1, #1
@@ -7622,13 +7622,13 @@ func_ov14_02141154: ; 0x02141154
 	ldr r2, [r2, #0x84]
 	blx r2
 	add sp, sp, #0x1e8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _021411b4:
 	mov r0, r4
 	ldr r1, [r0]
 	ldr r1, [r1, #0x28]
 	blx r1
-	ldr r1, [sl, #0x118]
+	ldr r1, [r10, #0x118]
 	ldr r0, [r1, #4]
 	ldr r0, [r0, #8]
 	cmp r0, #0
@@ -7637,7 +7637,7 @@ _021411b4:
 	mov r2, #1
 	bl func_ov00_020a9e28
 _021411e4:
-	ldr r1, [sl, #0x138]
+	ldr r1, [r10, #0x138]
 	ldr r0, [r1, #4]
 	ldr r0, [r0, #8]
 	cmp r0, #0
@@ -7646,7 +7646,7 @@ _021411e4:
 	mov r2, #0
 	bl func_ov00_020a9e28
 _02141204:
-	ldr r0, [sl, #0x11c]
+	ldr r0, [r10, #0x11c]
 	ldr r1, [r0, #4]
 	ldr r1, [r1, #8]
 	cmp r1, #0
@@ -7655,12 +7655,12 @@ _02141204:
 	ldr r0, [r0, #4]
 	cmp r0, #0
 	ble _02141238
-	ldr r1, [sl, #0x11c]
+	ldr r1, [r10, #0x11c]
 	mov r0, r4
 	mov r2, #1
 	bl func_ov00_020a9e28
 _02141238:
-	ldr r0, [sl, #0x13c]
+	ldr r0, [r10, #0x13c]
 	ldr r1, [r0, #4]
 	ldr r1, [r1, #8]
 	cmp r1, #0
@@ -7669,27 +7669,27 @@ _02141238:
 	ldr r0, [r0, #4]
 	cmp r0, #0
 	ble _0214126c
-	ldr r1, [sl, #0x13c]
+	ldr r1, [r10, #0x13c]
 	mov r0, r4
 	mov r2, #0
 	bl func_ov00_020a9e28
 _0214126c:
-	ldr r0, [sl, #0x144]
+	ldr r0, [r10, #0x144]
 	cmp r0, #0
 	beq _0214128c
 	mov r0, r4
 	ldr r2, [r0]
-	ldr r1, [sl, #0x140]
+	ldr r1, [r10, #0x140]
 	ldr r2, [r2, #0x24]
 	blx r2
 _0214128c:
-	ldrb r0, [sl, #0x14b]
+	ldrb r0, [r10, #0x14b]
 	cmp r0, #0
 	beq _021412a8
 	bl func_ov14_021415d4
 	bl _ZN15LinkStateDamage18func_ov00_020aca94Ev
 	add sp, sp, #0x1e8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _021412a8:
 	mov r0, r5, lsl #0x10
 	mov r0, r0, lsr #0x10
@@ -7717,7 +7717,7 @@ _021412a8:
 	moveq r7, #1
 _02141308:
 	bl func_ov14_021415e4
-	ldr r1, [sl, #0x490]
+	ldr r1, [r10, #0x490]
 	str r0, [sp, #4]
 	cmp r1, #1
 	bne _02141338
@@ -7729,7 +7729,7 @@ _02141308:
 	bl func_ov00_020aa124
 	b _02141418
 _02141338:
-	add r0, sl, #0x400
+	add r0, r10, #0x400
 	ldrsh r8, [r0, #0xa2]
 	mov r0, r4
 	mov sb, #0x1f
@@ -7740,7 +7740,7 @@ _02141338:
 	blx r1
 	mov r1, r8
 	bl func_020197fc
-	add r0, sl, #0x400
+	add r0, r10, #0x400
 	ldrsh sb, [r0, #0xa2]
 	b _02141380
 _02141370:
@@ -7818,9 +7818,9 @@ _02141418:
 	orr r7, r7, r6, lsl #20
 	orr r2, r2, r1, lsl #20
 	add r1, r7, r2
-	str r1, [sl, #0x34]
+	str r1, [r10, #0x34]
 	ldr r1, [r0, #0x50]
-	str r1, [sl, #0x38]
+	str r1, [r10, #0x38]
 	ldr r2, [r0, #0x54]
 	ldr r1, [r0, #0x4c]
 	smull r3, r5, r2, r5
@@ -7834,10 +7834,10 @@ _02141418:
 	orr r6, r6, r5, lsl #20
 	orr r2, r2, r1, lsl #20
 	sub r1, r6, r2
-	str r1, [sl, #0x3c]
+	str r1, [r10, #0x3c]
 _021414cc:
-	ldr r2, [sl, #0x120]
-	ldr r1, [sl, #0x100]
+	ldr r2, [r10, #0x120]
+	ldr r1, [r10, #0x100]
 	cmp r1, r2
 	cmpne r0, #0
 	beq _0214159c
@@ -7855,7 +7855,7 @@ _021414f4:
 	tst r1, #1
 	orreq r1, r1, #1
 	streq r1, [r0]
-	ldr r0, [sl, #0x118]
+	ldr r0, [r10, #0x118]
 	bl func_ov00_020c0d4c
 	mov r1, r0
 	ldr r2, [r4, #0x5c]
@@ -7890,12 +7890,12 @@ _021414f4:
 	bic r0, r0, #2
 	str r0, [r5]
 _0214159c:
-	ldrh r1, [sl, #0x2c]
-	ldrh r2, [sl, #0x30]
+	ldrh r1, [r10, #0x2c]
+	ldrh r2, [r10, #0x30]
 	mov r0, r4
 	bl func_ov00_020a9c14
 	add sp, sp, #0x1e8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_02141154
 _021415b4: .word data_027e0c54
@@ -8061,31 +8061,31 @@ _02141788: .word 0x00000266
 	.global func_ov14_0214178c
 	arm_func_start func_ov14_0214178c
 func_ov14_0214178c: ; 0x0214178c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #0xc
-	mov sl, r0
-	ldrb r0, [sl, #0x14c]
+	mov r10, r0
+	ldrb r0, [r10, #0x14c]
 	mov sb, r2
 	cmp r0, #0
 	addeq sp, sp, #0xc
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	mov r0, #0xc
 	mul r8, r1, r0
-	add r7, sl, #0xd4
-	add r6, sl, #0xec
+	add r7, r10, #0xd4
+	add r6, r10, #0xec
 	ldr r1, [r6, r8]
 	ldr r0, [r7, r8]
 	cmp r1, r0
 	addge sp, sp, #0xc
 	movge r0, #0
-	ldmgeia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
-	add r5, sl, #0xd0
+	ldmgeia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	add r5, r10, #0xd0
 	ldr r1, [r5, r8]
 	ldr r0, _021418e8 ; =data_027e0e60
 	str r1, [sp]
 	ldr r1, [r7, r8]
-	add r4, sl, #0xd8
+	add r4, r10, #0xd8
 	str r1, [sp, #4]
 	ldr r2, [r4, r8]
 	ldr r0, [r0]
@@ -8099,14 +8099,14 @@ func_ov14_0214178c: ; 0x0214178c
 	cmp r3, r0
 	addge sp, sp, #0xc
 	movge r0, #0
-	ldmgeia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmgeia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	ldr r0, [r6, r8]
 	add r2, r3, #0xf6
 	cmp r0, r2
 	bgt _021418dc
-	add r1, sl, #0xe8
+	add r1, r10, #0xe8
 	ldr ip, [r1, r8]
-	add r0, sl, #0xf0
+	add r0, r10, #0xf0
 	str ip, [sb]
 	ldr r6, [r6, r8]
 	str r6, [sb, #4]
@@ -8116,7 +8116,7 @@ func_ov14_0214178c: ; 0x0214178c
 	cmp r3, r2
 	addgt sp, sp, #0xc
 	movgt r0, #1
-	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	ldr r2, [r1, r8]
 	ldr r3, [r5, r8]
 	ldr r1, [r4, r8]
@@ -8135,7 +8135,7 @@ func_ov14_0214178c: ; 0x0214178c
 _021418a8:
 	add sp, sp, #0xc
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 _021418b4:
 	mul r0, r1, r1
 	mul r1, r2, r2
@@ -8146,11 +8146,11 @@ _021418b4:
 	cmp r0, #0x45
 	addgt sp, sp, #0xc
 	movgt r0, #1
-	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 _021418dc:
 	mov r0, #0
 	add sp, sp, #0xc
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov14_0214178c
 _021418e8: .word data_027e0e60
@@ -8432,7 +8432,7 @@ func_ov14_02141c38: ; 0x02141c38
 	.global func_ov14_02141c60
 	arm_func_start func_ov14_02141c60
 func_ov14_02141c60: ; 0x02141c60
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x4c
 	mov sb, r0
 	ldr r0, [sb, #0x18]
@@ -8529,7 +8529,7 @@ _02141d88:
 	mov r5, #1
 	ldr r4, _02142040 ; =data_027e0e60
 	add r6, sp, #0xe
-	add sl, sp, #0xc
+	add r10, sp, #0xc
 	mov r11, r5
 _02141dd4:
 	ldrb r8, [sb, #0x15]
@@ -8547,7 +8547,7 @@ _02141df0:
 	strb r8, [sp, #0xf]
 	bl func_ov00_02082680
 	ldr r0, [r4]
-	mov r1, sl
+	mov r1, r10
 	strb r7, [sp, #0xc]
 	strb r8, [sp, #0xd]
 	mov r2, r11
@@ -8578,7 +8578,7 @@ _02141e5c:
 	mov r5, #1
 	ldr r4, _02142040 ; =data_027e0e60
 	add r6, sp, #0xa
-	add sl, sp, #8
+	add r10, sp, #8
 	mov r11, r5
 _02141e88:
 	ldrb r8, [sb, #0x15]
@@ -8596,7 +8596,7 @@ _02141ea4:
 	strb r8, [sp, #0xb]
 	bl func_ov00_02082680
 	ldr r0, [r4]
-	mov r1, sl
+	mov r1, r10
 	strb r7, [sp, #8]
 	strb r8, [sp, #9]
 	mov r2, r11
@@ -8699,7 +8699,7 @@ _02142004:
 	add r0, r0, #0x2d
 	str r0, [sb, #0x4c]
 	add sp, sp, #0x4c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_02141c60
 _02142040: .word data_027e0e60
@@ -9231,24 +9231,24 @@ func_ov14_02142784: ; 0x02142784
 	.global func_ov14_0214278c
 	arm_func_start func_ov14_0214278c
 func_ov14_0214278c: ; 0x0214278c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x20
-	mov sl, r0
-	ldr r0, [sl, #4]
+	mov r10, r0
+	ldr r0, [r10, #4]
 	str r1, [sp, #0x10]
 	tst r0, #0x10
 	addeq sp, sp, #0x20
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, _02142904 ; =data_027e0d38
 	ldr r0, [r0]
 	add r0, r0, #0xc
 	bl func_ov00_020a5e9c
 	cmp r0, #0x1a
 	addeq sp, sp, #0x20
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
-	ldrb r0, [sl, #0x38]
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldrb r0, [r10, #0x38]
 	ldr r1, _02142904 ; =data_027e0d38
-	ldrb r7, [sl, #0x39]
+	ldrb r7, [r10, #0x39]
 	str r0, [sp, #0x18]
 	ldr r0, [r1]
 	mov r8, #4
@@ -9273,11 +9273,11 @@ _02142818:
 	mov r0, #0
 	str r0, [sp, #0x1c]
 	addle sp, sp, #0x20
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	str r0, [sp, #0x14]
 	mvn r11, #0
 _02142838:
-	ldr r0, [sl, #0x40]
+	ldr r0, [r10, #0x40]
 	cmp r0, #0
 	beq _02142858
 	cmp r0, #1
@@ -9298,7 +9298,7 @@ _02142868:
 	mov sb, r5
 	mvn r4, #0
 _0214287c:
-	ldr r0, [sl, #0x40]
+	ldr r0, [r10, #0x40]
 	cmp r0, #2
 	beq _02142898
 	cmp r0, #3
@@ -9315,9 +9315,9 @@ _021428a4:
 	mov r0, #0
 	stmib sp, {r0, r6}
 	str r1, [sp, #0xc]
-	ldrsh r1, [sl, #0xc]
+	ldrsh r1, [r10, #0xc]
 	ldr r3, [sp, #0x10]
-	mov r0, sl
+	mov r0, r10
 	mov r2, #0xa
 	bl func_ov00_0208c0dc
 	add r5, r5, #1
@@ -9335,7 +9335,7 @@ _021428d8:
 	str r0, [sp, #0x14]
 	blt _02142838
 	add sp, sp, #0x20
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_0214278c
 _02142904: .word data_027e0d38
@@ -9344,16 +9344,16 @@ _02142908: .word data_027e0e60
 	.global func_ov14_0214290c
 	arm_func_start func_ov14_0214290c
 func_ov14_0214290c: ; 0x0214290c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x30
 	ldr r2, [r0]
-	mov sl, r0
+	mov r10, r0
 	ldr r2, [r2, #0x88]
 	blx r2
 	cmp r0, #0
 	addeq sp, sp, #0x30
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
-	ldrsh r1, [sl, #0xc]
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldrsh r1, [r10, #0xc]
 	ldr r3, _02142b58 ; =data_02050f54
 	add r0, sp, #0xc
 	add r1, r1, #0x4000
@@ -9367,32 +9367,32 @@ func_ov14_0214290c: ; 0x0214290c
 	ldrsh r1, [r3, r4]
 	ldrsh r2, [r3, r2]
 	blx func_01ff8214
-	ldr r2, [sl, #0x60]
-	ldr r1, [sl, #0x1c]
-	ldr r0, [sl, #0x58]
+	ldr r2, [r10, #0x60]
+	ldr r1, [r10, #0x1c]
+	ldr r0, [r10, #0x58]
 	mov r6, #0
 	str r1, [sp, #4]
 	str r2, [sp, #8]
 	str r0, [sp]
-	ldrb r0, [sl, #0x38]
+	ldrb r0, [r10, #0x38]
 	cmp r0, #0
 	addle sp, sp, #0x30
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	mov r8, r6
 _02142998:
-	ldr r0, [sl, #0x40]
+	ldr r0, [r10, #0x40]
 	cmp r0, #0
 	beq _021429f0
 	cmp r0, #1
-	ldr r0, [sl, #0x58]
+	ldr r0, [r10, #0x58]
 	bne _02142a34
 	sub r2, r0, r8
 	str r2, [sp]
-	ldrb r0, [sl, #0x38]
+	ldrb r0, [r10, #0x38]
 	sub r0, r0, #1
 	cmp r6, r0
 	bne _02142a3c
-	ldr r1, [sl, #0x54]
+	ldr r1, [r10, #0x54]
 	cmp r1, #0
 	beq _02142a3c
 	ldr r0, [sp, #4]
@@ -9403,14 +9403,14 @@ _02142998:
 	str r0, [sp, #4]
 	b _02142a3c
 _021429f0:
-	ldr r0, [sl, #0x58]
+	ldr r0, [r10, #0x58]
 	add r2, r0, r8
 	str r2, [sp]
-	ldrb r0, [sl, #0x38]
+	ldrb r0, [r10, #0x38]
 	sub r0, r0, #1
 	cmp r6, r0
 	bne _02142a3c
-	ldr r1, [sl, #0x54]
+	ldr r1, [r10, #0x54]
 	cmp r1, #0
 	beq _02142a3c
 	ldr r0, [sp, #4]
@@ -9424,7 +9424,7 @@ _02142a34:
 	add r0, r0, r8
 	str r0, [sp]
 _02142a3c:
-	ldrb r0, [sl, #0x39]
+	ldrb r0, [r10, #0x39]
 	mov r7, #0
 	cmp r0, #0
 	ble _02142b3c
@@ -9433,19 +9433,19 @@ _02142a3c:
 	mov r5, r7
 	add r11, sp, #0xc
 _02142a5c:
-	ldr r0, [sl, #0x40]
+	ldr r0, [r10, #0x40]
 	cmp r0, #2
 	beq _02142ab4
 	cmp r0, #3
-	ldr r0, [sl, #0x60]
+	ldr r0, [r10, #0x60]
 	bne _02142af8
 	sub r0, r0, sb
 	str r0, [sp, #8]
-	ldrb r1, [sl, #0x39]
+	ldrb r1, [r10, #0x39]
 	sub r1, r1, #1
 	cmp r7, r1
 	bne _02142b00
-	ldr r2, [sl, #0x54]
+	ldr r2, [r10, #0x54]
 	cmp r2, #0
 	beq _02142b00
 	ldr r1, [sp, #4]
@@ -9456,14 +9456,14 @@ _02142a5c:
 	str r0, [sp, #4]
 	b _02142b00
 _02142ab4:
-	ldr r0, [sl, #0x60]
+	ldr r0, [r10, #0x60]
 	add r0, r0, sb
 	str r0, [sp, #8]
-	ldrb r1, [sl, #0x39]
+	ldrb r1, [r10, #0x39]
 	sub r1, r1, #1
 	cmp r7, r1
 	bne _02142b00
-	ldr r2, [sl, #0x54]
+	ldr r2, [r10, #0x54]
 	cmp r2, #0
 	beq _02142b00
 	ldr r1, [sp, #4]
@@ -9479,27 +9479,27 @@ _02142af8:
 _02142b00:
 	cmp r6, #0
 	cmpeq r7, #0
-	streqh r5, [sl, #0x6e]
-	strneh r4, [sl, #0x6e]
-	add r0, sl, #0x64
+	streqh r5, [r10, #0x6e]
+	strneh r4, [r10, #0x6e]
+	add r0, r10, #0x64
 	ldr r3, [r0]
 	mov r1, r11
 	ldr r3, [r3, #0x14]
 	add r2, sp, #0
 	blx r3
-	ldrb r0, [sl, #0x39]
+	ldrb r0, [r10, #0x39]
 	add r7, r7, #1
 	add sb, sb, #0x1000
 	cmp r7, r0
 	blt _02142a5c
 _02142b3c:
-	ldrb r0, [sl, #0x38]
+	ldrb r0, [r10, #0x38]
 	add r6, r6, #1
 	add r8, r8, #0x1000
 	cmp r6, r0
 	blt _02142998
 	add sp, sp, #0x30
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_0214290c
 _02142b58: .word data_02050f54
@@ -10258,27 +10258,27 @@ _021434b4: .word data_027e0f64
 	.global func_ov14_021434b8
 	arm_func_start func_ov14_021434b8
 func_ov14_021434b8: ; 0x021434b8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #8
-	mov sl, r0
-	ldr r0, [sl, #4]
+	mov r10, r0
+	ldr r0, [r10, #4]
 	tst r0, #0x10
 	addeq sp, sp, #8
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldrh r0, [r1]
 	tst r0, #4
 	bne _021434ec
 	tst r0, #8
 	addeq sp, sp, #8
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _021434ec:
-	ldr r0, [sl, #0x138]
+	ldr r0, [r10, #0x138]
 	mov r8, #0
 	cmp r0, #0
 	addle sp, sp, #8
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r4, _02143584 ; =data_027e0d3c
-	mov sb, sl
+	mov sb, r10
 	mov r11, r8
 	add r7, sp, #4
 	add r6, sp, #0
@@ -10302,16 +10302,16 @@ _02143518:
 	ldr r1, [sp, #4]
 	ldr r2, [sp]
 	mov r3, r11
-	add r0, sl, #0x200
+	add r0, r10, #0x200
 	bl func_02034a1c
 _02143568:
-	ldr r0, [sl, #0x138]
+	ldr r0, [r10, #0x138]
 	add r8, r8, #1
 	cmp r8, r0
 	add sb, sb, #6
 	blt _02143518
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_021434b8
 _02143584: .word data_027e0d3c
@@ -14717,25 +14717,25 @@ _021467b4: .word 0x55555556
 	.global func_ov14_021467b8
 	arm_func_start func_ov14_021467b8
 func_ov14_021467b8: ; 0x021467b8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x48
-	mov sl, r0
+	mov r10, r0
 	cmp r1, #0
-	ldrneb r0, [sl, #0xa5]
-	ldreqb r0, [sl, #0xa4]
+	ldrneb r0, [r10, #0xa5]
+	ldreqb r0, [r10, #0xa4]
 	cmp r0, #0
-	ldrne r0, [sl, #0x130]
+	ldrne r0, [r10, #0x130]
 	cmpne r0, #2
 	addeq sp, sp, #0x48
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
-	add r0, sl, #0x100
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	add r0, r10, #0x100
 	ldrsh r1, [r0, #0x58]
-	ldrh r0, [sl, #0x20]
+	ldrh r0, [r10, #0x20]
 	ldr r3, _021469cc ; =data_02050f54
 	rsb r1, r1, #0xe
 	mov r1, r1, lsl #0x1
 	rsb r5, r1, #0x1f
-	ldrh r1, [sl, #0x78]
+	ldrh r1, [r10, #0x78]
 	cmp r0, #2
 	ldreq r6, _021469d0 ; =0x00000b33
 	mov r1, r1, asr #0x4
@@ -14792,10 +14792,10 @@ func_ov14_021467b8: ; 0x021467b8
 	mov r2, #1
 	bl func_01ffa9fc
 	stmia sp, {r6, r7}
-	add r0, sl, #0x100
+	add r0, r10, #0x100
 	ldrsh r2, [r0, #0x80]
-	mov r0, sl
-	add r1, sl, #0x48
+	mov r0, r10
+	add r1, r10, #0x48
 	str r2, [sp, #8]
 	add r2, sp, #0x24
 	mov r3, r5
@@ -14808,7 +14808,7 @@ func_ov14_021467b8: ; 0x021467b8
 	mov r3, r7, asr #0x1f
 	mla r4, r3, r0, r4
 	adc r3, r4, #0
-	ldrh r2, [sl, #0x20]
+	ldrh r2, [r10, #0x20]
 	mov r1, r1, lsr #0xc
 	orr r1, r1, r3, lsl #20
 	cmp r2, #2
@@ -14816,7 +14816,7 @@ func_ov14_021467b8: ; 0x021467b8
 	str r1, [sp, #0xc]
 	smull r0, r1, r6, r0
 	adds r2, r0, #0x800
-	add r4, sl, #0x100
+	add r4, r10, #0x100
 	ldrsh r0, [r4, #0x82]
 	adc r1, r1, #0
 	mov r11, r2, lsr #0xc
@@ -14824,8 +14824,8 @@ func_ov14_021467b8: ; 0x021467b8
 	orr r11, r11, r1, lsl #20
 	mov r8, #0
 	addle sp, sp, #0x48
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
-	add sb, sl, #0x15c
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	add sb, r10, #0x15c
 _0214696c:
 	ldr r0, [sp, #0xc]
 	add r1, r6, r11
@@ -14838,7 +14838,7 @@ _0214696c:
 	str r7, [sp, #4]
 	ldrsh r1, [r4, #0x80]
 	sub r5, r5, #5
-	mov r0, sl
+	mov r0, r10
 	str r1, [sp, #8]
 	mov r1, sb
 	add r2, sp, #0x24
@@ -14850,7 +14850,7 @@ _0214696c:
 	cmp r8, r0
 	blt _0214696c
 	add sp, sp, #0x48
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_021467b8
 _021469cc: .word data_02050f54
@@ -16917,19 +16917,19 @@ func_ov14_02148334: ; 0x02148334
 	.global func_ov14_02148364
 	arm_func_start func_ov14_02148364
 func_ov14_02148364: ; 0x02148364
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x128
 	ldr r2, _02148644 ; =data_027e0e60
-	mov sl, r0
+	mov r10, r0
 	ldr r0, [r2]
 	mov r2, #0
 	mov sb, r1
 	bl func_ov00_02083ee0
-	ldr r1, [sl, #0x4c]
+	ldr r1, [r10, #0x4c]
 	cmp r1, r0
 	addlt sp, sp, #0x128
 	movlt r0, #0
-	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r1, _02148644 ; =data_027e0e60
 	add r0, sp, #0x14
 	ldr r1, [r1]
@@ -16955,7 +16955,7 @@ _021483e4:
 _021483ec:
 	add sp, sp, #0x128
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _021483f8:
 	ldr r1, _02148648 ; =0x0000ffff
 	mov r0, #0
@@ -16974,17 +16974,17 @@ _021483f8:
 	strb r0, [sp, #0x123]
 	strb r0, [sp, #0x124]
 	strb r0, [sp, #0x125]
-	ldr r2, [sl, #0x48]
-	add r1, sl, #0x8c
+	ldr r2, [r10, #0x48]
+	add r1, r10, #0x8c
 	str r2, [sp, #0x2c]
-	ldr r3, [sl, #0x4c]
-	add r2, sl, #0x100
+	ldr r3, [r10, #0x4c]
+	add r2, r10, #0x100
 	str r3, [sp, #0x30]
-	ldr r3, [sl, #0x50]
+	ldr r3, [r10, #0x50]
 	ldr r4, _02148644 ; =data_027e0e60
 	str r3, [sp, #0x34]
 	str r1, [sp]
-	ldr r3, [sl, #8]
+	ldr r3, [r10, #8]
 	add r1, sp, #0xc8
 	str r3, [sp, #4]
 	ldrh r5, [r2, #0x5a]
@@ -16998,18 +16998,18 @@ _021483f8:
 	cmp r0, #0
 	addne sp, sp, #0x128
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, _0214864c ; =data_ov14_02153ed8
 	add r4, sp, #0xb8
 	ldmia r0, {r0, r1, r2, r3}
 	stmia r4, {r0, r1, r2, r3}
-	ldr r0, [sl, #0x48]
+	ldr r0, [r10, #0x48]
 	add r8, sp, #0xa0
 	str r0, [sp, #0xac]
-	ldr r3, [sl, #0x4c]
+	ldr r3, [r10, #0x4c]
 	mov r7, #4
 	str r3, [sp, #0xb0]
-	ldr r0, [sl, #0x50]
+	ldr r0, [r10, #0x50]
 	ldr r5, _02148650 ; =data_027e0fe4
 	str r0, [sp, #0xb4]
 	ldmia sb, {r0, r1, r2}
@@ -17074,22 +17074,22 @@ _0214858c:
 	beq _02148628
 	mov r1, r5
 	bl _ZN5Actor10GetUnk_08cEP8Cylinder
-	ldr r1, [sl, #0x48]
+	ldr r1, [r10, #0x48]
 	mov r0, r5
 	str r1, [sp, #0x20]
-	ldr r2, [sl, #0x4c]
+	ldr r2, [r10, #0x4c]
 	add r1, sp, #0x20
 	str r2, [sp, #0x24]
-	ldr r3, [sl, #0x50]
+	ldr r3, [r10, #0x50]
 	mov r2, sb
 	str r3, [sp, #0x28]
-	ldr r3, [sl, #0x98]
+	ldr r3, [r10, #0x98]
 	bl func_ov00_0208f030
 	cmp r0, #0
 	addne sp, sp, #0x128
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
-	ldr r3, [sl, #0x98]
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldr r3, [r10, #0x98]
 	mov r0, r5
 	add r1, sp, #0xac
 	add r2, sp, #0xa0
@@ -17097,7 +17097,7 @@ _0214858c:
 	cmp r0, #0
 	addne sp, sp, #0x128
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02148628:
 	add r7, r7, #1
 	cmp r7, r6
@@ -17106,7 +17106,7 @@ _02148628:
 _02148638:
 	mov r0, #1
 	add sp, sp, #0x128
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_02148364
 _02148644: .word data_027e0e60
@@ -19541,10 +19541,10 @@ _0214a71c: .word data_02050f54
 	.global func_ov14_0214a720
 	arm_func_start func_ov14_0214a720
 func_ov14_0214a720: ; 0x0214a720
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x10
 	movs sb, r1
-	mov sl, r0
+	mov r10, r0
 	mov r6, r2
 	mov r8, r3
 	beq _0214a750
@@ -19561,7 +19561,7 @@ _0214a758:
 _0214a75c:
 	cmp sb, #2
 	beq _0214a770
-	ldrb r0, [sl, #0x8e]
+	ldrb r0, [r10, #0x8e]
 	cmp r0, #0
 	beq _0214a77c
 _0214a770:
@@ -19570,13 +19570,13 @@ _0214a770:
 	b _0214a868
 _0214a77c:
 	add r1, sp, #4
-	mov r0, sl
+	mov r0, r10
 	bl func_ov14_0214aa2c
 	cmp r0, #0
 	addeq sp, sp, #0x10
 	moveq r0, r8
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
-	ldrsh r4, [sl, #0x6c]
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldrsh r4, [r10, #0x6c]
 	ldr r5, [sp, #4]
 	ldr r0, [r6]
 	rsb r1, r4, #0
@@ -19606,7 +19606,7 @@ _0214a7ec:
 	mov r4, r5
 	mov r8, r0, asr #0x10
 _0214a808:
-	ldrsh r5, [sl, #0x6e]
+	ldrsh r5, [r10, #0x6e]
 	ldr r11, [sp, #8]
 	ldr r3, [r6, #4]
 	rsb r0, r5, #0
@@ -19631,18 +19631,18 @@ _0214a808:
 	cmp sb, r6
 	movlt sb, r6
 _0214a868:
-	ldrb r0, [sl, #0x8f]
+	ldrb r0, [r10, #0x8f]
 	cmp r0, #0
 	beq _0214a888
-	strh r4, [sl, #0x68]
-	strh sb, [sl, #0x6a]
+	strh r4, [r10, #0x68]
+	strh sb, [r10, #0x6a]
 	mov r0, #0
-	strb r0, [sl, #0x8f]
+	strb r0, [r10, #0x8f]
 	b _0214a918
 _0214a888:
-	ldrsh r0, [sl, #0x68]
+	ldrsh r0, [r10, #0x68]
 	strh r0, [sp, #2]
-	ldrsh r2, [sl, #0x6a]
+	ldrsh r2, [r10, #0x6a]
 	subs r1, r4, r0
 	rsbmi r1, r1, #0
 	strh r2, [sp]
@@ -19675,13 +19675,13 @@ _0214a8e8:
 	mov r2, r5
 	bl func_0202b154
 	ldrsh r0, [sp, #2]
-	strh r0, [sl, #0x68]
+	strh r0, [r10, #0x68]
 	ldrsh r0, [sp]
-	strh r0, [sl, #0x6a]
+	strh r0, [r10, #0x6a]
 _0214a918:
 	mov r0, r8
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_0214a720
 _0214a924: .word 0x00000222
@@ -21985,20 +21985,20 @@ _0214c674: .word func_0202b2e8
 	.global func_ov14_0214c678
 	arm_func_start func_ov14_0214c678
 func_ov14_0214c678: ; 0x0214c678
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x94
-	mov sl, r0
+	mov r10, r0
 	mov sb, r1
 	bl func_ov14_0214c660
 	cmp r0, #0
 	beq _0214c92c
-	ldrb r0, [sl, #0x10]
+	ldrb r0, [r10, #0x10]
 	cmp r0, #0
 	beq _0214c920
 	sub r0, r0, #1
-	strb r0, [sl, #0x10]
+	strb r0, [r10, #0x10]
 	ldr lr, _0214c938 ; =data_027e0764
-	ldr r6, [sl, #0xc]
+	ldr r6, [r10, #0xc]
 	ldr r7, [lr]
 	ldmib lr, {r1, r3}
 	umull r8, r0, r3, r7
@@ -22084,31 +22084,31 @@ _0214c7d0:
 _0214c7ec:
 	ldr r0, [sb]
 	mov r1, r7, lsl #0x1
-	str r0, [sl]
+	str r0, [r10]
 	add r0, sp, #0x14
 	ldrh r0, [r0, r1]
 	ldr r2, [sb, #4]
 	add r3, sp, #0x28
-	str r2, [sl, #4]
+	str r2, [r10, #4]
 	mov r0, r0, asr #0x4
 	ldr r1, [sb, #8]
 	mov r2, r0, lsl #0x1
 	mov r0, r2, lsl #0x1
-	str r1, [sl, #8]
+	str r1, [r10, #8]
 	ldrsh r1, [r6, r0]
 	add r0, r6, r2, lsl #1
-	ldr r2, [sl]
+	ldr r2, [r10]
 	mov r1, r1, lsl #0xc
 	add r1, r1, #0x800
 	add r1, r2, r1, asr #12
-	str r1, [sl]
+	str r1, [r10]
 	ldrsh r0, [r0, #2]
-	ldr r2, [sl, #8]
+	ldr r2, [r10, #8]
 	add r1, sp, #0x34
 	mov r0, r0, lsl #0xc
 	add r0, r0, #0x800
 	add r0, r2, r0, asr #12
-	str r0, [sl, #8]
+	str r0, [r10, #8]
 	ldr r0, [sb]
 	mov r2, r11
 	str r0, [sp, #0x28]
@@ -22116,11 +22116,11 @@ _0214c7ec:
 	str r0, [sp, #0x2c]
 	ldr r0, [sb, #8]
 	str r0, [sp, #0x30]
-	ldr r0, [sl]
+	ldr r0, [r10]
 	str r0, [sp, #0x1c]
-	ldr r0, [sl, #4]
+	ldr r0, [r10, #4]
 	str r0, [sp, #0x20]
-	ldr r0, [sl, #8]
+	ldr r0, [r10, #8]
 	str r0, [sp, #0x24]
 	ldr r0, _0214c944 ; =0x0000ffff
 	strh r5, [sp, #0x60]
@@ -22138,7 +22138,7 @@ _0214c7ec:
 	strb r5, [sp, #0x8f]
 	strb r5, [sp, #0x90]
 	strb r5, [sp, #0x91]
-	ldr ip, [sl, #0xc]
+	ldr ip, [r10, #0xc]
 	add r0, ip, #0x8c
 	str r0, [sp]
 	ldr r0, [ip, #8]
@@ -22149,7 +22149,7 @@ _0214c7ec:
 	bl func_01ffbe78
 	cmp r0, #0
 	bne _0214c910
-	ldrb r1, [sl, #0x11]
+	ldrb r1, [r10, #0x11]
 	ldr r0, [r4]
 	mov r2, r11
 	bl func_ov00_02083770
@@ -22163,11 +22163,11 @@ _0214c910:
 _0214c920:
 	add sp, sp, #0x94
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0214c92c:
 	mov r0, #0
 	add sp, sp, #0x94
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_0214c678
 _0214c938: .word data_027e0764
@@ -23658,7 +23658,7 @@ _0214dc78: .word data_02050f54
 	.global func_ov14_0214dc7c
 	arm_func_start func_ov14_0214dc7c
 func_ov14_0214dc7c: ; 0x0214dc7c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0xf8
 	ldr r2, _0214e120 ; =0x0000ffff
 	mov r1, #0
@@ -23858,7 +23858,7 @@ _0214df30:
 	bge _0214df78
 	cmp r3, r2
 	addeq sp, sp, #0xf8
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0214df50:
 	ldr r1, [r3]
 	add r3, r3, #0xc
@@ -23869,7 +23869,7 @@ _0214df50:
 	cmp r3, r2
 	bne _0214df50
 	add sp, sp, #0xf8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0214df78:
 	cmp r3, r2
 	beq _0214dfa0
@@ -23927,7 +23927,7 @@ _0214e01c:
 	ldr r5, [r2, #8]
 	adds r4, lr, #0x800
 	mla sb, ip, r8, sb
-	ldr sl, [r2]
+	ldr r10, [r2]
 	mov r7, r7, lsl #0xc
 	str r5, [sp, #0x24]
 	mov r5, r7, asr #0x1f
@@ -23936,7 +23936,7 @@ _0214e01c:
 	adc r8, sb, #0
 	mov r4, r4, lsr #0xc
 	orr r4, r4, r8, lsl #20
-	add sl, sl, r4
+	add r10, r10, r4
 	ldr r4, [sp, #0x14]
 	mov r5, r6, asr #0x1f
 	str r5, [sp, #0x28]
@@ -23964,7 +23964,7 @@ _0214e01c:
 	orr r6, r6, r4, lsl #20
 	ldr r4, [sp, #0x24]
 	cmp r5, #0
-	strne sl, [r5, #0x58]
+	strne r10, [r5, #0x58]
 	add r6, r4, r6
 	ldr r4, [r3]
 	add r11, r11, #1
@@ -23981,7 +23981,7 @@ _0214e01c:
 	cmp r11, #2
 	blo _0214e01c
 	add sp, sp, #0xf8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_0214dc7c
 _0214e120: .word 0x0000ffff
@@ -23993,7 +23993,7 @@ _0214e130: .word data_ov14_0215a1a0
 	.global func_ov14_0214e134
 	arm_func_start func_ov14_0214e134
 func_ov14_0214e134: ; 0x0214e134
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0xc
 	ldr r2, _0214e268 ; =data_027e0e60
 	mov r5, r0
@@ -24046,19 +24046,19 @@ _0214e1e4:
 	ldr r0, [sp, #4]
 	cmp sb, r0
 	addgt sp, sp, #0xc
-	ldmgtia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmgtia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r6, _0214e268 ; =data_027e0e60
 	add r11, sp, #8
 _0214e1fc:
-	ldr sl, [sp]
-	mov r0, sl
+	ldr r10, [sp]
+	mov r0, r10
 	cmp r0, r8
 	bgt _0214e250
 	and r7, sb, #0xff
 _0214e210:
 	ldr r0, [r6]
 	mov r1, sb
-	mov r2, sl
+	mov r2, r10
 	bl func_ov00_02083e34
 	ldr r1, [r5, #0x1c]
 	cmp r1, r0
@@ -24067,11 +24067,11 @@ _0214e210:
 	mov r1, r11
 	mov r2, r4
 	strb r7, [sp, #8]
-	strb sl, [sp, #9]
+	strb r10, [sp, #9]
 	bl func_ov00_020826a0
 _0214e244:
-	add sl, sl, #1
-	cmp sl, r8
+	add r10, r10, #1
+	cmp r10, r8
 	ble _0214e210
 _0214e250:
 	ldr r0, [sp, #4]
@@ -24079,7 +24079,7 @@ _0214e250:
 	cmp sb, r0
 	ble _0214e1fc
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_0214e134
 _0214e268: .word data_027e0e60
@@ -26264,7 +26264,7 @@ func_ov14_0214fe70: ; 0x0214fe70
 	.global func_ov14_0214fe98
 	arm_func_start func_ov14_0214fe98
 func_ov14_0214fe98: ; 0x0214fe98
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x20
 	mov r4, r0
 	ldr r0, [r4, #0x18]
@@ -26356,10 +26356,10 @@ _0214ffc0:
 	add r6, sp, #4
 	mov r11, r7
 _0214ffec:
-	ldrb sl, [r4, #0x15]
+	ldrb r10, [r4, #0x15]
 	ldrb r0, [r4, #0x39]
-	add r0, sl, r0
-	cmp sl, r0
+	add r0, r10, r0
+	cmp r10, r0
 	bge _02150050
 	ldr r0, [sp]
 	and sb, r0, #0xff
@@ -26368,19 +26368,19 @@ _02150008:
 	mov r1, r8
 	mov r2, r7
 	strb sb, [sp, #6]
-	strb sl, [sp, #7]
+	strb r10, [sp, #7]
 	bl func_ov00_02082680
 	ldr r0, [r5]
 	mov r1, r6
 	strb sb, [sp, #4]
-	strb sl, [sp, #5]
+	strb r10, [sp, #5]
 	mov r2, r11
 	bl func_ov00_020826a0
 	ldrb r1, [r4, #0x15]
 	ldrb r0, [r4, #0x39]
-	add sl, sl, #1
+	add r10, r10, #1
 	add r0, r1, r0
-	cmp sl, r0
+	cmp r10, r0
 	blt _02150008
 _02150050:
 	ldrb sb, [r4, #0x38]
@@ -26415,7 +26415,7 @@ _02150070:
 	str r0, [r4, #0x68]
 	str r6, [r4, #0x6c]
 	add sp, sp, #0x20
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_0214fe98
 _021500d0: .word data_027e0e60
@@ -26484,20 +26484,20 @@ _02150160:
 	.global func_ov14_02150168
 	arm_func_start func_ov14_02150168
 func_ov14_02150168: ; 0x02150168
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x30
-	mov sl, r0
-	ldr r2, [sl, #0x4c]
-	ldr r1, [sl, #0x1c]
-	ldr r0, [sl, #0x44]
+	mov r10, r0
+	ldr r2, [r10, #0x4c]
+	ldr r1, [r10, #0x1c]
+	ldr r0, [r10, #0x44]
 	mov r8, #0
 	str r1, [sp, #4]
 	str r2, [sp, #8]
 	str r0, [sp]
-	ldrb r0, [sl, #0x39]
+	ldrb r0, [r10, #0x39]
 	cmp r0, #0
 	addle sp, sp, #0x30
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _021501a0:
 	cmp r8, #0
 	subne r0, r0, #1
@@ -26509,7 +26509,7 @@ _021501a0:
 	ldr r0, [r0]
 	bl func_ov00_0208ccdc
 	mov r1, r0
-	add r0, sl, #0x50
+	add r0, r10, #0x50
 	ldr r2, [r0]
 	ldr r2, [r2, #0xc]
 	blx r2
@@ -26520,17 +26520,17 @@ _021501dc:
 	ldr r0, [r0]
 	bl func_ov00_0208ccdc
 	mov r1, r0
-	add r0, sl, #0x50
+	add r0, r10, #0x50
 	ldr r2, [r0]
 	ldr r2, [r2, #0xc]
 	blx r2
 _02150200:
-	ldrb r0, [sl, #0x39]
+	ldrb r0, [r10, #0x39]
 	sub r0, r0, #1
 	cmp r8, r0
 	add r0, sp, #0xc
 	bne _0215023c
-	ldrh r2, [sl, #0xc]
+	ldrh r2, [r10, #0xc]
 	ldr r1, _02150308 ; =data_02050f54
 	mov r2, r2, asr #0x4
 	mov r2, r2, lsl #0x1
@@ -26541,7 +26541,7 @@ _02150200:
 	blx func_01ff8214
 	b _0215026c
 _0215023c:
-	ldrsh r1, [sl, #0xc]
+	ldrsh r1, [r10, #0xc]
 	ldr r3, _02150308 ; =data_02050f54
 	sub r1, r1, #0x8000
 	mov r1, r1, lsl #0x10
@@ -26559,7 +26559,7 @@ _0215026c:
 	mov r7, #0
 	addne r0, r0, #0x1000
 	strne r0, [sp, #8]
-	ldrb r0, [sl, #0x38]
+	ldrb r0, [r10, #0x38]
 	cmp r0, #0
 	ble _021502ec
 	mov sb, r7
@@ -26568,32 +26568,32 @@ _0215026c:
 	add r4, sp, #0xc
 	add r11, sp, #0
 _021502a0:
-	ldr r0, [sl, #0x44]
+	ldr r0, [r10, #0x44]
 	cmp r7, #0
 	streq r0, [sp]
 	addne r0, r0, sb
 	strne r0, [sp]
 	cmp r7, #0
-	streqh r6, [sl, #0x5a]
-	strneh r5, [sl, #0x5a]
-	add r0, sl, #0x50
+	streqh r6, [r10, #0x5a]
+	strneh r5, [r10, #0x5a]
+	add r0, r10, #0x50
 	ldr r3, [r0]
 	mov r1, r4
 	ldr r3, [r3, #0x14]
 	mov r2, r11
 	blx r3
-	ldrb r0, [sl, #0x38]
+	ldrb r0, [r10, #0x38]
 	add r7, r7, #1
 	add sb, sb, #0x1000
 	cmp r7, r0
 	blt _021502a0
 _021502ec:
-	ldrb r0, [sl, #0x39]
+	ldrb r0, [r10, #0x39]
 	add r8, r8, #1
 	cmp r8, r0
 	blt _021501a0
 	add sp, sp, #0x30
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_02150168
 _02150304: .word data_027e0f68
@@ -26602,10 +26602,10 @@ _02150308: .word data_02050f54
 	.global func_ov14_0215030c
 	arm_func_start func_ov14_0215030c
 func_ov14_0215030c: ; 0x0215030c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x30
-	mov sl, r0
-	ldrh r1, [sl, #0xc]
+	mov r10, r0
+	ldrh r1, [r10, #0xc]
 	ldr r3, _021504d4 ; =data_02050f54
 	add r0, sp, #0xc
 	mov r1, r1, asr #0x4
@@ -26616,17 +26616,17 @@ func_ov14_0215030c: ; 0x0215030c
 	ldrsh r1, [r3, r4]
 	ldrsh r2, [r3, r2]
 	blx func_01ff8214
-	ldr r2, [sl, #0x4c]
-	ldr r1, [sl, #0x1c]
-	ldr r0, [sl, #0x44]
+	ldr r2, [r10, #0x4c]
+	ldr r1, [r10, #0x1c]
+	ldr r0, [r10, #0x44]
 	mov r7, #0
 	str r1, [sp, #4]
 	str r2, [sp, #8]
 	str r0, [sp]
-	ldrb r0, [sl, #0x38]
+	ldrb r0, [r10, #0x38]
 	cmp r0, #0
 	addle sp, sp, #0x30
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02150370:
 	cmp r7, #0
 	subne r0, r0, #1
@@ -26638,7 +26638,7 @@ _02150370:
 	ldr r0, [r0]
 	bl func_ov00_0208ccdc
 	mov r1, r0
-	add r0, sl, #0x50
+	add r0, r10, #0x50
 	ldr r2, [r0]
 	ldr r2, [r2, #0xc]
 	blx r2
@@ -26649,17 +26649,17 @@ _021503ac:
 	ldr r0, [r0]
 	bl func_ov00_0208ccdc
 	mov r1, r0
-	add r0, sl, #0x50
+	add r0, r10, #0x50
 	ldr r2, [r0]
 	ldr r2, [r2, #0xc]
 	blx r2
 _021503d0:
-	ldrb r0, [sl, #0x38]
+	ldrb r0, [r10, #0x38]
 	sub r0, r0, #1
 	cmp r7, r0
 	add r0, sp, #0xc
 	bne _0215040c
-	ldrh r2, [sl, #0xc]
+	ldrh r2, [r10, #0xc]
 	ldr r1, _021504d4 ; =data_02050f54
 	mov r2, r2, asr #0x4
 	mov r2, r2, lsl #0x1
@@ -26670,7 +26670,7 @@ _021503d0:
 	blx func_01ff8214
 	b _0215043c
 _0215040c:
-	ldrsh r1, [sl, #0xc]
+	ldrsh r1, [r10, #0xc]
 	ldr r3, _021504d4 ; =data_02050f54
 	sub r1, r1, #0x8000
 	mov r1, r1, lsl #0x10
@@ -26688,7 +26688,7 @@ _0215043c:
 	mov r8, #0
 	addne r0, r0, #0x1000
 	strne r0, [sp]
-	ldrb r0, [sl, #0x39]
+	ldrb r0, [r10, #0x39]
 	cmp r0, #0
 	ble _021504bc
 	mov sb, r8
@@ -26697,32 +26697,32 @@ _0215043c:
 	add r4, sp, #0xc
 	add r11, sp, #0
 _02150470:
-	ldr r0, [sl, #0x4c]
+	ldr r0, [r10, #0x4c]
 	cmp r8, #0
 	streq r0, [sp, #8]
 	addne r0, r0, sb
 	strne r0, [sp, #8]
 	cmp r8, #0
-	streqh r6, [sl, #0x5a]
-	strneh r5, [sl, #0x5a]
-	add r0, sl, #0x50
+	streqh r6, [r10, #0x5a]
+	strneh r5, [r10, #0x5a]
+	add r0, r10, #0x50
 	ldr r3, [r0]
 	mov r1, r4
 	ldr r3, [r3, #0x14]
 	mov r2, r11
 	blx r3
-	ldrb r0, [sl, #0x39]
+	ldrb r0, [r10, #0x39]
 	add r8, r8, #1
 	add sb, sb, #0x1000
 	cmp r8, r0
 	blt _02150470
 _021504bc:
-	ldrb r0, [sl, #0x38]
+	ldrb r0, [r10, #0x38]
 	add r7, r7, #1
 	cmp r7, r0
 	blt _02150370
 	add sp, sp, #0x30
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_0215030c
 _021504d4: .word data_02050f54
@@ -26731,10 +26731,10 @@ _021504d8: .word data_027e0f68
 	.global func_ov14_021504dc
 	arm_func_start func_ov14_021504dc
 func_ov14_021504dc: ; 0x021504dc
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x30
-	mov sl, r0
-	ldrh r1, [sl, #0xc]
+	mov r10, r0
+	ldrh r1, [r10, #0xc]
 	ldr r3, _02150604 ; =data_02050f54
 	add r0, sp, #0xc
 	mov r1, r1, asr #0x4
@@ -26751,21 +26751,21 @@ func_ov14_021504dc: ; 0x021504dc
 	mov r2, #2
 	bl func_ov00_0208ccdc
 	mov r1, r0
-	add r0, sl, #0x50
+	add r0, r10, #0x50
 	ldr r2, [r0]
 	ldr r2, [r2, #0xc]
 	blx r2
-	ldr r2, [sl, #0x4c]
-	ldr r1, [sl, #0x1c]
-	ldr r0, [sl, #0x44]
+	ldr r2, [r10, #0x4c]
+	ldr r1, [r10, #0x1c]
+	ldr r0, [r10, #0x44]
 	mov r7, #0
 	str r1, [sp, #4]
 	str r2, [sp, #8]
 	str r0, [sp]
-	ldrb r0, [sl, #0x38]
+	ldrb r0, [r10, #0x38]
 	cmp r0, #0
 	addle sp, sp, #0x30
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	mvn r5, #0
 	mov r6, r7
 	add r4, sp, #0xc
@@ -26776,38 +26776,38 @@ _02150578:
 	mov r8, #0
 	addne r0, r0, #0x1000
 	strne r0, [sp]
-	ldrb r0, [sl, #0x39]
+	ldrb r0, [r10, #0x39]
 	cmp r0, #0
 	ble _021505ec
 	mov sb, r8
 _0215059c:
-	ldr r0, [sl, #0x4c]
+	ldr r0, [r10, #0x4c]
 	cmp r8, #0
 	streq r0, [sp, #8]
 	addne r0, r0, sb
 	strne r0, [sp, #8]
 	cmp r7, #0
 	cmpeq r8, #0
-	streqh r6, [sl, #0x5a]
-	strneh r5, [sl, #0x5a]
-	add r0, sl, #0x50
+	streqh r6, [r10, #0x5a]
+	strneh r5, [r10, #0x5a]
+	add r0, r10, #0x50
 	ldr r3, [r0]
 	mov r1, r4
 	ldr r3, [r3, #0x14]
 	mov r2, r11
 	blx r3
-	ldrb r0, [sl, #0x39]
+	ldrb r0, [r10, #0x39]
 	add r8, r8, #1
 	add sb, sb, #0x1000
 	cmp r8, r0
 	blt _0215059c
 _021505ec:
-	ldrb r0, [sl, #0x38]
+	ldrb r0, [r10, #0x38]
 	add r7, r7, #1
 	cmp r7, r0
 	blt _02150578
 	add sp, sp, #0x30
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_021504dc
 _02150604: .word data_02050f54
@@ -28693,21 +28693,21 @@ _0215193c: .word func_ov03_020f23b4
 	.global func_ov14_02151940
 	arm_func_start func_ov14_02151940
 func_ov14_02151940: ; 0x02151940
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x24
-	mov sl, r0
+	mov r10, r0
 	mov sb, r1
 	ldr r0, _02151a24 ; =data_027e0cbc
 	mov r1, #1
 	bl func_0203d7e0
 	cmp r0, #0
-	ldrnesb r0, [sl, #0x14]
+	ldrnesb r0, [r10, #0x14]
 	cmpne r0, #0
 	addeq sp, sp, #0x24
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	add r0, sp, #4
 	bl func_01ffbe34
-	mov r0, sl
+	mov r0, r10
 	bl func_ov09_0211bcfc
 	cmp r0, #0
 	movne r0, #1
@@ -28719,11 +28719,11 @@ func_ov14_02151940: ; 0x02151940
 	mov r3, r1
 	mov r0, #4
 	bl func_0203493c
-	ldrb r0, [sl, #0x1d]
+	ldrb r0, [r10, #0x1d]
 	mov r7, #0
 	cmp r0, #0
 	addle sp, sp, #0x24
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r4, _02151a28 ; =gItemManager
 	mov r8, r7
 	mov r5, r7
@@ -28738,21 +28738,21 @@ _021519d0:
 	cmp r0, #0
 	beq _02151a08
 _021519ec:
-	str sl, [sp]
-	ldr r0, [sl, #0x20]
+	str r10, [sp]
+	ldr r0, [r10, #0x20]
 	mov r1, sb
 	mov r2, r5
 	mov r3, r11
 	add r0, r0, r8
 	bl func_ov00_020d00c4
 _02151a08:
-	ldrb r0, [sl, #0x1d]
+	ldrb r0, [r10, #0x1d]
 	add r7, r7, #1
 	add r8, r8, #0x18
 	cmp r7, r0
 	blt _021519d0
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_02151940
 _02151a24: .word data_027e0cbc
@@ -29467,35 +29467,35 @@ _02152258: .word data_027e077c
 	.global func_ov14_0215225c
 	arm_func_start func_ov14_0215225c
 func_ov14_0215225c: ; 0x0215225c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	mov sb, r0
 	ldr r0, [sb, #0x84]
 	cmp r0, #0
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, _021523b4 ; =data_027e077c
 	ldr r0, [r0]
 	cmp r0, #0x37
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, _021523b8 ; =data_027e0c68
 	bl func_020366c4
 	add r0, r0, #0x100
 	ldrsh r0, [r0, #0x5c]
 	cmp r0, #0
 	movgt r0, #0
-	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldrsh r1, [sb, #4]
 	ldrsh r0, [sb, #6]
 	cmp r1, r0
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	mov r8, #0
 	mov r5, r8
 	mov r7, sb
 	add r6, sb, #0x20
 	mov r11, r8
-	mov sl, #1
+	mov r10, #1
 	mov r4, r8
 _021522d4:
 	ldr r0, [sb, #0x88]
@@ -29552,7 +29552,7 @@ _0215234c:
 	cmp r0, #0
 	beq _02152394
 _0215238c:
-	mov r8, sl
+	mov r8, r10
 	b _02152398
 _02152394:
 	mov r8, r11
@@ -29563,7 +29563,7 @@ _02152398:
 	add r7, r7, #0x18
 	blt _021522d4
 	mov r0, r8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_0215225c
 _021523b4: .word data_027e077c
@@ -29605,15 +29605,15 @@ _0215240c: .word data_027e077c
 	.global func_ov14_02152410
 	arm_func_start func_ov14_02152410
 func_ov14_02152410: ; 0x02152410
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	mov sb, r0
 	ldr r0, [sb, #0x84]
 	cmp r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, _02152650 ; =data_027e0618
 	ldrb r0, [r0, #0x101]
 	cmp r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, [sb, #0x84]
 	cmp r0, #3
 	bne _0215244c
@@ -29624,7 +29624,7 @@ _0215244c:
 	ldr r0, _02152654 ; =data_027e077c
 	ldr r0, [r0]
 	cmp r0, #0x37
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0215245c:
 	ldrsh r0, [sb, #4]
 	ldrsh r2, [sb, #6]
@@ -29671,7 +29671,7 @@ _021524ec:
 	ldrb r0, [r1, r0]
 	mov r8, #0
 	tst r0, #1
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, _0215265c ; =data_027e0cbc
 	mov r1, #0x14
 	bl func_0203d7e0
@@ -29681,13 +29681,13 @@ _021524ec:
 	mov r1, #0x15
 	bl func_0203d7e0
 	cmp r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02152534:
 	mov ip, #0x3c000
 	umull r0, r11, r7, ip
 	mov r5, #0
 	mov r2, #0x50000
-	umull sl, r3, r7, r2
+	umull r10, r3, r7, r2
 	adds r0, r0, #0x800
 	mla r11, r7, r5, r11
 	mov r1, r7, asr #0x1f
@@ -29695,7 +29695,7 @@ _02152534:
 	mla r11, r1, ip, r11
 	mla r3, r1, r2, r3
 	adc r11, r11, #0
-	adds r2, sl, #0x800
+	adds r2, r10, #0x800
 	mov r0, r0, lsr #0xc
 	orr r0, r0, r11, lsl #20
 	add r0, r0, #0x800
@@ -29705,7 +29705,7 @@ _02152534:
 	add r1, r2, #0x800
 	add r7, sb, #0x20
 	mov r11, r1, asr #0xc
-	mov sl, r0, asr #0xc
+	mov r10, r0, asr #0xc
 _02152590:
 	ldr r1, [sb, #0x88]
 	cmp r1, #2
@@ -29739,7 +29739,7 @@ _021525f0:
 	cmp r5, #1
 	cmpne r5, #2
 	beq _0215263c
-	mov r8, sl
+	mov r8, r10
 	b _02152618
 _02152604:
 	cmp r5, #3
@@ -29762,7 +29762,7 @@ _0215263c:
 	cmp r5, #4
 	add r7, r7, #0x18
 	blt _02152590
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov14_02152410
 _02152650: .word data_027e0618
@@ -30787,21 +30787,21 @@ _02153320: .word data_027e109c
 	.global func_ov14_02153324
 	arm_func_start func_ov14_02153324
 func_ov14_02153324: ; 0x02153324
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	mov r7, r3
 	mov r5, r7, lsr #0x1
-	mov sl, r0
+	mov r10, r0
 	add r0, r5, #1
 	mov r3, #0
 	mov sb, r1
 	mov r8, r2
 	mov r2, r3
 	cmp r0, #1
-	ldr r1, [sl, #0x14]
+	ldr r1, [r10, #0x14]
 	mov r4, #1
 	bls _02153408
 _02153358:
-	ldr r0, [sl, #0x1c]
+	ldr r0, [r10, #0x1c]
 	sub r0, r4, r0
 	cmp r0, r4
 	bge _021533a8
@@ -30811,8 +30811,8 @@ _02153368:
 	ldrgesh r11, [sb, r6]
 	ldrgesh r6, [r8, r6]
 	bge _02153394
-	ldr r11, [sl, #0xc]
-	ldr r6, [sl, #0x10]
+	ldr r11, [r10, #0xc]
+	ldr r6, [r10, #0x10]
 	add r11, r11, r0, lsl #1
 	add r6, r6, r0, lsl #1
 	ldrsh r11, [r11, #0x10]
@@ -30824,21 +30824,21 @@ _02153394:
 	cmp r0, r4
 	blt _02153368
 _021533a8:
-	ldr r6, [sl, #0x24]
+	ldr r6, [r10, #0x24]
 	mov r0, r1, lsl #0x1
 	mul r6, r3, r6
 	mov r3, r6, asr #0x9
 	add r3, r6, r3, lsr #22
-	ldr r6, [sl, #4]
+	ldr r6, [r10, #4]
 	mov r3, r3, asr #0xa
 	strh r3, [r6, r0]
-	ldr r3, [sl, #0x24]
+	ldr r3, [r10, #0x24]
 	add r1, r1, #1
 	mul r3, r2, r3
 	mov r2, r3, asr #0x9
 	add r2, r3, r2, lsr #22
 	cmp r1, #0x1000
-	ldr r3, [sl, #8]
+	ldr r3, [r10, #8]
 	mov r2, r2, asr #0xa
 	strh r2, [r3, r0]
 	mov r3, #0
@@ -30850,27 +30850,27 @@ _021533a8:
 	blo _02153358
 _02153408:
 	sub r4, r5, #8
-	ldr r1, [sl, #0xc]
+	ldr r1, [r10, #0xc]
 	add r0, sb, r4, lsl #1
 	mov r2, #0x10
 	bl func_02007908
-	ldr r1, [sl, #0x10]
+	ldr r1, [r10, #0x10]
 	add r0, r8, r4, lsl #1
 	mov r2, #0x10
 	bl func_02007908
-	ldr r1, [sl, #0x14]
-	ldr r0, [sl, #0x18]
+	ldr r1, [r10, #0x14]
+	ldr r0, [r10, #0x18]
 	subs r6, r1, r0
 	addmi r6, r6, #0x1000
 	add r1, r6, r5
 	cmp r1, #0x1000
 	bhs _02153474
-	ldr r0, [sl, #4]
+	ldr r0, [r10, #4]
 	mov r1, sb
 	mov r2, r7
 	add r0, r0, r6, lsl #1
 	bl func_02007984
-	ldr r0, [sl, #8]
+	ldr r0, [r10, #8]
 	mov r1, r8
 	mov r2, r7
 	add r0, r0, r6, lsl #1
@@ -30879,7 +30879,7 @@ _02153408:
 _02153474:
 	rsb r4, r6, #0x1000
 	sub r3, r1, #0x1000
-	ldr r0, [sl, #4]
+	ldr r0, [r10, #4]
 	mov r11, r4, lsl #0x1
 	mov r3, r3, lsl #0x1
 	mov r1, sb
@@ -30887,34 +30887,34 @@ _02153474:
 	add r0, r0, r6, lsl #1
 	str r3, [sp]
 	bl func_02007984
-	ldr r0, [sl, #8]
+	ldr r0, [r10, #8]
 	mov r1, r8
 	add r0, r0, r6, lsl #1
 	mov r2, r11
 	bl func_02007984
-	ldr r0, [sl, #4]
+	ldr r0, [r10, #4]
 	ldr r2, [sp]
 	add r1, sb, r4, lsl #1
 	bl func_02007984
 	ldr r2, [sp]
-	ldr r0, [sl, #8]
+	ldr r0, [r10, #8]
 	add r1, r8, r4, lsl #1
 	bl func_02007984
 _021534d0:
-	ldr r0, [sl, #0x14]
+	ldr r0, [r10, #0x14]
 	mov r1, r7
 	add r0, r0, r5
-	str r0, [sl, #0x14]
+	str r0, [r10, #0x14]
 	cmp r0, #0x1000
-	ldrhs r0, [sl, #0x14]
+	ldrhs r0, [r10, #0x14]
 	subhs r0, r0, #0x1000
-	strhs r0, [sl, #0x14]
+	strhs r0, [r10, #0x14]
 	mov r0, sb
 	bl func_0200e2c0
 	mov r0, r8
 	mov r1, r7
 	bl func_0200e2c0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	arm_func_end func_ov14_02153324
 
 	.global func_ov14_02153508

--- a/asm/ov15.s
+++ b/asm/ov15.s
@@ -575,7 +575,7 @@ func_ov15_0211fd64: ; 0x0211fd64
 	.global func_ov15_0211fd88
 	arm_func_start func_ov15_0211fd88
 func_ov15_0211fd88: ; 0x0211fd88
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #0x19c
 	ldr r3, _02120598 ; =data_027e0d78
 	mov sb, r0
@@ -765,20 +765,20 @@ _02120048:
 	ldr r0, [sp, #0x198]
 	str r0, [sb, #0x34]
 _02120058:
-	ldr sl, _021205c0 ; =data_ov15_02189420
+	ldr r10, _021205c0 ; =data_ov15_02189420
 	mov r2, #0
 	ldr r6, [sb, #0x34]
 	ldr r5, [sb, #0x30]
-	ldr ip, [sl]
+	ldr ip, [r10]
 	mov r3, r2
 	mov r4, r2
 	cmp ip, r5, asr #12
 	mov r1, r6, asr #0xc
 	mov r0, r5, asr #0xc
 	bgt _02120094
-	ldr sl, [sl, #8]
-	add sl, ip, sl
-	cmp r0, sl
+	ldr r10, [r10, #8]
+	add r10, ip, r10
+	cmp r0, r10
 	movlt r4, #1
 _02120094:
 	cmp r4, #0
@@ -932,15 +932,15 @@ _021202bc:
 	strb r0, [sb, #0x58]
 	add sp, sp, #0x19c
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 _021202d0:
 	ldr r0, [sb, #0x2c]
 	bl func_ov15_02121998
 	cmp r0, #0
 	bne _02120548
-	ldr sl, _021205c0 ; =data_ov15_02189420
+	ldr r10, _021205c0 ; =data_ov15_02189420
 	mov r3, r6
-	ldr r0, [sl, #0x10]
+	ldr r0, [r10, #0x10]
 	add r1, r4, #0x800
 	add r2, r5, #0x800
 	cmp r0, r1, asr #12
@@ -949,8 +949,8 @@ _021202d0:
 	mov r2, r2, asr #0xc
 	mov r1, r1, asr #0xc
 	bgt _0212031c
-	ldr sl, [sl, #0x18]
-	add r0, r0, sl
+	ldr r10, [r10, #0x18]
+	add r0, r0, r10
 	cmp r1, r0
 	movlt lr, #1
 _0212031c:
@@ -1030,7 +1030,7 @@ _02120354:
 	str r1, [sp, #0xc4]
 	str r1, [sp, #0xc8]
 	ldr r1, [sb, #0x30]
-	mov sl, #0x1000
+	mov r10, #0x1000
 	str r1, [sp, #0x24]
 	ldr r1, [sb, #0x34]
 	mov r3, #7
@@ -1041,7 +1041,7 @@ _02120354:
 	ldr ip, [sb, #0x34]
 	ldr r1, _021205bc ; =data_027e0e60
 	str ip, [sp, #0x20]
-	str sl, [sp]
+	str r10, [sp]
 	str r3, [sp, #4]
 	str r2, [sp, #8]
 	str r0, [sp, #0xc]
@@ -1117,7 +1117,7 @@ _02120548:
 _0212058c:
 	mov r0, r6
 	add sp, sp, #0x19c
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0211fd88
 _02120598: .word data_027e0d78
@@ -1687,20 +1687,20 @@ _02120cd8: .word data_027e0cbc
 	.global func_ov15_02120cdc
 	arm_func_start func_ov15_02120cdc
 func_ov15_02120cdc: ; 0x02120cdc
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	ldr r1, _02120e40 ; =data_027e103c
-	mov sl, r0
+	mov r10, r0
 	ldr r0, [r1]
 	bl func_ov00_020cf07c
 	ldrb r0, [r0, #0x58]
 	cmp r0, #0
 	beq _02120d0c
 	mov r0, #1
-	strb r0, [sl, #0x1e]
+	strb r0, [r10, #0x1e]
 	mov r0, #0
-	strb r0, [sl, #0x20]
+	strb r0, [r10, #0x20]
 _02120d0c:
-	ldrsb r0, [sl, #0x14]
+	ldrsb r0, [r10, #0x14]
 	mov sb, #0
 	cmp r0, #0
 	beq _02120e38
@@ -1708,17 +1708,17 @@ _02120d0c:
 	bl func_02036808
 	cmp r0, #0
 	bne _02120e38
-	add r0, sl, #0x100
+	add r0, r10, #0x100
 	ldr r1, _02120e48 ; =data_ov15_021894bc
-	ldrsh r3, [sl, #0xe]
+	ldrsh r3, [r10, #0xe]
 	ldr r2, [r1, #0x28]
 	ldrsh r1, [r0, #0x14]
 	ldrsh r0, [r0, #0x16]
 	sub r5, r3, r2
 	cmp r1, r0
 	bne _02120da4
-	ldrb r1, [sl, #0x1c]
-	add r3, sl, #0x2c
+	ldrb r1, [r10, #0x1c]
+	add r3, r10, #0x2c
 	mov r0, #0x18
 	mla r0, r1, r0, r3
 	ldr r4, [r0]
@@ -1729,27 +1729,27 @@ _02120d0c:
 	blx r4
 	tst r0, #8
 	beq _02120da4
-	ldrb r2, [sl, #0x1c]
+	ldrb r2, [r10, #0x1c]
 	mov r1, #0x18
-	mov r0, sl
-	mla r1, r2, r1, sl
+	mov r0, r10
+	mla r1, r2, r1, r10
 	ldrh r1, [r1, #0x36]
 	mov sb, #1
 	bl func_ov15_02120e4c
 	cmp r0, #0
 	moveq sb, #0
 _02120da4:
-	mov r0, sl
+	mov r0, r10
 	bl func_ov15_02120b6c
 	cmp r0, #0
 	beq _02120e38
-	add r0, sl, #0x300
+	add r0, r10, #0x300
 	ldrh r0, [r0, #0x4c]
 	cmp r0, #0
 	bne _02120e38
 	mov r6, #0
-	mov r8, sl
-	add r7, sl, #0x5c
+	mov r8, r10
+	add r7, r10, #0x5c
 	mov r11, r6
 	mov r4, #1
 _02120dd8:
@@ -1765,7 +1765,7 @@ _02120dd8:
 	cmp sb, #0
 	bne _02120e18
 	ldrh r1, [r8, #0x66]
-	mov r0, sl
+	mov r0, r10
 	bl func_ov15_02120e4c
 	cmp r0, #0
 	beq _02120e20
@@ -1782,7 +1782,7 @@ _02120e24:
 	blt _02120dd8
 _02120e38:
 	mov r0, sb
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02120cdc
 _02120e40: .word data_027e103c
@@ -2012,20 +2012,20 @@ _02121138: .word data_027e077c
 	.global func_ov15_0212113c
 	arm_func_start func_ov15_0212113c
 func_ov15_0212113c: ; 0x0212113c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x5c
 	ldr r1, _021216d4 ; =data_027e0618
 	mov sb, r0
 	ldrb r0, [r1, #0x101]
 	cmp r0, #0
 	addne sp, sp, #0x5c
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, _021216d8 ; =data_027e0cbc
 	mov r1, #0xb
 	bl func_0203d7e0
 	cmp r0, #0
 	addeq sp, sp, #0x5c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	mov r0, sb
 	bl func_ov15_02121700
 	cmp r0, #0
@@ -2121,10 +2121,10 @@ _021212d0:
 _021212d4:
 	bl func_ov15_0213ce4c
 	bl func_ov15_0213d1f4
-	mov sl, r0
+	mov r10, r0
 	cmp r5, #0
 	beq _02121424
-	cmp sl, #0
+	cmp r10, #0
 	ble _02121424
 	ldrb r0, [r4, #0x58]
 	cmp r0, #0
@@ -2134,7 +2134,7 @@ _021212d4:
 	str r1, [sp]
 	ldr r3, [r0, #4]
 	ldr r2, _021216f0 ; =data_027e0d3c
-	sub r1, sl, #1
+	sub r1, r10, #1
 	mov r0, #0xc
 	smlabb r1, r1, r0, r3
 	ldr r0, [r2]
@@ -2230,7 +2230,7 @@ _02121424:
 _02121464:
 	cmp r7, #0
 	addeq sp, sp, #0x5c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	add r0, sb, #0x100
 	ldrsh r3, [r0, #0x14]
 	ldrsh r2, [r0, #0x16]
@@ -2272,7 +2272,7 @@ _021214b0:
 	ldrh r0, [r0, #0x4c]
 	cmp r0, #0
 	addne sp, sp, #0x5c
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	mov r5, #0
 	add r6, sb, #0x5c
 	mov r4, r5
@@ -2288,11 +2288,11 @@ _02121520:
 	add r6, r6, #0x18
 	blt _02121520
 	add sp, sp, #0x5c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02121550:
 	cmp r8, #0
 	addeq sp, sp, #0x5c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, _021216f8 ; =gItemManager
 	mov r1, #0x21
 	ldr r0, [r0]
@@ -2308,7 +2308,7 @@ _02121550:
 	mov r1, #0x22
 	bl _ZNK11ItemManager7HasItemEi
 	ldr r1, _021216f8 ; =gItemManager
-	mov sl, r0
+	mov r10, r0
 	ldr r0, [r1]
 	mov r1, #0x24
 	bl _ZNK11ItemManager7HasItemEi
@@ -2329,7 +2329,7 @@ _021215d4: ; jump table
 	b _02121610 ; case 2
 	b _02121628 ; case 3
 _021215e4:
-	cmp sl, #0
+	cmp r10, #0
 	movne r5, #1
 	cmp r11, #0
 	movne r8, #1
@@ -2351,7 +2351,7 @@ _02121610:
 _02121628:
 	cmp r11, #0
 	movne r6, #1
-	cmp sl, #0
+	cmp r10, #0
 	movne r7, #1
 _02121638:
 	cmp r5, #0
@@ -2386,7 +2386,7 @@ _02121680:
 _021216a4:
 	cmp r8, #0
 	addeq sp, sp, #0x5c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	mov r3, #0
 	str r3, [sp]
 	add r0, sb, #0x2c0
@@ -2395,7 +2395,7 @@ _021216a4:
 	str r3, [sp, #4]
 	bl func_02034b0c
 	add sp, sp, #0x5c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0212113c
 _021216d4: .word data_027e0618
@@ -3326,7 +3326,7 @@ _021222b8: .word data_027e0764
 	.global func_ov15_021222bc
 	arm_func_start func_ov15_021222bc
 func_ov15_021222bc: ; 0x021222bc
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #0x60
 	ldr r2, _02122638 ; =data_027e0f90
 	mov r4, r1
@@ -3335,13 +3335,13 @@ func_ov15_021222bc: ; 0x021222bc
 	ldrsh r1, [r2, #0xa]
 	cmp r1, #0
 	addle sp, sp, #0x60
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	ldr r1, _0212263c ; =0x42554949
 	cmp r4, r1
 	bne _021222fc
 	bl func_ov15_02122674
 	add sp, sp, #0x60
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _021222fc:
 	ldr r0, _02122640 ; =data_027e0f94
 	add r3, sp, #0x48
@@ -3391,13 +3391,13 @@ _02122384:
 	mov r3, #0
 	str r0, [sp, #0x5c]
 	ldmib sb, {r0, r7}
-	umull sl, r2, r7, r1
+	umull r10, r2, r7, r1
 	mla r2, r7, r0, r2
 	ldr r6, [sb, #0xc]
 	ldr ip, [sb, #0x10]
 	mla r2, r6, r1, r2
 	ldr r8, [sb, #0x14]
-	adds r1, ip, sl
+	adds r1, ip, r10
 	adc r0, r8, r2
 	mov r2, r3, lsl #0x2
 	orr r2, r2, r0, lsr #30
@@ -3412,11 +3412,11 @@ _02122384:
 	blo _02122448
 	cmp r2, #0
 	ble _0212243c
-	umull lr, sl, r7, r1
-	mla sl, r7, r0, sl
-	mla sl, r6, r1, sl
+	umull lr, r10, r7, r1
+	mla r10, r7, r0, r10
+	mla r10, r6, r1, r10
 	adds r1, ip, lr
-	adc r0, r8, sl
+	adc r0, r8, r10
 	cmp r2, #0
 	moveq lr, r0
 	umullne r6, lr, r0, r2
@@ -3442,25 +3442,25 @@ _02122450:
 	mla r6, ip, r1, r6
 	adds r8, r7, r8
 	ldr r0, [r3, #0x14]
-	umull sl, sb, lr, r8
+	umull r10, sb, lr, r8
 	adc r1, r0, r6
 	mla sb, lr, r1, sb
 	str r8, [r3]
 	mla sb, ip, r8, sb
-	adds r6, r7, sl
+	adds r6, r7, r10
 	adc sb, r0, sb
 	mov r0, #3
-	umull r7, sl, r1, r0
+	umull r7, r10, r1, r0
 	str r1, [r3, #4]
 	str r6, [r3]
 	mov r6, #0
 	umull r7, r8, sb, r2
 	str sb, [r3, #4]
-	mla sl, r1, r6, sl
+	mla r10, r1, r6, r10
 	mov r3, r6
-	mla sl, r3, r0, sl
+	mla r10, r3, r0, r10
 	mla r8, sb, r6, r8
-	and r1, sl, #0xff
+	and r1, r10, #0xff
 	mla r8, r3, r2, r8
 	sub r0, r2, #0x8000
 	add r0, r8, r0
@@ -3545,7 +3545,7 @@ _021225f0:
 	ldreq r0, [r5, #0x164]
 	addeq sp, sp, #0x60
 	streq r0, [r5, #0x160]
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	add r1, r5, #0x168
 	str r1, [sp]
 	ldr r0, _02122670 ; =data_027e0fe8
@@ -3555,7 +3555,7 @@ _021225f0:
 	mov r1, r4
 	bl func_ov00_020c4048
 	add sp, sp, #0x60
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov15_021222bc
 _02122638: .word data_027e0f90
@@ -3577,7 +3577,7 @@ _02122670: .word data_027e0fe8
 	.global func_ov15_02122674
 	arm_func_start func_ov15_02122674
 func_ov15_02122674: ; 0x02122674
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0xe4
 	ldr r1, _02122d9c ; =data_027e0f94
 	add r3, sp, #0xc0
@@ -3593,7 +3593,7 @@ func_ov15_02122674: ; 0x02122674
 	moveq r0, #0
 	addeq sp, sp, #0xe4
 	streq r0, [r4, #0x160]
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r3, [sp, #0xd8]
 	ldr r2, [sp, #0xdc]
 	ldr r1, [sp, #0xe0]
@@ -3612,7 +3612,7 @@ func_ov15_02122674: ; 0x02122674
 	movne r0, #0
 	addne sp, sp, #0xe4
 	strne r0, [r4, #0x160]
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	add r0, sp, #0xc0
 	add r1, sp, #0xd8
 	bl func_ov00_020ce2f0
@@ -3620,7 +3620,7 @@ func_ov15_02122674: ; 0x02122674
 	movlt r0, #0
 	addlt sp, sp, #0xe4
 	strlt r0, [r4, #0x160]
-	ldmltia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmltia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldrsh r5, [sp, #0x20]
 	ldr r2, [sp, #0xd8]
 	ldr r1, [sp, #0xdc]
@@ -3700,18 +3700,18 @@ _02122794:
 	mov r0, r0, asr #0x4
 	mov r11, r0, lsl #0x1
 	add sb, r7, #1
-	mov sl, r7, lsl #0x1
+	mov r10, r7, lsl #0x1
 	add r8, r11, #1
 	ldr r2, [sp, #0xd8]
 	ldr r0, [sp, #0xe0]
 	mov ip, #0
 	ldr r5, _02122da4 ; =data_02050f54
 	mov r7, r11, lsl #0x1
-	ldrsh r11, [r5, sl]
+	ldrsh r11, [r5, r10]
 	mov sb, sb, lsl #0x1
 	ldrsh sb, [r5, sb]
-	mov sl, r11, asr #0x1f
-	mov sl, sl, lsl #0xd
+	mov r10, r11, asr #0x1f
+	mov r10, r10, lsl #0xd
 	str r1, [sp, #0x88]
 	str r1, [sp, #0x94]
 	str r1, [sp, #0xa0]
@@ -3727,16 +3727,16 @@ _02122794:
 	str r3, [sp, #0x3c]
 	str r3, [sp, #0x40]
 	adds r3, r1, r11, lsl #13
-	orr sl, sl, r11, lsr #19
-	adc sl, sl, #0
+	orr r10, r10, r11, lsr #19
+	adc r10, r10, #0
 	mov r3, r3, lsr #0xc
-	orr r3, r3, sl, lsl #20
+	orr r3, r3, r10, lsl #20
 	add r3, r2, r3
-	adds sl, r1, sb, lsl #13
+	adds r10, r1, sb, lsl #13
 	orr r8, r8, sb, lsr #19
 	str r3, [sp, #0x9c]
 	adc r3, r8, #0
-	mov r8, sl, lsr #0xc
+	mov r8, r10, lsr #0xc
 	orr r8, r8, r3, lsl #20
 	add r3, r0, r8
 	mov r6, r7, asr #0x1f
@@ -3775,7 +3775,7 @@ _02122794:
 	moveq r0, #0
 	addeq sp, sp, #0xe4
 	streq r0, [r4, #0x160]
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	mov r0, #1
 	strh r0, [sp, #0x5a]
 	add r1, sp, #0x3c
@@ -3799,7 +3799,7 @@ _02122794:
 	str r0, [r4, #0x160]
 	add sp, sp, #0xe4
 	strb r0, [r6, #0x118]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _021229e8:
 	ldr r0, _02122db0 ; =data_027e0fe4
 	add r1, sp, #0x3c
@@ -3816,7 +3816,7 @@ _021229e8:
 	strb r0, [r5, #0x118]
 	add sp, sp, #0xe4
 	str r0, [r4, #0x160]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02122a28:
 	ldr r0, [sp, #0x44]
 	add r1, sp, #0xcc
@@ -3832,7 +3832,7 @@ _02122a28:
 	str r0, [r6, #0x2dc]
 	add sp, sp, #0xe4
 	str r6, [r5, #0x2b0]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02122a64:
 	add r1, r5, #0x4000
 	mov r0, r0, asr #0x10
@@ -3852,55 +3852,55 @@ _02122a64:
 	ldr r3, _02122da4 ; =data_02050f54
 	mov sb, r0, lsl #0x1
 	add r7, r8, #1
-	mov sl, r8, lsl #0x1
+	mov r10, r8, lsl #0x1
 	add r6, r0, #1
 	mov r8, r7, lsl #0x1
 	ldrsh r8, [r3, r8]
 	mov r7, r6, lsl #0x1
-	ldrsh r0, [r3, sl]
+	ldrsh r0, [r3, r10]
 	ldrsh ip, [r3, sb]
 	ldrsh r3, [r3, r7]
 	mov r11, r8, asr #0x1f
-	mov sl, ip, asr #0x1f
-	mov lr, sl, lsl #0xe
+	mov r10, ip, asr #0x1f
+	mov lr, r10, lsl #0xe
 	mov r7, r11, lsl #0xc
 	strh r5, [sp, #0x58]
 	mov r5, r11, lsl #0xe
-	mov sl, r3, asr #0x1f
-	mov r11, sl, lsl #0xe
-	ldr sl, [sp, #0xd8]
+	mov r10, r3, asr #0x1f
+	mov r11, r10, lsl #0xe
+	ldr r10, [sp, #0xd8]
 	mov r6, r0, asr #0x1f
 	mov sb, r6, lsl #0xc
-	str sl, [sp, #8]
-	mov sl, #0
+	str r10, [sp, #8]
+	mov r10, #0
 	mov r6, r6, lsl #0xe
 	str r1, [sp, #0x88]
 	str r1, [sp, #0x94]
 	str r1, [sp, #0xa0]
 	mov r1, #0x800
-	strh sl, [sp, #0x5a]
-	adds sl, r1, r0, lsl #12
+	strh r10, [sp, #0x5a]
+	adds r10, r1, r0, lsl #12
 	orr sb, sb, r0, lsr #20
-	str sl, [sp, #0xc]
+	str r10, [sp, #0xc]
 	adc sb, sb, #0
-	mov sl, sl, lsr #0xc
-	orr sb, sl, sb, lsl #20
-	ldr sl, [sp, #8]
+	mov r10, r10, lsr #0xc
+	orr sb, r10, sb, lsl #20
+	ldr r10, [sp, #8]
 	str sb, [sp, #0x18]
-	add sb, sl, sb
-	ldr sl, [sp, #0xe0]
+	add sb, r10, sb
+	ldr r10, [sp, #0xe0]
 	orr r7, r7, r8, lsr #20
-	str sl, [sp, #0x1c]
-	adds sl, r1, r8, lsl #12
-	str sl, [sp, #0x14]
+	str r10, [sp, #0x1c]
+	adds r10, r1, r8, lsl #12
+	str r10, [sp, #0x14]
 	adc r7, r7, #0
 	orr r6, r6, r0, lsr #18
 	adds r0, r1, r0, lsl #14
-	mov sl, sl, lsr #0xc
-	orr sl, sl, r7, lsl #20
+	mov r10, r10, lsr #0xc
+	orr r10, r10, r7, lsl #20
 	ldr r7, [sp, #0x1c]
 	adc r6, r6, #0
-	add r7, r7, sl
+	add r7, r7, r10
 	mov r0, r0, lsr #0xc
 	orr r0, r0, r6, lsl #20
 	add r0, sb, r0
@@ -3931,7 +3931,7 @@ _02122a64:
 	str r2, [sp, #0x30]
 	str sb, [sp, #0xd8]
 	str sb, [sp, #0x84]
-	str sl, [sp, #0x10]
+	str r10, [sp, #0x10]
 	str r7, [sp, #0xe0]
 	str r7, [sp, #0x8c]
 	str r0, [sp, #0x98]
@@ -3951,7 +3951,7 @@ _02122a64:
 	moveq r0, #0
 	addeq sp, sp, #0xe4
 	streq r0, [r4, #0x160]
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	mov r0, #1
 	strh r0, [sp, #0x5a]
 	add r1, sp, #0x2c
@@ -3975,7 +3975,7 @@ _02122a64:
 	str r0, [r4, #0x160]
 	add sp, sp, #0xe4
 	strb r0, [r5, #0x118]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02122c9c:
 	mov r0, #2
 	strh r0, [sp, #0x5a]
@@ -4001,7 +4001,7 @@ _02122c9c:
 	strb r0, [r5, #0x118]
 	add sp, sp, #0xe4
 	strb r0, [r6, #0x118]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02122d00:
 	ldr r0, _02122db0 ; =data_027e0fe4
 	add r1, sp, #0x24
@@ -4025,7 +4025,7 @@ _02122d3c:
 	strb r0, [r7, #0x118]
 	add sp, sp, #0xe4
 	str r0, [r4, #0x160]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02122d58:
 	ldr r0, [sp, #0x34]
 	add r1, sp, #0xcc
@@ -4043,7 +4043,7 @@ _02122d58:
 	str r6, [r7, #0x2b4]
 	str r7, [r6, #0x2b0]
 	add sp, sp, #0xe4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02122674
 _02122d9c: .word data_027e0f94
@@ -5164,7 +5164,7 @@ _02123c44: .word data_ov15_0218988c
 	.global func_ov15_02123c48
 	arm_func_start func_ov15_02123c48
 func_ov15_02123c48: ; 0x02123c48
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	mov r1, #0
 	mov r4, r0
 	bl func_ov15_02123474
@@ -5193,9 +5193,9 @@ func_ov15_02123c48: ; 0x02123c48
 	ldr r6, [r2, #0xc]
 	ldr r11, [r2, #0x10]
 	mla r8, r6, r5, r8
-	ldr sl, [r2, #0x14]
+	ldr r10, [r2, #0x14]
 	adds r6, r11, sb
-	adc r5, sl, r8
+	adc r5, r10, r8
 	str r6, [r2]
 	str r5, [r2, #4]
 	umull r2, lr, r5, r3
@@ -5223,7 +5223,7 @@ func_ov15_02123c48: ; 0x02123c48
 	str r1, [r4, #0x2a0]
 	mov r0, r4
 	str r1, [r4, #0x2a4]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02123c48
 _02123d38: .word data_ov15_021897c4
@@ -6162,39 +6162,39 @@ _02124a3c: .word data_027e10a4
 	.global func_ov15_02124a40
 	arm_func_start func_ov15_02124a40
 func_ov15_02124a40: ; 0x02124a40
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x1c
-	mov sl, r0
+	mov r10, r0
 	mov r5, r1
 	bl _ZN5Actor18func_ov00_020c313cEj
 	movs r4, r0
 	beq _02124b9c
-	ldr r1, [sl, #0x48]
+	ldr r1, [r10, #0x48]
 	ldr r0, _0212502c ; =data_027e0e60
-	str r1, [sl, #0x54]
-	ldr r2, [sl, #0x4c]
+	str r1, [r10, #0x54]
+	ldr r2, [r10, #0x4c]
 	add r1, sp, #4
-	str r2, [sl, #0x58]
-	ldr r3, [sl, #0x50]
+	str r2, [r10, #0x58]
+	ldr r3, [r10, #0x50]
 	mov r2, #0
-	str r3, [sl, #0x5c]
-	ldr r3, [sl, #0x48]
+	str r3, [r10, #0x5c]
+	ldr r3, [r10, #0x48]
 	ldr r0, [r0]
 	str r3, [sp, #4]
-	ldr r3, [sl, #0x4c]
+	ldr r3, [r10, #0x4c]
 	str r3, [sp, #8]
-	ldr r3, [sl, #0x50]
+	ldr r3, [r10, #0x50]
 	str r3, [sp, #0xc]
 	bl func_ov00_02083ee0
-	str r0, [sl, #0x2a8]
-	ldrb r0, [sl, #0x118]
+	str r0, [r10, #0x2a8]
+	ldrb r0, [r10, #0x118]
 	cmp r0, #0
 	addeq sp, sp, #0x1c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
-	mov r0, sl
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	mov r0, r10
 	bl func_ov15_02125210
 	cmp r0, #0
-	mov r0, sl
+	mov r0, r10
 	beq _02124ad4
 	mov r1, #0xa
 	bl func_ov15_02124418
@@ -6203,79 +6203,79 @@ _02124ad4:
 	ldr r1, [r0]
 	ldr r1, [r1, #0xb4]
 	blx r1
-	add r0, sl, #0x48
-	add r1, sl, #0x60
+	add r0, r10, #0x48
+	add r1, r10, #0x60
 	mov r2, r0
 	bl func_01ff9bc4
-	ldrb r2, [sl, #0x2b8]
-	ldr r0, [sl, #0x2a8]
+	ldrb r2, [r10, #0x2b8]
+	ldr r0, [r10, #0x2a8]
 	cmp r2, #1
 	sub r1, r0, #0x1800
 	bne _02124b24
-	ldr r0, [sl, #0x4c]
+	ldr r0, [r10, #0x4c]
 	cmp r0, r1, asr #1
 	bge _02124b24
-	mov r0, sl
+	mov r0, r10
 	bl func_ov15_02125118
 	mov r0, #0
-	strb r0, [sl, #0x2b8]
+	strb r0, [r10, #0x2b8]
 	b _02124b48
 _02124b24:
 	cmp r2, #0
 	bne _02124b48
-	ldr r0, [sl, #0x4c]
+	ldr r0, [r10, #0x4c]
 	cmp r0, r1, asr #1
 	blt _02124b48
-	mov r0, sl
+	mov r0, r10
 	bl func_ov15_0212504c
 	mov r0, #1
-	strb r0, [sl, #0x2b8]
+	strb r0, [r10, #0x2b8]
 _02124b48:
-	mov r0, sl
+	mov r0, r10
 	mov r1, #1
 	mov r2, #0
 	bl _ZN5Actor18func_ov00_020c1e2cEiP5Vec3p
 	cmp r0, #0
 	beq _02124b6c
-	mov r0, sl
+	mov r0, r10
 	mov r1, #6
 	bl func_ov15_02124418
 _02124b6c:
-	mov r0, sl
+	mov r0, r10
 	bl _ZN5Actor20IncreaseActiveFramesEv
-	mov r0, sl
+	mov r0, r10
 	bl func_ov15_02125278
-	mov r0, sl
+	mov r0, r10
 	ldr r1, [r0]
 	ldr r1, [r1, #0xb8]
 	blx r1
-	ldrb r0, [sl, #0x118]
+	ldrb r0, [r10, #0x118]
 	cmp r0, #0
 	addeq sp, sp, #0x1c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02124b9c:
 	mov r1, r5
-	add r0, sl, #0xa4
-	add r2, sl, #0x48
+	add r0, r10, #0xa4
+	add r2, r10, #0x48
 	bl func_ov00_0207a1c8
 	cmp r4, #0
 	beq _02124bbc
-	add r0, sl, #0x184
+	add r0, r10, #0x184
 	bl func_ov00_020c5e20
 _02124bbc:
-	ldrb r0, [sl, #0x118]
+	ldrb r0, [r10, #0x118]
 	cmp r0, #0
 	cmpne r4, #0
 	beq _02124fdc
 	add r1, sp, #0x10
-	mov r0, sl
+	mov r0, r10
 	bl func_ov15_02124068
-	ldr r0, [sl, #0x60]
+	ldr r0, [r10, #0x60]
 	cmp r0, #0
-	ldreq r0, [sl, #0x68]
+	ldreq r0, [r10, #0x68]
 	cmpeq r0, #0
 	beq _02124fb8
-	ldr r0, [sl, #0x198]
+	ldr r0, [r10, #0x198]
 	cmp r0, #1
 	bne _02124eb8
 	ldr r6, _02125030 ; =0x00000733
@@ -6283,7 +6283,7 @@ _02124bbc:
 	str r0, [sp, #0x10]
 	str r0, [sp, #0x14]
 	str r6, [sp, #0x18]
-	ldrh r2, [sl, #0x78]
+	ldrh r2, [r10, #0x78]
 	ldr r3, _02125034 ; =data_02050f54
 	add r1, sp, #0x10
 	mov r2, r2, asr #0x4
@@ -6317,7 +6317,7 @@ _02124bbc:
 	orr r0, r0, ip, lsl #20
 	add r3, r0, r6
 	mov r2, r1
-	add r0, sl, #0x48
+	add r0, r10, #0x48
 	str r4, [sp, #0x10]
 	str r3, [sp, #0x18]
 	mov r8, sb, asr #0x1f
@@ -6350,7 +6350,7 @@ _02124bbc:
 	mov r3, r3, asr #0x10
 	str r3, [sp]
 	ldr r3, _02125038 ; =0xfffffb33
-	add r1, sl, #0x2bc
+	add r1, r10, #0x2bc
 	umull r5, r3, r7, r3
 	mla r3, r7, r11, r3
 	ldr r11, _02125038 ; =0xfffffb33
@@ -6373,11 +6373,11 @@ _02124bbc:
 	mov r11, r3, asr #0x10
 	bl func_ov00_0207c474
 	ldr r0, _0212503c ; =data_027e0e58
-	add r1, sl, #0x2c8
+	add r1, r10, #0x2c8
 	ldr r0, [r0]
 	add r2, sp, #0x10
 	bl func_ov00_0207c474
-	ldr r2, [sl, #0x2bc]
+	ldr r2, [r10, #0x2bc]
 	cmp r2, #0
 	beq _02124da4
 	ldr r0, [sp]
@@ -6386,7 +6386,7 @@ _02124bbc:
 	strh r1, [r2, #0x52]
 	strh r11, [r2, #0x54]
 _02124da4:
-	ldr r2, [sl, #0x2c8]
+	ldr r2, [r10, #0x2c8]
 	cmp r2, #0
 	beq _02124dc4
 	ldr r0, [sp]
@@ -6421,16 +6421,16 @@ _02124dc4:
 	ldr r6, _0212503c ; =data_027e0e58
 	add r2, sp, #0x10
 	ldr r0, [r6]
-	add r1, sl, #0x2d4
+	add r1, r10, #0x2d4
 	mov r4, r3, asr #0x10
 	mov r5, r5, asr #0x10
 	bl func_ov00_0207c474
 	mov r0, r6
 	ldr r0, [r0]
 	add r2, sp, #0x10
-	add r1, sl, #0x2e0
+	add r1, r10, #0x2e0
 	bl func_ov00_0207c474
-	ldr r1, [sl, #0x2d4]
+	ldr r1, [r10, #0x2d4]
 	cmp r1, #0
 	beq _02124e6c
 	ldr r0, _02125040 ; =0x00000d71
@@ -6438,7 +6438,7 @@ _02124dc4:
 	strh r0, [r1, #0x52]
 	strh r5, [r1, #0x54]
 _02124e6c:
-	ldr r1, [sl, #0x2e0]
+	ldr r1, [r10, #0x2e0]
 	cmp r1, #0
 	beq _02124e88
 	ldr r0, _02125040 ; =0x00000d71
@@ -6446,12 +6446,12 @@ _02124e6c:
 	strh r0, [r1, #0x52]
 	strh r5, [r1, #0x54]
 _02124e88:
-	ldr r1, [sl, #0x2d4]
+	ldr r1, [r10, #0x2d4]
 	cmp r1, #0
 	ldrne r0, [r1, #0x24]
 	bicne r0, r0, #2
 	strne r0, [r1, #0x24]
-	ldr r1, [sl, #0x2e0]
+	ldr r1, [r10, #0x2e0]
 	cmp r1, #0
 	beq _02124ef0
 	ldr r0, [r1, #0x24]
@@ -6462,24 +6462,24 @@ _02124eb8:
 	ldr r0, _0212503c ; =data_027e0e58
 	add r2, sp, #0x10
 	ldr r0, [r0]
-	add r1, sl, #0x2bc
+	add r1, r10, #0x2bc
 	bl func_ov00_0207c474
 	ldr r0, _0212503c ; =data_027e0e58
 	add r2, sp, #0x10
 	ldr r0, [r0]
-	add r1, sl, #0x2c8
+	add r1, r10, #0x2c8
 	bl func_ov00_0207c474
-	add r0, sl, #0x2d4
+	add r0, r10, #0x2d4
 	bl func_ov00_020b7e6c
-	add r0, sl, #0x2e0
+	add r0, r10, #0x2e0
 	bl func_ov00_020b7e6c
 _02124ef0:
-	ldr r0, [sl, #0x2a8]
+	ldr r0, [r10, #0x2a8]
 	str r0, [sp, #0x14]
-	ldrb r0, [sl, #0x2f8]
+	ldrb r0, [r10, #0x2f8]
 	cmp r0, #0xb
 	blo _02124f30
-	ldr r0, [sl, #0x130]
+	ldr r0, [r10, #0x130]
 	cmp r0, #0xa
 	cmpne r0, #9
 	beq _02124f30
@@ -6489,21 +6489,21 @@ _02124ef0:
 	mov r3, r2
 	bl func_ov00_020c75f4
 	mov r0, #0
-	strb r0, [sl, #0x2f8]
+	strb r0, [r10, #0x2f8]
 _02124f30:
-	ldr r0, [sl, #0x130]
+	ldr r0, [r10, #0x130]
 	mov r2, #0
 	cmp r0, #0xa
 	beq _02124f5c
-	ldr r1, [sl, #0x4c]
-	ldr r0, [sl, #0x2a8]
+	ldr r1, [r10, #0x4c]
+	ldr r0, [r10, #0x2a8]
 	cmp r1, r0
 	bgt _02124f5c
-	ldr r0, [sl, #0x2f4]
+	ldr r0, [r10, #0x2f4]
 	cmp r0, #0x11
 	movge r2, #1
 _02124f5c:
-	ldr r3, [sl, #0x2bc]
+	ldr r3, [r10, #0x2bc]
 	cmp r3, #0
 	beq _02124f88
 	cmp r2, #0
@@ -6515,7 +6515,7 @@ _02124f5c:
 	orr r0, r1, r0, lsr #30
 	str r0, [r3, #0x24]
 _02124f88:
-	ldr r3, [sl, #0x2c8]
+	ldr r3, [r10, #0x2c8]
 	cmp r3, #0
 	beq _02124ffc
 	cmp r2, #0
@@ -6528,37 +6528,37 @@ _02124f88:
 	str r0, [r3, #0x24]
 	b _02124ffc
 _02124fb8:
-	add r0, sl, #0x2bc
+	add r0, r10, #0x2bc
 	bl func_ov00_020b7e6c
-	add r0, sl, #0x2c8
+	add r0, r10, #0x2c8
 	bl func_ov00_020b7e6c
-	add r0, sl, #0x2d4
+	add r0, r10, #0x2d4
 	bl func_ov00_020b7e6c
-	add r0, sl, #0x2e0
+	add r0, r10, #0x2e0
 	bl func_ov00_020b7e6c
 	b _02124ffc
 _02124fdc:
-	add r0, sl, #0x2bc
+	add r0, r10, #0x2bc
 	bl func_ov00_020b7e6c
-	add r0, sl, #0x2c8
+	add r0, r10, #0x2c8
 	bl func_ov00_020b7e6c
-	add r0, sl, #0x2d4
+	add r0, r10, #0x2d4
 	bl func_ov00_020b7e6c
-	add r0, sl, #0x2e0
+	add r0, r10, #0x2e0
 	bl func_ov00_020b7e6c
 _02124ffc:
-	ldr r1, [sl, #0x2f4]
+	ldr r1, [r10, #0x2f4]
 	ldr r0, _02125048 ; =data_ov15_02190458
 	add r1, r1, #1
-	str r1, [sl, #0x2f4]
-	ldrb r3, [sl, #0x2f8]
-	add r1, sl, #0x48
+	str r1, [r10, #0x2f4]
+	ldrb r3, [r10, #0x2f8]
+	add r1, r10, #0x48
 	mov r2, #0
 	add r3, r3, #1
-	strb r3, [sl, #0x2f8]
+	strb r3, [r10, #0x2f8]
 	bl func_ov15_02184a40
 	add sp, sp, #0x1c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02124a40
 _0212502c: .word data_027e0e60
@@ -11825,7 +11825,7 @@ func_ov15_02129254: ; 0x02129254
 	.global func_ov15_0212925c
 	arm_func_start func_ov15_0212925c
 func_ov15_0212925c: ; 0x0212925c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x74
 	ldr r2, _021296c0 ; =data_027e0e60
 	mov sb, r0
@@ -11849,7 +11849,7 @@ func_ov15_0212925c: ; 0x0212925c
 	add r3, r3, #0xe800
 	sub r2, r2, #0xe800
 	ldr r4, [sp, #0x68]
-	mov sl, r0
+	mov r10, r0
 	add r0, r4, #0xe800
 	ldr r1, [sp, #0x64]
 	str r0, [sp, #0x68]
@@ -11956,7 +11956,7 @@ _0212941c:
 	add r0, r0, r6
 	str r1, [sp, #0x50]
 	str r1, [sp, #0x2c]
-	sub r1, r2, sl
+	sub r1, r2, r10
 	str r0, [sp, #0x44]
 	str r0, [sp, #0x38]
 	add r0, r2, #0xe800
@@ -11985,7 +11985,7 @@ _0212947c:
 	sub r1, r2, #0xe800
 	str r0, [sp, #0x44]
 	str r0, [sp, #0x38]
-	add r0, r2, sl
+	add r0, r2, r10
 	str r4, [sp, #0x30]
 	str r1, [sp, #0x58]
 	str r1, [sp, #0x34]
@@ -12119,7 +12119,7 @@ _021296ac:
 	cmp r7, #4
 	blt _02129300
 	add sp, sp, #0x74
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0212925c
 _021296c0: .word data_027e0e60
@@ -13505,10 +13505,10 @@ _0212a76c:
 	.global func_ov15_0212a780
 	arm_func_start func_ov15_0212a780
 func_ov15_0212a780: ; 0x0212a780
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x7c
 	ldr r2, _0212ad74 ; =data_027e0f94
-	mov sl, r0
+	mov r10, r0
 	ldr r3, [r2, #4]
 	ldr r4, [r2]
 	str r3, [sp, #0x74]
@@ -13518,7 +13518,7 @@ func_ov15_0212a780: ; 0x0212a780
 	mov r5, r1
 	mov r3, #0
 	mov r2, r0
-	add r1, sl, #0x50
+	add r1, r10, #0x50
 	str r4, [sp, #0x78]
 	str r3, [sp, #0x74]
 	bl func_01ff9bc4
@@ -13531,7 +13531,7 @@ func_ov15_0212a780: ; 0x0212a780
 	cmp r0, #3
 	beq _0212a7f8
 _0212a7e4:
-	ldr r0, [sl, #4]
+	ldr r0, [r10, #4]
 	add r1, sp, #0x70
 	ldr r2, [r0]
 	ldr r2, [r2, #0x18]
@@ -13646,8 +13646,8 @@ _0212a98c:
 	str r0, [r3]
 	str r0, [r3]
 	str r0, [r3]
-	ldrh r2, [sl, #0x78]
-	ldrh r1, [sl, #0x7a]
+	ldrh r2, [r10, #0x78]
+	ldrh r1, [r10, #0x7a]
 	mov r0, #0
 	cmp r5, #0
 	orr r1, r2, r1, lsl #16
@@ -13668,7 +13668,7 @@ _0212a98c:
 	cmp r0, #3
 	ldr r1, _0212ada0 ; =0x040004a8
 	bne _0212aa7c
-	ldr r5, [sl, #0x40]
+	ldr r5, [r10, #0x40]
 	mov r0, r5, lsl #0x10
 	and r2, r5, #0x1c000000
 	mov r0, r0, lsr #0x10
@@ -13687,8 +13687,8 @@ _0212a98c:
 	orr r0, r0, #0x30000
 	orr r0, r0, r2, lsl #29
 	str r0, [r1]
-	ldr r0, [sl, #0x40]
-	ldrh r2, [sl, #0x44]
+	ldr r0, [r10, #0x40]
+	ldrh r2, [r10, #0x44]
 	and r0, r0, #0x1c000000
 	mov r0, r0, lsr #0x1a
 	cmp r0, #2
@@ -13702,7 +13702,7 @@ _0212a98c:
 	str r1, [r0]
 	b _0212ab84
 _0212aa7c:
-	ldr r5, [sl, #0x1c]
+	ldr r5, [r10, #0x1c]
 	mov r0, r5, lsl #0x10
 	and r2, r5, #0x1c000000
 	mov r0, r0, lsr #0x10
@@ -13721,8 +13721,8 @@ _0212aa7c:
 	orr r0, r0, #0x30000
 	orr r0, r0, r2, lsl #29
 	str r0, [r1]
-	ldr r0, [sl, #0x1c]
-	ldrh r2, [sl, #0x20]
+	ldr r0, [r10, #0x1c]
+	ldrh r2, [r10, #0x20]
 	and r0, r0, #0x1c000000
 	mov r0, r0, lsr #0x1a
 	cmp r0, #2
@@ -13736,7 +13736,7 @@ _0212aa7c:
 	str r1, [r0]
 	b _0212ab84
 _0212ab00:
-	ldr r5, [sl, #0x1c]
+	ldr r5, [r10, #0x1c]
 	ldr r1, _0212ada0 ; =0x040004a8
 	mov r0, r5, lsl #0x10
 	and r2, r5, #0x1c000000
@@ -13756,8 +13756,8 @@ _0212ab00:
 	orr r0, r0, #0x30000
 	orr r0, r0, r2, lsl #29
 	str r0, [r1]
-	ldr r0, [sl, #0x1c]
-	ldrh r2, [sl, #0x20]
+	ldr r0, [r10, #0x1c]
+	ldrh r2, [r10, #0x20]
 	and r0, r0, #0x1c000000
 	mov r0, r0, lsr #0x1a
 	cmp r0, #2
@@ -13778,7 +13778,7 @@ _0212ab94:
 	ldr r0, [sp]
 	cmp r0, #0x18
 	bhs _0212ad4c
-	ldr r1, [sl, #0x4c]
+	ldr r1, [r10, #0x4c]
 	add r4, r0, #1
 	mul r1, r0, r1
 	sub r7, r1, #0x800
@@ -13801,7 +13801,7 @@ _0212ab94:
 	sub r5, r1, #0x78
 	sub r4, r1, #0x74
 _0212abf8:
-	ldr r1, [sl, #0x4c]
+	ldr r1, [r10, #0x4c]
 	ldr r2, [sp, #4]
 	mul r1, r6, r1
 	sub r1, r1, #0x800
@@ -13811,7 +13811,7 @@ _0212abf8:
 	mov sb, r1, lsr #0x10
 	orr r1, sb, r11, lsl #16
 	str r1, [r5]
-	ldr r3, [sl, #0x64]
+	ldr r3, [r10, #0x64]
 	add r0, sp, #0x24
 	add r2, r3, r2, lsl #2
 	ldr r3, [r2, r6, lsl #2]
@@ -13841,7 +13841,7 @@ _0212abf8:
 	orr r1, r2, r1, lsr #16
 	str r1, [r4]
 	str r3, [r4]
-	ldr r2, [sl, #0x4c]
+	ldr r2, [r10, #0x4c]
 	add r0, sp, #0x18
 	add r2, r7, r2
 	mov r2, r2, lsl #0x14
@@ -13850,7 +13850,7 @@ _0212abf8:
 	mov r2, r2, lsr #0x10
 	orr r2, sb, r2, lsl #16
 	str r2, [r5]
-	ldr r3, [sl, #0x64]
+	ldr r3, [r10, #0x64]
 	ldr r2, [sp, #8]
 	mov r1, r8
 	add r2, r3, r2, lsl #2
@@ -13896,7 +13896,7 @@ _0212ad4c:
 	mov r1, #1
 	str r1, [r0]
 	add sp, sp, #0x7c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0212a780
 _0212ad74: .word data_027e0f94
@@ -15669,10 +15669,10 @@ _0212c4c8: .word data_027e0f64
 	.global func_ov15_0212c4cc
 	arm_func_start func_ov15_0212c4cc
 func_ov15_0212c4cc: ; 0x0212c4cc
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x18
 	ldr r1, _0212c6a4 ; =data_027e0d38
-	mov sl, r0
+	mov r10, r0
 	ldr r0, [r1]
 	add r0, r0, #0xc
 	bl func_ov00_020a5e9c
@@ -15683,12 +15683,12 @@ func_ov15_0212c4cc: ; 0x0212c4cc
 _0212c4f8:
 	mov r0, #0
 _0212c4fc:
-	str r0, [sl, #8]
-	ldr r1, [sl, #8]
+	str r0, [r10, #8]
+	ldr r1, [r10, #8]
 	mov r0, #0xc
 	mul r3, r1, r0
 	ldr r1, _0212c6a8 ; =data_ov15_0218a434
-	ldr r2, [sl, #4]
+	ldr r2, [r10, #4]
 	ldr r0, [r1, r3]
 	add r3, r1, r3
 	str r0, [r2, #0x50]
@@ -15697,10 +15697,10 @@ _0212c4fc:
 	str r0, [r2, #0x54]
 	ldr r0, [r3, #8]
 	str r0, [r2, #0x58]
-	ldmib sl, {r0, r2}
+	ldmib r10, {r0, r2}
 	ldr r1, [r1, r2, lsl #2]
 	str r1, [r0, #0x4c]
-	ldr r0, [sl, #4]
+	ldr r0, [r10, #4]
 	bl func_ov15_0212a4ec
 	mov r8, #0
 	str r8, [sp, #0xc]
@@ -15724,7 +15724,7 @@ _0212c574:
 	str r6, [sp, #4]
 	str sb, [sp, #8]
 	bl func_01ff9bc4
-	ldr r0, [sl, #4]
+	ldr r0, [r10, #4]
 	mov r1, r5
 	bl func_ov15_0212adb8
 	add r7, r7, #1
@@ -15750,7 +15750,7 @@ _0212c5dc:
 	add r0, r0, r4
 	mov r1, r1, lsl #0x10
 	mov r2, r0, lsl #0x10
-	ldr r0, [sl, #4]
+	ldr r0, [r10, #4]
 	mov r1, r1, lsr #0x10
 	mov r2, r2, lsr #0x10
 	bl func_ov15_0212ae5c
@@ -15762,7 +15762,7 @@ _0212c608:
 	add r0, r0, r4
 	mov r1, r1, lsl #0x10
 	mov r2, r0, lsl #0x10
-	ldr r0, [sl, #4]
+	ldr r0, [r10, #4]
 	mov r1, r1, lsr #0x10
 	mov r2, r2, lsr #0x10
 	bl func_ov15_0212ae5c
@@ -15773,7 +15773,7 @@ _0212c634:
 	add r0, r8, r5
 	mov r1, r1, lsl #0x10
 	mov r2, r0, lsl #0x10
-	ldr r0, [sl, #4]
+	ldr r0, [r10, #4]
 	mov r1, r1, lsr #0x10
 	mov r2, r2, lsr #0x10
 	bl func_ov15_0212ae5c
@@ -15784,7 +15784,7 @@ _0212c65c:
 	add r0, r8, r6
 	mov r1, r1, lsl #0x10
 	mov r2, r0, lsl #0x10
-	ldr r0, [sl, #4]
+	ldr r0, [r10, #4]
 	mov r1, r1, lsr #0x10
 	mov r2, r2, lsr #0x10
 	bl func_ov15_0212ae5c
@@ -15796,7 +15796,7 @@ _0212c684:
 	cmp r7, #0x19
 	blo _0212c5c0
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0212c4cc
 _0212c6a4: .word data_027e0d38
@@ -17823,7 +17823,7 @@ _0212e2bc: .word data_ov15_02190458
 	.global func_ov15_0212e2c0
 	arm_func_start func_ov15_0212e2c0
 func_ov15_0212e2c0: ; 0x0212e2c0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x88
 	mov r4, r0
 	bl _ZN5Actor14GetAngleToLinkEv
@@ -17836,7 +17836,7 @@ func_ov15_0212e2c0: ; 0x0212e2c0
 	ldr r0, [r4, #0x254]
 	cmp r0, #0
 	addne sp, sp, #0x88
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, _0212e770 ; =data_027e0f94
 	add r6, sp, #0x7c
 	ldmia r0, {r0, r1, r2}
@@ -17898,10 +17898,10 @@ func_ov15_0212e2c0: ; 0x0212e2c0
 	ldmib r2, {r3, r6, lr}
 	umull r8, r7, r6, ip
 	mla r7, r6, r3, r7
-	ldr sl, [r2, #0x10]
+	ldr r10, [r2, #0x10]
 	mla r7, lr, ip, r7
 	ldr sb, [r2, #0x14]
-	adds r6, sl, r8
+	adds r6, r10, r8
 	adc r3, sb, r7
 	str r6, [r2]
 	str r3, [r2, #4]
@@ -17929,7 +17929,7 @@ func_ov15_0212e2c0: ; 0x0212e2c0
 	orr r7, r7, r0, lsl #20
 	cmp r7, #0x12c00
 	addgt sp, sp, #0x88
-	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	cmp r7, #0x2000
 	movle r6, #0xf6
 	ble _0212e494
@@ -17966,13 +17966,13 @@ _0212e4e0:
 	ldr r3, _0212e784 ; =0x0000014a
 	ldr r1, [r8]
 	ldmib r8, {r0, r2}
-	umull sl, sb, r2, r1
+	umull r10, sb, r2, r1
 	mla sb, r2, r0, sb
 	ldr r0, [r8, #0xc]
 	ldr r2, [r8, #0x10]
 	mla sb, r0, r1, sb
 	ldr r0, [r8, #0x14]
-	adds r1, r2, sl
+	adds r1, r2, r10
 	adc r0, r0, sb
 	str r1, [r8]
 	mov r2, r0, lsr #0x10
@@ -17983,11 +17983,11 @@ _0212e4e0:
 	mov r2, r2, lsl #0x10
 	mov r2, r2, lsr #0x10
 	mov r1, #0
-	umull sl, sb, r2, r3
+	umull r10, sb, r2, r3
 	str r0, [r8, #4]
 	mla sb, r2, r1, sb
 	mov r0, r1
-	adds r8, sl, #0x800
+	adds r8, r10, #0x800
 	mla sb, r0, r3, sb
 	adc r0, sb, #0
 	mov r1, r8, lsr #0xc
@@ -18039,8 +18039,8 @@ _0212e4e0:
 	add r8, r2, #0
 	ldmia r0, {r0, r1, r2}
 	ldr sb, _0212e790 ; =0x000004cd
-	add sl, sp, #0x58
-	stmia sl, {r0, r1, r2}
+	add r10, sp, #0x58
+	stmia r10, {r0, r1, r2}
 	str sb, [sp, #0x54]
 	ldr r1, [sp, #8]
 	mov r3, #0
@@ -18055,7 +18055,7 @@ _0212e4e0:
 	add r0, r0, #0x66
 	add r0, r0, #0x600
 	str r0, [sp, #0x5c]
-	mov r0, sl
+	mov r0, r10
 	add r1, sp, #0x4c
 	mov r2, r0
 	bl func_01ff9bc4
@@ -18080,7 +18080,7 @@ _0212e4e0:
 	ldr r0, _0212e794 ; =data_027e0fe8
 	ldr r1, _0212e798 ; =0x434e424c
 	ldr r0, [r0]
-	mov r2, sl
+	mov r2, r10
 	add r3, sp, #0x20
 	bl func_ov00_020c4048
 	ldr r0, _0212e79c ; =data_027e0fe4
@@ -18089,7 +18089,7 @@ _0212e4e0:
 	bl _ZN12ActorManager8GetActorEP8ActorRef
 	cmp r0, #0
 	addeq sp, sp, #0x88
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	str r6, [r0, #0x60]
 	str r5, [r0, #0x64]
 	str r8, [r0, #0x68]
@@ -18126,7 +18126,7 @@ _0212e730:
 	mov r3, #0
 	bl func_ov00_020ceacc
 	add sp, sp, #0x88
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0212e2c0
 _0212e770: .word data_027e0f94
@@ -18245,7 +18245,7 @@ _0212e8d8:
 	.global func_ov15_0212e8e0
 	arm_func_start func_ov15_0212e8e0
 func_ov15_0212e8e0: ; 0x0212e8e0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	mov r6, r0
 	ldr r0, [r6, #0x130]
 	mov r4, r3
@@ -18283,14 +18283,14 @@ func_ov15_0212e8e0: ; 0x0212e8e0
 _0212e96c:
 	tst lr, r1, lsl r3
 	bne _0212e998
-	sub sl, r0, r7
-	mov sl, sl, lsl #0x10
-	movs sl, sl, asr #0x10
-	rsbmi sl, sl, #0
-	movmi sl, sl, lsl #0x10
-	movmi sl, sl, asr #0x10
-	cmp sl, r2
-	movlt r2, sl
+	sub r10, r0, r7
+	mov r10, r10, lsl #0x10
+	movs r10, r10, asr #0x10
+	rsbmi r10, r10, #0
+	movmi r10, r10, lsl #0x10
+	movmi r10, r10, asr #0x10
+	cmp r10, r2
+	movlt r2, r10
 	movlt ip, r3
 _0212e998:
 	add r7, r7, sb
@@ -18351,15 +18351,15 @@ _0212ea44:
 	ldr r6, [r6, #0x250]
 	ldr sb, [r8, #0x18]
 	mov r8, #0x800
-	smull sl, sb, r6, sb
-	adds sl, sl, #0x800
+	smull r10, sb, r6, sb
+	adds r10, r10, #0x800
 	adc sb, sb, #0
-	mov sl, sl, lsr #0xc
-	orr sl, sl, sb, lsl #20
-	mov sb, sl, asr #0x1f
+	mov r10, r10, lsr #0xc
+	orr r10, r10, sb, lsl #20
+	mov sb, r10, asr #0x1f
 	mov sb, sb, lsl #0xd
-	adds r11, r8, sl, lsl #13
-	orr sb, sb, sl, lsr #19
+	adds r11, r8, r10, lsl #13
+	orr sb, sb, r10, lsr #19
 	adc r8, sb, #0
 	mov sb, r11, lsr #0xc
 	orr sb, sb, r8, lsl #20
@@ -18369,15 +18369,15 @@ _0212eaa4:
 	ldr r6, [r6, #0x250]
 	ldr sb, [r8, #0x1c]
 	mov r8, #0x800
-	smull sl, sb, r6, sb
-	adds sl, sl, #0x800
+	smull r10, sb, r6, sb
+	adds r10, r10, #0x800
 	adc sb, sb, #0
-	mov sl, sl, lsr #0xc
-	orr sl, sl, sb, lsl #20
-	mov sb, sl, asr #0x1f
+	mov r10, r10, lsr #0xc
+	orr r10, r10, sb, lsl #20
+	mov sb, r10, asr #0x1f
 	mov sb, sb, lsl #0xd
-	adds r11, r8, sl, lsl #13
-	orr sb, sb, sl, lsr #19
+	adds r11, r8, r10, lsl #13
+	orr sb, sb, r10, lsr #19
 	adc r8, sb, #0
 	mov sb, r11, lsr #0xc
 	orr sb, sb, r8, lsl #20
@@ -18392,19 +18392,19 @@ _0212eae4:
 	mov r11, r6, lsl #0x1
 	mov r7, r4, lsl #0x1
 	add r6, r11, #1
-	add sl, r7, #1
+	add r10, r7, #1
 	ldr r8, _0212eb8c ; =data_02050f54
 	mov r4, r11, lsl #0x1
 	mov r7, r7, lsl #0x1
 	ldrsh r4, [r8, r4]
 	mov r6, r6, lsl #0x1
 	ldrsh r7, [r8, r7]
-	mov r11, sl, lsl #0x1
-	ldrsh sl, [r8, r6]
+	mov r11, r10, lsl #0x1
+	ldrsh r10, [r8, r6]
 	mul r6, r4, sb
 	ldrsh r8, [r8, r11]
 	mul r4, r7, r0
-	mul r7, sl, sb
+	mul r7, r10, sb
 	mul sb, r8, r0
 	add r6, r6, #0x800
 	add r0, r7, #0x800
@@ -18419,7 +18419,7 @@ _0212eae4:
 	str r2, [r5, #4]
 	add r0, r3, r0
 	str r0, [r5, #8]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0212e8e0
 _0212eb7c: .word data_027e0fac
@@ -18573,23 +18573,23 @@ _0212ed74: .word data_ov15_02185d4a
 	.global func_ov15_0212ed78
 	arm_func_start func_ov15_0212ed78
 func_ov15_0212ed78: ; 0x0212ed78
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #0xc
 	mov sb, r0
-	mov sl, r1
+	mov r10, r1
 	mov r8, r2
 	mov r7, r3
 	ldr r6, [sp, #0x30]
 	ldr r5, [sp, #0x34]
 	bl _ZN5Actor12XzDistanceToEP5Vec3p
 	mov r4, r0
-	mov r2, sl
+	mov r2, r10
 	add r0, sb, #0x48
 	mov r1, #0x2000
 	bl func_ov00_020ce284
 	cmp r0, #0
 	mov r0, sb
-	mov r1, sl
+	mov r1, r10
 	beq _0212ee3c
 	bl _ZN5Actor10GetAngleToEP5Vec3p
 	ldrsh r1, [sb, #0x78]
@@ -18682,7 +18682,7 @@ _0212ee94:
 	str r3, [sp, #8]
 	bl func_01ff9bc4
 	add sp, sp, #0xc
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0212ed78
 _0212ef20: .word data_ov15_0218a464
@@ -19729,7 +19729,7 @@ _0212fd20: .word data_ov15_0218a5ac
 	.global func_ov15_0212fd24
 	arm_func_start func_ov15_0212fd24
 func_ov15_0212fd24: ; 0x0212fd24
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x274
 	mov r4, r1
 	mov r5, r0
@@ -19928,7 +19928,7 @@ _0212fe8c:
 	ldr r1, [sp, #0x178]
 	str r0, [sp, #0x210]
 	ldr r0, [sp, #0x194]
-	ldr sl, [sp, #0x180]
+	ldr r10, [sp, #0x180]
 	ldr sb, [sp, #0x184]
 	ldr r8, [sp, #0x188]
 	str r0, [sp, #0x228]
@@ -19936,8 +19936,8 @@ _0212fe8c:
 	ldr r2, [sp, #0x18c]
 	str r1, [sp, #0x20c]
 	ldr r1, [sp, #0x190]
-	str sl, [sp, #0x214]
-	ldr sl, [sp, #0x198]
+	str r10, [sp, #0x214]
+	ldr r10, [sp, #0x198]
 	str sb, [sp, #0x218]
 	ldr sb, [sp, #0x19c]
 	str r8, [sp, #0x21c]
@@ -19953,8 +19953,8 @@ _0212fe8c:
 	ldr r2, [sp, #0x1a4]
 	str r1, [sp, #0x224]
 	ldr r1, [sp, #0x1a8]
-	str sl, [sp, #0x22c]
-	ldr sl, [sp, #0x1b0]
+	str r10, [sp, #0x22c]
+	ldr r10, [sp, #0x1b0]
 	str sb, [sp, #0x230]
 	ldr sb, [sp, #0x1b4]
 	str r8, [sp, #0x234]
@@ -19965,7 +19965,7 @@ _0212fe8c:
 	mov r11, #0
 	ldr r0, [r0]
 	add r1, sp, #0x1c4
-	str sl, [sp, #0x244]
+	str r10, [sp, #0x244]
 	str sb, [sp, #0x248]
 	str r8, [sp, #0x24c]
 	strb r7, [sp, #0x250]
@@ -20044,7 +20044,7 @@ _02130188:
 	bl func_ov15_02141344
 	cmp r0, #0
 	addeq sp, sp, #0x274
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _021301f8:
 	mov r1, #0
 	strb r1, [r5, #0x490]
@@ -20169,35 +20169,35 @@ _02130220:
 	ldr r2, [sp, #0xc]
 	ldr r1, [sp, #0x10]
 	ldr r0, [sp, #0x14]
-	ldr sl, [sp, #0x44]
+	ldr r10, [sp, #0x44]
 	ldr sb, [sp, #0x48]
 	ldr r8, [sp, #0x4c]
-	str sl, [sp, #0xd8]
-	ldr sl, [sp, #0x50]
+	str r10, [sp, #0xd8]
+	ldr r10, [sp, #0x50]
 	str sb, [sp, #0xdc]
 	ldr sb, [sp, #0x54]
 	str r8, [sp, #0xe0]
 	ldr r8, [sp, #0x58]
-	str sl, [sp, #0xe4]
-	ldr sl, [sp, #0x5c]
+	str r10, [sp, #0xe4]
+	ldr r10, [sp, #0x5c]
 	str sb, [sp, #0xe8]
 	ldr sb, [sp, #0x6c]
 	str r8, [sp, #0xec]
 	ldr r8, [sp, #0x70]
-	str sl, [sp, #0xf0]
-	ldr sl, [sp, #0x74]
+	str r10, [sp, #0xf0]
+	ldr r10, [sp, #0x74]
 	str sb, [sp, #0x100]
 	ldr sb, [sp, #0x78]
 	str r8, [sp, #0x104]
 	ldr r8, [sp, #0x7c]
-	str sl, [sp, #0x108]
-	ldr sl, [sp, #0x80]
+	str r10, [sp, #0x108]
+	ldr r10, [sp, #0x80]
 	str sb, [sp, #0x10c]
 	ldr sb, [sp, #0x84]
 	str r8, [sp, #0x110]
 	ldr r8, [sp, #0x88]
-	str sl, [sp, #0x114]
-	ldr sl, [sp, #0x8c]
+	str r10, [sp, #0x114]
+	ldr r10, [sp, #0x8c]
 	str sb, [sp, #0x118]
 	ldr sb, [sp, #0x90]
 	str r8, [sp, #0x11c]
@@ -20205,13 +20205,13 @@ _02130220:
 	ldrb r7, [sp, #0xa4]
 	ldrb r6, [sp, #0xa5]
 	ldrb r3, [sp, #0xa6]
-	str sl, [sp, #0x120]
-	ldr sl, [sp, #0x98]
+	str r10, [sp, #0x120]
+	ldr r10, [sp, #0x98]
 	str sb, [sp, #0x124]
 	ldr sb, [sp, #0x9c]
 	str r8, [sp, #0x128]
 	ldr r8, [sp, #0xa0]
-	str sl, [sp, #0x12c]
+	str r10, [sp, #0x12c]
 	str r2, [sp, #0x68]
 	str r1, [sp, #0x64]
 	str r0, [sp, #0x60]
@@ -20250,7 +20250,7 @@ _02130510:
 	str r0, [r5, #0x138]
 	str r4, [r5, #0x130]
 	add sp, sp, #0x274
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0212fd24
 _02130524: .word data_027e0764
@@ -25980,7 +25980,7 @@ func_ov15_02135484: ; 0x02135484
 	.global func_ov15_021354a0
 	arm_func_start func_ov15_021354a0
 func_ov15_021354a0: ; 0x021354a0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x30
 	mov r11, r0
 	bl func_ov15_0213ce4c
@@ -25992,14 +25992,14 @@ func_ov15_021354a0: ; 0x021354a0
 	bl func_ov15_021358f8
 	cmp r0, #0
 	beq _02135534
-	mov sl, #0
+	mov r10, #0
 	ldr r6, _0213554c ; =0x534e4156
 	ldr r5, _02135550 ; =data_027e0f94
 	ldr r4, _02135554 ; =data_027e0fe8
-	str sl, [r11, #0x24]
+	str r10, [r11, #0x24]
 	add sb, sp, #4
 	mvn r8, #0
-	mov r7, sl
+	mov r7, r10
 _021354f0:
 	mov r0, sb
 	bl func_ov00_020c1500
@@ -26007,7 +26007,7 @@ _021354f0:
 	str r8, [sp, #0x20]
 	str r8, [sp, #0x24]
 	bl func_ov00_020c3348
-	and r0, sl, #0xff
+	and r0, r10, #0xff
 	strh r0, [sp, #4]
 	str r7, [sp]
 	ldr r0, [r4]
@@ -26015,15 +26015,15 @@ _021354f0:
 	mov r2, r5
 	mov r3, sb
 	bl func_ov00_020c4048
-	add sl, sl, #1
-	cmp sl, #3
+	add r10, r10, #1
+	cmp r10, #3
 	blt _021354f0
 _02135534:
 	mov r0, r11
 	mov r1, #1
 	bl func_ov15_02175d14
 	add sp, sp, #0x30
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_021354a0
 _02135548: .word data_027e103c
@@ -27823,7 +27823,7 @@ _02136d00: .word data_027e0fac
 	.global func_ov15_02136d04
 	arm_func_start func_ov15_02136d04
 func_ov15_02136d04: ; 0x02136d04
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x18
 	mov r4, r0
 	ldrb r0, [r4, #0x25f]
@@ -27901,10 +27901,10 @@ _02136d5c:
 	umull r8, r7, r6, lr
 	mla r7, r6, ip, r7
 	ldr r5, [r2, #0xc]
-	ldr sl, [r2, #0x10]
+	ldr r10, [r2, #0x10]
 	mla r7, r5, lr, r7
 	ldr sb, [r2, #0x14]
-	adds r5, sl, r8
+	adds r5, r10, r8
 	adc r7, sb, r7
 	stmia r2, {r5, r7}
 	umull r2, r5, r7, r1
@@ -28100,7 +28100,7 @@ _021370f8:
 	mov r0, r4
 	bl func_ov15_02136888
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02136d04
 _0213711c: .word data_027e0f94
@@ -29477,7 +29477,7 @@ _02138474: .word 0x00000ccc
 	.global func_ov15_02138478
 	arm_func_start func_ov15_02138478
 func_ov15_02138478: ; 0x02138478
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x78
 	ldr r2, _02138ba0 ; =data_027e10a4
 	ldr r4, _02138ba4 ; =data_027e0fa0
@@ -29669,9 +29669,9 @@ _02138750:
 	smull r3, r1, r2, r1
 	adds r2, r3, #0x800
 	adc r1, r1, #0
-	mov sl, r2, lsr #0xc
-	orr sl, sl, r1, lsl #20
-	mov r6, sl
+	mov r10, r2, lsr #0xc
+	orr r10, r10, r1, lsl #20
+	mov r6, r10
 	b _0213879c
 _0213877c:
 	ldr r1, [sp, #0x64]
@@ -29679,9 +29679,9 @@ _0213877c:
 	smull r3, r1, r2, r1
 	adds r2, r3, #0x800
 	adc r1, r1, #0
-	mov sl, r2, lsr #0xc
-	orr sl, sl, r1, lsl #20
-	rsb r6, sl, #0
+	mov r10, r2, lsr #0xc
+	orr r10, r10, r1, lsl #20
+	rsb r6, r10, #0
 _0213879c:
 	mov r1, r0, asr #0x1f
 	mov r3, r1, lsl #0x4
@@ -29696,11 +29696,11 @@ _0213879c:
 	mov r3, r2
 	rsb r0, ip, #0
 	bl func_01ff9e64
-	mov r0, sl, asr #0x1f
+	mov r0, r10, asr #0x1f
 	mov r1, r0, lsl #0x4
 	mov r0, #0x800
-	orr r1, r1, sl, lsr #28
-	adds r2, r0, sl, lsl #4
+	orr r1, r1, r10, lsr #28
+	adds r2, r0, r10, lsl #4
 	adc r0, r1, #0
 	mov r1, r2, lsr #0xc
 	orr r1, r1, r0, lsl #20
@@ -29721,7 +29721,7 @@ _0213879c:
 	cmp r0, #0
 	beq _02138894
 	ldr r0, _02138bb4 ; =data_027e0fac
-	ldr sl, _02138bb0 ; =data_02050f54
+	ldr r10, _02138bb0 ; =data_02050f54
 	ldrh r0, [r0]
 	ldr r2, [sb, #0x78]
 	mov r0, r0, asr #0x4
@@ -29729,18 +29729,18 @@ _0213879c:
 	mov r1, r0, lsl #0x1
 	add r0, r0, #1
 	mov r0, r0, lsl #0x1
-	ldrsh r1, [sl, r1]
-	ldrsh lr, [sl, r0]
-	smull sl, r0, r1, r2
-	adds r1, sl, #0x800
-	smull sl, r2, lr, r2
+	ldrsh r1, [r10, r1]
+	ldrsh lr, [r10, r0]
+	smull r10, r0, r1, r2
+	adds r1, r10, #0x800
+	smull r10, r2, lr, r2
 	adc r0, r0, r3
-	adds sl, sl, #0x800
+	adds r10, r10, #0x800
 	mov r1, r1, lsr #0xc
 	orr r1, r1, r0, lsl #20
 	add r0, r3, r1
 	adc r1, r2, r3
-	mov r2, sl, lsr #0xc
+	mov r2, r10, lsr #0xc
 	orr r2, r2, r1, lsl #20
 	str r0, [ip]
 	add r0, r3, r2
@@ -29752,10 +29752,10 @@ _02138894:
 	mov r1, #0x1000
 	mov r2, r3, asr #0x1f
 	mov r2, r2, lsl #0x6
-	adds sl, r0, r3, lsl #6
+	adds r10, r0, r3, lsl #6
 	orr r2, r2, r3, lsr #26
 	adc r0, r2, #0
-	mov r2, sl, lsr #0xc
+	mov r2, r10, lsr #0xc
 	orr r2, r2, r0, lsl #20
 	smull r2, r0, r11, r2
 	adds r3, r2, #0x800
@@ -29764,12 +29764,12 @@ _02138894:
 	orr r0, r0, r2, lsl #20
 	bl Divide
 	ldr r2, _02138ba8 ; =data_ov15_0218aa28
-	ldrsh sl, [sb, #0x96]
+	ldrsh r10, [sb, #0x96]
 	ldr r3, [r2, #0x24]
 	mov r1, #0x800
 	mov r2, r3, asr #0x1f
 	mov r2, r2, lsl #0x6
-	add r0, sl, r0
+	add r0, r10, r0
 	orr r2, r2, r3, lsr #26
 	adds r3, r1, r3, lsl #6
 	strh r0, [sb, #0x96]
@@ -29936,7 +29936,7 @@ _02138b08:
 	add r0, r5, r0
 	str r0, [r1, #4]
 	add sp, sp, #0x78
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02138b78:
 	umull r3, r2, r5, r4
 	mla r2, r5, r0, r2
@@ -29947,7 +29947,7 @@ _02138b78:
 	sub r0, r5, r0
 	str r0, [r1, #4]
 	add sp, sp, #0x78
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02138478
 _02138ba0: .word data_027e10a4
@@ -32934,7 +32934,7 @@ _0213b454: .word 0x4b4d4741
 	.global func_ov15_0213b458
 	arm_func_start func_ov15_0213b458
 func_ov15_0213b458: ; 0x0213b458
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	ldr r1, _0213b63c ; =data_027e0fe4
 	mov r4, r0
 	ldr r0, [r1]
@@ -32950,7 +32950,7 @@ func_ov15_0213b458: ; 0x0213b458
 	bl func_ov15_021517a0
 	cmp r0, #0
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0213b49c:
 	ldr r2, _0213b644 ; =data_027e0764
 	mov r11, #0
@@ -32981,7 +32981,7 @@ _0213b49c:
 	mov r6, #0x80
 	str r1, [r4, #0x58]
 	ldr r1, [r4, #0x50]
-	mov sl, r11
+	mov r10, r11
 	str r1, [r4, #0x5c]
 	ldr r1, [r0]
 	mov r3, #0x1080
@@ -33001,15 +33001,15 @@ _0213b49c:
 	str r5, [r4, #0x94]
 	ldr r5, [r4, #0x88]
 	str r5, [r4, #0x98]
-	str sl, [r4, #0xa8]
+	str r10, [r4, #0xa8]
 	str r6, [r4, #0xac]
-	str sl, [r4, #0xb0]
+	str r10, [r4, #0xb0]
 	str r3, [r4, #0xb4]
 	ldrh r3, [r4, #0x9c]
 	bic r3, r3, #0x12
 	strh r3, [r4, #0x9c]
-	str sl, [r4, #0x6c]
-	strh sl, [r1, #0x8c]
+	str r10, [r4, #0x6c]
+	strh r10, [r1, #0x8c]
 	ldr ip, [r2]
 	ldmib r2, {r3, r5, lr}
 	umull r7, r6, r5, ip
@@ -33022,16 +33022,16 @@ _0213b49c:
 	stmia r2, {r3, r5}
 	ldr r2, _0213b650 ; =0x0000ffff
 	umull r2, r3, r5, r2
-	mla r3, r5, sl, r3
+	mla r3, r5, r10, r3
 	ldr r2, _0213b650 ; =0x0000ffff
 	mla r3, r11, r2, r3
 	strh r3, [r4, #0x78]
-	strh sl, [r1, #0x8e]
+	strh r10, [r1, #0x8e]
 	mov r1, #0x200
 	str r1, [r4, #0x27c]
 	mov r1, #2
 	str r1, [r4, #0x12c]
-	strb sl, [r4, #0x292]
+	strb r10, [r4, #0x292]
 	bl func_ov15_0213b908
 	ldr r0, _0213b644 ; =data_027e0764
 	mov r1, r11
@@ -33055,7 +33055,7 @@ _0213b49c:
 	add r0, r5, #0x5a
 	str r0, [r4, #0x284]
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0213b458
 _0213b63c: .word data_027e0fe4
@@ -34159,7 +34159,7 @@ _0213c5b8:
 	.global func_ov15_0213c5c4
 	arm_func_start func_ov15_0213c5c4
 func_ov15_0213c5c4: ; 0x0213c5c4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	mov r4, r0
 	add r0, r4, #0x158
 	mov r1, #1
@@ -34210,10 +34210,10 @@ func_ov15_0213c5c4: ; 0x0213c5c4
 	ldr ip, _0213c780 ; =data_027e0f94
 	ldr r8, [lr]
 	ldr r6, [ip, #4]
-	ldmib lr, {r7, sl}
-	umull r11, ip, sl, r8
+	ldmib lr, {r7, r10}
+	umull r11, ip, r10, r8
 	ldr r1, [lr, #0x10]
-	mla ip, sl, r7, ip
+	mla ip, r10, r7, ip
 	ldr sb, [lr, #0xc]
 	ldr r0, [lr, #0x14]
 	adds r1, r1, r11
@@ -34267,7 +34267,7 @@ func_ov15_0213c5c4: ; 0x0213c5c4
 	ldr r0, [r0, #0x34]
 	str r1, [r4, #0x274]
 	str r0, [r4, #0x278]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0213c5c4
 _0213c778: .word data_027e0764
@@ -34278,7 +34278,7 @@ _0213c784: .word data_ov15_0218ac90
 	.global func_ov15_0213c788
 	arm_func_start func_ov15_0213c788
 func_ov15_0213c788: ; 0x0213c788
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x10
 	mov r4, r0
 	bl _ZN5Actor16XzDistanceToLinkEv
@@ -34315,10 +34315,10 @@ _0213c7b4:
 	str r3, [r0]
 	mov r2, #0x78
 	umull r1, r3, r5, r2
-	mov sl, #0
-	mov r1, sl
+	mov r10, #0
+	mov r1, r10
 	mla r3, r5, r1, r3
-	mla r3, sl, r2, r3
+	mla r3, r10, r2, r3
 	str r5, [r0, #4]
 	add r1, r3, #0x3c
 	str r1, [r4, #0x288]
@@ -34334,9 +34334,9 @@ _0213c7b4:
 	ldr r11, _0213cb08 ; =0x00002001
 	adc r3, r3, r5
 	umull r1, r2, r3, r11
-	mov r1, sl
+	mov r1, r10
 	mla r2, r3, r1, r2
-	mla r2, sl, r11, r2
+	mla r2, r10, r11, r2
 	str r6, [r0]
 	str r3, [r0, #4]
 	sub r1, r2, #0x1000
@@ -34352,7 +34352,7 @@ _0213c7b4:
 	add r2, r1, #0x1600
 	ldr r8, [r0, #0x14]
 	adds r5, sb, r7
-	mov r1, sl, lsl #0xb
+	mov r1, r10, lsl #0xb
 	adc r3, r8, r6
 	str r5, [r0]
 	orr r1, r1, r3, lsr #21
@@ -34371,9 +34371,9 @@ _0213c7b4:
 	adc r3, r8, r6
 	stmia r0, {r1, r3}
 	umull r1, r2, r3, r11
-	mov r1, sl
+	mov r1, r10
 	mla r2, r3, r1, r2
-	mla r2, sl, r11, r2
+	mla r2, r10, r11, r2
 	sub r1, r2, #0x1000
 	str r1, [r4, #0x270]
 	ldr r2, [r0]
@@ -34389,10 +34389,10 @@ _0213c7b4:
 	stmia r0, {r1, r2}
 	mov r0, #0x3f
 	umull r0, r1, r2, r0
-	mov r0, sl
+	mov r0, r10
 	mla r1, r2, r0, r1
 	mov r0, #0x3f
-	mla r1, sl, r0, r1
+	mla r1, r10, r0, r1
 	add r0, r1, #0x8f
 	str r0, [r4, #0x280]
 _0213c958:
@@ -34499,11 +34499,11 @@ _0213c9ec:
 	bl func_ov15_0213b8c4
 	cmp r0, #0
 	addeq sp, sp, #0x10
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	mov r0, r4
 	bl func_ov15_0213c27c
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0213c788
 _0213cb00: .word data_027e0fa0
@@ -35384,22 +35384,22 @@ _0213d5ec: .word data_027e10a4
 	.global func_ov15_0213d5f0
 	arm_func_start func_ov15_0213d5f0
 func_ov15_0213d5f0: ; 0x0213d5f0
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
-	mov sl, r0
-	ldrsh r5, [sl, #0xe]
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	mov r10, r0
+	ldrsh r5, [r10, #0xe]
 	mov sb, r1
 	cmp r5, #0
 	blt _0213d614
-	ldrh r0, [sl, #0xc]
+	ldrh r0, [r10, #0xc]
 	cmp r5, r0
 	blt _0213d62c
 _0213d614:
 	mov r0, #0
-	strb r0, [sl, #0x3c]
+	strb r0, [r10, #0x3c]
 	sub r0, r0, #1
-	strh r0, [sl, #0xe]
-	ldrsh r0, [sl, #0xe]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	strh r0, [r10, #0xe]
+	ldrsh r0, [r10, #0xe]
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _0213d62c:
 	mov r6, r5
 	cmp r5, r0
@@ -35409,14 +35409,14 @@ _0213d62c:
 	smulbb r8, r5, r0
 	ldr r4, _0213d70c ; =data_027e0f94
 _0213d648:
-	ldr r0, [sl, #4]
+	ldr r0, [r10, #4]
 	mov r1, r4
 	add r0, r0, r8
 	bl func_01ff9ec0
 	cmp r0, r7
 	movlt r7, r0
 	add r0, r5, #1
-	ldrh r1, [sl, #0xc]
+	ldrh r1, [r10, #0xc]
 	mov r0, r0, lsl #0x10
 	movlt r6, r5
 	cmp r1, r0, asr #16
@@ -35424,7 +35424,7 @@ _0213d648:
 	mov r5, r0, asr #0x10
 	bgt _0213d648
 _0213d680:
-	strh r6, [sl, #0xe]
+	strh r6, [r10, #0xe]
 	cmp r7, #0x2000
 	blt _0213d6d4
 	mov r0, r7, asr #0xb
@@ -35436,7 +35436,7 @@ _0213d680:
 	cmp r2, #5
 	movge r2, #5
 	cmp r2, #0
-	ldrh r1, [sl, #0xc]
+	ldrh r1, [r10, #0xc]
 	mov r6, r0, asr #0x10
 	movlt r2, #0
 	add r0, r6, r2
@@ -35447,11 +35447,11 @@ _0213d680:
 	b _0213d6dc
 _0213d6d4:
 	mov r0, #0
-	strb r0, [sl, #0x3c]
+	strb r0, [r10, #0x3c]
 _0213d6dc:
 	mov r0, #0xc
 	smulbb r1, r6, r0
-	ldr r2, [sl, #4]
+	ldr r2, [r10, #4]
 	ldr r0, [r2, r1]
 	add r1, r2, r1
 	str r0, [sb]
@@ -35460,7 +35460,7 @@ _0213d6dc:
 	ldr r0, [r1, #8]
 	str r0, [sb, #8]
 	mov r0, r6
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0213d5f0
 _0213d70c: .word data_027e0f94
@@ -36044,7 +36044,7 @@ _0213de48: .word data_027e0f94
 	arm_func_start func_ov15_0213de4c
 func_ov15_0213de4c: ; 0x0213de4c
 	stmdb sp!, {r0, r1, r2, r3}
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x80
 	add r1, sp, #0xac
 	mov r5, r0
@@ -36086,7 +36086,7 @@ func_ov15_0213de4c: ; 0x0213de4c
 	bl _ZN12ActorManager8GetActorEP8ActorRef
 	movs r4, r0
 	addeq sp, sp, #0x80
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	addeq sp, sp, #0x10
 	bxeq lr
 	ldr r0, _0213e3a8 ; =data_027e0f94
@@ -36152,7 +36152,7 @@ _0213df4c:
 	sub r0, r0, #0x8000
 	mov r0, r0, lsl #0x10
 	str r8, [r1, #4]
-	mov sl, r0, lsr #0x10
+	mov r10, r0, lsr #0x10
 	ldr r0, [r5, #0x194]
 	mov r2, r11
 	add r3, r0, #1
@@ -36172,7 +36172,7 @@ _0213df4c:
 	mla r0, r11, r3, r0
 	mov r2, r0
 _0213e048:
-	mov r0, sl, asr #0x4
+	mov r0, r10, asr #0x4
 	mov r3, r0, lsl #0x1
 	add r0, r3, #1
 	ldr r1, _0213e3b0 ; =data_02050f54
@@ -36360,11 +36360,11 @@ _0213e2cc:
 	smull r1, r8, r0, r6
 	adc r0, r2, #0
 	mov r2, r7, lsr #0xc
-	adds sl, r1, #0x800
+	adds r10, r1, #0x800
 	orr r2, r2, r0, lsl #20
 	mov r1, r6
 	adc sb, r8, #0
-	mov r6, sl, lsr #0xc
+	mov r6, r10, lsr #0xc
 	ldr r7, [sp, #0x40]
 	ldr r0, [sp, #0x78]
 	add r8, r2, #0
@@ -36386,7 +36386,7 @@ _0213e360:
 	movge r0, #0
 	strge r0, [r5, #0x188]
 	add sp, sp, #0x80
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	add sp, sp, #0x10
 	bx lr
 	.align 2, 0
@@ -36903,7 +36903,7 @@ _0213ea4c: .word 0x00001555
 	.global func_ov15_0213ea50
 	arm_func_start func_ov15_0213ea50
 func_ov15_0213ea50: ; 0x0213ea50
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x1c8
 	str r1, [sp, #8]
 	ldr r2, [sp, #8]
@@ -36969,7 +36969,7 @@ _0213eac8:
 	bl func_ov15_02141344
 	cmp r0, #0
 	addeq sp, sp, #0x1c8
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	mov r1, #3
 	add r0, sp, #0x118
 	strh r1, [r4, #0x7a]
@@ -37100,7 +37100,7 @@ _0213eac8:
 	str ip, [sp, #0x188]
 	ldr ip, [sp, #0x100]
 	ldrb r11, [sp, #0x110]
-	ldrb sl, [sp, #0x111]
+	ldrb r10, [sp, #0x111]
 	ldrb sb, [sp, #0x112]
 	ldrb r8, [sp, #0x113]
 	ldrb r7, [sp, #0x114]
@@ -37126,7 +37126,7 @@ _0213eac8:
 	str r2, [sp, #0x160]
 	str r3, [sp, #0x164]
 	str r2, [sp, #0x168]
-	strb sl, [sp, #0x1a5]
+	strb r10, [sp, #0x1a5]
 	strb sb, [sp, #0x1a6]
 	strb r8, [sp, #0x1a7]
 	strb r7, [sp, #0x1a8]
@@ -37184,46 +37184,46 @@ _0213eac8:
 	str r0, [sp, #0xe4]
 	ldr r11, [r4, #0x380]
 	str r11, [sp, #0xe8]
-	ldr sl, [r4, #0x384]
-	str sl, [sp, #0xc]
-	str sl, [sp, #0xec]
-	ldr sl, [r4, #0x388]
-	str sl, [sp, #0x10]
-	str sl, [sp, #0xf0]
-	ldr sl, [r4, #0x38c]
-	str sl, [sp, #0x14]
-	str sl, [sp, #0xf4]
-	ldr sl, [r4, #0x390]
-	str sl, [sp, #0x18]
-	str sl, [sp, #0xf8]
-	ldr sl, [r4, #0x394]
-	str sl, [sp, #0x1c]
-	str sl, [sp, #0xfc]
-	ldr sl, [r4, #0x398]
-	str sl, [sp, #0x20]
-	str sl, [sp, #0x100]
-	ldr sl, [r4, #0x39c]
-	str sl, [sp, #0x24]
-	str sl, [sp, #0x104]
-	ldr sl, [r4, #0x3a0]
-	str sl, [sp, #0x28]
-	str sl, [sp, #0x108]
-	ldr sl, [r4, #0x3a4]
-	str sl, [sp, #0x2c]
-	str sl, [sp, #0x10c]
-	ldrb sl, [r4, #0x3a8]
-	str sl, [sp, #0x30]
-	strb sl, [sp, #0x110]
-	ldrb sl, [r4, #0x3a9]
-	str sl, [sp, #0x34]
-	strb sl, [sp, #0x111]
-	ldrb sl, [r4, #0x3aa]
-	str sl, [sp, #0x38]
-	strb sl, [sp, #0x112]
-	ldrb sl, [r4, #0x3ab]
-	str sl, [sp, #0x3c]
-	strb sl, [sp, #0x113]
-	ldrb sl, [r4, #0x3ac]
+	ldr r10, [r4, #0x384]
+	str r10, [sp, #0xc]
+	str r10, [sp, #0xec]
+	ldr r10, [r4, #0x388]
+	str r10, [sp, #0x10]
+	str r10, [sp, #0xf0]
+	ldr r10, [r4, #0x38c]
+	str r10, [sp, #0x14]
+	str r10, [sp, #0xf4]
+	ldr r10, [r4, #0x390]
+	str r10, [sp, #0x18]
+	str r10, [sp, #0xf8]
+	ldr r10, [r4, #0x394]
+	str r10, [sp, #0x1c]
+	str r10, [sp, #0xfc]
+	ldr r10, [r4, #0x398]
+	str r10, [sp, #0x20]
+	str r10, [sp, #0x100]
+	ldr r10, [r4, #0x39c]
+	str r10, [sp, #0x24]
+	str r10, [sp, #0x104]
+	ldr r10, [r4, #0x3a0]
+	str r10, [sp, #0x28]
+	str r10, [sp, #0x108]
+	ldr r10, [r4, #0x3a4]
+	str r10, [sp, #0x2c]
+	str r10, [sp, #0x10c]
+	ldrb r10, [r4, #0x3a8]
+	str r10, [sp, #0x30]
+	strb r10, [sp, #0x110]
+	ldrb r10, [r4, #0x3a9]
+	str r10, [sp, #0x34]
+	strb r10, [sp, #0x111]
+	ldrb r10, [r4, #0x3aa]
+	str r10, [sp, #0x38]
+	strb r10, [sp, #0x112]
+	ldrb r10, [r4, #0x3ab]
+	str r10, [sp, #0x3c]
+	strb r10, [sp, #0x113]
+	ldrb r10, [r4, #0x3ac]
 	str r5, [sp, #0x160]
 	mov r5, #5
 	str r5, [sp, #0xb4]
@@ -37238,7 +37238,7 @@ _0213eac8:
 	str r6, [sp, #0x158]
 	str lr, [sp, #0x164]
 	str ip, [sp, #0x168]
-	strb sl, [sp, #0x114]
+	strb r10, [sp, #0x114]
 	str r5, [sp, #0xc8]
 	str r5, [sp, #0x15c]
 	str r1, [sp, #0x174]
@@ -37270,7 +37270,7 @@ _0213eac8:
 	ldr sb, [sp, #0x2c]
 	str r3, [sp, #0x16c]
 	str r2, [sp, #0x170]
-	and r3, sl, #0xff
+	and r3, r10, #0xff
 	mov r2, #0x5c
 	str r1, [sp, #0x190]
 	ldr r0, [r0]
@@ -37573,7 +37573,7 @@ _0213f47c:
 	ldr r0, [sp, #8]
 	str r0, [r4, #0x130]
 	add sp, sp, #0x1c8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0213ea50
 _0213f494: .word 0x0000ffff
@@ -39017,14 +39017,14 @@ func_ov15_02140854: ; 0x02140854
 	.global func_ov15_021408bc
 	arm_func_start func_ov15_021408bc
 func_ov15_021408bc: ; 0x021408bc
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #0x138
 	mov r4, r0
 	bl _ZN5Actor18func_ov00_020c198cEv
 	cmp r0, #0
 	addeq sp, sp, #0x138
 	mov r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	add r5, sp, #0xc
 	add r1, sp, #0x1c
 	mov r2, #4
@@ -39040,7 +39040,7 @@ func_ov15_021408bc: ; 0x021408bc
 	cmp r0, #0
 	addeq sp, sp, #0x138
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	mov r1, #3
 	add r0, sp, #0x88
 	strh r1, [r4, #0x7a]
@@ -39143,39 +39143,39 @@ func_ov15_021408bc: ; 0x021408bc
 	str r1, [sp, #0x30]
 	bl func_ov15_02123bb4
 	ldr r1, [sp, #0x28]
-	ldr sl, [sp, #0x20]
+	ldr r10, [sp, #0x20]
 	ldr lr, [sp, #0x24]
 	str r1, [sp, #0xbc]
 	ldr r1, [sp, #0x48]
-	str sl, [sp, #0xb4]
+	str r10, [sp, #0xb4]
 	mov r2, r8
-	ldr sl, [sp, #0x2c]
+	ldr r10, [sp, #0x2c]
 	mov ip, #0x5800
 	mov r3, #0x2000
 	str lr, [sp, #0xb8]
 	ldr lr, [sp, #0x30]
 	str r1, [sp, #0xdc]
 	ldr r1, [sp, #0x54]
-	str sl, [sp, #0xc0]
-	ldr sl, [sp, #0x4c]
+	str r10, [sp, #0xc0]
+	ldr r10, [sp, #0x4c]
 	str lr, [sp, #0xc4]
 	ldr lr, [sp, #0x50]
 	str r1, [sp, #0xe8]
 	ldr r1, [sp, #0x60]
-	str sl, [sp, #0xe0]
-	ldr sl, [sp, #0x58]
+	str r10, [sp, #0xe0]
+	ldr r10, [sp, #0x58]
 	str lr, [sp, #0xe4]
 	ldr lr, [sp, #0x5c]
 	str r1, [sp, #0xf4]
 	ldr r1, [sp, #0x6c]
-	str sl, [sp, #0xec]
-	ldr sl, [sp, #0x64]
+	str r10, [sp, #0xec]
+	ldr r10, [sp, #0x64]
 	str lr, [sp, #0xf0]
 	ldr lr, [sp, #0x68]
 	str r1, [sp, #0x100]
 	ldr r1, [sp, #0x78]
-	str sl, [sp, #0xf8]
-	ldr sl, [sp, #0x70]
+	str r10, [sp, #0xf8]
+	ldr r10, [sp, #0x70]
 	ldrb sb, [sp, #0x80]
 	ldrb r8, [sp, #0x81]
 	ldrb r7, [sp, #0x82]
@@ -39184,15 +39184,15 @@ func_ov15_021408bc: ; 0x021408bc
 	str lr, [sp, #0xfc]
 	ldr lr, [sp, #0x74]
 	str r1, [sp, #0x10c]
-	str sl, [sp, #0x104]
-	ldr sl, [sp, #0x7c]
+	str r10, [sp, #0x104]
+	ldr r10, [sp, #0x7c]
 	str lr, [sp, #0x108]
 	mov lr, #0x5c
 	ldr r1, _02140bfc ; =data_027e0f74
 	str r0, [sp, #0x34]
 	str r0, [sp, #0xc8]
 	ldr r0, [r1]
-	str sl, [sp, #0x110]
+	str r10, [sp, #0x110]
 	add r1, sp, #0x88
 	strb sb, [sp, #0x114]
 	str ip, [sp, #0x38]
@@ -39219,7 +39219,7 @@ func_ov15_021408bc: ; 0x021408bc
 	bl func_ov00_0209a508
 	mov r0, #1
 	add sp, sp, #0x138
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov15_021408bc
 _02140be8: .word data_027e10a4
@@ -43905,7 +43905,7 @@ _02144928:
 	.global func_ov15_021449b0
 	arm_func_start func_ov15_021449b0
 func_ov15_021449b0: ; 0x021449b0
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x1c4
 	mov sb, r0
 	ldr r0, [sb, #0x378]
@@ -44511,7 +44511,7 @@ _021452b0:
 	b _02145420
 _021452cc:
 	add sp, sp, #0x1c4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _021452d4:
 	bl func_ov15_021464fc
 	mov r5, r0
@@ -44769,7 +44769,7 @@ _02145524:
 	add r0, r0, #0x400
 	mov lr, #0
 	mov r1, #0x35
-	sub sl, r1, #0x36
+	sub r10, r1, #0x36
 	sub r3, r1, #0x9f
 	umull ip, r11, r5, r1
 	mla r11, r5, lr, r11
@@ -44780,11 +44780,11 @@ _02145524:
 	orr r11, r11, r1, lsl #20
 	add r1, r8, r11
 	umull r11, r8, r7, r3
-	mla r8, r7, sl, r8
+	mla r8, r7, r10, r8
 	mla r8, r6, r3, r8
-	adds sl, r11, #0x800
+	adds r10, r11, #0x800
 	adc r3, r8, #0
-	mov r8, sl, lsr #0xc
+	mov r8, r10, lsr #0xc
 	orr r8, r8, r3, lsl #20
 	add r1, r1, r8
 	bl Approach_thunk
@@ -44813,10 +44813,10 @@ _02145524:
 	mov r1, #0x35
 	sub ip, r1, #0x36
 	sub r3, r1, #0x9f
-	umull sl, lr, r7, r1
+	umull r10, lr, r7, r1
 	mla lr, r7, r11, lr
 	mla lr, r6, r1, lr
-	adds r6, sl, #0x800
+	adds r6, r10, #0x800
 	adc r1, lr, #0
 	mov r6, r6, lsr #0xc
 	orr r6, r6, r1, lsl #20
@@ -44843,7 +44843,7 @@ _02145798:
 	mov r2, #2
 	bl func_ov00_02089318
 	add sp, sp, #0x1c4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_021449b0
 _021457cc: .word data_027e0f64
@@ -47262,7 +47262,7 @@ func_ov15_02147604: ; 0x02147604
 	.global func_ov15_0214761c
 	arm_func_start func_ov15_0214761c
 func_ov15_0214761c: ; 0x0214761c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x1c
 	ldr r1, _02147bb0 ; =data_027e10a4
 	mov r4, r0
@@ -47308,25 +47308,25 @@ _02147670:
 	cmp r1, #2
 	beq _0214792c
 	add sp, sp, #0x1c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _021476d0:
-	ldr sl, _02147bb4 ; =data_027e0764
+	ldr r10, _02147bb4 ; =data_027e0764
 	mov r1, #0
-	ldr r0, [sl, #8]
-	ldr r3, [sl]
-	ldr r2, [sl, #4]
+	ldr r0, [r10, #8]
+	ldr r3, [r10]
+	ldr r2, [r10, #4]
 	umull sb, r8, r0, r3
 	mla r8, r0, r2, r8
-	ldr r2, [sl, #0xc]
-	ldr r7, [sl, #0x10]
+	ldr r2, [r10, #0xc]
+	ldr r7, [r10, #0x10]
 	mla r8, r2, r3, r8
 	adds sb, r7, sb
-	ldr r3, [sl, #0x14]
+	ldr r3, [r10, #0x14]
 	umull ip, r11, r0, sb
 	adc r8, r3, r8
-	str sb, [sl]
+	str sb, [r10]
 	mla r11, r0, r8, r11
-	str r8, [sl, #4]
+	str r8, [r10, #4]
 	tst r8, #0x80000000
 	beq _0214775c
 	mla r11, r2, sb, r11
@@ -47337,7 +47337,7 @@ _021476d0:
 	mov r1, r1, lsl #0x8
 	add r1, r1, #0x400
 	smull r2, r1, r5, r1
-	stmia sl, {r0, r3}
+	stmia r10, {r0, r3}
 	adds r2, r2, #0x800
 	adc r0, r1, #0
 	mov r1, r2, lsr #0xc
@@ -47354,7 +47354,7 @@ _0214775c:
 	mov r1, r1, lsl #0x8
 	add r1, r1, #0x400
 	smull r2, r1, r5, r1
-	stmia sl, {r0, r3}
+	stmia r10, {r0, r3}
 	adds r2, r2, #0x800
 	adc r0, r1, #0
 	mov r1, r2, lsr #0xc
@@ -47409,7 +47409,7 @@ _02147798:
 	mov r0, r0, lsl #0xb
 	add sp, sp, #0x1c
 	str r0, [r4, #0x3f4]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02147858:
 	mov r2, #0x100
 	add r0, r4, #0x3fc
@@ -47424,7 +47424,7 @@ _02147858:
 	bl func_ov15_021529f8
 	cmp r0, #0
 	addeq sp, sp, #0x1c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, [r4, #0x424]
 	cmp r0, #0
 	beq _021478c8
@@ -47438,7 +47438,7 @@ _02147858:
 	bl func_ov15_021529f0
 	cmp r0, #0x1e
 	addlt sp, sp, #0x1c
-	ldmltia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmltia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _021478c8:
 	mov r0, #2
 	ldr r2, _02147bb4 ; =data_027e0764
@@ -47464,7 +47464,7 @@ _021478c8:
 	mov r0, r0, lsl #0xb
 	add sp, sp, #0x1c
 	str r0, [r4, #0x3f4]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0214792c:
 	mov r0, #0
 	str r0, [r4, #0x3f0]
@@ -47481,7 +47481,7 @@ _0214792c:
 	bl func_ov15_02152a0c
 	cmp r0, #0
 	addeq sp, sp, #0x1c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	add r0, sp, #0x10
 	ldr r6, [r4, #0x420]
 	bl func_01ff9cec
@@ -47491,7 +47491,7 @@ _0214792c:
 	add r1, r1, #0xb00
 	cmp r0, r1
 	addge sp, sp, #0x1c
-	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r2, _02147bb4 ; =data_027e0764
 	mov r1, #0
 	ldr r3, [r2]
@@ -47512,7 +47512,7 @@ _0214792c:
 	cmp r6, #3
 	addge sp, sp, #0x1c
 	str r7, [r2, #4]
-	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	mov r1, #1
 	mov r0, r4
 	strb r1, [r4, #0x43c]
@@ -47587,18 +47587,18 @@ _02147acc:
 	str r3, [r2]
 	mov r1, #0x28
 	umull r0, r3, r5, r1
-	mov sl, #0
-	mla r3, r5, sl, r3
-	mov r0, sl
+	mov r10, #0
+	mla r3, r5, r10, r3
+	mov r0, r10
 	mla r3, r0, r1, r3
 	str r5, [r2, #4]
 	add r0, r3, #0x14
 	str r0, [r4, #0x424]
-	str sl, [r4, #0x3fc]
+	str r10, [r4, #0x3fc]
 	ldr r1, [r4, #0x40c]
 	mov r0, #0x1e0
 	umull r5, r3, r1, r0
-	mla r3, r1, sl, r3
+	mla r3, r1, r10, r3
 	mov r1, r1, asr #0x1f
 	mla r3, r1, r0, r3
 	adds r5, r5, #0x800
@@ -47618,8 +47618,8 @@ _02147acc:
 	mov r11, #0x3c
 	stmia r2, {r3, r5}
 	umull r2, r3, r5, r11
-	mla r3, r5, sl, r3
-	mov r2, sl
+	mla r3, r5, r10, r3
+	mov r2, r10
 	mla r3, r2, r11, r3
 	add r2, r3, #0x1e
 	mov r0, r4
@@ -47627,7 +47627,7 @@ _02147acc:
 	str r2, [r4, #0x428]
 	bl func_ov15_02148684
 	add sp, sp, #0x1c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0214761c
 _02147bb0: .word data_027e10a4
@@ -48013,7 +48013,7 @@ _0214812c: .word data_ov15_02186220
 	.global func_ov15_02148130
 	arm_func_start func_ov15_02148130
 func_ov15_02148130: ; 0x02148130
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #4
 	mov r4, r0
 	ldrb r1, [r4, #0x439]
@@ -48137,14 +48137,14 @@ _02148274:
 	adds r5, ip, r5
 	adc lr, r3, sb
 	mov r7, #0xa
-	umull sb, sl, lr, r7
-	mla sl, lr, r6, sl
+	umull sb, r10, lr, r7
+	mla r10, lr, r6, r10
 	mov r0, r6
-	mla sl, r0, r7, sl
+	mla r10, r0, r7, r10
 	umull sb, r7, r2, r5
 	mla r7, r2, lr, r7
 	stmia r8, {r5, lr}
-	cmp sl, #2
+	cmp r10, #2
 	bge _02148358
 	mla r7, r1, r5, r7
 	adds sb, ip, sb
@@ -48171,13 +48171,13 @@ _02148358:
 _02148380:
 	add sp, sp, #4
 	str r0, [r4, #0x428]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 _0214838c:
 	ldr r0, [r4, #0x42c]
 	add r0, r0, #1
 	str r0, [r4, #0x42c]
 	add sp, sp, #4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02148130
 _021483a0: .word data_ov15_0218b588
@@ -50572,7 +50572,7 @@ _0214a3ac: .word data_02050f54
 	.global func_ov15_0214a3b0
 	arm_func_start func_ov15_0214a3b0
 func_ov15_0214a3b0: ; 0x0214a3b0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x80
 	mov r6, r0
 	ldr r2, [r6, #0xe0]
@@ -50596,7 +50596,7 @@ func_ov15_0214a3b0: ; 0x0214a3b0
 	bl func_01fffb4c
 	cmp r0, #0
 	addeq sp, sp, #0x80
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r2, [r6, #0xc]
 	mov r0, #0x800
 	mov r1, r2, asr #0x1f
@@ -50614,10 +50614,10 @@ func_ov15_0214a3b0: ; 0x0214a3b0
 	add r0, r0, r2
 	cmp r1, r0
 	addge sp, sp, #0x80
-	ldmgeia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmgeia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	cmp r2, #0
 	addle sp, sp, #0x80
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r2, [r6, #0xf8]
 	ldr r1, [r6, #0xfc]
 	ldr r0, [r6, #0x100]
@@ -50771,7 +50771,7 @@ _0214a6bc:
 	ldr lr, [sp, #0x74]
 	ldr r3, _0214a86c ; =0x00000333
 	cmp r5, #0x80000
-	umull sl, sb, lr, r3
+	umull r10, sb, lr, r3
 	mov r3, #0
 	mla sb, lr, r3, sb
 	moveq r5, #0
@@ -50780,9 +50780,9 @@ _0214a6bc:
 	ldr r3, _0214a86c ; =0x00000333
 	mov ip, lr, asr #0x1f
 	mla sb, ip, r3, sb
-	adds sl, sl, #0x800
+	adds r10, r10, #0x800
 	adc r3, sb, #0
-	mov sb, sl, lsr #0xc
+	mov sb, r10, lsr #0xc
 	orr sb, sb, r3, lsl #20
 	add r1, sp, #0x74
 	mov r2, r0
@@ -50871,7 +50871,7 @@ _0214a82c:
 	str r2, [sp]
 	bl func_01ffa9fc
 	add sp, sp, #0x80
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0214a3b0
 _0214a858: .word 0x0000ffff
@@ -50885,16 +50885,16 @@ _0214a870: .word data_ov15_0218b704
 	.global func_ov15_0214a874
 	arm_func_start func_ov15_0214a874
 func_ov15_0214a874: ; 0x0214a874
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0xb4
-	mov sl, r0
-	ldr r3, [sl, #0xc]
+	mov r10, r0
+	ldr r3, [r10, #0xc]
 	mov r0, #0x800
 	mov r2, r3, asr #0x1f
 	mov r2, r2, lsl #0xb
 	adds r4, r0, r3, lsl #11
 	orr r2, r2, r3, lsr #21
-	ldrb r0, [sl, #0x1c5]
+	ldrb r0, [r10, #0x1c5]
 	adc r2, r2, #0
 	mov r4, r4, lsr #0xc
 	mov sb, r1
@@ -50924,11 +50924,11 @@ _0214a8e8:
 	ldr r3, [sb, #8]
 	mov r2, r0
 	str r3, [sp, #0xb0]
-	ldr r3, [sl, #0xf8]
+	ldr r3, [r10, #0xf8]
 	str r3, [sp, #0x6c]
-	ldr r3, [sl, #0xfc]
+	ldr r3, [r10, #0xfc]
 	str r3, [sp, #0x70]
-	ldr r3, [sl, #0x100]
+	ldr r3, [r10, #0x100]
 	str r3, [sp, #0x74]
 	bl func_01ff9bf8
 	ldr r1, [sp, #0xac]
@@ -50940,21 +50940,21 @@ _0214a8e8:
 	bl func_01fffb4c
 	cmp r0, #0
 	addeq sp, sp, #0xb4
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	add r0, sp, #0xa8
 	mov r1, r4
 	bl func_01fffbec
 _0214a95c:
 	ldr r2, [sp, #0xac]
 	ldr r0, [sb, #4]
-	ldr r1, [sl, #0xfc]
+	ldr r1, [r10, #0xfc]
 	add r0, r0, r2
 	cmp r1, r0
 	addge sp, sp, #0xb4
-	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	cmp r2, #0
 	addle sp, sp, #0xb4
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r2, [sb]
 	ldr r1, [sb, #4]
 	ldr r0, [sb, #8]
@@ -51026,20 +51026,20 @@ _0214a95c:
 	cmp r0, #6
 	cmpne r0, #5
 	beq _0214aab8
-	ldr r2, [sl, #0xf0]
-	ldr r1, [sl, #0xf4]
-	ldr r0, [sl, #0xec]
+	ldr r2, [r10, #0xf0]
+	ldr r1, [r10, #0xf4]
+	ldr r0, [r10, #0xec]
 	str r0, [sp, #0x90]
 	str r2, [sp, #0x94]
 	str r1, [sp, #0x98]
 _0214aab8:
-	ldr r1, [sl, #0xf8]
+	ldr r1, [r10, #0xf8]
 	add r0, sp, #0x90
 	str r1, [sp, #0x54]
-	ldr r2, [sl, #0xfc]
+	ldr r2, [r10, #0xfc]
 	add r1, sp, #0x54
 	str r2, [sp, #0x58]
-	ldr r3, [sl, #0x100]
+	ldr r3, [r10, #0x100]
 	mov r2, r0
 	str r3, [sp, #0x5c]
 	bl func_01ff9bf8
@@ -51080,7 +51080,7 @@ _0214ab04:
 	orr r4, r4, r2, lsl #20
 	streq r0, [sp, #0x84]
 	beq _0214ab98
-	ldrb r1, [sl, #0x1c5]
+	ldrb r1, [r10, #0x1c5]
 	cmp r1, #0
 	beq _0214ab98
 	bl func_ov15_021520e4
@@ -51315,7 +51315,7 @@ _0214adf4:
 	bl func_01ffa9fc
 	ldr r2, [sb, #4]
 	ldr r1, [sp, #0x7c]
-	ldr r0, [sl, #0xfc]
+	ldr r0, [r10, #0xfc]
 	add r1, r2, r1
 	cmp r1, r0
 	cmpge r1, r4
@@ -51336,7 +51336,7 @@ _0214af2c:
 	str r2, [sp]
 	bl func_01ffa9fc
 	add sp, sp, #0xb4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0214a874
 _0214af58: .word data_027e10a4
@@ -51672,7 +51672,7 @@ _0214b3f4:
 	.global func_ov15_0214b408
 	arm_func_start func_ov15_0214b408
 func_ov15_0214b408: ; 0x0214b408
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x78
 	mov sb, r0
 	ldr r0, _0214b5f4 ; =0x0000019a
@@ -51719,17 +51719,17 @@ func_ov15_0214b408: ; 0x0214b408
 	ldr r1, [sb, #0x108]
 	bl func_01ffa0f4
 	mov r7, #0
-	mov sl, #0x180
+	mov r10, #0x180
 	ldr r4, _0214b5f8 ; =data_02050f54
 	mov r8, r7
-	rsb sl, sl, #0
+	rsb r10, r10, #0
 	add r6, sp, #0x3c
 	add r5, sp, #0x48
 	add r11, sp, #0x18
 _0214b4e0:
 	add r1, r7, #1
 	mul r0, r1, r1
-	mul r1, r0, sl
+	mul r1, r0, r10
 	ldr ip, [sp, #0x54]
 	ldr r3, [sp, #0x58]
 	ldr r2, [sp, #0x5c]
@@ -51797,7 +51797,7 @@ _0214b59c:
 	str r2, [sp, #8]
 	bl func_ov15_0214b600
 	add sp, sp, #0x78
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0214b408
 _0214b5f4: .word 0x0000019a
@@ -55247,21 +55247,21 @@ func_ov15_0214e118: ; 0x0214e118
 	.global func_ov15_0214e138
 	arm_func_start func_ov15_0214e138
 func_ov15_0214e138: ; 0x0214e138
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0xbc
-	mov sl, r0
-	ldr r2, [sl, #0x1a0]
+	mov r10, r0
+	ldr r2, [r10, #0x1a0]
 	ldr r0, [r1]
 	cmp r2, r0
 	bge _0214e16c
 	mov r0, #0
-	str r0, [sl, #0x64]
-	ldr r0, [sl, #0x58]
+	str r0, [r10, #0x64]
+	ldr r0, [r10, #0x58]
 	add sp, sp, #0xbc
-	str r0, [sl, #0x4c]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	str r0, [r10, #0x4c]
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0214e16c:
-	add r0, sl, #0x100
+	add r0, r10, #0x100
 	ldrh r1, [r0, #0x68]
 	ldrh r3, [r0, #0x6a]
 	mov r0, #0
@@ -55294,41 +55294,41 @@ _0214e16c:
 	str r0, [sp, #0xac]
 	str r0, [sp, #0x98]
 	str r0, [sp, #0x94]
-	ldrsh r0, [sl, #0x78]
+	ldrsh r0, [r10, #0x78]
 	add r1, sp, #0x98
 	bl func_0202af4c
-	ldrsh r0, [sl, #0x78]
+	ldrsh r0, [r10, #0x78]
 	add r1, sp, #0x8c
 	bl func_0202af4c
-	ldr r0, [sl, #0x48]
+	ldr r0, [r10, #0x48]
 	add r2, sp, #0x80
 	str r0, [sp, #0x80]
-	ldr r0, [sl, #0x4c]
+	ldr r0, [r10, #0x4c]
 	add r1, sp, #0x98
 	str r0, [sp, #0x84]
-	ldr r0, [sl, #0x50]
+	ldr r0, [r10, #0x50]
 	mov r3, r2
 	str r0, [sp, #0x88]
-	ldr r0, [sl, #0x48]
+	ldr r0, [r10, #0x48]
 	str r0, [sp, #0x74]
-	ldr r0, [sl, #0x4c]
+	ldr r0, [r10, #0x4c]
 	str r0, [sp, #0x78]
-	ldr r0, [sl, #0x50]
+	ldr r0, [r10, #0x50]
 	str r0, [sp, #0x7c]
-	ldr r0, [sl, #0x48]
+	ldr r0, [r10, #0x48]
 	str r0, [sp, #0x68]
-	ldr r0, [sl, #0x4c]
+	ldr r0, [r10, #0x4c]
 	str r0, [sp, #0x6c]
-	ldr r0, [sl, #0x50]
+	ldr r0, [r10, #0x50]
 	str r0, [sp, #0x70]
-	ldr r0, [sl, #0x48]
+	ldr r0, [r10, #0x48]
 	str r0, [sp, #0x5c]
-	ldr r0, [sl, #0x4c]
+	ldr r0, [r10, #0x4c]
 	str r0, [sp, #0x60]
-	ldr r0, [sl, #0x50]
+	ldr r0, [r10, #0x50]
 	str r0, [sp, #0x64]
-	ldr r11, [sl, #0x19c]
-	ldr r4, [sl, #0x198]
+	ldr r11, [r10, #0x19c]
+	ldr r4, [r10, #0x198]
 	mov r0, r11
 	bl func_01ff9e64
 	add r2, sp, #0x74
@@ -55347,18 +55347,18 @@ _0214e16c:
 	rsb r0, r4, #0
 	bl func_01ff9e64
 	add r1, sp, #0x80
-	mov r0, sl
+	mov r0, r10
 	bl func_ov15_0214eabc
 	mov sb, r0
 	add r1, sp, #0x74
-	mov r0, sl
+	mov r0, r10
 	bl func_ov15_0214eabc
 	mov r5, r0
-	mov r0, sl
+	mov r0, r10
 	add r1, sp, #0x68
 	bl func_ov15_0214eabc
 	mov r8, r0
-	mov r0, sl
+	mov r0, r10
 	add r1, sp, #0x5c
 	bl func_ov15_0214eabc
 	mov r6, r0
@@ -55447,24 +55447,24 @@ _0214e3dc:
 	add r1, sp, #0xa4
 	mov r3, r2
 	bl func_01ff9e64
-	ldr r1, [sl, #0x64]
+	ldr r1, [r10, #0x64]
 	ldr r0, [sp, #0x54]
 	add r0, r1, r0
-	str r0, [sl, #0x64]
-	ldr r1, [sl, #0x160]
+	str r0, [r10, #0x64]
+	ldr r1, [r10, #0x160]
 	ldr r0, [sp, #0x58]
 	add r0, r1, r0
-	str r0, [sl, #0x160]
-	ldr r1, [sl, #0x164]
+	str r0, [r10, #0x160]
+	ldr r1, [r10, #0x164]
 	ldr r0, [sp, #0x50]
 	add r0, r1, r0
-	str r0, [sl, #0x164]
+	str r0, [r10, #0x164]
 	mov r0, #0
-	str r0, [sl, #0x60]
-	str r0, [sl, #0x68]
-	ldrh r0, [sl, #0x78]
-	ldr r7, [sl, #0x160]
-	ldr r3, [sl, #0x60]
+	str r0, [r10, #0x60]
+	str r0, [r10, #0x68]
+	ldrh r0, [r10, #0x78]
+	ldr r7, [r10, #0x160]
+	ldr r3, [r10, #0x60]
 	mov r0, r0, asr #0x4
 	mov r2, r0, lsl #0x1
 	ldr r0, _0214eaac ; =data_02050f54
@@ -55481,17 +55481,17 @@ _0214e3dc:
 	mov r2, r2, lsr #0xc
 	orr r2, r2, r1, lsl #20
 	add r1, r3, r2
-	str r1, [sl, #0x60]
+	str r1, [r10, #0x60]
 	adds r1, r7, #0x800
 	adc r0, r0, #0
 	mov r1, r1, lsr #0xc
 	orr r1, r1, r0, lsl #20
-	ldr r0, [sl, #0x68]
+	ldr r0, [r10, #0x68]
 	add r0, r0, r1
-	str r0, [sl, #0x68]
-	ldrsh r1, [sl, #0x78]
-	ldr r0, [sl, #0x164]
-	ldr r7, [sl, #0x60]
+	str r0, [r10, #0x68]
+	ldrsh r1, [r10, #0x78]
+	ldr r0, [r10, #0x164]
+	ldr r7, [r10, #0x60]
 	add r1, r1, #0x4000
 	mov r1, r1, lsl #0x10
 	mov r1, r1, asr #0x10
@@ -55509,11 +55509,11 @@ _0214e3dc:
 	mov r1, r1, lsr #0xc
 	orr r1, r1, r2, lsl #20
 	add r1, r7, r1
-	str r1, [sl, #0x60]
+	str r1, [r10, #0x60]
 	add r1, ip, #1
 	mov r2, r1, lsl #0x1
 	ldr r1, _0214eaac ; =data_02050f54
-	ldr ip, [sl, #0x68]
+	ldr ip, [r10, #0x68]
 	ldrsh r3, [r1, r2]
 	mov r1, r11, lsl #0x1
 	umull r11, r7, r3, r0
@@ -55527,7 +55527,7 @@ _0214e3dc:
 	mov r2, r2, lsr #0xc
 	orr r2, r2, r0, lsl #20
 	add r0, ip, r2
-	str r0, [sl, #0x68]
+	str r0, [r10, #0x68]
 	ldr r0, _0214eab0 ; =data_ov15_0218bd58
 	ldr r2, [r0]
 	ldr r0, [sp, #0x10]
@@ -55543,7 +55543,7 @@ _0214e3dc:
 	mov r1, r4, lsl #0x1
 	ldr r4, [r2, #0xc]
 	ldr r2, [sp, #0xc]
-	add r3, sl, #0x100
+	add r3, r10, #0x100
 	smull r7, r4, r2, r4
 	adds r7, r7, #0x800
 	adc r2, r4, #0
@@ -55553,7 +55553,7 @@ _0214e3dc:
 	mov r0, r7, lsr #0xc
 	orr r0, r0, r2, lsl #20
 	bl Divide
-	add r1, sl, #0x100
+	add r1, r10, #0x100
 	ldrsh r3, [r1, #0x6e]
 	ldr r2, _0214eab4 ; =0xffffc71c
 	add r0, r3, r0
@@ -55574,7 +55574,7 @@ _0214e3dc:
 	cmp r3, r0
 	strgth r0, [r1, #0x6a]
 _0214e63c:
-	add r1, sl, #0x100
+	add r1, r10, #0x100
 	ldrsh r3, [r1, #0x68]
 	ldr r2, _0214eab4 ; =0xffffc71c
 	cmp r3, r2
@@ -55584,91 +55584,91 @@ _0214e63c:
 	cmp r3, r0
 	strgth r0, [r1, #0x68]
 _0214e660:
-	add r4, sl, #0x48
+	add r4, r10, #0x48
 	add r3, sp, #0x44
 	ldmia r4, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
-	ldr r0, [sl, #0x8c]
+	ldr r0, [r10, #0x8c]
 	add r1, sp, #0x34
 	str r0, [sp, #0x34]
-	ldr r2, [sl, #0x90]
+	ldr r2, [r10, #0x90]
 	mov r0, r4
 	str r2, [sp, #0x38]
-	ldr r3, [sl, #0x94]
+	ldr r3, [r10, #0x94]
 	mov r2, r1
 	str r3, [sp, #0x3c]
-	ldr r3, [sl, #0x98]
+	ldr r3, [r10, #0x98]
 	str r3, [sp, #0x40]
 	bl func_01ff9bc4
 	add r1, sp, #0x34
 	add r2, sp, #0x28
-	add r0, sl, #0x60
+	add r0, r10, #0x60
 	bl func_01ff9bc4
-	ldrb r0, [sl, #0x1a8]
+	ldrb r0, [r10, #0x1a8]
 	cmp r0, #4
 	beq _0214e6e4
-	add r0, sl, #0x170
-	add r1, sl, #8
+	add r0, r10, #0x170
+	add r1, r10, #8
 	bl func_ov00_020ccf0c
 	cmp r0, #0
 	beq _0214e6e4
 	add r2, sp, #0x28
-	add r1, sl, #0x170
+	add r1, r10, #0x170
 	mov r3, r2
 	mov r0, #0xc00
 	bl func_01ff9e64
 _0214e6e4:
-	mov r0, sl
+	mov r0, r10
 	mov r1, #0
 	bl func_01fffd04
-	ldrb r0, [sl, #0x110]
+	ldrb r0, [r10, #0x110]
 	cmp r0, #0
-	ldreqb r0, [sl, #0x112]
+	ldreqb r0, [r10, #0x112]
 	cmpeq r0, #0
-	ldreqb r0, [sl, #0x113]
+	ldreqb r0, [r10, #0x113]
 	cmpeq r0, #0
 	beq _0214e728
-	ldr r0, [sl, #0xb8]
+	ldr r0, [r10, #0xb8]
 	str r0, [sp, #0x28]
-	ldr r0, [sl, #0xbc]
+	ldr r0, [r10, #0xbc]
 	str r0, [sp, #0x2c]
-	ldr r0, [sl, #0xc0]
+	ldr r0, [r10, #0xc0]
 	str r0, [sp, #0x30]
 	b _0214e738
 _0214e728:
-	ldrb r0, [sl, #0x111]
+	ldrb r0, [r10, #0x111]
 	cmp r0, #0
-	ldrne r0, [sl, #0xbc]
+	ldrne r0, [r10, #0xbc]
 	strne r0, [sp, #0x2c]
 _0214e738:
 	ldr r0, [sp, #0x28]
 	add r7, sp, #0x14
-	str r0, [sl, #0x48]
+	str r0, [r10, #0x48]
 	ldr r0, [sp, #0x2c]
 	mvn r4, #0
-	str r0, [sl, #0x4c]
+	str r0, [r10, #0x4c]
 	ldr r1, [sp, #0x30]
 	ldr r0, _0214eab8 ; =data_027e0ff8
-	str r1, [sl, #0x50]
-	ldr r2, [sl, #0x4c]
-	ldr r1, [sl, #0x184]
+	str r1, [r10, #0x50]
+	ldr r2, [r10, #0x4c]
+	ldr r1, [r10, #0x184]
 	add r3, sp, #0x44
 	sub r1, r2, r1
-	str r1, [sl, #0x4c]
-	ldr r2, [sl, #0x188]
-	add r1, sl, #8
+	str r1, [r10, #0x4c]
+	ldr r2, [r10, #0x188]
+	add r1, r10, #8
 	str r2, [sp, #0x14]
-	ldr r11, [sl, #0x18c]
-	add r2, sl, #0x48
+	ldr r11, [r10, #0x18c]
+	add r2, r10, #0x48
 	str r11, [sp, #0x18]
-	ldr r11, [sl, #0x190]
+	ldr r11, [r10, #0x190]
 	str r11, [sp, #0x1c]
-	ldr ip, [sl, #0x194]
+	ldr ip, [r10, #0x194]
 	mov r11, ip, lsl #0x1
 	str ip, [sp, #0x20]
 	str r11, [sp, #0x24]
 	str r7, [sp]
-	ldrb r7, [sl, #0x1a8]
+	ldrb r7, [r10, #0x1a8]
 	str r7, [sp, #4]
 	str r4, [sp, #8]
 	ldr r0, [r0]
@@ -55699,7 +55699,7 @@ _0214e738:
 	mov r0, #0x800
 	adds r0, r0, r5, lsl #9
 	orr r4, r4, r5, lsr #23
-	add r5, sl, #0x100
+	add r5, r10, #0x100
 	mov r6, r0, lsr #0xc
 	adc r4, r4, #0
 	ldrsh r0, [r5, #0x6c]
@@ -55738,7 +55738,7 @@ _0214e890:
 	mov r0, #0x800
 	adds r0, r0, r5, lsl #9
 	orr r4, r4, r5, lsr #23
-	add r5, sl, #0x100
+	add r5, r10, #0x100
 	mov r6, r0, lsr #0xc
 	adc r4, r4, #0
 	ldrsh r0, [r5, #0x6e]
@@ -55776,7 +55776,7 @@ _0214e924:
 	orr r4, r4, r1, lsr #23
 	adc r0, r4, #0
 	mov r5, r5, lsr #0xc
-	ldr r6, [sl, #0x64]
+	ldr r6, [r10, #0x64]
 	orr r5, r5, r0, lsl #20
 	cmp r6, #0
 	mov r0, r5, asr #0x1f
@@ -55800,7 +55800,7 @@ _0214e980:
 	orr r0, r0, r1, lsl #20
 	sub r0, r6, r0
 _0214e99c:
-	str r0, [sl, #0x64]
+	str r0, [r10, #0x64]
 	mov r0, r2, asr #0x1f
 	mov r1, r0, lsl #0x6
 	mov r0, #0x800
@@ -55808,7 +55808,7 @@ _0214e99c:
 	orr r1, r1, r2, lsr #26
 	adc r0, r1, #0
 	mov r5, r4, lsr #0xc
-	ldr r6, [sl, #0x160]
+	ldr r6, [r10, #0x160]
 	orr r5, r5, r0, lsl #20
 	cmp r6, #0
 	mov r0, r5, asr #0x1f
@@ -55832,7 +55832,7 @@ _0214e9f8:
 	orr r0, r0, r1, lsl #20
 	sub r0, r6, r0
 _0214ea14:
-	str r0, [sl, #0x160]
+	str r0, [r10, #0x160]
 	add r0, r2, r3
 	add r0, r0, r0, lsr #31
 	mov r1, r0, asr #0x1
@@ -55843,7 +55843,7 @@ _0214ea14:
 	orr r2, r2, r1, lsr #23
 	adc r0, r2, #0
 	mov r3, r3, lsr #0xc
-	ldr r4, [sl, #0x164]
+	ldr r4, [r10, #0x164]
 	orr r3, r3, r0, lsl #20
 	cmp r4, #0
 	mov r0, r3, asr #0x1f
@@ -55858,8 +55858,8 @@ _0214ea14:
 	orr r0, r0, r2, lsl #20
 	add r0, r4, r0
 	add sp, sp, #0xbc
-	str r0, [sl, #0x164]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	str r0, [r10, #0x164]
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0214ea84:
 	umull r2, r1, r4, r3
 	mla r1, r4, r0, r1
@@ -55868,9 +55868,9 @@ _0214ea84:
 	mov r0, r2, lsr #0xc
 	orr r0, r0, r1, lsl #20
 	sub r0, r4, r0
-	str r0, [sl, #0x164]
+	str r0, [r10, #0x164]
 	add sp, sp, #0xbc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0214e138
 _0214eaac: .word data_02050f54
@@ -56213,7 +56213,7 @@ func_ov15_0214eedc: ; 0x0214eedc
 	.global func_ov15_0214ef04
 	arm_func_start func_ov15_0214ef04
 func_ov15_0214ef04: ; 0x0214ef04
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #0x48
 	ldr r1, _0214f10c ; =data_027e0f74
 	mov r7, r0
@@ -56223,7 +56223,7 @@ func_ov15_0214ef04: ; 0x0214ef04
 	cmp r0, #0
 	addne sp, sp, #0x48
 	movne r0, #0
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	ldr r0, _0214f110 ; =data_027e0ff0
 	ldrh r1, [r7, #0x20]
 	ldr r0, [r0]
@@ -56239,7 +56239,7 @@ func_ov15_0214ef04: ; 0x0214ef04
 	cmp r5, #0
 	ble _0214f058
 	mov r6, r4
-	add sl, sp, #0x30
+	add r10, sp, #0x30
 	add sb, sp, #0x3c
 	mov r8, #0x24
 _0214ef78:
@@ -56283,9 +56283,9 @@ _0214efcc:
 	str r2, [sp, #0x34]
 	str r1, [sp, #0x38]
 _0214f010:
-	mov r0, sl
+	mov r0, r10
 	mov r1, sb
-	mov r2, sl
+	mov r2, r10
 	bl func_01ff9bf8
 	ldr r0, [sp, #0x30]
 	ldr r1, [sp, #0x38]
@@ -56293,7 +56293,7 @@ _0214f010:
 	add r1, r7, r4, lsl #1
 	add r1, r1, #0x100
 	strh r0, [r1, #0x64]
-	mov r0, sl
+	mov r0, r10
 	bl func_01ff9cec
 	add r1, r7, r4, lsl #2
 	add r4, r4, #1
@@ -56348,7 +56348,7 @@ _0214f0d0:
 	strb r2, [r7, #0x20c]
 	str r2, [r7, #0x1a0]
 	add sp, sp, #0x48
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0214ef04
 _0214f10c: .word data_027e0f74
@@ -56802,7 +56802,7 @@ func_ov15_0214f754: ; 0x0214f754
 	.global func_ov15_0214f768
 	arm_func_start func_ov15_0214f768
 func_ov15_0214f768: ; 0x0214f768
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x4c
 	ldr r1, _0214f9c8 ; =data_027e0f94
 	mov sb, r0
@@ -56823,14 +56823,14 @@ func_ov15_0214f768: ; 0x0214f768
 	ldr r8, [sp]
 	cmp r5, #0
 	ble _0214f81c
-	mov sl, r8
+	mov r10, r8
 	add r4, sp, #0x28
 _0214f7c4:
 	ldr r1, [sb, #0x158]
 	mov r0, r7
 	ldr r2, [r1, #4]
 	add r1, sp, #0x34
-	add r2, r2, sl
+	add r2, r2, r10
 	ldr r11, [r2, #0xc]
 	ldmib r2, {r3, ip}
 	mov r2, r4
@@ -56846,13 +56846,13 @@ _0214f7c4:
 	add r8, r8, #1
 	movlt r6, r0
 	cmp r8, r5
-	add sl, sl, #0x24
+	add r10, r10, #0x24
 	blt _0214f7c4
 _0214f81c:
 	cmp r5, #0
 	mov r8, #0
 	ble _0214f92c
-	ldr sl, _0214f9cc ; =data_02050f54
+	ldr r10, _0214f9cc ; =data_02050f54
 	mov r7, r8
 	add r11, sp, #0x28
 _0214f834:
@@ -56885,7 +56885,7 @@ _0214f834:
 	mov r1, r4, asr #0x4
 	mov r2, r1, lsl #0x1
 	mov r1, r2, lsl #0x1
-	add r2, sl, r2, lsl #1
+	add r2, r10, r2, lsl #1
 	ldrsh lr, [r2, #2]
 	mov ip, r0, asr #0x1f
 	smull r3, r2, lr, r0
@@ -56898,7 +56898,7 @@ _0214f834:
 	ldr r2, [r2, #0x178]
 	cmp r3, r2
 	bge _0214f91c
-	ldrsh r2, [sl, r1]
+	ldrsh r2, [r10, r1]
 	umull lr, r3, r2, r0
 	mla r3, r2, ip, r3
 	mov r1, r2, asr #0x1f
@@ -56960,7 +56960,7 @@ _0214f99c:
 _0214f9bc:
 	ldr r0, [sp]
 	add sp, sp, #0x4c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0214f768
 _0214f9c8: .word data_027e0f94
@@ -56970,7 +56970,7 @@ _0214f9d0: .word data_027e0ff0
 	.global func_ov15_0214f9d4
 	arm_func_start func_ov15_0214f9d4
 func_ov15_0214f9d4: ; 0x0214f9d4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x60
 	ldr r1, _0214fbdc ; =data_027e0f74
 	str r0, [sp]
@@ -56979,7 +56979,7 @@ func_ov15_0214f9d4: ; 0x0214f9d4
 	bl func_ov00_02097760
 	cmp r0, #0
 	addeq sp, sp, #0x60
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, [sp]
 	add r0, r0, #0x100
 	str r0, [sp, #8]
@@ -56987,7 +56987,7 @@ func_ov15_0214f9d4: ; 0x0214f9d4
 	ldrsb r0, [r0, #0xa4]
 	cmp r1, r0
 	addeq sp, sp, #0x60
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, _0214fbe4 ; =data_027e10a4
 	ldr r1, _0214fbe8 ; =data_027e0f94
 	ldr r3, [r0]
@@ -57006,16 +57006,16 @@ func_ov15_0214f9d4: ; 0x0214f9d4
 	str r0, [sp, #4]
 	cmp r0, #0
 	addle sp, sp, #0x60
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, [sp]
-	mov sl, r8
+	mov r10, r8
 	add r0, r0, #0xa5
 	add r4, r0, #0x100
 	add r11, sp, #0x3c
 	add r6, sp, #0x54
 _0214fa80:
 	ldr r0, [r7, #4]
-	add r2, r0, sl
+	add r2, r0, r10
 	ldrsb sb, [r2, #0x10]
 	cmp sb, #0
 	blt _0214fbb8
@@ -57092,17 +57092,17 @@ _0214fb98:
 	mov r1, #0
 	strb r1, [r0, #0x1a5]
 	add sp, sp, #0x60
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0214fbb8:
 	add r0, r8, #1
 	mov r1, r0, lsl #0x18
 	ldr r0, [sp, #4]
-	add sl, sl, #0x24
+	add r10, r10, #0x24
 	cmp r0, r1, asr #24
 	mov r8, r1, asr #0x18
 	bgt _0214fa80
 	add sp, sp, #0x60
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0214f9d4
 _0214fbdc: .word data_027e0f74
@@ -57548,11 +57548,11 @@ _021501a8: .word data_027e0f6c
 	.global func_ov15_021501ac
 	arm_func_start func_ov15_021501ac
 func_ov15_021501ac: ; 0x021501ac
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x8c
 	ldr r1, _02150848 ; =data_027e0dbc
 	add r6, sp, #0x7c
-	mov sl, r0
+	mov r10, r0
 	ldmia r1, {r0, r1, r2, r3}
 	stmia r6, {r0, r1, r2, r3}
 	ldr r5, _0215084c ; =data_027e0dcc
@@ -57585,64 +57585,64 @@ _02150220:
 	strhsb r1, [r0, #0x29]
 _02150234:
 	mov r0, #0
-	str r0, [sl, #0x4c]
-	ldr r1, [sl, #0x48]
+	str r0, [r10, #0x4c]
+	ldr r1, [r10, #0x48]
 	mov r2, #0xc00
-	str r1, [sl, #0x54]
-	ldr r1, [sl, #0x4c]
+	str r1, [r10, #0x54]
+	ldr r1, [r10, #0x4c]
 	mov r7, #0x1800
-	str r1, [sl, #0x58]
-	ldr r4, [sl, #0x50]
+	str r1, [r10, #0x58]
+	ldr r4, [r10, #0x50]
 	mov r1, #0x800
-	str r4, [sl, #0x5c]
-	strb r0, [sl, #0x29d]
-	str r2, [sl, #0x198]
-	str r1, [sl, #0x19c]
-	str r7, [sl, #0x184]
+	str r4, [r10, #0x5c]
+	strb r0, [r10, #0x29d]
+	str r2, [r10, #0x198]
+	str r1, [r10, #0x19c]
+	str r7, [r10, #0x184]
 	mov r1, #0x10
-	str r1, [sl, #0x6c]
-	str r0, [sl, #0x7c]
-	str r7, [sl, #0x80]
-	str r0, [sl, #0x84]
-	str r7, [sl, #0x88]
-	str r0, [sl, #0x8c]
-	str r7, [sl, #0x90]
-	str r0, [sl, #0x94]
-	str r7, [sl, #0x98]
-	ldr r1, [sl, #0x8c]
+	str r1, [r10, #0x6c]
+	str r0, [r10, #0x7c]
+	str r7, [r10, #0x80]
+	str r0, [r10, #0x84]
+	str r7, [r10, #0x88]
+	str r0, [r10, #0x8c]
+	str r7, [r10, #0x90]
+	str r0, [r10, #0x94]
+	str r7, [r10, #0x98]
+	ldr r1, [r10, #0x8c]
 	mov r5, #0x2800
-	str r1, [sl, #0x188]
-	ldr r1, [sl, #0x90]
+	str r1, [r10, #0x188]
+	ldr r1, [r10, #0x90]
 	mov r4, #2
-	str r1, [sl, #0x18c]
-	ldr r2, [sl, #0x94]
+	str r1, [r10, #0x18c]
+	ldr r2, [r10, #0x94]
 	mov r3, #5
-	str r2, [sl, #0x190]
-	ldr r6, [sl, #0x98]
-	add r1, sl, #0x100
-	str r6, [sl, #0x194]
-	str r0, [sl, #0xa8]
-	str r7, [sl, #0xac]
-	str r0, [sl, #0xb0]
-	str r5, [sl, #0xb4]
-	strh r4, [sl, #0x9c]
+	str r2, [r10, #0x190]
+	ldr r6, [r10, #0x98]
+	add r1, r10, #0x100
+	str r6, [r10, #0x194]
+	str r0, [r10, #0xa8]
+	str r7, [r10, #0xac]
+	str r0, [r10, #0xb0]
+	str r5, [r10, #0xb4]
+	strh r4, [r10, #0x9c]
 	strh r3, [r1, #0x20]
 	ldr r2, _02150854 ; =0x00000999
-	strb r0, [sl, #0x124]
-	str r2, [sl, #0x158]
+	strb r0, [r10, #0x124]
+	str r2, [r10, #0x158]
 	rsb r2, r3, #0x338
-	str r2, [sl, #0x15c]
+	str r2, [r10, #0x15c]
 	strh r0, [r1, #0x68]
 	strh r0, [r1, #0x6a]
 	strh r0, [r1, #0x6e]
 	strh r0, [r1, #0x6c]
-	str r0, [sl, #0x164]
-	str r0, [sl, #0x160]
-	ldr r2, [sl, #0x4c]
-	ldr r1, [sl, #0x184]
+	str r0, [r10, #0x164]
+	str r0, [r10, #0x160]
+	ldr r2, [r10, #0x4c]
+	ldr r1, [r10, #0x184]
 	ldr r0, _02150850 ; =data_027e0fe4
 	add r1, r2, r1
-	str r1, [sl, #0x1a0]
+	str r1, [r10, #0x1a0]
 	ldr r1, [r0]
 	ldr r0, _02150858 ; =data_027e0e60
 	ldrb r6, [r1, #0x28]
@@ -57650,7 +57650,7 @@ _02150234:
 	bl func_ov00_02082d40
 	strb r0, [sp, #8]
 	and r0, r0, #0xff
-	strb r0, [sl, #0x29c]
+	strb r0, [r10, #0x29c]
 	cmp r6, #0xff
 	beq _0215035c
 	ldr r0, _02150850 ; =data_027e0fe4
@@ -57673,11 +57673,11 @@ _0215036c:
 	stmia r4, {r0, r1, r2}
 	beq _02150714
 	ldr r0, [sp, #0x64]
-	str r0, [sl, #0x48]
+	str r0, [r10, #0x48]
 	ldr r0, [sp, #0x68]
-	str r0, [sl, #0x4c]
+	str r0, [r10, #0x4c]
 	ldr r0, [sp, #0x6c]
-	str r0, [sl, #0x50]
+	str r0, [r10, #0x50]
 	ldrb r0, [sp, #8]
 	cmp r6, r0
 	beq _0215072c
@@ -57686,9 +57686,9 @@ _0215036c:
 	cmp r0, #0
 	addne sp, sp, #0x8c
 	movne r0, #0
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	add r1, sp, #8
-	mov r0, sl
+	mov r0, r10
 	bl func_ov15_02151208
 	ldr r1, _0215085c ; =data_027e0ff0
 	mov r4, r0
@@ -57725,7 +57725,7 @@ _02150408:
 	add sp, sp, #0x8c
 	strb r2, [r1, #0x28]
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02150460:
 	ldr r0, _02150868 ; =data_027e0f94
 	add r3, sp, #0x48
@@ -57817,7 +57817,7 @@ _02150578:
 	cmp r0, r1
 	bne _021506e0
 	add r1, sp, #9
-	add r0, sl, #0x1b0
+	add r0, r10, #0x1b0
 	bl func_ov00_020c6940
 	add r0, sp, #0x48
 	add r1, sp, #0x64
@@ -57841,13 +57841,13 @@ _021505f4:
 	mov r0, #0x1e
 	ldr r3, [r4, #4]
 	mul r0, r2, r0
-	str r3, [sl, #0x48]
+	str r3, [r10, #0x48]
 	ldr r2, [r4, #8]
 	add r0, r0, #1
-	str r2, [sl, #0x4c]
+	str r2, [r10, #0x4c]
 	ldr r2, [r4, #0xc]
 	cmp r0, #0
-	str r2, [sl, #0x50]
+	str r2, [r10, #0x50]
 	movle r5, #0
 	ble _02150674
 	ldr r2, _0215086c ; =data_027e0764
@@ -57882,22 +57882,22 @@ _02150674:
 	bne _021506c4
 	cmp r6, #1
 	cmpne r6, #3
-	ldr r0, [sl, #0x50]
+	ldr r0, [r10, #0x50]
 	bne _021506b8
 	sub r0, r0, r1
-	str r0, [sl, #0x50]
+	str r0, [r10, #0x50]
 	b _02150734
 _021506b8:
 	add r0, r0, r1
-	str r0, [sl, #0x50]
+	str r0, [r10, #0x50]
 	b _02150734
 _021506c4:
-	ldr r0, [sl, #0x48]
+	ldr r0, [r10, #0x48]
 	cmp r6, #1
 	subls r0, r0, r1
-	strls r0, [sl, #0x48]
+	strls r0, [r10, #0x48]
 	addhi r0, r0, r1
-	strhi r0, [sl, #0x48]
+	strhi r0, [r10, #0x48]
 	b _02150734
 _021506e0:
 	add r0, r5, #1
@@ -57912,25 +57912,25 @@ _021506e0:
 	add sp, sp, #0x8c
 	strb r2, [r1, #0x28]
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02150714:
-	ldr r0, [sl, #0x48]
+	ldr r0, [r10, #0x48]
 	str r0, [r5, #0x1c]
-	ldr r0, [sl, #0x4c]
+	ldr r0, [r10, #0x4c]
 	str r0, [r5, #0x20]
-	ldr r0, [sl, #0x50]
+	ldr r0, [r10, #0x50]
 	str r0, [r5, #0x24]
 _0215072c:
 	mov r0, #0xa4
-	str r0, [sl, #0x290]
+	str r0, [r10, #0x290]
 _02150734:
-	ldr r1, [sl, #0x48]
+	ldr r1, [r10, #0x48]
 	ldr r0, _02150850 ; =data_027e0fe4
-	str r1, [sl, #0x1c8]
-	ldr r1, [sl, #0x4c]
-	str r1, [sl, #0x1cc]
-	ldr r1, [sl, #0x50]
-	str r1, [sl, #0x1d0]
+	str r1, [r10, #0x1c8]
+	ldr r1, [r10, #0x4c]
+	str r1, [r10, #0x1cc]
+	ldr r1, [r10, #0x50]
+	str r1, [r10, #0x1d0]
 	ldr r0, [r0]
 	ldrb r0, [r0, #0x29]
 	cmp r0, #0
@@ -57941,7 +57941,7 @@ _02150734:
 	add r0, r0, #0x2000
 	bl func_ov00_020c4588
 	mov r1, r0
-	add r0, sl, #0x234
+	add r0, r10, #0x234
 	ldr r2, [r0]
 	ldr r2, [r2, #0xc]
 	blx r2
@@ -57952,35 +57952,35 @@ _0215078c:
 	add r0, r0, #0x2300
 	bl func_ov00_020c4588
 	mov r1, r0
-	add r0, sl, #0x234
+	add r0, r10, #0x234
 	ldr r2, [r0]
 	ldr r2, [r2, #0xc]
 	blx r2
 _021507b0:
 	mov r0, #0x59
-	strh r0, [sl, #0x7a]
-	ldr r1, [sl, #8]
+	strh r0, [r10, #0x7a]
+	ldr r1, [r10, #8]
 	mov r0, #0
-	str r1, [sl, #0x1f8]
-	ldr r2, [sl, #0xc]
+	str r1, [r10, #0x1f8]
+	ldr r2, [r10, #0xc]
 	bic r1, r0, #0x6000
-	str r2, [sl, #0x1fc]
-	strb r0, [sl, #0x22c]
-	ldrh r2, [sl, #0x20]
-	ldr r0, [sl, #0x48]
+	str r2, [r10, #0x1fc]
+	strb r0, [r10, #0x22c]
+	ldrh r2, [r10, #0x20]
+	ldr r0, [r10, #0x48]
 	bic r1, r1, #0x1f
 	str r0, [sp, #0x10]
-	ldr r0, [sl, #0x4c]
+	ldr r0, [r10, #0x4c]
 	orr r3, r1, #7
 	str r0, [sp, #0x14]
-	ldr r1, [sl, #0x50]
+	ldr r1, [r10, #0x50]
 	mov r0, #0x3000
 	str r1, [sp, #0x18]
 	str r0, [sp, #0x1c]
 	str r0, [sp, #0x20]
-	add r0, sl, #0x2cc
+	add r0, r10, #0x2cc
 	str r0, [sp]
-	add r0, sl, #0x2a4
+	add r0, r10, #0x2a4
 	ldr r4, [r0]
 	and r1, r2, #0xff
 	bic r3, r3, #0x3f0000
@@ -57991,10 +57991,10 @@ _021507b0:
 	str r3, [sp, #0xc]
 	blx r4
 	mov r0, #0
-	strb r0, [sl, #0x2a8]
+	strb r0, [r10, #0x2a8]
 	mov r0, #1
 	add sp, sp, #0x8c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_021501ac
 _02150848: .word data_027e0dbc
@@ -59231,14 +59231,14 @@ _021518f0: .word data_027e0764
 	.global func_ov15_021518f4
 	arm_func_start func_ov15_021518f4
 func_ov15_021518f4: ; 0x021518f4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x28
-	mov sl, r0
+	mov r10, r0
 	mov r0, #0
 	str r0, [sp]
 _02151908:
 	ldr r0, [sp]
-	add r0, sl, r0, lsl #2
+	add r0, r10, r0, lsl #2
 	ldr r8, [r0, #0x160]
 	cmp r8, #0
 	beq _02151a2c
@@ -59250,7 +59250,7 @@ _02151908:
 	add r6, sp, #0x1c
 	add r11, sp, #0x10
 _02151938:
-	add r0, sl, r7, lsl #2
+	add r0, r10, r7, lsl #2
 	ldr sb, [r0, #0x160]
 	cmp sb, #0
 	beq _02151a20
@@ -59319,7 +59319,7 @@ _02151a2c:
 	cmp r0, #4
 	blt _02151908
 	add sp, sp, #0x28
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	arm_func_end func_ov15_021518f4
 
 	.global func_ov15_02151a48
@@ -60564,7 +60564,7 @@ _02152a40:
 	.global func_ov15_02152a48
 	arm_func_start func_ov15_02152a48
 func_ov15_02152a48: ; 0x02152a48
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x1ac
 	ldr r1, _02153464 ; =data_027e0fe4
 	mov r5, r0
@@ -60678,7 +60678,7 @@ _02152b98:
 	add r3, r6, #1
 	mov r3, r3, lsl #0x1
 	ldrsh r6, [r11, r3]
-	umull sl, sb, r8, r0
+	umull r10, sb, r8, r0
 	umull ip, r7, r6, r0
 	mov r2, r2, lsl #0x10
 	mov r2, r2, lsr #0x10
@@ -60687,7 +60687,7 @@ _02152b98:
 	add r2, r3, #1
 	mov r2, r2, lsl #0x1
 	ldrsh lr, [r11, r2]
-	adds sl, sl, #0x800
+	adds r10, r10, #0x800
 	mla sb, r8, r1, sb
 	mla r7, r6, r1, r7
 	mov r1, r6, asr #0x1f
@@ -60698,10 +60698,10 @@ _02152b98:
 	mla sb, r11, r0, sb
 	rsb r2, r0, #0x800
 	mla r7, r1, r0, r7
-	mov sl, sl, lsr #0xc
+	mov r10, r10, lsr #0xc
 	adc r8, sb, #0
-	orr sl, sl, r8, lsl #20
-	sub r8, sl, #0x2000
+	orr r10, r10, r8, lsl #20
+	sub r8, r10, #0x2000
 	str r8, [r5, #0x4b8]
 	sub r0, r0, #0x1b4
 	str r0, [r5, #0x4bc]
@@ -60712,8 +60712,8 @@ _02152b98:
 	adc r0, r7, #0
 	mov r1, r1, lsr #0xc
 	orr r1, r1, r0, lsl #20
-	add sl, r1, #0x3800
-	str sl, [r5, #0x4c0]
+	add r10, r1, #0x3800
+	str r10, [r5, #0x4c0]
 	ldr r0, [r5, #0x4bc]
 	mla r8, lr, r11, r8
 	mov r7, lr, asr #0x1f
@@ -60724,7 +60724,7 @@ _02152b98:
 	adc r2, r8, #0
 	mov r7, r7, lsr #0xc
 	orr r7, r7, r2, lsl #20
-	add r2, sl, r7
+	add r2, r10, r7
 	umull r8, r7, ip, r3
 	mla r7, ip, r11, r7
 	mov r0, ip, asr #0x1f
@@ -61235,7 +61235,7 @@ _02153454:
 	mov r0, r5
 	bl func_ov15_021548c4
 	add sp, sp, #0x1ac
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02152a48
 _02153464: .word data_027e0fe4
@@ -61667,7 +61667,7 @@ _02153a5c: .word data_ov15_0218f6c8
 	.global func_ov15_02153a60
 	arm_func_start func_ov15_02153a60
 func_ov15_02153a60: ; 0x02153a60
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0xc0
 	ldr r1, _02153f58 ; =data_027e0fe4
 	mov r5, r0
@@ -61676,7 +61676,7 @@ func_ov15_02153a60: ; 0x02153a60
 	bl _ZN12ActorManager8GetActorEP8ActorRef
 	movs r4, r0
 	addeq sp, sp, #0xc0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	mov r0, r5
 	bl func_ov15_0214325c
 	ldrb r0, [r5, #0x436]
@@ -61710,7 +61710,7 @@ _02153ae4:
 	cmp r1, r0
 	add sp, sp, #0xc0
 	strle r0, [r5, #0x280]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02153b04:
 	ldr r0, _02153f5c ; =data_027e1060
 	bl func_ov15_0217705c
@@ -61906,13 +61906,13 @@ _02153d74:
 	mov r11, #0x3000
 	ldr lr, _02153f88 ; =data_ov15_021863a8
 	ldr r0, [r4, #0x41c]
-	umull sl, sb, r8, r11
+	umull r10, sb, r8, r11
 	ldr r2, [lr, r0, lsl #2]
 	mov r0, #0
 	mla sb, r8, r0, sb
 	mov r7, r8, asr #0x1f
 	mla sb, r7, r11, sb
-	adds r7, sl, #0x800
+	adds r7, r10, #0x800
 	adc r0, sb, #0
 	mov r7, r7, lsr #0xc
 	orr r7, r7, r0, lsl #20
@@ -61995,7 +61995,7 @@ _02153d74:
 	ldrsh r1, [r1, #0x4c]
 	bl func_ov15_0216ea14
 	add sp, sp, #0xc0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02153a60
 _02153f58: .word data_027e0fe4
@@ -65147,7 +65147,7 @@ _02156b00: .word 0x00000285
 	.global func_ov15_02156b04
 	arm_func_start func_ov15_02156b04
 func_ov15_02156b04: ; 0x02156b04
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x38
 	mov r6, r0
 	add r0, r6, #0x200
@@ -65156,7 +65156,7 @@ func_ov15_02156b04: ; 0x02156b04
 	movne r0, #0
 	addne sp, sp, #0x38
 	strne r0, [r6, #0x2e0]
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r1, [r6, #0x2e4]
 	add r0, r6, #0x2e0
 	mov r2, #0xcd
@@ -65183,12 +65183,12 @@ func_ov15_02156b04: ; 0x02156b04
 	ldrsh sb, [r8, sb]
 	mov r3, r3, lsl #0x1
 	ldrsh r8, [r8, r3]
-	smull r3, sl, sb, r4
+	smull r3, r10, sb, r4
 	adds r3, r3, #0x800
 	smull sb, r4, r8, r4
-	adc sl, sl, #0
+	adc r10, r10, #0
 	mov r3, r3, lsr #0xc
-	orr r3, r3, sl, lsl #20
+	orr r3, r3, r10, lsl #20
 	add r7, r7, r3
 	adds r8, sb, #0x800
 	adc r3, r4, #0
@@ -65343,7 +65343,7 @@ _02156d4c:
 	mov r2, r2, lsl #0x1
 	add r5, r7, #1
 	mov r7, r7, lsl #0x1
-	ldrsh sl, [r1, r7]
+	ldrsh r10, [r1, r7]
 	mov r5, r5, lsl #0x1
 	mov r7, r2, lsl #0x1
 	add r2, r2, #1
@@ -65351,7 +65351,7 @@ _02156d4c:
 	ldrsh r5, [r1, r5]
 	ldrsh r7, [r1, r7]
 	ldrsh r1, [r1, r2]
-	mov sb, sl, asr #0x1f
+	mov sb, r10, asr #0x1f
 	mov r8, r5, asr #0x1f
 	mov r2, r7, asr #0x1f
 	mov r11, sb, lsl #0xd
@@ -65359,16 +65359,16 @@ _02156d4c:
 	mov r8, r2, lsl #0xd
 	mov r2, r1, asr #0x1f
 	mov r2, r2, lsl #0xd
-	adds ip, r0, sl, lsl #13
-	orr r11, r11, sl, lsr #19
-	adc sl, r11, #0
+	adds ip, r0, r10, lsl #13
+	orr r11, r11, r10, lsr #19
+	adc r10, r11, #0
 	mov r11, ip, lsr #0xc
-	orr r11, r11, sl, lsl #20
+	orr r11, r11, r10, lsl #20
 	add r4, r4, r11
-	adds sl, r0, r5, lsl #13
+	adds r10, r0, r5, lsl #13
 	orr sb, sb, r5, lsr #19
 	adc r5, sb, #0
-	mov sb, sl, lsr #0xc
+	mov sb, r10, lsr #0xc
 	orr sb, sb, r5, lsl #20
 	add r5, r3, sb
 	adds sb, r0, r7, lsl #13
@@ -65421,7 +65421,7 @@ _02156ed4:
 	mov r2, r2, lsr #0x10
 	mov r2, r2, asr #0x4
 	mov r3, r4, lsl #0x1
-	ldrsh sl, [r0, r3]
+	ldrsh r10, [r0, r3]
 	add r3, r4, #1
 	mov r5, r3, lsl #0x1
 	mov r2, r2, lsl #0x1
@@ -65435,14 +65435,14 @@ _02156ed4:
 	mov ip, r8, lsl #0xe
 	mov r8, r2, asr #0x1f
 	mov r11, r8, lsl #0xe
-	mov r4, sl, asr #0x1f
+	mov r4, r10, asr #0x1f
 	mov r0, r4, lsl #0xc
 	ldr r8, [sp]
 	mov r5, lr, asr #0x1f
 	mov r7, r5, lsl #0xc
 	str r8, [sp, #0x30]
-	adds r8, r1, sl, lsl #12
-	orr r0, r0, sl, lsr #20
+	adds r8, r1, r10, lsl #12
+	orr r0, r0, r10, lsr #20
 	mov r4, r4, lsl #0xe
 	mov r5, r5, lsl #0xe
 	adc r0, r0, #0
@@ -65456,8 +65456,8 @@ _02156ed4:
 	mov r8, r8, lsr #0xc
 	orr r8, r8, r7, lsl #20
 	add r7, sb, r8
-	adds r8, r1, sl, lsl #14
-	orr r4, r4, sl, lsr #18
+	adds r8, r1, r10, lsl #14
+	orr r4, r4, r10, lsr #18
 	adc r4, r4, #0
 	mov r8, r8, lsr #0xc
 	orr r8, r8, r4, lsl #20
@@ -65500,7 +65500,7 @@ _02157038:
 	ldr r0, [sp, #0x10]
 	str r0, [r6, #0x5c]
 	add sp, sp, #0x38
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02156b04
 _02157078: .word data_02050f54
@@ -65511,17 +65511,17 @@ _02157084: .word data_027e0f94
 	.global func_ov15_02157088
 	arm_func_start func_ov15_02157088
 func_ov15_02157088: ; 0x02157088
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x18
-	mov sl, r0
-	add r0, sl, #0x200
+	mov r10, r0
+	add r0, r10, #0x200
 	ldrsh r7, [r0, #0xec]
-	ldr r8, [sl, #0x2e0]
+	ldr r8, [r10, #0x2e0]
 	cmp r7, #0
 	bge _02157114
 	ldrh r1, [r0, #0xee]
 	ldr r3, _02157274 ; =data_02050f54
-	ldr r0, [sl, #0x2c8]
+	ldr r0, [r10, #0x2c8]
 	mov r1, r1, asr #0x4
 	mov r4, r1, lsl #0x1
 	mov r1, r4, lsl #0x1
@@ -65537,19 +65537,19 @@ func_ov15_02157088: ; 0x02157088
 	orr r5, r5, r4, lsl #20
 	add r0, r0, r5
 	adds r1, r3, #0x800
-	str r0, [sl, #0x2c8]
+	str r0, [r10, #0x2c8]
 	adc r0, r2, #0
 	mov r1, r1, lsr #0xc
-	ldr r2, [sl, #0x2d0]
+	ldr r2, [r10, #0x2d0]
 	orr r1, r1, r0, lsl #20
 	add r0, r2, r1
 	add sp, sp, #0x18
-	str r0, [sl, #0x2d0]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	str r0, [r10, #0x2d0]
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02157114:
 	cmp r8, #0
 	addeq sp, sp, #0x18
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	bl func_ov15_0213ce4c
 	mov r1, #0xc
 	ldr r2, [r0, #4]
@@ -65562,10 +65562,10 @@ _02157114:
 	str r1, [sp, #0x10]
 	ldr r3, [r2, #8]
 	add r2, sp, #0
-	add r1, sl, #0x2c8
+	add r1, r10, #0x2c8
 	str r3, [sp, #0x14]
 	bl func_01ff9bf8
-	add r4, sl, #0x200
+	add r4, r10, #0x200
 	add r11, sp, #0xc
 	add r5, sp, #0
 	mov r6, #0
@@ -65575,10 +65575,10 @@ _0215716c:
 	bl func_01ff9cec
 	cmp r0, r8
 	ble _021571ec
-	add r0, sl, #0x200
+	add r0, r10, #0x200
 	ldrh r1, [r0, #0xee]
 	ldr r3, _02157274 ; =data_02050f54
-	ldr r0, [sl, #0x2c8]
+	ldr r0, [r10, #0x2c8]
 	mov r1, r1, asr #0x4
 	mov r4, r1, lsl #0x1
 	mov r1, r4, lsl #0x1
@@ -65594,13 +65594,13 @@ _0215716c:
 	adds r1, r3, #0x800
 	orr r5, r5, r4, lsl #20
 	add r0, r0, r5
-	str r0, [sl, #0x2c8]
+	str r0, [r10, #0x2c8]
 	adc r0, r2, #0
 	mov r1, r1, lsr #0xc
-	ldr r2, [sl, #0x2d0]
+	ldr r2, [r10, #0x2d0]
 	orr r1, r1, r0, lsl #20
 	add r0, r2, r1
-	str r0, [sl, #0x2d0]
+	str r0, [r10, #0x2d0]
 	b _02157264
 _021571ec:
 	sub r1, r7, #1
@@ -65610,11 +65610,11 @@ _021571ec:
 	movs r7, r1, asr #0x10
 	bmi _02157264
 	ldr r0, [sp, #0xc]
-	str r0, [sl, #0x2c8]
+	str r0, [r10, #0x2c8]
 	ldr r0, [sp, #0x10]
-	str r0, [sl, #0x2cc]
+	str r0, [r10, #0x2cc]
 	ldr r0, [sp, #0x14]
-	str r0, [sl, #0x2d0]
+	str r0, [r10, #0x2d0]
 	bl func_ov15_0213ce4c
 	ldr r2, [r0, #4]
 	mov r0, r11
@@ -65622,7 +65622,7 @@ _021571ec:
 	add r3, r2, sb
 	str r1, [sp, #0xc]
 	ldr r2, [r3, #4]
-	add r1, sl, #0x2c8
+	add r1, r10, #0x2c8
 	str r2, [sp, #0x10]
 	ldr r3, [r3, #8]
 	mov r2, r5
@@ -65634,10 +65634,10 @@ _021571ec:
 	strh r0, [r4, #0xee]
 	b _0215716c
 _02157264:
-	add r0, sl, #0x200
+	add r0, r10, #0x200
 	strh r7, [r0, #0xec]
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02157088
 _02157274: .word data_02050f54
@@ -65645,28 +65645,28 @@ _02157274: .word data_02050f54
 	.global func_ov15_02157278
 	arm_func_start func_ov15_02157278
 func_ov15_02157278: ; 0x02157278
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x24
 	ldr r2, [r1]
-	mov sl, r0
-	str r2, [sl, #0x2bc]
+	mov r10, r0
+	str r2, [r10, #0x2bc]
 	ldr r2, [r1, #4]
-	add r0, sl, #0x200
-	str r2, [sl, #0x2c0]
+	add r0, r10, #0x200
+	str r2, [r10, #0x2c0]
 	ldr r1, [r1, #8]
-	str r1, [sl, #0x2c4]
+	str r1, [r10, #0x2c4]
 	ldrsh r7, [r0, #0xec]
 	cmp r7, #0
 	bge _021572d0
 	ldr r0, _02157474 ; =data_027e0f94
 	add sp, sp, #0x24
 	ldr r1, [r0]
-	str r1, [sl, #0x2c8]
+	str r1, [r10, #0x2c8]
 	ldr r1, [r0, #4]
-	str r1, [sl, #0x2cc]
+	str r1, [r10, #0x2cc]
 	ldr r0, [r0, #8]
-	str r0, [sl, #0x2d0]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	str r0, [r10, #0x2d0]
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _021572d0:
 	bne _02157308
 	bl func_ov15_0213ce4c
@@ -65676,14 +65676,14 @@ _021572d0:
 	add sp, sp, #0x24
 	ldr r0, [r2, r1]
 	add r1, r2, r1
-	str r0, [sl, #0x2c8]
+	str r0, [r10, #0x2c8]
 	ldr r0, [r1, #4]
-	str r0, [sl, #0x2cc]
+	str r0, [r10, #0x2cc]
 	ldr r0, [r1, #8]
-	str r0, [sl, #0x2d0]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	str r0, [r10, #0x2d0]
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02157308:
-	add r0, sl, #0x2bc
+	add r0, r10, #0x2bc
 	mov r3, #0xc
 	add r6, sp, #0xc
 	ldmia r0, {r0, r1, r2}
@@ -65727,7 +65727,7 @@ _02157330:
 	ldr r0, [sp, #0x18]
 	ldr r1, [sp, #0x20]
 	bl func_01ffa0f4
-	add r1, sl, #0x200
+	add r1, r10, #0x200
 	strh r0, [r1, #0xee]
 	b _0215744c
 _021573c0:
@@ -65741,7 +65741,7 @@ _021573c0:
 	ldr r0, [sp, #0x18]
 	ldr r1, [sp, #0x20]
 	bl func_01ffa0f4
-	add r1, sl, #0x200
+	add r1, r10, #0x200
 	strh r0, [r1, #0xee]
 	add r0, sp, #0x18
 	mov r1, r0
@@ -65768,15 +65768,15 @@ _021573c0:
 	str r0, [sp, #0x14]
 _0215744c:
 	ldr r1, [sp, #0xc]
-	add r0, sl, #0x200
-	str r1, [sl, #0x2c8]
+	add r0, r10, #0x200
+	str r1, [r10, #0x2c8]
 	ldr r1, [sp, #0x10]
-	str r1, [sl, #0x2cc]
+	str r1, [r10, #0x2cc]
 	ldr r1, [sp, #0x14]
-	str r1, [sl, #0x2d0]
+	str r1, [r10, #0x2d0]
 	strh r7, [r0, #0xec]
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02157278
 _02157474: .word data_027e0f94
@@ -66134,7 +66134,7 @@ func_ov15_02157844: ; 0x02157844
 	.global func_ov15_021578e0
 	arm_func_start func_ov15_021578e0
 func_ov15_021578e0: ; 0x021578e0
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x5c
 	mov r4, r0
 	mov r11, r1
@@ -66176,12 +66176,12 @@ func_ov15_021578e0: ; 0x021578e0
 	cmp r0, r5
 	bge _02157b1c
 	ldr r3, [r4, #0x1e8]
-	ldr sl, [r4, #0x1ec]
+	ldr r10, [r4, #0x1ec]
 	ldr sb, [r4, #0x1e4]
 	ldr r5, _02157c2c ; =data_02050f54
 	str sb, [sp, #0x44]
 	str r3, [sp, #0x48]
-	str sl, [sp, #0x4c]
+	str r10, [sp, #0x4c]
 	ldrh r2, [r4, #0x78]
 	add r8, sp, #0x44
 	add r1, r4, #0x200
@@ -66203,7 +66203,7 @@ func_ov15_021578e0: ; 0x021578e0
 	adc r6, ip, #0
 	mov r7, r7, lsr #0xc
 	orr r7, r7, r6, lsl #20
-	add r6, sl, r7
+	add r6, r10, r7
 	str r6, [r8, #8]
 	str r2, [r8]
 	ldrh r1, [r1, #0x10]
@@ -66345,7 +66345,7 @@ _02157c08:
 	add r2, r4, #0x1d8
 	bl func_ov00_0207a1c8
 	add sp, sp, #0x5c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_021578e0
 _02157c20: .word data_ov15_0218c1d8
@@ -66542,17 +66542,17 @@ _02157e64: .word data_027e0d0c
 	.global func_ov15_02157e68
 	arm_func_start func_ov15_02157e68
 func_ov15_02157e68: ; 0x02157e68
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x5c
-	mov sl, r0
+	mov r10, r0
 	bl _ZN5Actor18func_ov00_020c313cEj
 	cmp r0, #0
 	addeq sp, sp, #0x5c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
-	ldrb r0, [sl, #0x176]
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldrb r0, [r10, #0x176]
 	cmp r0, #0
 	bne _021580c4
-	ldr r0, [sl, #0x170]
+	ldr r0, [r10, #0x170]
 	cmp r0, #0x96
 	bge _02157ed8
 	add r0, sp, #0xc
@@ -66566,33 +66566,33 @@ func_ov15_02157e68: ; 0x02157e68
 	ldreq r0, [sp, #0x58]
 	add sp, sp, #0x5c
 	cmpeq r0, #0
-	ldrne r0, [sl, #0x170]
+	ldrne r0, [r10, #0x170]
 	addne r0, r0, #1
-	strne r0, [sl, #0x170]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	strne r0, [r10, #0x170]
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02157ed8:
 	ldr r0, _021583a4 ; =data_027e10a4
 	ldr r0, [r0]
 	bl func_ov15_0213a54c
 	cmp r0, #0
 	addne sp, sp, #0x5c
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, _021583a8 ; =data_027e0e60
-	ldrh r1, [sl, #0x20]
+	ldrh r1, [r10, #0x20]
 	ldr r0, [r0]
 	mov r2, #0
 	bl func_ov00_020836dc
 	cmp r0, #0
 	addeq sp, sp, #0x5c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
-	add r0, sl, #0x100
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	add r0, r10, #0x100
 	ldrh r1, [r0, #0x74]
 	sub r1, r1, #1
 	strh r1, [r0, #0x74]
 	ldrh r1, [r0, #0x74]
 	cmp r1, #0
 	addne sp, sp, #0x5c
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	mov r1, #0x1e
 	ldr r2, _021583ac ; =data_027e0764
 	strh r1, [r0, #0x74]
@@ -66615,10 +66615,10 @@ _02157ed8:
 	cmp r11, #0xa
 	addge sp, sp, #0x5c
 	str r5, [r2, #4]
-	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	umull r8, r7, r1, r6
 	mla r7, r1, r5, r7
-	ldrh r5, [sl, #0x22]
+	ldrh r5, [r10, #0x22]
 	adds r1, r4, r8
 	mla r7, r0, r6, r7
 	adc r4, r3, r7
@@ -66644,10 +66644,10 @@ _02157ed8:
 	str r1, [sp, #0x34]
 	str r1, [sp, #0x38]
 	bl func_ov00_020c3348
-	ldr r0, [sl, #8]
+	ldr r0, [r10, #8]
 	ldr lr, _021583ac ; =data_027e0764
 	str r0, [sp, #0x34]
-	ldr r2, [sl, #0xc]
+	ldr r2, [r10, #0xc]
 	ldr r1, [lr]
 	str r2, [sp, #0x38]
 	ldr r3, [lr, #8]
@@ -66668,9 +66668,9 @@ _02157ed8:
 	strh r0, [sp, #0x18]
 	cmp sb, #0
 	addle sp, sp, #0x5c
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	mov r7, r6
-	add r8, sl, #0x158
+	add r8, r10, #0x158
 	mvn r11, #0
 _0215806c:
 	add r0, r7, r4, asr #16
@@ -66682,29 +66682,29 @@ _0215806c:
 	add r2, sp, #0x44
 	add r3, sp, #0x18
 	bl func_ov00_020c4048
-	add r0, sl, r6, lsl #3
+	add r0, r10, r6, lsl #3
 	ldr r0, [r0, #0x158]
 	add r6, r6, #1
 	cmp r0, r11
-	ldrneb r0, [sl, #0x176]
+	ldrneb r0, [r10, #0x176]
 	add r7, r7, r5, asr #16
 	add r8, r8, #8
 	addne r0, r0, #1
-	strneb r0, [sl, #0x176]
+	strneb r0, [r10, #0x176]
 	cmp r6, sb
 	blt _0215806c
 	add sp, sp, #0x5c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _021580c4:
 	mov r6, #0
 	mov r7, r6
 	mov r8, r6
-	add sb, sl, #0x158
+	add sb, r10, #0x158
 	add r5, sp, #4
 	mov r11, r6
 	mvn r4, #0
 _021580e0:
-	add r0, sl, r8, lsl #3
+	add r0, r10, r8, lsl #3
 	ldr r0, [r0, #0x158]
 	mov r1, r8, lsl #0x1
 	strh r11, [r5, r1]
@@ -66777,7 +66777,7 @@ _021581ac:
 	ldr r0, _021583bc ; =data_027e0fe4
 	mov r2, r2, lsl #0x10
 	mov r5, r2, lsr #0x10
-	add r2, sl, #0x158
+	add r2, r10, #0x158
 	ldr r0, [r0]
 	add r1, r2, r1, lsl #3
 	bl _ZN12ActorManager8GetActorEP8ActorRef
@@ -66789,7 +66789,7 @@ _021581ac:
 	strb r1, [r0, #0x2f1]
 _0215821c:
 	ldr r0, _021583bc ; =data_027e0fe4
-	add r1, sl, #0x158
+	add r1, r10, #0x158
 	ldr r0, [r0]
 	add r1, r1, r6, lsl #3
 	bl _ZN12ActorManager8GetActorEP8ActorRef
@@ -66802,7 +66802,7 @@ _0215821c:
 	b _02158394
 _0215824c:
 	ldr r4, _021583c4 ; =0xffffaaab
-	add sb, sl, #0x158
+	add sb, r10, #0x158
 	mov r8, #0
 	add r6, sp, #4
 	mvn r5, #0
@@ -66890,10 +66890,10 @@ _02158384:
 	add sb, sb, #8
 	blt _02158260
 _02158394:
-	mov r0, sl
+	mov r0, r10
 	bl func_ov15_0215846c
 	add sp, sp, #0x5c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02157e68
 _021583a4: .word data_027e10a4
@@ -66964,11 +66964,11 @@ _02158468: .word data_027e0fe4
 	.global func_ov15_0215846c
 	arm_func_start func_ov15_0215846c
 func_ov15_0215846c: ; 0x0215846c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	mov r5, r0
 	ldrb r0, [r5, #0x179]
 	cmp r0, #0
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	ldrh r0, [r5, #0x24]
 	mov r4, #0
 	ands r1, r0, #0xff
@@ -66980,13 +66980,13 @@ func_ov15_0215846c: ; 0x0215846c
 	cmp r0, #0
 	beq _021584f8
 	ldr r6, _02158570 ; =data_027e0fe4
-	add sl, r5, #0x158
+	add r10, r5, #0x158
 	mov sb, r4
 	mov r7, r4
 	mov r8, #1
 _021584bc:
 	ldr r0, [r6]
-	mov r1, sl
+	mov r1, r10
 	bl _ZN12ActorManager8GetActorEP8ActorRef
 	cmp r0, #0
 	beq _021584e0
@@ -66997,28 +66997,28 @@ _021584bc:
 _021584e0:
 	add sb, sb, #1
 	cmp sb, #3
-	add sl, sl, #8
+	add r10, r10, #8
 	blt _021584bc
 	strb r4, [r5, #0x179]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _021584f8:
 	ldrh r0, [r5, #0x26]
 	ands r1, r0, #0xff
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	ldr r0, _0215856c ; =data_027e0e60
 	mov r2, #0
 	ldr r0, [r0]
 	bl func_ov00_020836dc
 	cmp r0, #0
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	mov sb, #0
 	ldr r6, _02158570 ; =data_027e0fe4
-	add sl, r5, #0x158
+	add r10, r5, #0x158
 	mov r7, sb
 	mov r8, #1
 _02158530:
 	ldr r0, [r6]
-	mov r1, sl
+	mov r1, r10
 	bl _ZN12ActorManager8GetActorEP8ActorRef
 	cmp r0, #0
 	beq _02158554
@@ -67029,10 +67029,10 @@ _02158530:
 _02158554:
 	add sb, sb, #1
 	cmp sb, #3
-	add sl, sl, #8
+	add r10, r10, #8
 	blt _02158530
 	strb r4, [r5, #0x179]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0215846c
 _0215856c: .word data_027e0e60
@@ -67307,7 +67307,7 @@ _021588e0: .word data_ov15_0218650c
 	.global func_ov15_021588e4
 	arm_func_start func_ov15_021588e4
 func_ov15_021588e4: ; 0x021588e4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #0x24
 	mov r4, r1
 	mov r5, r0
@@ -67347,10 +67347,10 @@ _02158938:
 	umull sb, r8, r7, r6
 	mla r8, r7, r3, r8
 	ldr r3, [r2, #0xc]
-	ldr sl, [r2, #0x10]
+	ldr r10, [r2, #0x10]
 	mla r8, r3, r6, r8
 	ldr r7, [r2, #0x14]
-	adds sb, sl, sb
+	adds sb, r10, sb
 	adc r6, r7, r8
 	str sb, [r2]
 	mov r3, r6, asr #0x1f
@@ -67395,13 +67395,13 @@ _021589f8:
 	mov r0, r0, lsl #0x1
 	mov r3, #0x7000
 	ldrsh r6, [r1, r0]
-	umull r0, sl, sb, r3
+	umull r0, r10, sb, r3
 	adds r1, r0, r2
 	umull r8, r7, r6, r3
-	mla sl, sb, ip, sl
+	mla r10, sb, ip, r10
 	mov r0, sb, asr #0x1f
-	mla sl, r0, r3, sl
-	adc r0, sl, #0
+	mla r10, r0, r3, r10
+	adc r0, r10, #0
 	adds r8, r8, r2
 	mov r1, r1, lsr #0xc
 	mla r7, r6, ip, r7
@@ -67562,7 +67562,7 @@ _02158c9c:
 	str r0, [r5, #0x138]
 	str r4, [r5, #0x130]
 	add sp, sp, #0x24
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov15_021588e4
 _02158cb0: .word data_027e0d0c
@@ -68827,7 +68827,7 @@ _02159e38: .word 0xfffff4cd
 	.global func_ov15_02159e3c
 	arm_func_start func_ov15_02159e3c
 func_ov15_02159e3c: ; 0x02159e3c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #0x3c
 	str r0, [sp]
 	ldrb r0, [r0, #0xa4]
@@ -68876,14 +68876,14 @@ _02159ea0:
 	ldr r2, [sp, #4]
 	adc r4, r3, #0
 	smull r2, r7, r0, r2
-	adds sl, r2, #0x800
+	adds r10, r2, #0x800
 	ldr r2, [sp, #4]
 	mov r5, r5, lsr #0xc
 	smull r3, r8, r6, r2
 	adc r2, r7, #0
 	adds sb, r3, #0x800
 	ldr r6, [sp, #0xc]
-	mov r3, sl, lsr #0xc
+	mov r3, r10, lsr #0xc
 	orr r3, r3, r2, lsl #20
 	orr r5, r5, r4, lsl #20
 	add r3, r5, r3
@@ -68933,14 +68933,14 @@ _02159ea0:
 _02159fd0:
 	ldrsh sb, [r5]
 	ldr r0, [sp]
-	ldr sl, [sp, #0x10]
+	ldr r10, [sp, #0x10]
 	rsb r2, sb, #0
 	mov ip, r2, asr #0x1f
 	str ip, [sp, #0x1c]
 	ldr ip, [sp, #0xc]
 	ldrb r0, [r0, #0x2f3]
 	umull lr, ip, sb, ip
-	mla ip, sb, sl, ip
+	mla ip, sb, r10, ip
 	mov r3, sb, asr #0x1f
 	ldr sb, [sp, #0xc]
 	ldrsh r1, [r5, #4]
@@ -68951,8 +68951,8 @@ _02159fd0:
 	orr lr, lr, r3, lsl #20
 	ldr r3, [sp, #4]
 	str r0, [sp, #0x20]
-	umull sl, r3, r1, r3
-	adds sb, sl, #0x800
+	umull r10, r3, r1, r3
+	adds sb, r10, #0x800
 	mov ip, sb, lsr #0xc
 	ldr sb, [sp, #8]
 	mov r0, r1, asr #0x1f
@@ -68978,13 +68978,13 @@ _02159fd0:
 	mov r2, sb, lsr #0xc
 	orr r2, r2, r3, lsl #20
 	ldr r3, [sp, #0xc]
-	umull sl, sb, r1, r3
+	umull r10, sb, r1, r3
 	ldr r3, [sp, #0x10]
 	mla sb, r1, r3, sb
 	ldr r1, [sp, #0xc]
 	mla sb, r0, r1, sb
 	mov r0, #0x800
-	adds r3, sl, r0
+	adds r3, r10, r0
 	mov r0, #0
 	adc r1, sb, r0
 	ldr r0, [sp, #0x20]
@@ -69037,7 +69037,7 @@ _0215a140:
 	cmp r0, #4
 	blt _02159fd0
 	add sp, sp, #0x3c
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 _0215a16c:
 	ldr r0, [sp]
 	mov r6, #0
@@ -69054,7 +69054,7 @@ _0215a17c:
 	add r5, r5, #0xc
 	blt _0215a17c
 	add sp, sp, #0x3c
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02159e3c
 _0215a1a8: .word data_02050f54
@@ -69306,10 +69306,10 @@ func_ov15_0215a440: ; 0x0215a440
 	.global func_ov15_0215a478
 	arm_func_start func_ov15_0215a478
 func_ov15_0215a478: ; 0x0215a478
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x30
 	ldr r1, _0215a748 ; =data_027e0f74
-	mov sl, r0
+	mov r10, r0
 	ldr r0, [r1]
 	ldr r2, _0215a74c ; =data_027e10a8
 	mov r3, #0
@@ -69319,22 +69319,22 @@ func_ov15_0215a478: ; 0x0215a478
 	cmp r0, #0
 	addne sp, sp, #0x30
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	mvn r0, #0
-	str r0, [sl, #0x98]
-	str r0, [sl, #0x88]
+	str r0, [r10, #0x98]
+	str r0, [r10, #0x88]
 	mov r0, #7
-	str r0, [sl, #0x1bc]
+	str r0, [r10, #0x1bc]
 	mov r0, #2
-	str r0, [sl, #0x1c0]
+	str r0, [r10, #0x1c0]
 	mov r0, #0xa0000
-	str r0, [sl, #0x1c4]
+	str r0, [r10, #0x1c4]
 	mov r3, #0
 	ldr r2, _0215a750 ; =data_ov15_021865c8
-	str r3, [sl, #0x1dc]
+	str r3, [r10, #0x1dc]
 _0215a4e0:
 	ldr r1, [r2, r3, lsl #2]
-	add r0, sl, r3, lsl #2
+	add r0, r10, r3, lsl #2
 	add r3, r3, #1
 	str r1, [r0, #0x1c8]
 	cmp r3, #5
@@ -69343,7 +69343,7 @@ _0215a4e0:
 	mov r3, #0
 _0215a500:
 	ldr r1, [r2, r3, lsl #2]
-	add r0, sl, r3, lsl #2
+	add r0, r10, r3, lsl #2
 	add r3, r3, #1
 	str r1, [r0, #0x1e0]
 	cmp r3, #3
@@ -69354,46 +69354,46 @@ _0215a500:
 	add r0, r0, #0x2400
 	bl func_ov00_020c4588
 	mov r1, r0
-	add r0, sl, #0x158
+	add r0, r10, #0x158
 	ldr r2, [r0]
 	ldr r2, [r2, #0xc]
 	blx r2
-	add r0, sl, #0x158
+	add r0, r10, #0x158
 	bl func_ov15_0215a36c
-	ldrsb r0, [sl, #0x2c]
+	ldrsb r0, [r10, #0x2c]
 	cmp r0, #0
 	addlt sp, sp, #0x30
 	movlt r0, #0
-	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, _0215a75c ; =data_027e0e60
-	ldrh r1, [sl, #0x20]
+	ldrh r1, [r10, #0x20]
 	ldr r0, [r0]
 	add r2, sp, #0x18
 	bl func_ov00_020836bc
-	str r0, [sl, #0x1ec]
+	str r0, [r10, #0x1ec]
 	ldr r2, [sp, #0x24]
 	ldr r1, [sp, #0x18]
 	ldr r0, _0215a760 ; =data_027e0ff0
 	add r1, r2, r1
 	mov r1, r1, asr #0x1
-	str r1, [sl, #0x48]
+	str r1, [r10, #0x48]
 	ldr r2, [sp, #0x2c]
 	ldr r1, [sp, #0x20]
 	mov r8, #0
 	add r1, r2, r1
 	mov r1, r1, asr #0x1
-	str r1, [sl, #0x50]
+	str r1, [r10, #0x50]
 	ldr r0, [r0]
-	ldrb r1, [sl, #0x2c]
+	ldrb r1, [r10, #0x2c]
 	ldr r2, [r0]
 	ldr r0, [r2, r1, lsl #3]
 	add r6, r2, r1, lsl #3
 	ldrb r7, [r0, #1]
-	str r8, [sl, #0x1ec]
+	str r8, [r10, #0x1ec]
 	cmp r7, #0
 	ble _0215a6b0
 	mov sb, r8
-	add r5, sl, #0x1f0
+	add r5, r10, #0x1f0
 	mov r11, #0xc
 	mov r4, #0x24
 _0215a5d8:
@@ -69414,7 +69414,7 @@ _0215a5f8:
 	str ip, [sp, #0x10]
 	ldr r2, [r2, #0xc]
 	str r2, [sp, #0x14]
-	ldr ip, [sl, #0x1ec]
+	ldr ip, [r10, #0x1ec]
 	mul r2, ip, r11
 	str r3, [r5, r2]
 	ldr r3, [sp, #0x10]
@@ -69433,20 +69433,20 @@ _0215a5f8:
 	ldr r2, [r2, #0xc]
 	str r2, [sp, #8]
 	bl func_01ff9ec0
-	ldr r1, [sl, #0x1ec]
-	add r1, sl, r1, lsl #2
+	ldr r1, [r10, #0x1ec]
+	add r1, r10, r1, lsl #2
 	str r0, [r1, #0x214]
-	ldr r0, [sl, #0x1ec]
+	ldr r0, [r10, #0x1ec]
 	add r0, r0, #1
-	str r0, [sl, #0x1ec]
+	str r0, [r10, #0x1ec]
 	b _0215a698
 _0215a680:
-	add r0, sl, #0x48
+	add r0, r10, #0x48
 	add r1, r2, #4
 	bl func_01ff9ec0
 	mov r0, r0, lsl #0x1
-	str r0, [sl, #0x224]
-	str r0, [sl, #0x220]
+	str r0, [r10, #0x224]
+	str r0, [r10, #0x220]
 _0215a698:
 	add r0, r8, #1
 	mov r0, r0, lsl #0x18
@@ -69456,10 +69456,10 @@ _0215a698:
 	bgt _0215a5d8
 _0215a6b0:
 	mov r4, #0
-	str r4, [sl, #0x228]
-	strb r4, [sl, #0x1b4]
-	strb r4, [sl, #0x1b5]
-	ldr r1, [sl, #0x220]
+	str r4, [r10, #0x228]
+	strb r4, [r10, #0x1b4]
+	strb r4, [r10, #0x1b5]
+	ldr r1, [r10, #0x220]
 	mov r0, #0x8f
 	umull r3, r2, r1, r0
 	mla r2, r1, r4, r2
@@ -69477,22 +69477,22 @@ _0215a6b0:
 	orr r1, r1, r0, lsl #20
 	sub r0, r2, r1
 	bl func_01ff9958
-	str r0, [sl, #0x22c]
-	ldr r0, [sl, #0x48]
+	str r0, [r10, #0x22c]
+	ldr r0, [r10, #0x48]
 	mov r1, r4
-	str r0, [sl, #0x54]
-	ldr r2, [sl, #0x4c]
+	str r0, [r10, #0x54]
+	ldr r2, [r10, #0x4c]
 	mov r0, #1
-	str r2, [sl, #0x58]
-	ldr r2, [sl, #0x50]
-	str r2, [sl, #0x5c]
-	strb r1, [sl, #0x236]
-	strb r1, [sl, #0x237]
-	strb r1, [sl, #0x238]
-	strb r1, [sl, #0x239]
-	strb r1, [sl, #0x23a]
+	str r2, [r10, #0x58]
+	ldr r2, [r10, #0x50]
+	str r2, [r10, #0x5c]
+	strb r1, [r10, #0x236]
+	strb r1, [r10, #0x237]
+	strb r1, [r10, #0x238]
+	strb r1, [r10, #0x239]
+	strb r1, [r10, #0x23a]
 	add sp, sp, #0x30
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0215a478
 _0215a748: .word data_027e0f74
@@ -69661,7 +69661,7 @@ func_ov15_0215a95c: ; 0x0215a95c
 	.global func_ov15_0215a970
 	arm_func_start func_ov15_0215a970
 func_ov15_0215a970: ; 0x0215a970
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x40
 	ldr r1, _0215b264 ; =data_027e0f94
 	add r3, sp, #0x34
@@ -69680,7 +69680,7 @@ func_ov15_0215a970: ; 0x0215a970
 	mov r0, r4
 	bl func_ov15_0215b790
 	add sp, sp, #0x40
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0215a9c0:
 	ldr r0, _0215b26c ; =data_027e0e60
 	mov r6, #0
@@ -69755,7 +69755,7 @@ _0215aa5c:
 	cmp r0, #0
 	addne sp, sp, #0x40
 	strneb r3, [r4, #0x238]
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	add r1, sp, #0x10
 	add r2, sp, #0xc
 	mov r0, r4
@@ -69830,7 +69830,7 @@ _0215aba8:
 	bgt _0215abf8
 	mov r0, #3
 	strb r0, [r4, #0x236]
-	mov sl, #0x1000
+	mov r10, #0x1000
 	b _0215ac10
 _0215abf8:
 	sub r0, r1, r0
@@ -69838,13 +69838,13 @@ _0215abf8:
 	bl Divide
 	mov r1, #1
 	strb r1, [r4, #0x236]
-	rsb sl, r0, #0x1000
+	rsb r10, r0, #0x1000
 _0215ac10:
 	mov r0, #0x8e000
 	mov r8, #0
-	umull r2, r1, sl, r0
-	mla r1, sl, r8, r1
-	mov sb, sl, asr #0x1f
+	umull r2, r1, r10, r0
+	mla r1, r10, r8, r1
+	mov sb, r10, asr #0x1f
 	mla r1, sb, r0, r1
 	adds r2, r2, #0x800
 	adc r0, r1, #0
@@ -69861,9 +69861,9 @@ _0215ac50:
 	ldr r2, [r3, r8, lsl #2]
 	add r0, r8, #1
 	sub ip, r2, r6
-	umull r5, lr, sl, ip
+	umull r5, lr, r10, ip
 	mov r2, ip, asr #0x1f
-	mla lr, sl, r2, lr
+	mla lr, r10, r2, lr
 	adds r5, r5, #0x800
 	mla lr, sb, ip, lr
 	adc r2, lr, r11
@@ -69876,22 +69876,22 @@ _0215ac50:
 	cmp r8, #5
 	blo _0215ac50
 	mov r0, #0x9000
-	umull r3, r2, sl, r0
+	umull r3, r2, r10, r0
 	mov r1, #0
-	mla r2, sl, r1, r2
+	mla r2, r10, r1, r2
 	mla r2, sb, r0, r2
 	adds r3, r3, #0x800
 	mov r0, r3, lsr #0xc
 	adc r1, r2, #0
 	orr r0, r0, r1, lsl #20
-	mov r11, sl, lsl #0x2
+	mov r11, r10, lsl #0x2
 	cmp r11, #0x1000
 	movge r11, #0x1000
 	mov ip, #0
 	ldr sb, _0215b284 ; =data_ov15_021865dc
 	ldr r3, _0215b288 ; =data_ov15_021865fc
 	str r0, [sp, #4]
-	mov sl, r11, asr #0x1f
+	mov r10, r11, asr #0x1f
 	add r1, sp, #0x14
 	mov lr, ip
 _0215ace4:
@@ -69902,7 +69902,7 @@ _0215ace4:
 	mov r2, r5, asr #0x1f
 	umull r7, r6, r11, r5
 	mla r6, r11, r2, r6
-	mla r6, sl, r5, r6
+	mla r6, r10, r5, r6
 	adds r5, r7, #0x800
 	adc r2, r6, lr
 	mov r5, r5, lsr #0xc
@@ -70013,9 +70013,9 @@ _0215ae78:
 	bl func_ov00_0209779c
 _0215ae94:
 	mov r0, #0x8e000
-	mov sl, #0
+	mov r10, #0
 	umull r2, r1, r5, r0
-	mla r1, r5, sl, r1
+	mla r1, r5, r10, r1
 	mov sb, r5, asr #0x1f
 	mla r1, sb, r0, r1
 	adds r2, r2, #0x800
@@ -70027,11 +70027,11 @@ _0215ae94:
 	ldr r8, _0215b27c ; =data_ov15_021865c8
 	ldr r1, _0215b280 ; =data_ov15_021865e8
 	add r0, sp, #0x20
-	mov lr, sl
+	mov lr, r10
 _0215aed4:
-	ldr r7, [r8, sl, lsl #2]
-	ldr r2, [r1, sl, lsl #2]
-	add r11, sl, #1
+	ldr r7, [r8, r10, lsl #2]
+	ldr r2, [r1, r10, lsl #2]
+	add r11, r10, #1
 	sub r2, r2, r7
 	umull ip, r3, r5, r2
 	adds r6, ip, #0x800
@@ -70043,9 +70043,9 @@ _0215aed4:
 	orr r6, r6, r2, lsl #20
 	add r2, r7, r6
 	mov r11, r11, lsl #0x10
-	str r2, [r0, sl, lsl #2]
-	mov sl, r11, lsr #0x10
-	cmp sl, #5
+	str r2, [r0, r10, lsl #2]
+	mov r10, r11, lsr #0x10
+	cmp r10, #5
 	blo _0215aed4
 	mov r0, #0x9000
 	umull r3, r2, r5, r0
@@ -70063,7 +70063,7 @@ _0215aed4:
 	ldr sb, _0215b284 ; =data_ov15_021865dc
 	ldr r3, _0215b288 ; =data_ov15_021865fc
 	str r0, [sp, #4]
-	mov sl, r11, asr #0x1f
+	mov r10, r11, asr #0x1f
 	add r1, sp, #0x14
 	mov lr, ip
 _0215af68:
@@ -70074,7 +70074,7 @@ _0215af68:
 	mov r2, r5, asr #0x1f
 	umull r7, r6, r11, r5
 	mla r6, r11, r2, r6
-	mla r6, sl, r5, r6
+	mla r6, r10, r5, r6
 	adds r5, r7, #0x800
 	adc r2, r6, lr
 	mov r5, r5, lsr #0xc
@@ -70103,8 +70103,8 @@ _0215afb4:
 	orr r2, r2, r3, lsl #20
 	bl Approach_thunk
 	tst r0, #1
-	movne sl, #1
-	moveq sl, #0
+	movne r10, #1
+	moveq r10, #0
 	mov sb, #0
 	add r5, r4, #0x1c8
 _0215b004:
@@ -70125,12 +70125,12 @@ _0215b004:
 	mov r2, r11, lsr #0xc
 	orr r2, r2, r3, lsl #20
 	bl Approach_thunk
-	tst sl, r0
+	tst r10, r0
 	add r0, sb, #1
 	mov r0, r0, lsl #0x10
-	movne sl, #1
+	movne r10, #1
 	mov sb, r0, lsr #0x10
-	moveq sl, #0
+	moveq r10, #0
 	cmp sb, #5
 	blo _0215b004
 	mov r0, #0x9000
@@ -70145,9 +70145,9 @@ _0215b004:
 	add r0, r4, #0x1dc
 	orr r2, r2, r3, lsl #20
 	bl Approach_thunk
-	tst sl, r0
-	movne sl, #1
-	moveq sl, #0
+	tst r10, r0
+	movne r10, #1
+	moveq r10, #0
 	mov r7, r8, asr #0x1f
 	mov sb, #0
 	add r5, r4, #0x1e0
@@ -70169,12 +70169,12 @@ _0215b0b0:
 	mov r2, r11, lsr #0xc
 	orr r2, r2, r3, lsl #20
 	bl Approach_thunk
-	tst sl, r0
+	tst r10, r0
 	add r0, sb, #1
 	mov r0, r0, lsl #0x10
-	movne sl, #1
+	movne r10, #1
 	mov sb, r0, lsr #0x10
-	moveq sl, #0
+	moveq r10, #0
 	cmp sb, #3
 	blo _0215b0b0
 	ldr r0, [r4, #0x1dc]
@@ -70222,7 +70222,7 @@ _0215b164:
 	mov r5, r3, lsr #0xc
 	cmp r0, #3
 	orr r5, r5, r1, lsl #20
-	cmpeq sl, #1
+	cmpeq r10, #1
 	bne _0215b240
 	ldr r0, _0215b26c ; =data_027e0e60
 	ldr r0, [r0]
@@ -70264,7 +70264,7 @@ _0215b248:
 	add r0, r4, #0x228
 	bl Approach_thunk
 	add sp, sp, #0x40
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0215a970
 _0215b264: .word data_027e0f94
@@ -70285,23 +70285,23 @@ _0215b298: .word 0x0005000e
 	.global func_ov15_0215b29c
 	arm_func_start func_ov15_0215b29c
 func_ov15_0215b29c: ; 0x0215b29c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x10
 	ldr r5, _0215b354 ; =data_027e0f94
 	add r4, sp, #4
-	mov sl, r0
+	mov r10, r0
 	mov r6, #0
 	mov r11, r1
 	str r2, [sp]
 	ldmia r5, {r0, r1, r2}
 	stmia r4, {r0, r1, r2}
-	ldr r0, [sl, #0x1ec]
+	ldr r0, [r10, #0x1ec]
 	mov sb, r3
 	mov r7, r6
 	cmp r0, #0
 	mvn r5, #0x80000000
 	bls _0215b30c
-	add r8, sl, #0x1f0
+	add r8, r10, #0x1f0
 _0215b2e0:
 	mov r0, r8
 	mov r1, r4
@@ -70309,7 +70309,7 @@ _0215b2e0:
 	cmp r0, r5
 	movlt r5, r0
 	movlt r6, r7
-	ldr r0, [sl, #0x1ec]
+	ldr r0, [r10, #0x1ec]
 	add r7, r7, #1
 	cmp r7, r0
 	add r8, r8, #0xc
@@ -70322,9 +70322,9 @@ _0215b30c:
 	strne r6, [r0]
 	cmp sb, #0
 	addeq sp, sp, #0x10
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	mov r0, #0xc
-	mla r1, r6, r0, sl
+	mla r1, r6, r0, r10
 	ldr r0, [r1, #0x1f0]
 	str r0, [sb]
 	ldr r0, [r1, #0x1f4]
@@ -70332,7 +70332,7 @@ _0215b30c:
 	ldr r0, [r1, #0x1f8]
 	str r0, [sb, #8]
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0215b29c
 _0215b354: .word data_027e0f94
@@ -70340,7 +70340,7 @@ _0215b354: .word data_027e0f94
 	.global func_ov15_0215b358
 	arm_func_start func_ov15_0215b358
 func_ov15_0215b358: ; 0x0215b358
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	str r0, [sp]
 	ldr r0, _0215b620 ; =data_ov00_020ee0a0
 	mov r1, #0xa0
@@ -70355,7 +70355,7 @@ func_ov15_0215b358: ; 0x0215b358
 	mov r5, #1
 	sub r8, r0, r6
 	mov r7, r8, asr #0x1f
-	mov sl, #0
+	mov r10, #0
 	mov sb, #0x800
 _0215b39c:
 	mov r1, r5, lsl #0x9
@@ -70364,7 +70364,7 @@ _0215b39c:
 	mla r2, r8, r0, r2
 	adds r3, r3, sb
 	mla r2, r7, r1, r2
-	adc r0, r2, sl
+	adc r0, r2, r10
 	mov r1, r3, lsr #0xc
 	orr r1, r1, r0, lsl #20
 	add r0, r6, r1
@@ -70391,7 +70391,7 @@ _0215b39c:
 	mov r8, #9
 	sub r6, r0, r7
 	mov r5, r6, asr #0x1f
-	mov sl, #0
+	mov r10, #0
 	mov sb, #0x800
 _0215b428:
 	sub r0, r8, #8
@@ -70401,7 +70401,7 @@ _0215b428:
 	mla r2, r6, r0, r2
 	adds r3, r3, sb
 	mla r2, r5, r1, r2
-	adc r0, r2, sl
+	adc r0, r2, r10
 	mov r1, r3, lsr #0xc
 	orr r1, r1, r0, lsl #20
 	add r0, r7, r1
@@ -70428,7 +70428,7 @@ _0215b428:
 	mov r8, #0x11
 	sub r6, r0, r7
 	mov r5, r6, asr #0x1f
-	mov sl, #0
+	mov r10, #0
 	mov sb, #0x800
 _0215b4b8:
 	sub r0, r8, #0x10
@@ -70438,7 +70438,7 @@ _0215b4b8:
 	mla r2, r6, r0, r2
 	adds r3, r3, sb
 	mla r2, r5, r1, r2
-	adc r0, r2, sl
+	adc r0, r2, r10
 	mov r1, r3, lsr #0xc
 	orr r1, r1, r0, lsl #20
 	add r0, r7, r1
@@ -70464,12 +70464,12 @@ _0215b4b8:
 	ldr r0, [r0, #0x10]
 	ldr r4, _0215b628 ; =0x00000249
 	sub r8, r0, sb
-	mov sl, #0x19
+	mov r10, #0x19
 	mov r7, r8, asr #0x1f
 	mov r6, #0
 	mov r5, #0x800
 _0215b54c:
-	sub r0, sl, #0x18
+	sub r0, r10, #0x18
 	mul r1, r0, r4
 	mov r0, r1, asr #0x1f
 	umull r3, r2, r8, r1
@@ -70483,12 +70483,12 @@ _0215b54c:
 	mov r1, r0, asr #0xc
 	mov r0, r11
 	and r2, r1, #0xff
-	mov r1, sl
+	mov r1, r10
 	bl func_ov00_0209cd40
-	add r0, sl, #1
+	add r0, r10, #1
 	mov r0, r0, lsl #0x10
-	mov sl, r0, lsr #0x10
-	cmp sl, #0x1f
+	mov r10, r0, lsr #0x10
+	cmp r10, #0x1f
 	blo _0215b54c
 	ldr r1, _0215b624 ; =data_ov15_021865c8
 	ldr r0, _0215b620 ; =data_ov00_020ee0a0
@@ -70521,7 +70521,7 @@ _0215b54c:
 	mov r1, #0
 	ldr r0, [r0]
 	bl func_ov00_020823a4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0215b358
 _0215b620: .word data_ov00_020ee0a0
@@ -70652,24 +70652,24 @@ _0215b78c: .word data_027e10a8
 	.global func_ov15_0215b790
 	arm_func_start func_ov15_0215b790
 func_ov15_0215b790: ; 0x0215b790
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x14
 	ldr r1, _0215b840 ; =data_027e10a8
 	mov r2, #1
-	mov sl, r0
+	mov r10, r0
 	mov r8, #0
 	mov r0, #0x7f000
 	strb r2, [r1]
-	str r8, [sl, #0x228]
-	strb r8, [sl, #0x237]
+	str r8, [r10, #0x228]
+	strb r8, [r10, #0x237]
 	str r0, [sp]
 	str r0, [sp, #4]
 	str r0, [sp, #8]
 	str r0, [sp, #0xc]
 	str r0, [sp, #0x10]
-	strb r2, [sl, #0x23a]
-	add r4, sl, #0x3a
-	add sb, sl, #0x1c8
+	strb r2, [r10, #0x23a]
+	add r4, r10, #0x3a
+	add sb, r10, #0x1c8
 	mov r11, r8
 	mov r5, r2
 	add r7, sp, #0
@@ -70691,12 +70691,12 @@ _0215b7e8:
 	ldr r0, _0215b844 ; =data_027e0e58
 	ldr r2, _0215b848 ; =data_027e0f94
 	ldr r0, [r0]
-	add r1, sl, #0x1b8
+	add r1, r10, #0x1b8
 	bl func_ov00_0207c474
-	mov r0, sl
+	mov r0, r10
 	bl func_ov15_0215b84c
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0215b790
 _0215b840: .word data_027e10a8
@@ -71752,14 +71752,14 @@ _0215c6c4:
 	.global func_ov15_0215c6d4
 	arm_func_start func_ov15_0215c6d4
 func_ov15_0215c6d4: ; 0x0215c6d4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x44
 	ldr r4, _0215c7d8 ; =data_027e0ff0
 	mov r7, #0
 	ldr r3, [r4]
 	str r0, [sp]
 	ldr r0, [r3, #4]
-	mov sl, r1
+	mov r10, r1
 	mov sb, r2
 	mov r8, r7
 	cmp r0, #0
@@ -71778,7 +71778,7 @@ _0215c710:
 	bne _0215c7a8
 	ldrb r3, [r2]
 	mov r0, r6
-	mov r1, sl
+	mov r1, r10
 	mov r2, r5
 	strb r3, [sp, #4]
 	bl func_ov15_0215c7dc
@@ -71788,13 +71788,13 @@ _0215c710:
 	ldr r0, [sp, #0x28]
 	str r1, [sp, #0x3c]
 	str r0, [sp, #0x40]
-	ldr r1, [sl]
+	ldr r1, [r10]
 	mov r0, r11
 	str r1, [sp, #8]
-	ldr r2, [sl, #4]
+	ldr r2, [r10, #4]
 	add r1, sp, #0x38
 	str r2, [sp, #0xc]
-	ldr r2, [sl, #8]
+	ldr r2, [r10, #8]
 	str r2, [sp, #0x10]
 	bl func_01ff9ec0
 	cmp r0, r7
@@ -71819,7 +71819,7 @@ _0215c7c0:
 	ldmia r0, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
 	add sp, sp, #0x44
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0215c6d4
 _0215c7d8: .word data_027e0ff0
@@ -71827,7 +71827,7 @@ _0215c7d8: .word data_027e0ff0
 	.global func_ov15_0215c7dc
 	arm_func_start func_ov15_0215c7dc
 func_ov15_0215c7dc: ; 0x0215c7dc
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x34
 	ldr r3, _0215c8b0 ; =data_027e0ff0
 	mov r7, #0
@@ -71836,7 +71836,7 @@ func_ov15_0215c7dc: ; 0x0215c7dc
 	ldr r3, [r3]
 	str r0, [sp]
 	ldr r0, [r3, r2, lsl #3]
-	mov sl, r1
+	mov r10, r1
 	ldrb r6, [r0, #1]
 	mov r5, r7
 	add r8, r3, r2, lsl #3
@@ -71854,12 +71854,12 @@ _0215c824:
 	str ip, [sp, #0x2c]
 	str r3, [sp, #0x30]
 	str r2, [sp, #0x28]
-	ldr r2, [sl]
+	ldr r2, [r10]
 	mov r1, r11
 	str r2, [sp, #4]
-	ldr r2, [sl, #4]
+	ldr r2, [r10, #4]
 	str r2, [sp, #8]
-	ldr r2, [sl, #8]
+	ldr r2, [r10, #8]
 	str r2, [sp, #0xc]
 	bl func_01ff9ec0
 	cmp r0, r7
@@ -71882,7 +71882,7 @@ _0215c898:
 	ldmia r0, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
 	add sp, sp, #0x34
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0215c7dc
 _0215c8b0: .word data_027e0ff0
@@ -71890,12 +71890,12 @@ _0215c8b0: .word data_027e0ff0
 	.global func_ov15_0215c8b4
 	arm_func_start func_ov15_0215c8b4
 func_ov15_0215c8b4: ; 0x0215c8b4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x60
 	ldr r3, _0215cb1c ; =data_027e0ff0
 	ldrb r1, [r1]
 	ldr r3, [r3]
-	mov sl, r0
+	mov r10, r0
 	ldr r3, [r3]
 	mvn r5, #0
 	add r8, r3, r1, lsl #3
@@ -71948,13 +71948,13 @@ _0215c95c:
 	bl func_01fffb4c
 	cmp r0, #0
 	beq _0215cb00
-	ldr r1, [sl]
+	ldr r1, [r10]
 	add r0, sp, #0xc
 	str r1, [sp, #0xc]
-	ldr r2, [sl, #4]
+	ldr r2, [r10, #4]
 	add r1, sp, #0x54
 	str r2, [sp, #0x10]
-	ldr r3, [sl, #8]
+	ldr r3, [r10, #8]
 	add r2, sp, #0x3c
 	str r3, [sp, #0x14]
 	bl func_01ff9bf8
@@ -72009,7 +72009,7 @@ _0215ca60:
 	str r0, [sp, #0x44]
 _0215ca78:
 	add r0, sp, #0x3c
-	mov r1, sl
+	mov r1, r10
 	mov r2, r0
 	bl func_01ff9bf8
 	mov r0, #0
@@ -72024,11 +72024,11 @@ _0215ca78:
 	cmp r0, #0
 	movne r5, r6
 	bne _0215cae0
-	mov r0, sl
+	mov r0, r10
 	add r1, sp, #0x54
 	bl func_ov00_020ce2f0
 	mov r4, r0
-	mov r0, sl
+	mov r0, r10
 	add r1, sp, #0x48
 	bl func_ov00_020ce2f0
 	cmp r4, r0
@@ -72052,7 +72052,7 @@ _0215cb00:
 _0215cb10:
 	mov r0, r5
 	add sp, sp, #0x60
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0215c8b4
 _0215cb1c: .word data_027e0ff0
@@ -72140,7 +72140,7 @@ _0215cc2c: .word data_027e0f94
 	.global func_ov15_0215cc30
 	arm_func_start func_ov15_0215cc30
 func_ov15_0215cc30: ; 0x0215cc30
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x24
 	ldr r6, _0215cee4 ; =data_027e0f94
 	add r4, sp, #0xc
@@ -72168,12 +72168,12 @@ func_ov15_0215cc30: ; 0x0215cc30
 	ldr r1, _0215ceec ; =data_027e0fac
 	umull sb, r0, r8, r6
 	mov r7, #0
-	ldrh sl, [r1]
+	ldrh r10, [r1]
 	adds r1, sb, #0x800
 	mla r0, r8, r7, r0
 	mov r7, r8, asr #0x1f
 	mla r0, r7, r6, r0
-	mov r6, sl, asr #0x4
+	mov r6, r10, asr #0x4
 	mov r7, r6, lsl #0x1
 	add r6, r7, #1
 	ldr r8, _0215cef0 ; =data_02050f54
@@ -72208,8 +72208,8 @@ _0215cd18:
 	ldr r8, [r0, #0x10]
 	mla r3, lr, r2, r3
 	ldr r7, [r0, #0x14]
-	adds sl, r8, sb
-	str sl, [r0]
+	adds r10, r8, sb
+	str r10, [r0]
 	adc sb, r7, r3
 	str sb, [r0, #4]
 	mov r1, ip, lsl #0x10
@@ -72222,10 +72222,10 @@ _0215cd18:
 	cmp r3, #0
 	movle r1, ip
 	ble _0215cda8
-	umull r2, r1, r6, sl
+	umull r2, r1, r6, r10
 	mla r1, r6, sb, r1
 	adds r2, r8, r2
-	mla r1, lr, sl, r1
+	mla r1, lr, r10, r1
 	adc r1, r7, r1
 	str r2, [r0]
 	str r1, [r0, #4]
@@ -72315,7 +72315,7 @@ _0215ced0:
 	ldmia r0, {r0, r1, r2}
 	stmia r11, {r0, r1, r2}
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0215cc30
 _0215cee4: .word data_027e0f94
@@ -72452,7 +72452,7 @@ _0215d074: .word data_02050f54
 	.global func_ov15_0215d078
 	arm_func_start func_ov15_0215d078
 func_ov15_0215d078: ; 0x0215d078
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #0x6c
 	mov r5, #0
 	sub r4, r5, #2
@@ -72476,7 +72476,7 @@ func_ov15_0215d078: ; 0x0215d078
 	cmp r0, #0
 	addeq sp, sp, #0x6c
 	moveq r0, r5
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	cmp r4, #0
 	beq _0215d1cc
 	add r3, sp, #0x48
@@ -72517,7 +72517,7 @@ func_ov15_0215d078: ; 0x0215d078
 	ldrb r4, [sp, #0x67]
 	ldrb lr, [sp, #0x68]
 	ldrb ip, [sp, #0x69]
-	ldr sl, [sp, #0x54]
+	ldr r10, [sp, #0x54]
 	ldr sb, [sp, #0x58]
 	ldr r8, [sp, #0x5c]
 	ldr r7, [sp, #0x60]
@@ -72525,7 +72525,7 @@ func_ov15_0215d078: ; 0x0215d078
 	add r1, sp, #0x24
 	mov r2, r2, lsl #0xc
 	mov r3, r3, lsl #0xc
-	str sl, [sp, #0x24]
+	str r10, [sp, #0x24]
 	str sb, [sp, #0x28]
 	str r8, [sp, #0x2c]
 	str r7, [sp, #0x30]
@@ -72536,7 +72536,7 @@ func_ov15_0215d078: ; 0x0215d078
 	strb ip, [sp, #0x39]
 	bl func_ov15_0214146c
 	add sp, sp, #0x6c
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 _0215d1cc:
 	ldr r0, _0215d234 ; =data_027e10a4
 	ldrsh r6, [sp, #0x64]
@@ -72544,13 +72544,13 @@ _0215d1cc:
 	ldrb r4, [sp, #0x67]
 	ldrb r3, [sp, #0x68]
 	ldrb r2, [sp, #0x69]
-	ldr sl, [sp, #0x54]
+	ldr r10, [sp, #0x54]
 	ldr sb, [sp, #0x58]
 	ldr r8, [sp, #0x5c]
 	ldr r7, [sp, #0x60]
 	ldr r0, [r0]
 	add r1, sp, #0xc
-	str sl, [sp, #0xc]
+	str r10, [sp, #0xc]
 	str sb, [sp, #0x10]
 	str r8, [sp, #0x14]
 	str r7, [sp, #0x18]
@@ -72561,7 +72561,7 @@ _0215d1cc:
 	strb r2, [sp, #0x21]
 	bl func_ov15_021413f8
 	add sp, sp, #0x6c
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0215d078
 _0215d22c: .word data_027e0e60
@@ -74315,7 +74315,7 @@ _0215e884:
 	.global func_ov15_0215e890
 	arm_func_start func_ov15_0215e890
 func_ov15_0215e890: ; 0x0215e890
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0xd0
 	mov sb, r0
 	ldr r1, [sb, #0x3b8]
@@ -75094,14 +75094,14 @@ _0215f40c:
 	ldr r8, _0215f80c ; =data_ov15_0218f81c
 	ldr r11, _0215f810 ; =data_027e0fe4
 	mov r4, r8
-	mov sl, #1
+	mov r10, #1
 	mvn r5, #0
 _0215f430:
 	ldr r0, [r11]
 	mov r1, r8
 	bl _ZN12ActorManager8GetActorEP8ActorRef
 	cmp r0, #0
-	strneb sl, [r0, #0x11a]
+	strneb r10, [r0, #0x11a]
 	str r5, [r4, r7, lsl #3]
 	add r0, r4, r7, lsl #3
 	str r5, [r0, #4]
@@ -75194,10 +75194,10 @@ _0215f50c:
 	orr r0, r0, r8, lsl #20
 	mov r3, r3, lsl #0x1
 	smull r1, r8, r5, r0
-	adds sl, r1, #0x800
+	adds r10, r1, #0x800
 	ldrsh r1, [r7, r3]
 	adc r5, r8, #0
-	mov r7, sl, lsr #0xc
+	mov r7, r10, lsr #0xc
 	smull r3, r0, r1, r0
 	adds r1, r3, #0x800
 	ldr r3, [sp, #0x64]
@@ -75221,13 +75221,13 @@ _0215f50c:
 	mov r1, r0
 	ldr r7, [r3, #8]
 	ldmia r3, {r4, lr}
-	umull sl, r8, r7, r4
+	umull r10, r8, r7, r4
 	mla r8, r7, lr, r8
 	ldr r5, [r3, #0xc]
 	ldr ip, [r3, #0x10]
 	mla r8, r5, r4, r8
 	ldr r11, [r3, #0x14]
-	adds r4, ip, sl
+	adds r4, ip, r10
 	adc r8, r11, r8
 	umull r5, r7, r8, r0
 	mov r5, #0
@@ -75243,13 +75243,13 @@ _0215f50c:
 	str r0, [sb, #0x3c4]
 	ldr r4, [r3]
 	ldmib r3, {r0, r7}
-	umull sl, r8, r7, r4
+	umull r10, r8, r7, r4
 	mla r8, r7, r0, r8
 	ldr r5, [r3, #0xc]
 	ldr ip, [r3, #0x10]
 	mla r8, r5, r4, r8
 	ldr r11, [r3, #0x14]
-	adds r0, ip, sl
+	adds r0, ip, r10
 	adc r7, r11, r8
 	stmia r3, {r0, r7}
 	umull r0, r4, r7, r1
@@ -75269,9 +75269,9 @@ _0215f50c:
 	ldr r4, [r3, #0xc]
 	ldr r11, [r3, #0x10]
 	mla r7, r4, r1, r7
-	ldr sl, [r3, #0x14]
+	ldr r10, [r3, #0x14]
 	adds r0, r11, r8
-	adc r4, sl, r7
+	adc r4, r10, r7
 	stmia r3, {r0, r4}
 	umull r0, r1, r4, r2
 	mov r0, #0
@@ -75318,7 +75318,7 @@ _0215f770:
 	ldr r3, [sb, #0x1ec]
 	cmp r3, #0
 	addeq sp, sp, #0xd0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	cmp r2, #0
 	moveq r0, #1
 	ldr r1, [r3, #0x24]
@@ -75328,12 +75328,12 @@ _0215f770:
 	orr r0, r1, r0, lsr #30
 	add sp, sp, #0xd0
 	str r0, [r3, #0x24]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0215f7a8:
 	add r0, sb, #0x1ec
 	bl func_ov00_020b7e6c
 	add sp, sp, #0xd0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0215e890
 _0215f7b8: .word data_027e0e60
@@ -78102,10 +78102,10 @@ _02161c84: .word data_027e0e2c
 	.global func_ov15_02161c88
 	arm_func_start func_ov15_02161c88
 func_ov15_02161c88: ; 0x02161c88
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x6c
 	ldr r1, _02162424 ; =data_027e0f74
-	mov sl, r0
+	mov r10, r0
 	ldr r0, [r1]
 	mov r1, #0x1f
 	bl func_ov00_02097760
@@ -78120,108 +78120,108 @@ func_ov15_02161c88: ; 0x02161c88
 _02161cc4:
 	add sp, sp, #0x6c
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02161cd0:
 	mov r1, #2
 	ldr r0, _02162428 ; =data_027e0fec
-	strb r1, [sl, #0x1a8]
+	strb r1, [r10, #0x1a8]
 	ldr r0, [r0]
 	add r0, r0, #0x2a8
 	add r0, r0, #0x2800
 	bl func_ov00_020c4588
 	mov r1, r0
-	add r0, sl, #0x1d8
+	add r0, r10, #0x1d8
 	ldr r2, [r0]
 	ldr r2, [r2, #0xc]
 	blx r2
 	mov r0, #0x800
 	rsb r0, r0, #0
-	str r0, [sl, #0x4c]
-	ldr r2, [sl, #0x48]
+	str r0, [r10, #0x4c]
+	ldr r2, [r10, #0x48]
 	mov r1, #0x1000
-	str r2, [sl, #0x54]
-	ldr r3, [sl, #0x4c]
+	str r2, [r10, #0x54]
+	ldr r3, [r10, #0x4c]
 	mov r2, #0x10
-	str r3, [sl, #0x58]
-	ldr r3, [sl, #0x50]
+	str r3, [r10, #0x58]
+	ldr r3, [r10, #0x50]
 	mov r0, #0
-	str r3, [sl, #0x5c]
-	str r1, [sl, #0x184]
-	str r2, [sl, #0x6c]
-	str r0, [sl, #0x7c]
-	str r1, [sl, #0x80]
-	str r0, [sl, #0x84]
-	str r1, [sl, #0x88]
-	ldr r2, [sl, #0x7c]
+	str r3, [r10, #0x5c]
+	str r1, [r10, #0x184]
+	str r2, [r10, #0x6c]
+	str r0, [r10, #0x7c]
+	str r1, [r10, #0x80]
+	str r0, [r10, #0x84]
+	str r1, [r10, #0x88]
+	ldr r2, [r10, #0x7c]
 	mov r6, #5
-	str r2, [sl, #0x188]
-	ldr r3, [sl, #0x80]
+	str r2, [r10, #0x188]
+	ldr r3, [r10, #0x80]
 	mov r7, #0x2000
-	str r3, [sl, #0x18c]
-	ldr r3, [sl, #0x84]
-	add r2, sl, #0x100
-	str r3, [sl, #0x190]
-	ldr r3, [sl, #0x88]
+	str r3, [r10, #0x18c]
+	ldr r3, [r10, #0x84]
+	add r2, r10, #0x100
+	str r3, [r10, #0x190]
+	ldr r3, [r10, #0x88]
 	ldr r5, _0216242c ; =0x00000999
-	str r3, [sl, #0x194]
-	ldr r3, [sl, #0x188]
+	str r3, [r10, #0x194]
+	ldr r3, [r10, #0x188]
 	rsb r4, r6, #0x338
-	str r3, [sl, #0x8c]
-	ldr r3, [sl, #0x18c]
-	str r3, [sl, #0x90]
-	ldr r3, [sl, #0x190]
-	str r3, [sl, #0x94]
-	ldr r8, [sl, #0x194]
+	str r3, [r10, #0x8c]
+	ldr r3, [r10, #0x18c]
+	str r3, [r10, #0x90]
+	ldr r3, [r10, #0x190]
+	str r3, [r10, #0x94]
+	ldr r8, [r10, #0x194]
 	mov r3, #0x400
-	str r8, [sl, #0x98]
-	str r0, [sl, #0xa8]
-	str r1, [sl, #0xac]
-	str r0, [sl, #0xb0]
-	str r7, [sl, #0xb4]
+	str r8, [r10, #0x98]
+	str r0, [r10, #0xa8]
+	str r1, [r10, #0xac]
+	str r0, [r10, #0xb0]
+	str r7, [r10, #0xb4]
 	strh r6, [r2, #0x20]
-	strb r0, [sl, #0x124]
-	str r5, [sl, #0x158]
-	str r4, [sl, #0x15c]
+	strb r0, [r10, #0x124]
+	str r5, [r10, #0x158]
+	str r4, [r10, #0x15c]
 	strh r0, [r2, #0x68]
 	strh r0, [r2, #0x6a]
 	strh r0, [r2, #0x6e]
 	strh r0, [r2, #0x6c]
-	str r0, [sl, #0x164]
-	str r0, [sl, #0x160]
-	str r3, [sl, #0x198]
+	str r0, [r10, #0x164]
+	str r0, [r10, #0x160]
+	str r3, [r10, #0x198]
 	mov r1, #0x800
-	str r1, [sl, #0x19c]
-	str r0, [sl, #0x238]
-	str r0, [sl, #0x23c]
-	str r0, [sl, #0x24c]
-	str r0, [sl, #0x234]
-	ldr r1, [sl, #8]
-	str r1, [sl, #0x394]
-	ldr r1, [sl, #0xc]
-	str r1, [sl, #0x398]
-	strb r0, [sl, #0x3c8]
-	strb r0, [sl, #0x3d0]
+	str r1, [r10, #0x19c]
+	str r0, [r10, #0x238]
+	str r0, [r10, #0x23c]
+	str r0, [r10, #0x24c]
+	str r0, [r10, #0x234]
+	ldr r1, [r10, #8]
+	str r1, [r10, #0x394]
+	ldr r1, [r10, #0xc]
+	str r1, [r10, #0x398]
+	strb r0, [r10, #0x3c8]
+	strb r0, [r10, #0x3d0]
 	sub r0, r6, #6
-	str r0, [sl, #0x288]
-	str r0, [sl, #0x28c]
-	ldr r2, [sl, #0x4c]
-	ldr r1, [sl, #0x184]
+	str r0, [r10, #0x288]
+	str r0, [r10, #0x28c]
+	ldr r2, [r10, #0x4c]
+	ldr r1, [r10, #0x184]
 	mov r0, #0xaa
 	add r1, r2, r1
-	str r1, [sl, #0x1a0]
-	str r0, [sl, #0x25c]
+	str r1, [r10, #0x1a0]
+	str r0, [r10, #0x25c]
 	mov r1, #2
-	str r1, [sl, #0x260]
+	str r1, [r10, #0x260]
 	mov r0, #0xab
-	str r0, [sl, #0x268]
-	str r1, [sl, #0x26c]
+	str r0, [r10, #0x268]
+	str r1, [r10, #0x26c]
 	mov r0, #0xac
-	str r0, [sl, #0x274]
-	str r1, [sl, #0x278]
+	str r0, [r10, #0x274]
+	str r1, [r10, #0x278]
 	mov r0, #0xad
-	str r0, [sl, #0x280]
+	str r0, [r10, #0x280]
 	ldr r0, _02162430 ; =data_027e0e60
-	str r1, [sl, #0x284]
+	str r1, [r10, #0x284]
 	ldr r0, [r0]
 	bl func_ov00_02082d40
 	ldr r1, _02162434 ; =data_027e0d38
@@ -78257,11 +78257,11 @@ _02161eac:
 	cmp r0, #4
 	bne _02161f18
 _02161ee4:
-	ldrb r0, [sl, #0x2b]
+	ldrb r0, [r10, #0x2b]
 	cmp r0, #0
 	beq _02161f00
 	mov r1, #1
-	mov r0, sl
+	mov r0, r10
 	mov r2, r1
 	bl _ZN5Actor18func_ov00_020c1c20Eiii
 _02161f00:
@@ -78270,7 +78270,7 @@ _02161f00:
 	ldr r1, [r1]
 	mov r0, #0
 	strb r5, [r1, #0x38]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02161f18:
 	ldr r0, _02162424 ; =data_027e0f74
 	mov r1, #0x62
@@ -78300,27 +78300,27 @@ _02161f2c:
 	add sp, sp, #0x6c
 	strb r2, [r1, #0x38]
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02161f88:
-	ldrb r0, [sl, #0x2a]
+	ldrb r0, [r10, #0x2a]
 	cmp r0, #0
 	beq _02161fd4
-	mov r0, sl
+	mov r0, r10
 	mov r1, #0
 	bl _ZN5Actor18func_Ov00_020c1bfcEi
 	cmp r0, #0
 	bne _02161fd4
-	ldrsh r2, [sl, #0x78]
-	ldrsb r3, [sl, #0x2c]
-	add r0, sl, #0x1b0
-	add r1, sl, #0x48
+	ldrsh r2, [r10, #0x78]
+	ldrsb r3, [r10, #0x2c]
+	add r0, r10, #0x1b0
+	add r1, r10, #0x48
 	bl func_ov00_020c66e4
-	mov r0, sl
+	mov r0, r10
 	mov r1, #0
 	bl func_ov15_02162688
 	add sp, sp, #0x6c
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02161fd4:
 	ldr r0, _02162438 ; =data_027e0fe4
 	add r3, sp, #0x60
@@ -78332,14 +78332,14 @@ _02161fd4:
 	beq _0216237c
 	ldr r0, [sp, #0x60]
 	cmp r7, r5
-	str r0, [sl, #0x48]
+	str r0, [r10, #0x48]
 	ldr r0, [sp, #0x64]
-	str r0, [sl, #0x4c]
+	str r0, [r10, #0x4c]
 	ldr r0, [sp, #0x68]
-	str r0, [sl, #0x50]
+	str r0, [r10, #0x50]
 	beq _02162394
 	ldr r0, _02162440 ; =data_027e0ff0
-	ldrsb r4, [sl, #0x2c]
+	ldrsb r4, [r10, #0x2c]
 	ldr r1, [r0]
 	mvn r0, #0
 	ldr r2, [r1]
@@ -78370,7 +78370,7 @@ _0216204c:
 	ldr r0, _02162438 ; =data_027e0fe4
 	ldrb r2, [r1, #0x11]
 	ldr r1, [r0]
-	mov r0, sl
+	mov r0, r10
 	strb r2, [r1, #0x38]
 	bl func_ov15_02164604
 	cmp r0, #0
@@ -78381,7 +78381,7 @@ _0216204c:
 _021620b0:
 	add sp, sp, #0x6c
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _021620bc:
 	ldr r0, _0216244c ; =data_027e0f94
 	add r3, sp, #0x44
@@ -78469,7 +78469,7 @@ _021621c4:
 	cmp r0, r1
 	bne _0216232c
 	add r1, sp, #4
-	add r0, sl, #0x1b0
+	add r0, r10, #0x1b0
 	bl func_ov00_020c6940
 	add r0, sp, #0x44
 	add r1, sp, #0x60
@@ -78493,13 +78493,13 @@ _02162240:
 	mov r0, #0x1e
 	ldr r3, [r5, #4]
 	mul r0, r2, r0
-	str r3, [sl, #0x48]
+	str r3, [r10, #0x48]
 	ldr r2, [r5, #8]
 	add r0, r0, #1
-	str r2, [sl, #0x4c]
+	str r2, [r10, #0x4c]
 	ldr r2, [r5, #0xc]
 	cmp r0, #0
-	str r2, [sl, #0x50]
+	str r2, [r10, #0x50]
 	movle r5, #0
 	ble _021622c0
 	ldr r2, _02162450 ; =data_027e0764
@@ -78534,22 +78534,22 @@ _021622c0:
 	bne _02162310
 	cmp r7, #1
 	cmpne r7, #3
-	ldr r0, [sl, #0x50]
+	ldr r0, [r10, #0x50]
 	bne _02162304
 	sub r0, r0, r1
-	str r0, [sl, #0x50]
+	str r0, [r10, #0x50]
 	b _021623a8
 _02162304:
 	add r0, r0, r1
-	str r0, [sl, #0x50]
+	str r0, [r10, #0x50]
 	b _021623a8
 _02162310:
-	ldr r0, [sl, #0x48]
+	ldr r0, [r10, #0x48]
 	cmp r7, #1
 	subls r0, r0, r1
-	strls r0, [sl, #0x48]
+	strls r0, [r10, #0x48]
 	addhi r0, r0, r1
-	strhi r0, [sl, #0x48]
+	strhi r0, [r10, #0x48]
 	b _021623a8
 _0216232c:
 	add r0, r6, #1
@@ -78561,7 +78561,7 @@ _0216232c:
 	ldr r0, _02162438 ; =data_027e0fe4
 	ldrb r2, [r1, #0x12]
 	ldr r1, [r0]
-	mov r0, sl
+	mov r0, r10
 	strb r2, [r1, #0x38]
 	bl func_ov15_02164604
 	cmp r0, #0
@@ -78572,22 +78572,22 @@ _0216232c:
 _02162370:
 	add sp, sp, #0x6c
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0216237c:
-	ldr r0, [sl, #0x48]
+	ldr r0, [r10, #0x48]
 	str r0, [r4, #0x2c]
-	ldr r0, [sl, #0x4c]
+	ldr r0, [r10, #0x4c]
 	str r0, [r4, #0x30]
-	ldr r0, [sl, #0x50]
+	ldr r0, [r10, #0x50]
 	str r0, [r4, #0x34]
 _02162394:
-	ldrsh r2, [sl, #0x78]
-	ldrsb r3, [sl, #0x2c]
-	add r0, sl, #0x1b0
-	add r1, sl, #0x48
+	ldrsh r2, [r10, #0x78]
+	ldrsb r3, [r10, #0x2c]
+	add r0, r10, #0x1b0
+	add r1, r10, #0x48
 	bl func_ov00_020c66e4
 _021623a8:
-	mov r0, sl
+	mov r0, r10
 	bl func_ov15_02164604
 	cmp r0, #0
 	beq _021623c4
@@ -78595,11 +78595,11 @@ _021623a8:
 	mov r1, #0x1e
 	bl func_ov15_021849c0
 _021623c4:
-	mov r0, sl
+	mov r0, r10
 	mov r1, #3
 	bl func_ov15_02162688
 	add r0, sp, #8
-	add r1, sl, #0x1b0
+	add r1, r10, #0x1b0
 	bl func_ov00_020c6e08
 	add r0, sp, #8
 	add r3, sp, #0x20
@@ -78607,18 +78607,18 @@ _021623c4:
 	stmia r3, {r0, r1, r2}
 	mov r0, r3
 	mov r2, r3
-	add r1, sl, #0x48
+	add r1, r10, #0x48
 	bl func_01ff9bf8
 	ldr r0, [sp, #0x20]
 	ldr r1, [sp, #0x28]
 	bl func_01ffa0f4
-	add r1, sl, #0x100
+	add r1, r10, #0x100
 	strh r0, [r1, #0xd4]
 	ldrsh r1, [r1, #0xd4]
 	mov r0, #1
-	strh r1, [sl, #0x78]
+	strh r1, [r10, #0x78]
 	add sp, sp, #0x6c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02161c88
 _02162424: .word data_027e0f74
@@ -78795,7 +78795,7 @@ _02162684: .word data_ov15_021867d4
 	.global func_ov15_02162688
 	arm_func_start func_ov15_02162688
 func_ov15_02162688: ; 0x02162688
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x394
 	mov r4, r1
 	mov r5, r0
@@ -79040,38 +79040,38 @@ _021629c0:
 	mov r1, #5
 	ldr r2, [sp, #0x27c]
 	ldr r11, [sp, #0x284]
-	ldr sl, [sp, #0x288]
+	ldr r10, [sp, #0x288]
 	ldr r0, [sp, #0x28c]
 	str r2, [sp, #0x310]
 	ldr r2, [sp, #0x290]
 	str r11, [sp, #0x318]
 	ldr r11, [sp, #0x294]
-	str sl, [sp, #0x31c]
-	ldr sl, [sp, #0x298]
+	str r10, [sp, #0x31c]
+	ldr r10, [sp, #0x298]
 	str r0, [sp, #0x320]
 	ldr r0, [sp, #0x29c]
 	str r2, [sp, #0x324]
 	ldr r2, [sp, #0x2a0]
 	str r11, [sp, #0x328]
 	ldr r11, [sp, #0x2a4]
-	str sl, [sp, #0x32c]
-	ldr sl, [sp, #0x2a8]
+	str r10, [sp, #0x32c]
+	ldr r10, [sp, #0x2a8]
 	str r0, [sp, #0x330]
 	ldr r0, [sp, #0x2ac]
 	str r2, [sp, #0x334]
 	ldr r2, [sp, #0x2b0]
 	str r11, [sp, #0x338]
 	ldr r11, [sp, #0x2b4]
-	str sl, [sp, #0x33c]
-	ldr sl, [sp, #0x2b8]
+	str r10, [sp, #0x33c]
+	ldr r10, [sp, #0x2b8]
 	str r0, [sp, #0x340]
 	ldr r0, [sp, #0x2bc]
 	str r2, [sp, #0x344]
 	ldr r2, [sp, #0x2c0]
 	str r11, [sp, #0x348]
 	ldr r11, [sp, #0x2c4]
-	str sl, [sp, #0x34c]
-	ldr sl, [sp, #0x2c8]
+	str r10, [sp, #0x34c]
+	ldr r10, [sp, #0x2c8]
 	ldrb sb, [sp, #0x2dc]
 	ldrb r8, [sp, #0x2dd]
 	ldrb r7, [sp, #0x2de]
@@ -79083,15 +79083,15 @@ _021629c0:
 	ldr r2, [sp, #0x2d0]
 	str r11, [sp, #0x358]
 	ldr r11, [sp, #0x2d4]
-	str sl, [sp, #0x35c]
-	ldr sl, [sp, #0x2d8]
+	str r10, [sp, #0x35c]
+	ldr r10, [sp, #0x2d8]
 	str r0, [sp, #0x360]
 	mov r0, #1
 	str r2, [sp, #0x364]
 	mov r2, #0x5c
 	str r11, [sp, #0x368]
 	strb r0, [sp, #0x2f8]
-	str sl, [sp, #0x36c]
+	str r10, [sp, #0x36c]
 	strb sb, [sp, #0x370]
 	strb r8, [sp, #0x371]
 	strb r7, [sp, #0x372]
@@ -79144,7 +79144,7 @@ _02162b58:
 	mov sb, #5
 	str r0, [r5, #0x298]
 	ldr r0, [sp, #0x168]
-	mov sl, #1
+	mov r10, #1
 	str r0, [r5, #0x29c]
 	ldr r0, [sp, #0x16c]
 	str r0, [r5, #0x2a0]
@@ -79208,7 +79208,7 @@ _02162b58:
 	ldr r1, [sp, #0x17c]
 	ldr r0, [sp, #0x180]
 	str sb, [sp, #0x168]
-	strb sl, [sp, #0x1e0]
+	strb r10, [sp, #0x1e0]
 	str r8, [sp, #0x1f8]
 	str sb, [sp, #0x1fc]
 	str r7, [sp, #0x200]
@@ -79264,7 +79264,7 @@ _02162b58:
 	strb r3, [sp, #0x25b]
 	strb r2, [sp, #0x25c]
 	str r11, [sp, #0x260]
-	strb sl, [sp, #0x1e2]
+	strb r10, [sp, #0x1e2]
 	bl func_ov00_02097810
 	str r0, [r5, #0x240]
 	ldr r0, _02162de4 ; =data_027e0c68
@@ -79279,7 +79279,7 @@ _02162dc4:
 	str r4, [r5, #0x130]
 	strb r0, [r5, #0x255]
 	add sp, sp, #0x394
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02162688
 _02162ddc: .word 0x0000ffff
@@ -86785,21 +86785,21 @@ _021694f0: .word data_027e0f6c
 	.global func_ov15_021694f4
 	arm_func_start func_ov15_021694f4
 func_ov15_021694f4: ; 0x021694f4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x20
-	mov sl, r0
+	mov r10, r0
 	str r1, [sp, #4]
 	bl _ZN5Actor18func_ov00_020c313cEj
 	cmp r0, #0
 	beq _02169650
-	mov r0, sl
+	mov r0, r10
 	bl _ZN5Actor20IncreaseActiveFramesEv
-	ldr r0, [sl, #0x130]
+	ldr r0, [r10, #0x130]
 	ldr r1, _02169668 ; =data_ov15_021868f0
 	add r1, r1, r0, lsl #3
 	ldr r0, [r1, #4]
 	tst r0, #1
-	add r0, sl, r0, asr #1
+	add r0, r10, r0, asr #1
 	ldreq r1, [r1]
 	beq _02169544
 	ldr r2, [r0]
@@ -86809,16 +86809,16 @@ _02169544:
 	blx r1
 	ldr r1, _0216966c ; =data_ov15_0218d1bc
 	ldr r2, _02169670 ; =data_ov15_0218d1c8
-	add r0, sl, #0x48
+	add r0, r10, #0x48
 	bl func_ov15_0215cb24
-	ldr r2, [sl, #0x4c]
+	ldr r2, [r10, #0x4c]
 	mov r1, #0
 	add r3, r2, r0
-	mov r0, sl
+	mov r0, r10
 	mov r2, r1
-	str r3, [sl, #0x2d4]
+	str r3, [r10, #0x2d4]
 	bl _ZN5Actor18func_ov00_020c243cEiPi
-	ldr r0, [sl, #0x130]
+	ldr r0, [r10, #0x130]
 	cmp r0, #3
 	beq _02169648
 	mov r7, #0
@@ -86827,25 +86827,25 @@ _02169544:
 	mov sb, r7
 	add r11, sp, #0x14
 _02169594:
-	add r0, sl, r7
+	add r0, r10, r7
 	ldrb r6, [r0, #0x23c]
 	tst r6, #1
 	beq _02169638
-	ldr r0, [sl, #0x48]
+	ldr r0, [r10, #0x48]
 	ldr r3, [r5, sb, lsl #2]
 	str r0, [sp, #8]
-	ldr r1, [sl, #0x4c]
+	ldr r1, [r10, #0x4c]
 	ldr r0, _0216967c ; =data_027e0e60
 	str r1, [sp, #0xc]
-	ldr r2, [sl, #0x50]
+	ldr r2, [r10, #0x50]
 	ldr r0, [r0]
 	str r2, [sp, #0x10]
-	ldr r8, [sl, #0x50]
+	ldr r8, [r10, #0x50]
 	add r1, sp, #8
 	mov r2, #0
 	add r8, r8, r3
 	bl func_ov00_02083ee0
-	ldr r2, [sl, #0x48]
+	ldr r2, [r10, #0x48]
 	ldr r1, [r5, sb, lsl #2]
 	str r0, [sp, #0x18]
 	add r0, r2, r1
@@ -86855,7 +86855,7 @@ _02169594:
 	cmp r6, #2
 	str r0, [sp]
 	bhs _02169620
-	ldr r3, [sl, #8]
+	ldr r3, [r10, #8]
 	mov r0, r4
 	mov r1, #0x358
 	mov r2, r11
@@ -86863,7 +86863,7 @@ _02169594:
 	bl func_ov00_020cec60
 	b _02169638
 _02169620:
-	ldr r3, [sl, #8]
+	ldr r3, [r10, #8]
 	ldr r1, _02169680 ; =0x00000359
 	mov r0, r4
 	mov r2, r11
@@ -86875,15 +86875,15 @@ _02169638:
 	cmp r7, #0x10
 	blt _02169594
 _02169648:
-	mov r0, sl
+	mov r0, r10
 	bl func_ov15_0216a39c
 _02169650:
 	ldr r1, [sp, #4]
-	add r0, sl, #0xa4
-	add r2, sl, #0x48
+	add r0, r10, #0xa4
+	add r2, r10, #0x48
 	bl func_ov00_0207a1c8
 	add sp, sp, #0x20
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_021694f4
 _02169668: .word data_ov15_021868f0
@@ -86973,15 +86973,15 @@ _02169778: .word data_027e0194
 	.global func_ov15_0216977c
 	arm_func_start func_ov15_0216977c
 func_ov15_0216977c: ; 0x0216977c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x44
 	ldrh r1, [r1]
-	mov sl, r0
+	mov r10, r0
 	tst r1, #4
 	bne _021697a0
 	tst r1, #8
 	addeq sp, sp, #0x44
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _021697a0:
 	add r1, sp, #0x14
 	str r1, [sp]
@@ -86992,11 +86992,11 @@ _021697a0:
 	str r2, [sp, #0xc]
 	ldr r0, [r0]
 	mov r3, r2
-	add r1, sl, #0x48
+	add r1, r10, #0x48
 	bl func_ov00_02079470
 	cmp r0, #0
 	addeq sp, sp, #0x44
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	add r0, sp, #0x24
 	bl func_01ffbe34
 	ldr r0, _02169928 ; =data_027e0d3c
@@ -87008,7 +87008,7 @@ _021697a0:
 	strb r2, [sp, #0x2f]
 	bl func_ov00_02079008
 	str r0, [sp, #0x24]
-	ldr r0, [sl, #0x130]
+	ldr r0, [r10, #0x130]
 	cmp r0, #3
 	bge _021698d8
 	add r1, sp, #0x24
@@ -87026,13 +87026,13 @@ _021697a0:
 	add r6, sp, #0x10
 	add r5, sp, #0x24
 _02169848:
-	add r0, sl, sb
+	add r0, r10, sb
 	ldrb r0, [r0, #0x23c]
 	cmp r0, #4
 	bhs _021698c0
-	ldr r2, [sl, #0x50]
+	ldr r2, [r10, #0x50]
 	ldr r0, [r8, #4]
-	ldr r1, [sl, #0x48]
+	ldr r1, [r10, #0x48]
 	add r2, r2, r0
 	ldr r0, [r8]
 	str r2, [sp, #0x20]
@@ -87062,28 +87062,28 @@ _021698c0:
 	add r8, r8, #8
 	blt _02169848
 	add sp, sp, #0x44
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _021698d8:
 	addne sp, sp, #0x44
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
-	add r0, sl, #0x100
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	add r0, r10, #0x100
 	ldrh r0, [r0, #0xb4]
 	cmp r0, #1
-	ldreq r1, [sl, #0x1d4]
-	ldreq r0, [sl, #0x1bc]
+	ldreq r1, [r10, #0x1d4]
+	ldreq r0, [r10, #0x1bc]
 	cmpeq r1, r0
 	moveq r0, #1
 	movne r0, #0
 	cmp r0, #0
 	addne sp, sp, #0x44
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r1, [sp, #0x14]
 	ldr r2, [sp, #0x10]
 	add r3, sp, #0x24
-	add r0, sl, #0x158
+	add r0, r10, #0x158
 	bl func_02034a1c
 	add sp, sp, #0x44
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0216977c
 _02169928: .word data_027e0d3c
@@ -87831,7 +87831,7 @@ _0216a398: .word data_027e0fe4
 	.global func_ov15_0216a39c
 	arm_func_start func_ov15_0216a39c
 func_ov15_0216a39c: ; 0x0216a39c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0xc
 	mov ip, #0xf000
 	rsb ip, ip, #0
@@ -87858,9 +87858,9 @@ _0216a3d4:
 	ldr r6, [r3, #0xc]
 	ldr lr, [r3, #0x10]
 	mla r8, r6, r5, r8
-	ldr sl, [r3, #0x14]
+	ldr r10, [r3, #0x14]
 	adds r4, lr, sb
-	adc r5, sl, r8
+	adc r5, r10, r8
 	stmia r3, {r4, r5}
 	mov r4, #0x1ec
 	umull r4, r6, r5, r4
@@ -87889,9 +87889,9 @@ _0216a458:
 	ldr r6, [r3, #0xc]
 	ldr lr, [r3, #0x10]
 	mla r8, r6, r5, r8
-	ldr sl, [r3, #0x14]
+	ldr r10, [r3, #0x14]
 	adds r4, lr, sb
-	adc r5, sl, r8
+	adc r5, r10, r8
 	stmia r3, {r4, r5}
 	mov r4, #0x1ec
 	umull r4, r6, r5, r4
@@ -87919,10 +87919,10 @@ _0216a4d4:
 	umull r8, r7, r6, r4
 	mla r7, r6, lr, r7
 	ldr r5, [r3, #0xc]
-	ldr sl, [r3, #0x10]
+	ldr r10, [r3, #0x10]
 	mla r7, r5, r4, r7
 	ldr sb, [r3, #0x14]
-	adds r4, sl, r8
+	adds r4, r10, r8
 	adc r5, sb, r7
 	stmia r3, {r4, r5}
 	mov r4, #0x1ec
@@ -87944,7 +87944,7 @@ _0216a540:
 	cmp r2, #0x10
 	blt _0216a3d4
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0216a39c
 _0216a554: .word data_027e0764
@@ -87976,7 +87976,7 @@ func_ov15_0216a574: ; 0x0216a574
 	.global func_ov15_0216a590
 	arm_func_start func_ov15_0216a590
 func_ov15_0216a590: ; 0x0216a590
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #8
 	mov r0, #1
 	ldr r1, _0216a734 ; =data_027e0f74
@@ -87991,7 +87991,7 @@ func_ov15_0216a590: ; 0x0216a590
 	mov r7, r11
 	mov r8, r11
 	mov sb, r11
-	mov sl, r11
+	mov r10, r11
 	bl func_ov00_02097738
 	cmp r0, #0
 	bne _0216a614
@@ -88008,9 +88008,9 @@ func_ov15_0216a590: ; 0x0216a590
 	add r0, r0, #0xc
 	bl func_ov00_020a5e9c
 	cmp r0, #0x32
-	movne sl, #0
+	movne r10, #0
 _0216a614:
-	cmp sl, #0
+	cmp r10, #0
 	bne _0216a630
 	ldr r0, _0216a744 ; =data_027e10a4
 	ldr r0, [r0]
@@ -88090,7 +88090,7 @@ _0216a704:
 _0216a728:
 	ldr r0, [sp, #4]
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0216a590
 _0216a734: .word data_027e0f74
@@ -89229,7 +89229,7 @@ _0216b588: .word 0x000011c7
 	.global func_ov15_0216b58c
 	arm_func_start func_ov15_0216b58c
 func_ov15_0216b58c: ; 0x0216b58c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x80
 	mov sb, r0
 	ldr r4, [sb, #0x88]
@@ -89257,7 +89257,7 @@ _0216b5e8:
 	cmp r0, #0
 	addeq sp, sp, #0x80
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, [sb, #0x48]
 	mov r2, #1
 	str r0, [sp, #0x3c]
@@ -89278,7 +89278,7 @@ _0216b5e8:
 	add r7, sp, #0x54
 	add r8, sp, #0x64
 	add r4, sp, #0x48
-	mov sl, #1
+	mov r10, #1
 	mov r5, r6
 _0216b650:
 	str r5, [sp, #0x48]
@@ -89331,7 +89331,7 @@ _0216b6cc:
 	mov r2, r4
 	str r3, [sp, #0x38]
 	bl func_01ff9bc4
-	str sl, [sp]
+	str r10, [sp]
 	ldr r0, [r11]
 	mov r1, r4
 	ldr r0, [r0, #4]
@@ -89341,7 +89341,7 @@ _0216b6cc:
 	cmp r0, #0
 	addeq sp, sp, #0x80
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	add r6, r6, #1
 	cmp r6, #4
 	add r7, r7, #4
@@ -89360,7 +89360,7 @@ _0216b6cc:
 	bne _0216b778
 	add sp, sp, #0x80
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0216b778:
 	ldr r1, [sp, #0x64]
 	ldr r0, [sp, #0x68]
@@ -89399,7 +89399,7 @@ _0216b7e0:
 	ldr r5, [sp, #0x64]
 	ldr sb, [sp, #0x68]
 	sub r6, r4, #8
-	sub sl, r3, r5
+	sub r10, r3, r5
 	ldr r4, [sp, #0x6c]
 	ldr r7, [sp, #0x70]
 	sub r5, r11, r6
@@ -89413,7 +89413,7 @@ _0216b7e0:
 	add r0, r0, #8
 	sub r3, r11, r0
 	smull r1, r0, sb, r6
-	smull r11, r2, sl, r5
+	smull r11, r2, r10, r5
 	smull lr, ip, sb, r4
 	str r0, [sp, #4]
 	str ip, [sp, #0x24]
@@ -89427,7 +89427,7 @@ _0216b7e0:
 	str r4, [sp, #0x5c]
 	str r6, [sp, #0x28]
 	str ip, [sp, #8]
-	smull ip, r6, sl, r4
+	smull ip, r6, r10, r4
 	str r6, [sp, #0x10]
 	smull r6, r4, r7, r4
 	str r4, [sp, #0x18]
@@ -89447,8 +89447,8 @@ _0216b7e0:
 	sbc r7, r3, r0
 	ldr r3, [sp, #0x28]
 	mov sb, ip
-	str sl, [sp, #0x64]
-	subs sl, r3, sb
+	str r10, [sp, #0x64]
+	subs r10, r3, sb
 	ldr sb, [sp, #8]
 	ldr r3, [sp, #0x10]
 	str ip, [sp, #0xc]
@@ -89472,7 +89472,7 @@ _0216b7e0:
 	subs lr, r8, r5
 	sbcs lr, r7, r5
 	blt _0216b92c
-	subs lr, sl, r5
+	subs lr, r10, r5
 	sbcs lr, sb, r5
 	bge _0216b9a4
 _0216b92c:
@@ -89483,7 +89483,7 @@ _0216b92c:
 	subs r2, r5, r8
 	sbcs r2, r5, r7
 	blt _0216b954
-	subs r2, r5, sl
+	subs r2, r5, r10
 	sbcs r2, r5, sb
 	bge _0216b9a4
 _0216b954:
@@ -89511,11 +89511,11 @@ _0216b97c:
 _0216b9a4:
 	add sp, sp, #0x80
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0216b9b0:
 	mov r0, #0
 	add sp, sp, #0x80
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0216b58c
 _0216b9bc: .word data_027e0f64
@@ -90497,7 +90497,7 @@ _0216c6b4: .word data_027e0e60
 	.global func_ov15_0216c6b8
 	arm_func_start func_ov15_0216c6b8
 func_ov15_0216c6b8: ; 0x0216c6b8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #0xc
 	mov r4, r0
 	ldr r0, [r4, #0x4d0]
@@ -90537,10 +90537,10 @@ func_ov15_0216c6b8: ; 0x0216c6b8
 	ldrsh r8, [ip, r0]
 	mov r6, #0
 	ldr lr, [sp]
-	umull sl, sb, r8, r5
+	umull r10, sb, r8, r5
 	mla sb, r8, r6, sb
 	mov r7, r8, asr #0x1f
-	adds r8, sl, #0x800
+	adds r8, r10, #0x800
 	mla sb, r7, r5, sb
 	ldr r0, _0216c7fc ; =data_027e0e58
 	mov r2, r3
@@ -90573,7 +90573,7 @@ _0216c7d8:
 	mov r0, r4
 	bl func_ov15_0216ced8
 	add sp, sp, #0xc
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0216c6b8
 _0216c7e8: .word data_027e0764
@@ -92821,7 +92821,7 @@ _0216e698: .word 0x000001df
 	.global func_ov15_0216e69c
 	arm_func_start func_ov15_0216e69c
 func_ov15_0216e69c: ; 0x0216e69c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x50
 	mov r4, r1
 	mvn ip, #0
@@ -92841,13 +92841,13 @@ func_ov15_0216e69c: ; 0x0216e69c
 	str r3, [sp, #0x4c]
 	ldr r3, _0216e96c ; =0x0000152d
 	mov r7, r8, asr #0x1f
-	umull sl, sb, r8, r3
+	umull r10, sb, r8, r3
 	mov r3, #0
 	mla sb, r8, r3, sb
 	ldr r3, _0216e96c ; =0x0000152d
 	mov r11, r2
 	mla sb, r7, r3, sb
-	adds r7, sl, #0x800
+	adds r7, r10, #0x800
 	add r0, sp, #0x44
 	adc r3, sb, #0
 	mov r7, r7, lsr #0xc
@@ -92996,7 +92996,7 @@ _0216e930:
 	add r2, r5, #0x64
 	cmp r3, r2
 	addeq sp, sp, #0x50
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0216e944:
 	ldr r1, [r3]
 	add r3, r3, #4
@@ -93007,7 +93007,7 @@ _0216e944:
 	cmp r3, r2
 	bne _0216e944
 	add sp, sp, #0x50
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0216e69c
 _0216e96c: .word 0x0000152d
@@ -93093,7 +93093,7 @@ func_ov15_0216ea14: ; 0x0216ea14
 	.global func_ov15_0216ea30
 	arm_func_start func_ov15_0216ea30
 func_ov15_0216ea30: ; 0x0216ea30
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #0x94
 	mov r8, r0
 	ldr r1, [r8, #0x11c]
@@ -93109,7 +93109,7 @@ func_ov15_0216ea30: ; 0x0216ea30
 	add r0, sp, #0x4c
 	str r1, [sp]
 	bl func_01ff80d4
-	add sl, sp, #0x4c
+	add r10, sp, #0x4c
 	add sb, sp, #0
 	b _0216eaa8
 _0216ea7c:
@@ -93120,8 +93120,8 @@ _0216ea7c:
 	ldr r7, [sp]
 	tst r0, #2
 	bne _0216eaa8
-	mov r0, sl
-	mov r2, sl
+	mov r0, r10
+	mov r2, r10
 	add r1, r1, #0x28
 	bl func_01ff8690
 _0216eaa8:
@@ -93176,7 +93176,7 @@ _0216eb64:
 	ldr r0, [r8, #0x11c]
 	tst r0, #2
 	addeq sp, sp, #0x94
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	ldr r1, [r8, #0x118]
 	mov r0, r8
 	bl func_ov00_020a9624
@@ -93198,7 +93198,7 @@ _0216eb64:
 	mov r2, r0
 	bl func_01ff8690
 	add sp, sp, #0x94
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0216ea30
 _0216ebcc: .word data_02050f54
@@ -93477,7 +93477,7 @@ func_ov15_0216ef0c: ; 0x0216ef0c
 	.global func_ov15_0216ef4c
 	arm_func_start func_ov15_0216ef4c
 func_ov15_0216ef4c: ; 0x0216ef4c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	mov r4, r0
 	add r1, r4, #0x200
 	mov r2, #0
@@ -93496,10 +93496,10 @@ func_ov15_0216ef4c: ; 0x0216ef4c
 	umull r8, r7, r6, lr
 	mla r7, r6, ip, r7
 	ldr r5, [r2, #0xc]
-	ldr sl, [r2, #0x10]
+	ldr r10, [r2, #0x10]
 	mla r7, r5, lr, r7
 	ldr sb, [r2, #0x14]
-	adds r6, sl, r8
+	adds r6, r10, r8
 	adc r5, sb, r7
 	str r6, [r2]
 	str r5, [r2, #4]
@@ -93516,7 +93516,7 @@ func_ov15_0216ef4c: ; 0x0216ef4c
 	ldr r2, [r2, r4, lsl #2]
 	bl func_ov00_0207c1f8
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0216ef4c
 _0216efec: .word data_027e0764
@@ -94579,7 +94579,7 @@ _0216fdfc: .word data_027e0764
 	.global func_ov15_0216fe00
 	arm_func_start func_ov15_0216fe00
 func_ov15_0216fe00: ; 0x0216fe00
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x338
 	mov r4, r1
 	mov r5, r0
@@ -94688,8 +94688,8 @@ _0216fe54:
 	ldr r1, [sp, #0x260]
 	str r0, [sp, #0x2f8]
 	ldr r0, [sp, #0x268]
-	mov sl, #1
-	strb sl, [sp, #0x29c]
+	mov r10, #1
+	strb r10, [sp, #0x29c]
 	str r1, [sp, #0x2f4]
 	str r0, [sp, #0x2fc]
 	ldr r0, [sp, #0x270]
@@ -94717,13 +94717,13 @@ _0216fe54:
 	strb r3, [sp, #0x317]
 	strb r2, [sp, #0x318]
 	str r11, [sp, #0x31c]
-	strb sl, [sp, #0x29e]
+	strb r10, [sp, #0x29e]
 	bl func_ov00_02097810
 	add r1, r5, #0xf8
 	str r0, [r5, #0x53c]
 	add r0, r1, #0x400
 	blx func_0202ab54
-	mov r0, sl
+	mov r0, r10
 	str r0, [r5, #0x4f8]
 	mov r1, #0
 	ldr r0, _02170634 ; =data_027e0f64
@@ -94797,7 +94797,7 @@ _021700a4:
 	mov sb, r0, lsl #0x1
 	mov r0, sb, lsl #0x1
 	add sb, sb, #1
-	mov sl, sb, lsl #0x1
+	mov r10, sb, lsl #0x1
 	ldrsh r8, [r7, r8]
 	mov sb, #0x4800
 	ldrsh r6, [r7, r6]
@@ -94816,7 +94816,7 @@ _021700a4:
 	str r1, [r5, #0x48]
 	ldrsh r1, [r7, r0]
 	mov r6, r6, asr #0xc
-	ldrsh r0, [r7, sl]
+	ldrsh r0, [r7, r10]
 	mul r2, r1, r6
 	mul r1, r0, r6
 	ldr r6, [r5, #0x50]
@@ -94842,12 +94842,12 @@ _021700a4:
 	ldrsh r8, [r7, r2]
 	add r2, r3, #1
 	mov r2, r2, lsl #0x1
-	umull sl, sb, r8, r0
+	umull r10, sb, r8, r0
 	ldrsh r2, [r7, r2]
 	mla sb, r8, r1, sb
 	umull r6, r3, r2, r0
 	mov r7, r8, asr #0x1f
-	adds r8, sl, #0x800
+	adds r8, r10, #0x800
 	mla sb, r7, r0, sb
 	adc r7, sb, #0
 	mov r8, r8, lsr #0xc
@@ -94900,7 +94900,7 @@ _0217029c:
 	bl func_ov00_0209a4f4
 	ldr r0, _02170630 ; =data_027e0f94
 	mvn r7, #0
-	mov sl, #0x32
+	mov r10, #0x32
 	mov sb, #0
 	mov r8, #3
 	mov r3, #1
@@ -94913,7 +94913,7 @@ _0217029c:
 	ldr r6, [sp, #0x50]
 	ldr r2, [sp, #0x54]
 	ldr r0, [r0]
-	strb sl, [sp, #0x179]
+	strb r10, [sp, #0x179]
 	strb sb, [sp, #0x17a]
 	strb r8, [sp, #0x17b]
 	add r1, sp, #0x170
@@ -94964,7 +94964,7 @@ _021703c8:
 	mov r1, #4
 	bl func_ov15_0216fe00
 	add sp, sp, #0x338
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _021703e8:
 	ldr r0, _0217063c ; =data_027e10a4
 	mov r6, #0
@@ -95067,7 +95067,7 @@ _021703e8:
 	ldrb r2, [sp, #0xbc]
 	ldr r1, [sp, #0xa4]
 	ldr r11, [sp, #0xac]
-	ldr sl, [sp, #0xb0]
+	ldr r10, [sp, #0xb0]
 	str sb, [sp, #0x134]
 	ldr sb, [sp, #0xb4]
 	str r1, [sp, #0x138]
@@ -95075,7 +95075,7 @@ _021703e8:
 	ldr r0, [r0]
 	add r1, sp, #0xc0
 	str r11, [sp, #0x140]
-	str sl, [sp, #0x144]
+	str r10, [sp, #0x144]
 	str sb, [sp, #0x148]
 	strb r8, [sp, #0x14c]
 	strb r7, [sp, #0x14d]
@@ -95109,7 +95109,7 @@ _0217060c:
 	str r4, [r5, #0x130]
 	strb r0, [r5, #0x56c]
 	add sp, sp, #0x338
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0216fe00
 _02170624: .word 0x0000ffff
@@ -95401,7 +95401,7 @@ _02170a00: .word 0x4852434e
 	.global func_ov15_02170a04
 	arm_func_start func_ov15_02170a04
 func_ov15_02170a04: ; 0x02170a04
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x294
 	mov r4, r0
 	ldrb r1, [r4, #0x56c]
@@ -95430,11 +95430,11 @@ _02170a5c:
 	bl func_ov15_021733b0
 	cmp r0, #0
 	addeq sp, sp, #0x294
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, [r4, #0x138]
 	cmp r0, #0x5a
 	addlt sp, sp, #0x294
-	ldmltia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmltia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	add r1, r4, #0x9c
 	ldr r0, _02170fe4 ; =data_027e0c68
 	ldr r2, _02170fe8 ; =0x00050027
@@ -95442,7 +95442,7 @@ _02170a5c:
 	bl func_02036ce4
 	cmp r0, #0
 	addeq sp, sp, #0x294
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	mov r0, r4
 	mov r1, #1
 	bl _ZN5Actor10SetUnk_11cEc
@@ -95452,7 +95452,7 @@ _02170a5c:
 	ldr r0, [r0]
 	bl func_ov15_021413d4
 	add sp, sp, #0x294
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02170ac8:
 	ldr r0, _02170fec ; =data_027e0f64
 	add r1, sp, #0x22c
@@ -95485,7 +95485,7 @@ _02170ac8:
 	and r0, r1, r0
 	cmp r0, #0x1000000
 	addeq sp, sp, #0x294
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	add r0, r4, #0x9c
 	add r0, r0, #0x400
 	ldr r1, [r0]
@@ -95497,7 +95497,7 @@ _02170ac8:
 	and r0, r1, r0
 	cmp r0, #0x1000000
 	addne sp, sp, #0x294
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	add r0, sp, #0x17c
 	bl func_ov00_0209a4f4
 	mvn r5, #0
@@ -95543,9 +95543,9 @@ _02170ac8:
 	sub r0, r0, #0x4a
 	sub r0, r0, #0x900
 	add r1, r2, r1
-	ldr sl, [sp, #0x2c]
+	ldr r10, [sp, #0x2c]
 	orr sb, sb, r6, lsl #20
-	add r6, sl, sb
+	add r6, r10, sb
 	str r0, [sp, #0x30]
 	str r0, [sp, #0x1a0]
 	ldr r0, _02170fec ; =data_027e0f64
@@ -95562,7 +95562,7 @@ _02170ac8:
 	mov r0, r4
 	bl _ZN5Actor14GetAngleToLinkEv
 	ldr r1, [sp, #0x114]
-	mov sl, #1
+	mov r10, #1
 	str r1, [sp, #0x1a8]
 	ldr r1, [sp, #0x11c]
 	str r0, [sp, #0x128]
@@ -95583,7 +95583,7 @@ _02170ac8:
 	str r0, [sp, #0x134]
 	str r0, [sp, #0x1c8]
 	ldr r0, [sp, #0x118]
-	strb sl, [sp, #0x190]
+	strb r10, [sp, #0x190]
 	str r0, [sp, #0x1ac]
 	ldr r0, [sp, #0x12c]
 	str r1, [sp, #0x1d0]
@@ -95629,7 +95629,7 @@ _02170ac8:
 	strb r3, [sp, #0x20b]
 	strb r2, [sp, #0x20c]
 	str r11, [sp, #0x210]
-	strb sl, [sp, #0x192]
+	strb r10, [sp, #0x192]
 	bl func_ov00_02097810
 	str r0, [r4, #0x540]
 	ldr r0, _02170ff8 ; =data_027e0f74
@@ -95662,7 +95662,7 @@ _02170db8:
 	strb r1, [r4, #0x575]
 	bl func_ov00_0209a508
 	add sp, sp, #0x294
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02170e08:
 	ldr r0, _02170fec ; =data_027e0f64
 	ldr r0, [r0]
@@ -95670,13 +95670,13 @@ _02170e08:
 	bl func_ov00_02089a2c
 	cmp r0, #0
 	addne sp, sp, #0x294
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	mov r0, #3
 	strb r0, [r4, #0x56c]
 	mov r0, #0
 	add sp, sp, #0x294
 	str r0, [r4, #0x138]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02170e3c:
 	add r0, r4, #0x4c
 	mov r1, #0x2000
@@ -95706,7 +95706,7 @@ _02170e3c:
 	ldr r0, [r4, #0x138]
 	cmp r0, #0x3c
 	addlt sp, sp, #0x294
-	ldmltia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmltia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	add r1, r4, #0x9c
 	ldr r0, _02170fe4 ; =data_027e0c68
 	ldr r2, _02171004 ; =0x00050028
@@ -95714,14 +95714,14 @@ _02170e3c:
 	bl func_02036ce4
 	cmp r0, #0
 	addeq sp, sp, #0x294
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	mov r0, r4
 	mov r1, #1
 	bl _ZN5Actor10SetUnk_11cEc
 	mov r0, #4
 	add sp, sp, #0x294
 	strb r0, [r4, #0x56c]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02170eec:
 	add r0, r4, #0x4c
 	mov r1, #0x2000
@@ -95754,7 +95754,7 @@ _02170eec:
 	and r0, r1, r0
 	cmp r0, #0x1000000
 	addeq sp, sp, #0x294
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	add r0, r4, #0x9c
 	add r0, r0, #0x400
 	ldr r1, [r0]
@@ -95766,7 +95766,7 @@ _02170eec:
 	and r0, r1, r0
 	cmp r0, #0x1000000
 	addne sp, sp, #0x294
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, _02170ff8 ; =data_027e0f74
 	ldr r1, [r4, #0x540]
 	ldr r0, [r0]
@@ -95785,7 +95785,7 @@ _02170fc4:
 	bl func_ov15_0216fe00
 _02170fd8:
 	add sp, sp, #0x294
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02170a04
 _02170fe0: .word data_027e10a4
@@ -97081,7 +97081,7 @@ func_ov15_02172238: ; 0x02172238
 	.global func_ov15_02172260
 	arm_func_start func_ov15_02172260
 func_ov15_02172260: ; 0x02172260
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x40
 	mov r4, r0
 	str r1, [sp]
@@ -97097,10 +97097,10 @@ func_ov15_02172260: ; 0x02172260
 	cmp r1, r0
 	addge sp, sp, #0x40
 	movge r0, #0
-	ldmgeia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
-	ldr sl, [r4, #0x48]
+	ldmgeia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldr r10, [r4, #0x48]
 	mov r1, #0x800
-	str sl, [sp, #0x28]
+	str r10, [sp, #0x28]
 	ldr r0, [r4, #0x4c]
 	sub ip, r1, #0x2800
 	str r0, [sp, #0x2c]
@@ -97110,7 +97110,7 @@ func_ov15_02172260: ; 0x02172260
 	str sb, [sp, #0x30]
 	mov r0, #0
 	sub r0, r0, #1
-	str sl, [sp, #0x34]
+	str r10, [sp, #0x34]
 	str sb, [sp, #0x3c]
 	ldrh r2, [r4, #0x78]
 	str r0, [sp, #0xc]
@@ -97134,7 +97134,7 @@ func_ov15_02172260: ; 0x02172260
 	mla r5, r2, r11, r5
 	adc r0, r5, #0
 	orr r7, r7, r0, lsl #20
-	add r0, sl, r7
+	add r0, r10, r7
 	mov r3, #0
 	umull r8, r7, r6, r11
 	str r0, [sp, #0x34]
@@ -97169,7 +97169,7 @@ func_ov15_02172260: ; 0x02172260
 	adc r3, r7, #0
 	mov r5, r5, lsr #0xc
 	orr r5, r5, r3, lsl #20
-	add r3, sl, r5
+	add r3, r10, r5
 	str r3, [sp, #0x28]
 	ldr r3, [sp, #8]
 	umull r7, r6, r11, lr
@@ -97230,11 +97230,11 @@ func_ov15_02172260: ; 0x02172260
 	cmp r1, r0
 	addlt sp, sp, #0x40
 	movlt r0, #1
-	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _021724b8:
 	mov r0, #0
 	add sp, sp, #0x40
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02172260
 _021724c4: .word 0x00001266
@@ -97314,17 +97314,17 @@ _021725c8: .word data_027e0f94
 	.global func_ov15_021725cc
 	arm_func_start func_ov15_021725cc
 func_ov15_021725cc: ; 0x021725cc
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #8
 	mov r5, r0
 	ldr r0, [r5, #0x578]
 	cmp r0, #0
 	addeq sp, sp, #8
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	ldr r0, [r5, #0x554]
 	cmp r0, #0
 	addne sp, sp, #8
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	mov r0, #1
 	strb r0, [sp]
 	ldr r1, [r5, #0x550]
@@ -97354,7 +97354,7 @@ func_ov15_021725cc: ; 0x021725cc
 	cmp r6, #0x2a
 	bne _021726b0
 	add sp, sp, #8
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _02172670:
 	ands r6, r4, #0xfc0
 	beq _021726b0
@@ -97371,7 +97371,7 @@ _02172670:
 	bl func_ov15_021728ac
 	cmp r6, #0xa80
 	addeq sp, sp, #8
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _021726b0:
 	ldrb lr, [sp]
 	cmp lr, #0
@@ -97386,16 +97386,16 @@ _021726b0:
 _021726d8:
 	cmp lr, #0
 	addne sp, sp, #8
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	ldrh r1, [sp, #2]
 	ldr r0, _02172848 ; =0x000037dc
 	cmp r1, r0
 	addlo sp, sp, #8
-	ldmloia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmloia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	ldr r0, _0217284c ; =0x00005208
 	cmp r1, r0
 	addhi sp, sp, #8
-	ldmhiia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmhiia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _02172708:
 	ldrb r0, [r5, #0x56f]
 	cmp r0, #0
@@ -97412,20 +97412,20 @@ _02172728:
 	subne r1, r1, #1
 	strneh r1, [r0, #0x62]
 	addne sp, sp, #8
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	mov r0, #3
 	mov r1, #0
 	ldr r8, _02172850 ; =data_027e0764
 	mov r7, r1
 	mov r6, r0
 _02172758:
-	ldr sl, [r8, #8]
+	ldr r10, [r8, #8]
 	ldmia r8, {sb, ip}
-	umull r3, r2, sl, sb
-	mla r2, sl, ip, r2
-	ldr sl, [r8, #0xc]
+	umull r3, r2, r10, sb
+	mla r2, r10, ip, r2
+	ldr r10, [r8, #0xc]
 	ldr ip, [r8, #0x10]
-	mla r2, sl, sb, r2
+	mla r2, r10, sb, r2
 	ldr sb, [r8, #0x14]
 	adds r3, ip, r3
 	adc sb, sb, r2
@@ -97478,7 +97478,7 @@ _02172830:
 	mov r1, #0x1e
 	strh r1, [r0, #0x66]
 	add sp, sp, #8
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov15_021725cc
 _02172844: .word 0x00002af8
@@ -98995,7 +98995,7 @@ func_ov15_02173c84: ; 0x02173c84
 	.global func_ov15_02173cb4
 	arm_func_start func_ov15_02173cb4
 func_ov15_02173cb4: ; 0x02173cb4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x78
 	mov r4, r0
 	add r0, r4, #0x48
@@ -99043,7 +99043,7 @@ func_ov15_02173cb4: ; 0x02173cb4
 	bl _ZN12ActorManager8GetActorEP8ActorRef
 	movs r4, r0
 	addeq sp, sp, #0x78
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, _02173fdc ; =data_027e0ffc
 	ldr r1, _02173fe0 ; =0x000002eb
 	add r2, sp, #0x6c
@@ -99058,16 +99058,16 @@ func_ov15_02173cb4: ; 0x02173cb4
 	ldr r0, _02173fe8 ; =data_027e0764
 	ldr lr, _02173fec ; =data_02050f54
 	ldr r6, [r0, #8]
-	ldr sl, [r0]
+	ldr r10, [r0]
 	ldr sb, [r0, #4]
-	umull ip, r11, r6, sl
+	umull ip, r11, r6, r10
 	mla r11, r6, sb, r11
 	ldr r5, [r0, #0xc]
 	ldr r8, [r0, #0x10]
-	mla r11, r5, sl, r11
+	mla r11, r5, r10, r11
 	ldr r7, [r0, #0x14]
 	mov r0, #0
-	adds sl, r8, ip
+	adds r10, r8, ip
 	adc sb, r7, r11
 	mov r3, r0, lsl #0x10
 	orr r3, r3, sb, lsr #16
@@ -99075,7 +99075,7 @@ func_ov15_02173cb4: ; 0x02173cb4
 	ldr r11, _02173fe8 ; =data_027e0764
 	mov r3, r3, lsl #0x10
 	mov r3, r3, lsr #0x10
-	str sl, [r11]
+	str r10, [r11]
 	mov r3, r3, asr #0x4
 	str sb, [r11, #4]
 	mov r11, r3, lsl #0x1
@@ -99084,9 +99084,9 @@ func_ov15_02173cb4: ; 0x02173cb4
 	mov r11, r11, lsl #0x1
 	ldrsh r3, [lr, r3]
 	ldrsh r11, [lr, r11]
-	umull lr, ip, r6, sl
+	umull lr, ip, r6, r10
 	mla ip, r6, sb, ip
-	mla ip, r5, sl, ip
+	mla ip, r5, r10, ip
 	adds r8, r8, lr
 	ldr r5, _02173fe8 ; =data_027e0764
 	str r0, [sp, #0x20]
@@ -99168,10 +99168,10 @@ func_ov15_02173cb4: ; 0x02173cb4
 	ldr r0, [sp, #0x70]
 	mov r8, sb, asr #0x1f
 	sub r0, r7, r0
-	umull sl, r7, sb, r3
+	umull r10, r7, sb, r3
 	mla r7, sb, r2, r7
 	mla r7, r8, r3, r7
-	adds r3, sl, #0x800
+	adds r3, r10, #0x800
 	adc r2, r7, #0
 	mov r3, r3, lsr #0xc
 	orr r3, r3, r2, lsl #20
@@ -99192,7 +99192,7 @@ func_ov15_02173cb4: ; 0x02173cb4
 	str r0, [r4, #0x64]
 	str r7, [r4, #0x68]
 	add sp, sp, #0x78
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02173cb4
 _02173fcc: .word data_027e0e58
@@ -101692,7 +101692,7 @@ _02176114: .word func_ov15_02176300
 	.global func_ov15_02176118
 	arm_func_start func_ov15_02176118
 func_ov15_02176118: ; 0x02176118
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	bl func_ov15_0213ce4c
 	bl func_ov15_0213d1ec
 	ldr r4, _021762cc ; =0x04000488
@@ -101743,8 +101743,8 @@ _02176138:
 	ldrsh r0, [r0, r1]
 	mov r1, r0, lsl #0x6
 	mov r0, r1, asr #0xb
-	add sl, r1, r0, lsr #20
-	mov r7, sl, asr #0xc
+	add r10, r1, r0, lsr #20
+	mov r7, r10, asr #0xc
 	add r0, r7, #0x80
 	bl func_ov05_0210e288
 	ldr r1, _021762dc ; =data_02050f54
@@ -101766,16 +101766,16 @@ _02176138:
 	orr r0, r0, r2, lsr #16
 	rsb sb, r8, #0x80
 	str r0, [r4, #0xc]
-	add r0, sb, sl, asr #12
+	add r0, sb, r10, asr #12
 	bl func_ov05_0210e288
-	mov sl, r0
+	mov r10, r0
 	rsb r7, r7, #0xc0
 	sub r0, r7, r8
 	bl func_ov05_0210e2a4
 	mov r0, r0, lsl #0x10
 	mov r0, r0, lsr #0x10
 	mov r1, #0
-	mov r2, sl, lsl #0x10
+	mov r2, r10, lsl #0x10
 	mov r0, r0, lsl #0x10
 	str r1, [r4]
 	orr r0, r0, r2, lsr #16
@@ -101801,7 +101801,7 @@ _02176138:
 	cmp r6, #4
 	mov r5, r0, lsr #0x10
 	blt _02176138
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02176118
 _021762cc: .word 0x04000488
@@ -102655,29 +102655,29 @@ _02176e30:
 	.global func_ov15_02176ed8
 	arm_func_start func_ov15_02176ed8
 func_ov15_02176ed8: ; 0x02176ed8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	ldr r2, _02177050 ; =data_027e0618
-	mov sl, r0
+	mov r10, r0
 	ldrb r0, [r2, #0x101]
 	mov r4, r1
 	cmp r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, _02177054 ; =data_027e0c54
 	bl func_020360a8
 	mov r1, r0
 	mov r0, r4
 	bl func_02031d58
 	cmp r0, #0
-	ldrne r8, [sl, #0x318]
+	ldrne r8, [r10, #0x318]
 	cmpne r8, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, _02177058 ; =data_027e0c38
 	mov sb, #0
 	ldr r0, [r0, #0x10]
-	add r5, sl, #0x17c
+	add r5, r10, #0x17c
 	cmp r0, #1
 	addeq r8, r8, #0x28
-	add r4, sl, #0x300
+	add r4, r10, #0x300
 	mov r6, sb
 	mov r11, #0x62
 	mov r7, sb
@@ -102701,13 +102701,13 @@ _02176f74:
 	cmp sb, #5
 	add r8, r8, #8
 	blt _02176f40
-	ldr r4, [sl, #0x318]
+	ldr r4, [r10, #0x318]
 	mov r1, #0
 	str r1, [sp]
 	ldr r5, [r4, #0x50]
-	ldr r2, [sl, #0x288]
+	ldr r2, [r10, #0x288]
 	ldr r3, [r4, #0x54]
-	ldr r0, [sl, #0x28c]
+	ldr r0, [r10, #0x28c]
 	add r2, r5, r2
 	add r3, r3, r0
 	mov r0, #0x62
@@ -102722,7 +102722,7 @@ _02176f74:
 	mov r0, #0
 	str r0, [sp]
 	ldr r1, [r4, #0x60]
-	ldr r0, [sl, #0x32c]
+	ldr r0, [r10, #0x32c]
 	ldr r3, [r4, #0x64]
 	add r2, r1, r0
 	mov r0, #0x62
@@ -102731,27 +102731,27 @@ _02176f74:
 	mov r0, #0
 	str r0, [sp]
 	ldr r3, [r4, #0x68]
-	ldr r2, [sl, #0x32c]
+	ldr r2, [r10, #0x32c]
 	ldr r5, [r4, #0x6c]
 	add r2, r3, r2
-	ldr r3, [sl, #0x330]
+	ldr r3, [r10, #0x330]
 	mov r0, #0x62
 	mov r1, #3
 	add r3, r5, r3
 	bl func_02034984
-	ldrb r0, [sl, #0x351]
+	ldrb r0, [r10, #0x351]
 	cmp r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
-	ldr r0, [sl, #0x324]
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldr r0, [r10, #0x324]
 	cmp r0, #1
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
-	add r0, sl, #0x204
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	add r0, r10, #0x204
 	ldr r1, [r4, #0x70]
 	ldr r2, [r4, #0x74]
 	add r0, r0, #0x400
 	mov r3, #0
 	bl func_02034a1c
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02176ed8
 _02177050: .word data_027e0618
@@ -102791,7 +102791,7 @@ _02177088: .word func_ov09_0211372c
 	.global func_ov15_0217708c
 	arm_func_start func_ov15_0217708c
 func_ov15_0217708c: ; 0x0217708c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	mov r0, #1
 	str r0, [sp]
 	ldr r11, [sp]
@@ -102803,7 +102803,7 @@ func_ov15_0217708c: ; 0x0217708c
 	mov r7, r11
 	mov r8, r11
 	mov sb, r11
-	mov sl, r11
+	mov r10, r11
 	bl func_ov00_02097738
 	cmp r0, #0
 	bne _02177104
@@ -102820,9 +102820,9 @@ func_ov15_0217708c: ; 0x0217708c
 	add r0, r0, #0xc
 	bl func_ov00_020a5e9c
 	cmp r0, #0x32
-	movne sl, #0
+	movne r10, #0
 _02177104:
-	cmp sl, #0
+	cmp r10, #0
 	bne _02177120
 	ldr r0, _0217720c ; =data_027e10a4
 	ldr r0, [r0]
@@ -102891,7 +102891,7 @@ _021771d4:
 	strne r0, [sp]
 _021771f4:
 	ldr r0, [sp]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0217708c
 _021771fc: .word data_027e0f74
@@ -103487,7 +103487,7 @@ _02177960: .word data_027e10b0
 	.global func_ov15_02177964
 	arm_func_start func_ov15_02177964
 func_ov15_02177964: ; 0x02177964
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x7c
 	ldr r1, _02177ef4 ; =data_027e10b0
 	mov r4, r0
@@ -103520,8 +103520,8 @@ func_ov15_02177964: ; 0x02177964
 	mov r0, #0x15
 	umull r1, r3, r6, r0
 	mla r3, r6, r8, r3
-	mov sl, r8
-	mla r3, sl, r0, r3
+	mov r10, r8
+	mla r3, r10, r0, r3
 	str r6, [r2, #4]
 	mov r5, #0x10
 	add r1, r3, #0x14
@@ -103615,7 +103615,7 @@ func_ov15_02177964: ; 0x02177964
 	adc r11, sb, r3
 	umull r3, sb, r11, r6
 	mla sb, r11, r8, sb
-	mla sb, sl, r6, sb
+	mla sb, r10, r6, sb
 	stmia r2, {r5, r11}
 	add r2, sb, #0x3c
 	strh r2, [r0, #0x64]
@@ -103663,7 +103663,7 @@ _02177bd4:
 _02177c14:
 	add sp, sp, #0x7c
 	mov r0, r8
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02177c20:
 	ldr r3, [r4, #0x4c]
 	ldr r2, [r4, #0x50]
@@ -103738,7 +103738,7 @@ _02177c84:
 	cmp r0, #5
 	addeq sp, sp, #0x7c
 	moveq r0, #1
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	add r0, sp, #0x44
 	bl func_ov00_020c1500
 	mvn r1, #0
@@ -103770,7 +103770,7 @@ _02177c84:
 	cmp r1, r0
 	addeq sp, sp, #0x7c
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, _02177f20 ; =data_027e0fe4
 	add r1, sp, #4
 	ldr r0, [r0]
@@ -103791,7 +103791,7 @@ _02177c84:
 	cmp r1, r0
 	addeq sp, sp, #0x7c
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, _02177f20 ; =data_027e0fe4
 	add r1, sp, #4
 	ldr r0, [r0]
@@ -103812,7 +103812,7 @@ _02177c84:
 	cmp r1, r0
 	addeq sp, sp, #0x7c
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, _02177f20 ; =data_027e0fe4
 	add r1, sp, #4
 	ldr r0, [r0]
@@ -103835,7 +103835,7 @@ _02177c84:
 	cmp r1, r0
 	addeq sp, sp, #0x7c
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, _02177f20 ; =data_027e0fe4
 	add r1, sp, #4
 	ldr r0, [r0]
@@ -103847,7 +103847,7 @@ _02177c84:
 	str r0, [r4, #0x3bc]
 	mov r0, #1
 	add sp, sp, #0x7c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02177964
 _02177ef4: .word data_027e10b0
@@ -105054,16 +105054,16 @@ _02178ff4: .word 0xffffe99a
 	.global func_ov15_02178ff8
 	arm_func_start func_ov15_02178ff8
 func_ov15_02178ff8: ; 0x02178ff8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0xa0
 	ldrh r1, [r1]
-	mov sl, r0
-	ldrh r4, [sl, #0x7a]
+	mov r10, r0
+	ldrh r4, [r10, #0x7a]
 	tst r1, #4
 	bne _02179020
 	tst r1, #8
 	addeq sp, sp, #0xa0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02179020:
 	cmp r4, #0x69
 	beq _021790c8
@@ -105076,16 +105076,16 @@ _02179020:
 	str r2, [sp, #0xc]
 	ldr r0, [r0]
 	mov r3, r2
-	add r1, sl, #0x48
+	add r1, r10, #0x48
 	bl func_ov00_02079470
 	cmp r0, #0
 	addeq sp, sp, #0xa0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	add r0, sp, #0x80
 	bl func_01ffbe34
 	mov r0, #1
 	str r0, [sp, #0x84]
-	ldrb r0, [sl, #0x4a9]
+	ldrb r0, [r10, #0x4a9]
 	cmp r0, #0
 	beq _02179098
 	ldr r0, _02179330 ; =data_027e103c
@@ -105096,7 +105096,7 @@ _02179020:
 	moveq r4, #0x5e
 	b _021790a4
 _02179098:
-	ldrb r0, [sl, #0x4aa]
+	ldrb r0, [r10, #0x4aa]
 	cmp r0, #0
 	movne r4, #0x63
 _021790a4:
@@ -105108,7 +105108,7 @@ _021790a4:
 	mov r3, r4
 	bl func_020313c8
 	add sp, sp, #0xa0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _021790c8:
 	add r0, sp, #0x60
 	bl func_01ffbe34
@@ -105121,7 +105121,7 @@ _021790c8:
 	ldr r6, _0217933c ; =data_ov15_02186e9c
 	mov sb, #0
 	str r0, [sp, #0x60]
-	add r4, sl, #0x400
+	add r4, r10, #0x400
 	add r11, sp, #0x44
 	add r5, sp, #0x60
 	mov r8, #1
@@ -105160,7 +105160,7 @@ _0217916c:
 	add r4, sp, #0x38
 	ldmia r0, {r0, r1, r2}
 	stmia r4, {r0, r1, r2}
-	add r5, sl, #0x400
+	add r5, r10, #0x400
 	ldrh r0, [r5, #0x5a]
 	ldr r3, _02179344 ; =data_02050f54
 	mov r2, #0
@@ -105181,7 +105181,7 @@ _0217916c:
 	orr r6, r6, r1, lsl #20
 	sub ip, r0, r6
 	str ip, [sp, #0x40]
-	ldr r8, [sl, #0x43c]
+	ldr r8, [r10, #0x43c]
 	ldrh r5, [r5, #0x5a]
 	mov r1, r4
 	mov r0, #0x7000
@@ -105245,13 +105245,13 @@ _0217916c:
 	ldr r2, [sp, #0x10]
 	mov r3, #0x68
 	bl func_020313c8
-	ldrh r4, [sl, #0x7a]
+	ldrh r4, [r10, #0x7a]
 	add r0, sp, #0x18
 	bl func_01ffbe34
 	mov r0, #1
 	mov r1, #2
 	strb r0, [sp, #0x2c]
-	add r0, sl, #0x400
+	add r0, r10, #0x400
 	str r1, [sp, #0x1c]
 	ldrsh r1, [r0, #0x56]
 	ldr r0, _02179334 ; =data_02063e4c
@@ -105264,7 +105264,7 @@ _0217916c:
 	str r5, [sp]
 	bl func_020313c8
 	add sp, sp, #0xa0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02178ff8
 _0217932c: .word data_027e0d3c
@@ -105279,7 +105279,7 @@ _02179348: .word data_02051f54
 	.global func_ov15_0217934c
 	arm_func_start func_ov15_0217934c
 func_ov15_0217934c: ; 0x0217934c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0xc8
 	mov r5, r1
 	ldr r3, [r5, #0x14]
@@ -105289,7 +105289,7 @@ func_ov15_0217934c: ; 0x0217934c
 	cmp r2, r1
 	addne sp, sp, #0xc8
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	add r0, r3, #0x48
 	add r8, sp, #0xbc
 	ldmia r0, {r0, r1, r2}
@@ -105311,7 +105311,7 @@ func_ov15_0217934c: ; 0x0217934c
 	cmp r1, r0
 	addge sp, sp, #0xc8
 	movge r0, #0
-	ldmgeia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmgeia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	add r0, r4, #0x48
 	add sb, sp, #0xa0
 	ldmia r0, {r0, r1, r2}
@@ -105319,7 +105319,7 @@ func_ov15_0217934c: ; 0x0217934c
 	ldrh r0, [r4, #0x78]
 	ldr r1, [sp, #0xa4]
 	ldr r2, _021796a8 ; =data_02050f54
-	add sl, r1, #0x4800
+	add r10, r1, #0x4800
 	mov r0, r0, asr #0x4
 	mov r0, r0, lsl #0x1
 	mov r3, r0, lsl #0x1
@@ -105337,11 +105337,11 @@ func_ov15_0217934c: ; 0x0217934c
 	adds r0, r0, #0x800
 	mov r7, r0, lsr #0xc
 	mov r0, r8
-	str sl, [sp, #0xa4]
+	str r10, [sp, #0xa4]
 	mov r1, sb
 	ldr sb, [r4, #0x448]
 	ldr r2, _021796ac ; =0xffffeccd
-	sub sb, sl, sb
+	sub sb, r10, sb
 	str sb, [sp, #0xa4]
 	mov sb, r5, asr #0x1f
 	ldr r5, _021796ac ; =0xffffeccd
@@ -105486,14 +105486,14 @@ func_ov15_0217934c: ; 0x0217934c
 	cmpge r0, #0
 	addlt sp, sp, #0xc8
 	movlt r0, #0
-	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0217968c:
 	add r0, r4, #0x1d8
 	mov r1, #1
 	bl func_ov00_020c5d74
 	mov r0, #1
 	add sp, sp, #0xc8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0217934c
 _021796a4: .word 0x434e424c
@@ -105581,7 +105581,7 @@ _021797cc: .word data_027e0f94
 	.global func_ov15_021797d0
 	arm_func_start func_ov15_021797d0
 func_ov15_021797d0: ; 0x021797d0
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0xc
 	mov r7, r0
 	add r1, r7, #0x400
@@ -105590,7 +105590,7 @@ func_ov15_021797d0: ; 0x021797d0
 	subne r0, r0, #1
 	strneh r0, [r1, #0x64]
 	addne sp, sp, #0xc
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r2, _02179ac0 ; =data_027e0764
 	mov r5, #0
 	ldr r3, [r2]
@@ -105632,21 +105632,21 @@ _0217987c:
 	ldrb r11, [sp]
 	cmp r11, #0
 	addeq sp, sp, #0xc
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldrh r2, [sp, #8]
 	ldr r3, _02179ac0 ; =data_027e0764
 	mov ip, #1
 	mov lr, #0
 _021798ac:
 	ldr sb, [r3]
-	ldmib r3, {r8, sl}
-	umull r1, r0, sl, sb
-	mla r0, sl, r8, r0
+	ldmib r3, {r8, r10}
+	umull r1, r0, r10, sb
+	mla r0, r10, r8, r0
 	ldr r8, [r3, #0xc]
-	ldr sl, [r3, #0x10]
+	ldr r10, [r3, #0x10]
 	mla r0, r8, sb, r0
 	ldr sb, [r3, #0x14]
-	adds r1, sl, r1
+	adds r1, r10, r1
 	mov r8, lr, lsl #0x2
 	adc r0, sb, r0
 	orr r8, r8, r0, lsr #30
@@ -105712,13 +105712,13 @@ _02179988:
 _021799bc:
 	ldr sb, [r4, #8]
 	ldr r3, [r4, #0xc]
-	umull r11, sl, sb, r1
-	mla sl, sb, r0, sl
-	mla sl, r3, r1, sl
+	umull r11, r10, sb, r1
+	mla r10, sb, r0, r10
+	mla r10, r3, r1, r10
 	ldr r1, [r4, #0x10]
 	ldr r0, [r4, #0x14]
 	adds r1, r1, r11
-	adc r0, r0, sl
+	adc r0, r0, r10
 	mov r3, r7, lsl #0x2
 	orr r3, r3, r0, lsr #30
 	mov r3, r3, lsl #0x10
@@ -105768,7 +105768,7 @@ _02179a78:
 	strneh r0, [sp, #4]
 	bne _02179aa8
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02179aa0:
 	mov r0, #0
 	strh r0, [sp, #4]
@@ -105778,7 +105778,7 @@ _02179aa8:
 	mov r0, r6
 	bl func_ov15_0217bbb0
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_021797d0
 _02179ac0: .word data_027e0764
@@ -106744,7 +106744,7 @@ _0217a84c: .word data_027e0e58
 	.global func_ov15_0217a850
 	arm_func_start func_ov15_0217a850
 func_ov15_0217a850: ; 0x0217a850
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x130
 	mov r4, r0
 	add r0, sp, #0x80
@@ -106833,7 +106833,7 @@ func_ov15_0217a850: ; 0x0217a850
 	ldrb r3, [sp, #0x7b]
 	ldrb r2, [sp, #0x7c]
 	ldr r0, [sp, #0x60]
-	ldr sl, [sp, #0x64]
+	ldr r10, [sp, #0x64]
 	ldr sb, [sp, #0x68]
 	ldr r8, [sp, #0x6c]
 	ldr r7, [sp, #0x70]
@@ -106843,7 +106843,7 @@ func_ov15_0217a850: ; 0x0217a850
 	str r0, [sp, #0xf4]
 	ldr r0, [r1]
 	add r1, sp, #0x80
-	str sl, [sp, #0xf8]
+	str r10, [sp, #0xf8]
 	str sb, [sp, #0xfc]
 	str r8, [sp, #0x100]
 	str r7, [sp, #0x104]
@@ -106859,7 +106859,7 @@ func_ov15_0217a850: ; 0x0217a850
 	add r0, sp, #0x80
 	bl func_ov00_0209a508
 	add sp, sp, #0x130
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0217a850
 _0217aa20: .word data_027e0e60
@@ -107936,7 +107936,7 @@ func_ov15_0217b848: ; 0x0217b848
 	.global func_ov15_0217b84c
 	arm_func_start func_ov15_0217b84c
 func_ov15_0217b84c: ; 0x0217b84c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x12c
 	mov r4, r0
 	ldrh r5, [r4, #0x20]
@@ -107949,12 +107949,12 @@ func_ov15_0217b84c: ; 0x0217b84c
 	mul r0, r8, r1
 	ldrb r2, [r4, #0x2e4]
 	ldr sb, _0217ba9c ; =data_ov15_0218e010
-	ldr sl, _0217baa0 ; =data_ov15_0218e00c
+	ldr r10, _0217baa0 ; =data_ov15_0218e00c
 	mov r7, r8, lsl #0x1
 	ldr r5, _0217baa4 ; =data_ov15_02186fa8
 	ldr r6, _0217baa8 ; =data_ov15_0218e014
-	ldr r8, [sl, r0]
-	ldr sl, [r6, r0]
+	ldr r8, [r10, r0]
+	ldr r10, [r6, r0]
 	ldr r3, _0217baac ; =data_ov15_02186fae
 	ldrh r5, [r5, r7]
 	cmp r2, #0
@@ -107975,20 +107975,20 @@ _0217b8c4:
 	ldr sb, _0217bab8 ; =data_ov15_02186f60
 	ldr r7, _0217babc ; =data_ov15_02186f78
 	ldr r6, _0217bac0 ; =data_ov15_02186f90
-	ldr sl, _0217bac4 ; =data_ov15_0218df84
+	ldr r10, _0217bac4 ; =data_ov15_0218df84
 	add r2, r2, r0
 	add r1, ip, r0
-	add r0, sl, r0
-	add sl, sb, r5, lsl #3
+	add r0, r10, r0
+	add r10, sb, r5, lsl #3
 	add sb, r7, r5, lsl #3
 	mov r8, r8, lsl #0x1
 	add r7, r6, r5, lsl #3
-	ldrh r5, [r8, sl]
+	ldrh r5, [r8, r10]
 	ldrh r6, [r8, sb]
 	ldrh r7, [r8, r7]
 	ldr r8, [r3, r2]
 	ldr sb, [r3, r1]
-	ldr sl, [r3, r0]
+	ldr r10, [r3, r0]
 _0217b91c:
 	ldr lr, [sp, #4]
 	add ip, sp, #0xfc
@@ -108003,7 +108003,7 @@ _0217b91c:
 	mov r2, r8
 	mov r3, sb
 	mov r1, r0
-	str sl, [sp]
+	str r10, [sp]
 	bl func_01ff8988
 	add r0, sp, #0xfc
 	mov r1, r11
@@ -108082,12 +108082,12 @@ _0217ba78:
 	ldr r0, [r4, #0x284]
 	cmp r0, #0
 	addeq sp, sp, #0x12c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r1, [sp, #4]
 	mov r2, r11
 	bl func_ov15_0217b84c
 	add sp, sp, #0x12c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0217b84c
 _0217ba9c: .word data_ov15_0218e010
@@ -109249,7 +109249,7 @@ _0217ca00: .word 0x000001b1
 	.global func_ov15_0217ca04
 	arm_func_start func_ov15_0217ca04
 func_ov15_0217ca04: ; 0x0217ca04
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #0x5c
 	mov r4, r0
 	ldr r0, [r4, #0x6c]
@@ -109306,8 +109306,8 @@ func_ov15_0217ca04: ; 0x0217ca04
 	str r1, [sp, #0x50]
 	ldr r8, [r4, #0x2e0]
 	ldr r0, [sp, #0x58]
-	smull sl, r8, sb, r8
-	adds sb, sl, #0x800
+	smull r10, r8, sb, r8
+	adds sb, r10, #0x800
 	adc r8, r8, #0
 	mov sb, sb, lsr #0xc
 	orr sb, sb, r8, lsl #20
@@ -109348,12 +109348,12 @@ func_ov15_0217ca04: ; 0x0217ca04
 	str r3, [sp, #0x3c]
 	str r2, [sp, #0x40]
 	bl func_ov00_020a61ac
-	ldr sl, _0217cec0 ; =data_027e0e58
+	ldr r10, _0217cec0 ; =data_027e0e58
 	mov sb, r4
 	add r8, r4, #0x2a0
 	add r5, sp, #0x44
 _0217cba0:
-	ldr r0, [sl]
+	ldr r0, [r10]
 	mov r1, r8
 	mov r2, r5
 	bl func_ov00_0207c474
@@ -109409,13 +109409,13 @@ _0217cc54:
 	mov r0, r4
 	bl func_ov15_0217cedc
 	add sp, sp, #0x5c
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 _0217cc78:
 	ldr r2, [r4, #0x4c]
 	ldr r0, [r1]
 	cmp r2, r0
 	addge sp, sp, #0x5c
-	ldmgeia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmgeia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	add r0, r4, #0x48
 	add r3, sp, #0x2c
 	ldmia r0, {r0, r1, r2}
@@ -109550,7 +109550,7 @@ _0217ce00:
 	bl func_01ff9958
 	str r0, [r4, #0x2dc]
 	add sp, sp, #0x5c
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0217ca04
 _0217cea0: .word 0x0000019a
@@ -109572,28 +109572,28 @@ _0217ced8: .word data_027e0d0c
 	.global func_ov15_0217cedc
 	arm_func_start func_ov15_0217cedc
 func_ov15_0217cedc: ; 0x0217cedc
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x20
-	mov sl, r0
-	ldr r1, [sl, #0x2e0]
+	mov r10, r0
+	ldr r1, [r10, #0x2e0]
 	cmp r1, #0
 	addge sp, sp, #0x20
-	ldmgeia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmgeia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	bl _ZN5Actor16XzDistanceToLinkEv
 	cmp r0, #0x6000
 	addlt sp, sp, #0x20
-	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
-	add r0, sl, #0x48
+	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	add r0, r10, #0x48
 	add r3, sp, #0x14
 	ldmia r0, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
-	ldr r1, [sl, #0x48]
+	ldr r1, [r10, #0x48]
 	ldr r0, _0217d008 ; =data_027e0e60
 	str r1, [sp, #8]
-	ldr r1, [sl, #0x4c]
+	ldr r1, [r10, #0x4c]
 	ldr r0, [r0]
 	str r1, [sp, #0xc]
-	ldr r3, [sl, #0x50]
+	ldr r3, [r10, #0x50]
 	add r1, sp, #8
 	mov r2, #0
 	str r3, [sp, #0x10]
@@ -109625,7 +109625,7 @@ func_ov15_0217cedc: ; 0x0217cedc
 	mov r8, #0
 	ldr r6, _0217d01c ; =data_ov15_02187048
 	ldr r4, _0217d00c ; =data_027e0e58
-	add sb, sl, #0x2a0
+	add sb, r10, #0x2a0
 	mov r7, r8
 	add r5, sp, #0x14
 	mov r11, #2
@@ -109645,9 +109645,9 @@ _0217cfc0:
 	add sb, sb, #0xc
 	blt _0217cfc0
 	mov r0, #0
-	strb r0, [sl, #0x118]
+	strb r0, [r10, #0x118]
 	add sp, sp, #0x20
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0217cedc
 _0217d008: .word data_027e0e60
@@ -109912,7 +109912,7 @@ _0217d3b8: .word 0x53485254
 	.global func_ov15_0217d3bc
 	arm_func_start func_ov15_0217d3bc
 func_ov15_0217d3bc: ; 0x0217d3bc
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x34
 	ldr r1, [sp, #0x58]
 	ldr r6, [sp, #0x5c]
@@ -109925,17 +109925,17 @@ func_ov15_0217d3bc: ; 0x0217d3bc
 	mov r5, #0
 _0217d3e8:
 	mov ip, #0
-	umull sl, sb, r4, r11
+	umull r10, sb, r4, r11
 	mla sb, r4, ip, sb
 	mov lr, r4, asr #0x1f
-	adds sl, sl, #0x800
+	adds r10, r10, #0x800
 	mla sb, lr, r11, sb
-	mov sl, sl, lsr #0xc
+	mov r10, r10, lsr #0xc
 	adc sb, sb, #0
-	orr sl, sl, sb, lsl #20
+	orr r10, r10, sb, lsl #20
 	ldr r2, _0217d53c ; =data_ov15_0218e198
 	ldr r3, _0217d540 ; =data_ov15_0218e19c
-	str sl, [sp, #0xc]
+	str r10, [sp, #0xc]
 	mov sb, ip
 	add r0, sp, #0x1c
 	add r1, sp, #0xc
@@ -109992,7 +109992,7 @@ _0217d3e8:
 	ldmia r1, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
 	add sp, sp, #0x34
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0217d4fc:
 	sub r1, r4, #0x1000
 	cmp r0, r1
@@ -110009,7 +110009,7 @@ _0217d50c:
 	ldmia r2, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
 	add sp, sp, #0x34
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0217d3bc
 _0217d538: .word 0x0000010a
@@ -110389,7 +110389,7 @@ func_ov15_0217d980: ; 0x0217d980
 	.global func_ov15_0217d994
 	arm_func_start func_ov15_0217d994
 func_ov15_0217d994: ; 0x0217d994
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #0x10
 	ldr r2, _0217db3c ; =data_027e10a4
 	mov r7, r0
@@ -110406,9 +110406,9 @@ func_ov15_0217d994: ; 0x0217d994
 	ldr sb, [r3, #0x30c]
 	str sb, [sp, #0xc]
 	ldr r5, [r7, #0x158]
-	ldr sl, [r0, r5, lsl #2]
-	ldr r4, [sl]
-	ldr r0, [sl, #4]
+	ldr r10, [r0, r5, lsl #2]
+	ldr r4, [r10]
+	ldr r0, [r10, #4]
 	sub r0, r4, r0
 	bl func_02042f68
 	ldr r2, [sp, #4]
@@ -110422,22 +110422,22 @@ func_ov15_0217d994: ; 0x0217d994
 	addge sp, sp, #0x10
 	rsb r1, r4, r2, asr #8
 	movge r0, #0
-	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	cmp r1, #0
 	addle sp, sp, #0x10
 	movle r0, #0
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	cmp r1, r0
 	movgt r1, r0
 	cmp ip, #0
 	movlt ip, #0
 	mov r4, ip
 	cmp ip, r1
-	add sl, sl, #8
+	add r10, r10, #8
 	mov r2, #0
 	bgt _0217da68
 _0217da50:
-	ldr r3, [sl, r4, lsl #2]
+	ldr r3, [r10, r4, lsl #2]
 	add r4, r4, #1
 	cmp r2, r3
 	movlt r2, r3
@@ -110451,15 +110451,15 @@ _0217da68:
 	cmp lr, r3
 	addgt sp, sp, #0x10
 	movgt r0, #0
-	ldmgtia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmgtia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	cmp r5, #2
 	bne _0217dab8
 	cmp ip, r1
-	add sl, sl, r0, lsl #2
+	add r10, r10, r0, lsl #2
 	mov r2, #0
 	bgt _0217dab8
 _0217daa0:
-	ldr r0, [sl, ip, lsl #2]
+	ldr r0, [r10, ip, lsl #2]
 	add ip, ip, #1
 	cmp r2, r0
 	movlt r2, r0
@@ -110471,7 +110471,7 @@ _0217dab8:
 	cmp r0, r1
 	addlt sp, sp, #0x10
 	movlt r0, #0
-	ldmltia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmltia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	ldr r0, [r7, #0x168]
 	cmp r0, #0
 	beq _0217daf8
@@ -110502,7 +110502,7 @@ _0217db24:
 _0217db30:
 	mov r0, #1
 	add sp, sp, #0x10
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0217d994
 _0217db3c: .word data_027e10a4
@@ -110803,21 +110803,21 @@ _0217def8: .word func_ov15_0217e1c8
 	.global func_ov15_0217defc
 	arm_func_start func_ov15_0217defc
 func_ov15_0217defc: ; 0x0217defc
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x24
-	mov sl, r0
+	mov r10, r0
 	mov sb, r1
 	ldr r0, _0217dffc ; =data_027e0cbc
 	mov r1, #2
 	bl func_0203d7e0
 	cmp r0, #0
-	ldrnesb r0, [sl, #0x14]
+	ldrnesb r0, [r10, #0x14]
 	cmpne r0, #0
 	addeq sp, sp, #0x24
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	add r0, sp, #4
 	bl func_01ffbe34
-	mov r0, sl
+	mov r0, r10
 	bl func_ov09_0211bcfc
 	cmp r0, #0
 	movne r0, #1
@@ -110836,11 +110836,11 @@ func_ov15_0217defc: ; 0x0217defc
 	mov r3, r1
 	mov r0, #0x11
 	bl func_0203493c
-	ldrb r0, [sl, #0x1d]
+	ldrb r0, [r10, #0x1d]
 	mov r7, #0
 	cmp r0, #0
 	addle sp, sp, #0x24
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	mov r11, r4
 	ldr r4, _0217e000 ; =gItemManager
 	mov r8, r7
@@ -110855,21 +110855,21 @@ _0217dfa8:
 	cmp r0, #0
 	beq _0217dfe0
 _0217dfc4:
-	str sl, [sp]
-	ldr r0, [sl, #0x20]
+	str r10, [sp]
+	ldr r0, [r10, #0x20]
 	mov r1, sb
 	mov r2, r5
 	mov r3, r11
 	add r0, r0, r8
 	bl func_ov00_020d00c4
 _0217dfe0:
-	ldrb r0, [sl, #0x1d]
+	ldrb r0, [r10, #0x1d]
 	add r7, r7, #1
 	add r8, r8, #0x18
 	cmp r7, r0
 	blt _0217dfa8
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0217defc
 _0217dffc: .word data_027e0cbc
@@ -111137,7 +111137,7 @@ func_ov15_0217e354: ; 0x0217e354
 	.global func_ov15_0217e368
 	arm_func_start func_ov15_0217e368
 func_ov15_0217e368: ; 0x0217e368
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	ldr r0, _0217e4a4 ; =data_027e0f74
 	mov r4, #1
 	ldr r0, [r0]
@@ -111146,7 +111146,7 @@ func_ov15_0217e368: ; 0x0217e368
 	mov r7, r4
 	mov r8, r4
 	mov sb, r4
-	mov sl, r4
+	mov r10, r4
 	bl func_ov00_02097738
 	cmp r0, #0
 	bne _0217e3d4
@@ -111163,9 +111163,9 @@ func_ov15_0217e368: ; 0x0217e368
 	add r0, r0, #0xc
 	bl func_ov00_020a5e9c
 	cmp r0, #0x32
-	movne sl, #0
+	movne r10, #0
 _0217e3d4:
-	cmp sl, #0
+	cmp r10, #0
 	bne _0217e3f0
 	ldr r0, _0217e4b4 ; =data_027e10a4
 	ldr r0, [r0]
@@ -111222,7 +111222,7 @@ _0217e498:
 	mov r4, #0
 _0217e49c:
 	mov r0, r4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0217e368
 _0217e4a4: .word data_027e0f74
@@ -111702,7 +111702,7 @@ _0217eb08: .word data_027e104c
 	.global func_ov15_0217eb0c
 	arm_func_start func_ov15_0217eb0c
 func_ov15_0217eb0c: ; 0x0217eb0c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x14
 	mov r4, r0
 	str r1, [r4, #0xc]
@@ -111797,7 +111797,7 @@ _0217ec5c:
 	ldr r0, [r0]
 	str r7, [sp, #0x10]
 	bl func_ov09_0211a604
-	ldr sl, _0217ee20 ; =data_ov15_0218e6d8
+	ldr r10, _0217ee20 ; =data_ov15_0218e6d8
 	ldr r11, _0217ee1c ; =data_027e104c
 	mov r8, #6
 	mov sb, r7
@@ -111812,9 +111812,9 @@ _0217ec88:
 	str r6, [sp]
 	str r5, [sp, #4]
 	ldr r0, [r11]
-	ldr r1, [sl, #0x1c]
-	ldr r2, [sl, #0x20]
-	ldr r3, [sl, #0x24]
+	ldr r1, [r10, #0x1c]
+	ldr r2, [r10, #0x20]
+	ldr r3, [r10, #0x24]
 	bl func_ov09_0211a74c
 	cmp r0, #0
 	beq _0217ece0
@@ -111829,7 +111829,7 @@ _0217ec88:
 _0217ece0:
 	add sb, sb, #1
 	cmp sb, #6
-	add sl, sl, #0x28
+	add r10, r10, #0x28
 	blt _0217ec88
 	str r8, [r4, #0x1c]
 	cmp r8, #6
@@ -111910,7 +111910,7 @@ _0217ede8:
 _0217ee04:
 	mov r0, #1
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0217eb0c
 _0217ee10: .word data_ov15_0218e688
@@ -111944,7 +111944,7 @@ _0217ee60: .word func_ov15_0217ee64
 	.global func_ov15_0217ee64
 	arm_func_start func_ov15_0217ee64
 func_ov15_0217ee64: ; 0x0217ee64
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x14c
 	ldr r3, _0217f3a0 ; =0x0000ffff
 	ldr r2, _0217f3a4 ; =0x040004c0
@@ -112131,7 +112131,7 @@ func_ov15_0217ee64: ; 0x0217ee64
 	ldr r1, [r0, #0x18]
 	mov r0, #0
 	str r0, [sp, #8]
-	add sl, r1, #0x20
+	add r10, r1, #0x20
 	mov r6, #0x50000
 	add r5, sp, #0x7c
 	mov r4, #0x20000
@@ -112145,7 +112145,7 @@ _0217f174:
 	mov r0, r5
 	mov r1, r4
 	str sb, [sp, #0x7c]
-	str sl, [sp, #0x80]
+	str r10, [sp, #0x80]
 	str r7, [sp, #0x84]
 	str r7, [sp, #0x88]
 	mov r2, r11
@@ -112157,13 +112157,13 @@ _0217f174:
 	add sb, sb, #0x20
 	blt _0217f174
 	ldr r0, [sp, #8]
-	add sl, sl, #0x20
+	add r10, r10, #0x20
 	add r0, r0, #1
 	str r0, [sp, #8]
 	cmp r0, #3
 	blt _0217f164
 	ldr r0, [sp, #4]
-	mov sl, #0
+	mov r10, #0
 	ldr r1, [r0, #0x18]
 	ldr r0, [r0, #0x14]
 	add sb, r1, #0x80
@@ -112184,8 +112184,8 @@ _0217f1f0:
 	str r6, [sp, #0x78]
 	str r5, [sp]
 	bl func_ov05_0210e2c4
-	add sl, sl, #1
-	cmp sl, #6
+	add r10, r10, #1
+	cmp r10, #6
 	add r8, r8, #0x20
 	blt _0217f1f0
 	ldr r0, [sp, #4]
@@ -112281,7 +112281,7 @@ _0217f1f0:
 	str r4, [sp]
 	bl func_ov05_0210e2c4
 	add sp, sp, #0x14c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0217ee64
 _0217f3a0: .word 0x0000ffff
@@ -113201,11 +113201,11 @@ _0217fe8c: .word data_027e10a4
 	.global func_ov15_0217fe90
 	arm_func_start func_ov15_0217fe90
 func_ov15_0217fe90: ; 0x0217fe90
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x50
 	mov r4, r0
-	mov sl, #0
-	str sl, [r4, #0x4c]
+	mov r10, #0
+	str r10, [r4, #0x4c]
 	ldr r1, [r4, #0x48]
 	ldr r0, _02180330 ; =data_027e0d0c
 	str r1, [r4, #0x54]
@@ -113224,7 +113224,7 @@ func_ov15_0217fe90: ; 0x0217fe90
 	ldr r2, [r0, #8]
 	mov r5, #0xae
 	str r2, [r4, #0x68]
-	str sl, [r4, #0x6c]
+	str r10, [r4, #0x6c]
 	ldr r2, [r0]
 	mov lr, #2
 	str r2, [r4, #0x7c]
@@ -113246,16 +113246,16 @@ func_ov15_0217fe90: ; 0x0217fe90
 	ldr r8, [r4, #0x88]
 	add r0, r4, #0x158
 	str r8, [r4, #0x98]
-	str sl, [r4, #0xa8]
+	str r10, [r4, #0xa8]
 	str sb, [r4, #0xac]
-	str sl, [r4, #0xb0]
+	str r10, [r4, #0xb0]
 	str r7, [r4, #0xb4]
 	strh r6, [r1, #0x20]
-	strb sl, [r4, #0x124]
-	str sl, [r4, #0x12c]
-	str sl, [r4, #0x37c]
-	str sl, [r4, #0x390]
-	str sl, [r4, #0x378]
+	strb r10, [r4, #0x124]
+	str r10, [r4, #0x12c]
+	str r10, [r4, #0x37c]
+	str r10, [r4, #0x390]
+	str r10, [r4, #0x378]
 	str r5, [r4, #0x408]
 	str lr, [r4, #0x40c]
 	str ip, [r4, #0x414]
@@ -113271,7 +113271,7 @@ func_ov15_0217fe90: ; 0x0217fe90
 	str lr, [r4, #0x448]
 	bl func_ov15_0217f9f0
 	ldr r1, [r4, #0x48]
-	mov r0, sl
+	mov r0, r10
 	str r1, [r4, #0x1d4]
 	ldr r1, [r4, #0x4c]
 	str r1, [r4, #0x1d8]
@@ -113288,7 +113288,7 @@ func_ov15_0217fe90: ; 0x0217fe90
 	bl func_ov15_021803ac
 	add sp, sp, #0x50
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0217fff0:
 	cmp r0, #8
 	bne _02180038
@@ -113302,14 +113302,14 @@ _0217fff0:
 _02180014:
 	add sp, sp, #0x50
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02180020:
 	mov r0, r4
 	mov r1, #0xa
 	bl func_ov15_021803ac
 	add sp, sp, #0x50
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02180038:
 	cmp r0, #9
 	bne _02180058
@@ -113318,7 +113318,7 @@ _02180038:
 	bl func_ov15_021803ac
 	add sp, sp, #0x50
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02180058:
 	ldrh r0, [r4, #0x24]
 	cmp r0, #0
@@ -113336,8 +113336,8 @@ _02180078:
 	cmp r0, #0
 	beq _021800fc
 	add sp, sp, #0x50
-	mov r0, sl
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	mov r0, r10
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0218009c:
 	ldr r0, _02180334 ; =data_027e0f74
 	mov r1, #0x33
@@ -113346,8 +113346,8 @@ _0218009c:
 	cmp r0, #0
 	beq _021800fc
 	add sp, sp, #0x50
-	mov r0, sl
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	mov r0, r10
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _021800c0:
 	ldr r0, _02180334 ; =data_027e0f74
 	mov r1, #0x33
@@ -113355,15 +113355,15 @@ _021800c0:
 	bl func_ov00_02097760
 	cmp r0, #0
 	addeq sp, sp, #0x50
-	moveq r0, sl
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	moveq r0, r10
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	mov r0, r4
-	mov r1, sl
+	mov r1, r10
 	bl _ZN5Actor18func_Ov00_020c1bfcEi
 	cmp r0, #0
 	addne sp, sp, #0x50
-	movne r0, sl
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	movne r0, r10
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _021800fc:
 	ldr r0, [r4, #8]
 	mov r1, #0
@@ -113522,7 +113522,7 @@ _0218031c:
 _02180324:
 	mov r0, #1
 	add sp, sp, #0x50
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 _02180330: .word data_027e0d0c
 _02180334: .word data_027e0f74
@@ -113565,7 +113565,7 @@ _021803a8: .word 0x53424f53
 	.global func_ov15_021803ac
 	arm_func_start func_ov15_021803ac
 func_ov15_021803ac: ; 0x021803ac
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x31c
 	mov r5, r0
 	mov r4, r1
@@ -113612,7 +113612,7 @@ _02180424:
 	bl func_ov15_02141344
 	cmp r0, #0
 	addeq sp, sp, #0x31c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	add r0, r5, #0x300
 	mov r1, #0
 	strh r1, [r0, #0x9a]
@@ -113754,7 +113754,7 @@ _0218064c:
 	bl func_ov15_02141344
 	cmp r0, #0
 	addeq sp, sp, #0x31c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	mov r2, #0
 	str r2, [r5, #0x37c]
 	strb r2, [r5, #0x39e]
@@ -113935,7 +113935,7 @@ _021806b8:
 	str r1, [sp, #0x1b4]
 	ldr r1, [sp, #0x134]
 	str sb, [sp, #0x1bc]
-	ldr sl, [sp, #0x13c]
+	ldr r10, [sp, #0x13c]
 	str r8, [sp, #0x1c0]
 	ldr sb, [sp, #0x140]
 	str r7, [sp, #0x1c4]
@@ -113944,7 +113944,7 @@ _021806b8:
 	str r1, [sp, #0x1c8]
 	ldr r0, [r0]
 	add r1, sp, #0x154
-	str sl, [sp, #0x1d0]
+	str r10, [sp, #0x1d0]
 	str sb, [sp, #0x1d4]
 	str r8, [sp, #0x1d8]
 	str r7, [sp, #0x1dc]
@@ -114032,7 +114032,7 @@ _02180ab8:
 	str r0, [r5, #0x138]
 	str r4, [r5, #0x130]
 	add sp, sp, #0x31c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_021803ac
 _02180acc: .word data_027e0d0c
@@ -114858,13 +114858,13 @@ _02181614: .word data_027e0f94
 	.global func_ov15_02181618
 	arm_func_start func_ov15_02181618
 func_ov15_02181618: ; 0x02181618
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x118
 	mov r4, r0
 	bl _ZN5Actor18func_ov00_020c198cEv
 	cmp r0, #0
 	addeq sp, sp, #0x118
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	add r0, sp, #0x68
 	bl func_ov00_0209a4f4
 	ldr r1, _021818c0 ; =data_027e0f94
@@ -114970,7 +114970,7 @@ func_ov15_02181618: ; 0x02181618
 	str r0, [sp, #0xc0]
 	ldr r0, [sp, #0x48]
 	ldr r1, [sp, #0x28]
-	ldr sl, [sp, #0x30]
+	ldr r10, [sp, #0x30]
 	ldr sb, [sp, #0x34]
 	str r8, [sp, #0xb0]
 	ldr r8, [sp, #0x38]
@@ -114987,8 +114987,8 @@ func_ov15_02181618: ; 0x02181618
 	ldrb r2, [sp, #0x64]
 	str r1, [sp, #0xbc]
 	ldr r1, [sp, #0x44]
-	str sl, [sp, #0xc4]
-	ldr sl, [sp, #0x4c]
+	str r10, [sp, #0xc4]
+	ldr r10, [sp, #0x4c]
 	str sb, [sp, #0xc8]
 	ldr sb, [sp, #0x50]
 	str r8, [sp, #0xcc]
@@ -115001,7 +115001,7 @@ func_ov15_02181618: ; 0x02181618
 	mov r11, #0x5c
 	ldr r0, [r0]
 	add r1, sp, #0x68
-	str sl, [sp, #0xe0]
+	str r10, [sp, #0xe0]
 	str sb, [sp, #0xe4]
 	str r8, [sp, #0xe8]
 	str r7, [sp, #0xec]
@@ -115028,7 +115028,7 @@ _021818b0:
 	add r0, sp, #0x68
 	bl func_ov00_0209a508
 	add sp, sp, #0x118
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02181618
 _021818c0: .word data_027e0f94
@@ -115620,7 +115620,7 @@ _0218210c: .word 0x4647474e
 	.global func_ov15_02182110
 	arm_func_start func_ov15_02182110
 func_ov15_02182110: ; 0x02182110
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x150
 	mov r4, r0
 	ldrb r1, [r4, #0x39e]
@@ -115753,7 +115753,7 @@ _02182140:
 	str r0, [sp, #0xfc]
 	ldr r0, [sp, #0x84]
 	ldr r1, [sp, #0x64]
-	ldr sl, [sp, #0x6c]
+	ldr r10, [sp, #0x6c]
 	str sb, [sp, #0xe8]
 	ldr sb, [sp, #0x70]
 	str r8, [sp, #0xec]
@@ -115771,8 +115771,8 @@ _02182140:
 	ldr r0, _02182588 ; =data_027e0f74
 	str r1, [sp, #0xf8]
 	ldr r1, [sp, #0x80]
-	str sl, [sp, #0x100]
-	ldr sl, [sp, #0x88]
+	str r10, [sp, #0x100]
+	ldr r10, [sp, #0x88]
 	str sb, [sp, #0x104]
 	ldr sb, [sp, #0x8c]
 	str r8, [sp, #0x108]
@@ -115785,7 +115785,7 @@ _02182140:
 	str r1, [sp, #0x114]
 	ldr r0, [r0]
 	add r1, sp, #0xa0
-	str sl, [sp, #0x11c]
+	str r10, [sp, #0x11c]
 	str sb, [sp, #0x120]
 	str r8, [sp, #0x124]
 	str r7, [sp, #0x128]
@@ -115903,13 +115903,13 @@ _02182548:
 	and r0, r1, r0
 	cmp r0, #0x1000000
 	addeq sp, sp, #0x150
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	add r0, r4, #0x3a4
 	ldr r1, [r0]
 	ldr r1, [r1, #0x10]
 	blx r1
 	add sp, sp, #0x150
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02182110
 _0218257c: .word data_027e0e60
@@ -116884,7 +116884,7 @@ _0218324c: .word data_02050f54
 	.global func_ov15_02183250
 	arm_func_start func_ov15_02183250
 func_ov15_02183250: ; 0x02183250
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #0x30
 	mov r4, r0
 	add r0, r4, #0x300
@@ -116893,7 +116893,7 @@ func_ov15_02183250: ; 0x02183250
 	subne r1, r1, #1
 	strneh r1, [r0, #0x9c]
 	addne sp, sp, #0x30
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	add r0, sp, #4
 	bl func_ov00_020c1500
 	mvn r1, #0
@@ -116929,10 +116929,10 @@ func_ov15_02183250: ; 0x02183250
 	umull r8, r7, r6, lr
 	mla r7, r6, ip, r7
 	ldr r5, [r3, #0xc]
-	ldr sl, [r3, #0x10]
+	ldr r10, [r3, #0x10]
 	mla r7, r5, lr, r7
 	ldr sb, [r3, #0x14]
-	adds r6, sl, r8
+	adds r6, r10, r8
 	mov r0, #0xb
 	adc r5, sb, r7
 	str r6, [r3]
@@ -116944,7 +116944,7 @@ func_ov15_02183250: ; 0x02183250
 	add r0, ip, #0x1e
 	strh r0, [r2, #0x9c]
 	add sp, sp, #0x30
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02183250
 _02183344: .word data_027e0fe8
@@ -117355,31 +117355,31 @@ func_ov15_02183898: ; 0x02183898
 	.global func_ov15_021838b8
 	arm_func_start func_ov15_021838b8
 func_ov15_021838b8: ; 0x021838b8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
-	mov sl, r0
-	ldrb r0, [sl, #0x48]
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	mov r10, r0
+	ldrb r0, [r10, #0x48]
 	cmp r0, #0
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
-	ldr r0, [sl, #0x14]
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldr r0, [r10, #0x14]
 	ldrb r0, [r0, #5]
 	cmp r0, #0
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
-	ldrsh r1, [sl]
-	ldrsh r0, [sl, #2]
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldrsh r1, [r10]
+	ldrsh r0, [r10, #2]
 	cmp r1, r0
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, _02183990 ; =data_027e077c
 	ldr r0, [r0]
 	cmp r0, #0x3b
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	mov sb, #0
 	mov r6, sb
-	mov r8, sl
-	add r7, sl, #0x18
+	mov r8, r10
+	add r7, r10, #0x18
 	mov r11, sb
 	mov r4, #1
 	mov r5, sb
@@ -117396,7 +117396,7 @@ _02183928:
 	cmp sb, #0
 	bne _02183968
 	ldrh r1, [r8, #0x22]
-	mov r0, sl
+	mov r0, r10
 	bl func_ov15_02183b00
 	cmp r0, #0
 	beq _02183970
@@ -117412,7 +117412,7 @@ _02183974:
 	add r8, r8, #0x18
 	blt _02183928
 	mov r0, sb
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_021838b8
 _02183990: .word data_027e077c
@@ -118529,12 +118529,12 @@ _02184800:
 	.global func_ov15_02184838
 	arm_func_start func_ov15_02184838
 func_ov15_02184838: ; 0x02184838
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	ldr r1, [r0, #4]
 	ldr r2, [r0, #0x10]
 	cmp r1, #0
 	mov r1, #0
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	ldr r4, _021848cc ; =0x54534950
 	ldr lr, _021848d0 ; =0x444e5043
 	ldr ip, _021848d4 ; =0x474f4332
@@ -118544,30 +118544,30 @@ func_ov15_02184838: ; 0x02184838
 	mov r8, r1
 	mov sb, r1
 _02184870:
-	ldr sl, [r2]
-	cmp sl, #0
-	ldrneb r5, [sl, #0x118]
+	ldr r10, [r2]
+	cmp r10, #0
+	ldrneb r5, [r10, #0x118]
 	cmpne r5, #0
 	beq _021848b4
-	ldr r5, [sl, #4]
+	ldr r5, [r10, #4]
 	cmp r5, r4
-	streqb sb, [sl, #0x29e]
+	streqb sb, [r10, #0x29e]
 	beq _021848b4
 	cmp r5, lr
-	streqb r8, [sl, #0x39a]
+	streqb r8, [r10, #0x39a]
 	beq _021848b4
 	cmp r5, ip
-	streqb r7, [sl, #0x4a9]
+	streqb r7, [r10, #0x4a9]
 	beq _021848b4
 	cmp r5, r3
-	streqb r6, [sl, #0x2f2]
+	streqb r6, [r10, #0x2f2]
 _021848b4:
 	ldr r5, [r0, #4]
 	add r1, r1, #1
 	cmp r1, r5
 	add r2, r2, #4
 	blt _02184870
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02184838
 _021848cc: .word 0x54534950
@@ -118886,7 +118886,7 @@ _02184c0c: .word func_ov15_02184c10
 	.global func_ov15_02184c10
 	arm_func_start func_ov15_02184c10
 func_ov15_02184c10: ; 0x02184c10
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x5c
 	ldr r1, _02184eb8 ; =data_027e0f64
 	mov r2, #0x60
@@ -118903,17 +118903,17 @@ func_ov15_02184c10: ; 0x02184c10
 	str r2, [sp, #8]
 	cmp r5, r1
 	addlt sp, sp, #0x5c
-	ldmltia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmltia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	cmp r5, #0x110
 	addgt sp, sp, #0x5c
-	ldmgtia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmgtia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	mov r0, r1
 	cmp r4, r0
 	addlt sp, sp, #0x5c
-	ldmltia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmltia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	cmp r4, #0xd0
 	addgt sp, sp, #0x5c
-	ldmgtia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmgtia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	sub r1, r3, r5
 	mov r3, r1, lsl #0xc
 	sub r0, r2, r4
@@ -118929,7 +118929,7 @@ func_ov15_02184c10: ; 0x02184c10
 	bl func_01fffb4c
 	cmp r4, #0xa0000
 	addge sp, sp, #0x5c
-	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	cmp r4, #0x50000
 	movle r7, #0x1000
 	ble _02184cec
@@ -118946,7 +118946,7 @@ _02184cec:
 	ldr r1, _02184ec0 ; =0xfffff4cd
 	cmp r0, r1
 	addle sp, sp, #0x5c
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	cmp r0, #0
 	bgt _02184d2c
 	rsb r0, r0, #0
@@ -118969,7 +118969,7 @@ _02184d2c:
 	ldr r0, [r5]
 	ldr r5, _02184ec8 ; =data_ov15_0218727c
 	str r0, [r4]
-	ldr sl, [sp, #0x10]
+	ldr r10, [sp, #0x10]
 	ldr r11, [sp, #0xc]
 	mov r6, r7, asr #0x1f
 	mov r4, #0
@@ -119026,7 +119026,7 @@ _02184d64:
 	adc r0, r2, r0
 	mov r1, r1, lsr #0xc
 	orr r1, r1, r0, lsl #20
-	add r0, r1, sl, lsl #12
+	add r0, r1, r10, lsl #12
 	bl func_ov05_0210e19c
 	mov sb, r0
 	ldr r1, [r5, #8]
@@ -119058,7 +119058,7 @@ _02184d64:
 	blt _02184d64
 	bl func_01ffa8d4
 	add sp, sp, #0x5c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02184c10
 _02184eb8: .word data_027e0f64
@@ -119326,10 +119326,10 @@ _021851fc: .word data_ov00_020ee734
 	.global func_ov15_02185200
 	arm_func_start func_ov15_02185200
 func_ov15_02185200: ; 0x02185200
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0xc
-	mov sl, r0
-	ldrb r4, [sl, #0xc]
+	mov r10, r0
+	ldrb r4, [r10, #0xc]
 	str r1, [sp]
 	str r2, [sp, #4]
 	str r3, [sp, #8]
@@ -119339,9 +119339,9 @@ func_ov15_02185200: ; 0x02185200
 	bl func_ov15_02185424
 _0218522c:
 	ldr r0, [sp]
-	str r0, [sl]
+	str r0, [r10]
 	ldr r0, [sp, #4]
-	str r0, [sl, #4]
+	str r0, [r10, #4]
 	ldr r0, [sp]
 	cmp r0, #0
 	bne _02185268
@@ -119364,38 +119364,38 @@ _0218527c:
 	mov r0, #7
 	str r0, [sp, #4]
 _02185284:
-	ldr r0, [sl]
+	ldr r0, [r10]
 	cmp r0, #1
-	ldrlt r1, [sl, #4]
+	ldrlt r1, [r10, #4]
 	cmplt r1, #7
 	addge sp, sp, #0xc
-	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	cmp r0, #0
 	bne _02185354
-	mov r0, sl
+	mov r0, r10
 	bl func_ov15_02185a54
 	cmp r0, #0
 	beq _02185354
-	mov r1, sl
-	add r0, sl, #0x10
+	mov r1, r10
+	add r0, r10, #0x10
 	mov r2, #0x65
 	mov r3, #0x3c
 	bl func_ov15_0218588c
-	mov r1, sl
-	add r0, sl, #0x28
+	mov r1, r10
+	add r0, r10, #0x28
 	mov r2, #0x67
 	mov r3, #0x3c
 	bl func_ov15_0218588c
 	mov r5, #0
 	ldr r11, _0218541c ; =data_ov15_021872e4
 	mov r7, r5
-	add r4, sl, #0x10
+	add r4, r10, #0x10
 _021852ec:
 	mov r6, #0
 	mov r8, r4
 	add sb, r11, r7
 _021852f8:
-	ldr r0, [sl, #4]
+	ldr r0, [r10, #4]
 	ldr r2, [r4, #0x14]
 	add r0, sb, r0, lsl #2
 	ldrb r1, [r6, r0]
@@ -119416,15 +119416,15 @@ _021852f8:
 	bl func_0201f83c
 	mov r0, #1
 	add sp, sp, #0xc
-	strb r0, [sl, #0xc]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	strb r0, [r10, #0xc]
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02185354:
 	mov r11, #0
 	mov r6, r11
 	mov r7, r11
-	add r4, sl, #0x10
+	add r4, r10, #0x10
 _02185364:
-	ldr r1, [sl]
+	ldr r1, [r10]
 	ldr r0, _02185420 ; =data_ov15_021872c4
 	add r2, r0, r1, lsl #4
 	ldr r0, [r2, r11, lsl #3]
@@ -119432,7 +119432,7 @@ _02185364:
 	beq _021853c8
 	ldr r3, [sp, #8]
 	mov r0, r4
-	mov r1, sl
+	mov r1, r10
 	add r2, r2, r6
 	bl func_ov15_02185838
 	ldr r0, _0218541c ; =data_ov15_021872e4
@@ -119441,7 +119441,7 @@ _02185364:
 	add sb, r0, r7
 _021853a0:
 	mov r0, r8
-	ldr r1, [sl, #4]
+	ldr r1, [r10, #4]
 	ldr r2, [r4, #0x14]
 	add r1, sb, r1, lsl #2
 	ldrb r1, [r5, r1]
@@ -119458,20 +119458,20 @@ _021853c8:
 	add r7, r7, #2
 	blt _02185364
 	mov r0, #1
-	strb r0, [sl, #0xc]
+	strb r0, [r10, #0xc]
 	ldr r0, [sp]
 	cmp r0, #0
 	addne sp, sp, #0xc
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, [sp, #4]
 	cmp r0, #1
 	addhi sp, sp, #0xc
-	ldmhiia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
-	ldr r0, [sl, #0x24]
+	ldmhiia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldr r0, [r10, #0x24]
 	mov r1, #0xfa
 	bl func_0201f8ac
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02185200
 _0218541c: .word data_ov15_021872e4

--- a/asm/ov15.s
+++ b/asm/ov15.s
@@ -1687,7 +1687,7 @@ _02120cd8: .word data_027e0cbc
 	.global func_ov15_02120cdc
 	arm_func_start func_ov15_02120cdc
 func_ov15_02120cdc: ; 0x02120cdc
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	ldr r1, _02120e40 ; =data_027e103c
 	mov sl, r0
 	ldr r0, [r1]
@@ -1750,7 +1750,7 @@ _02120da4:
 	mov r6, #0
 	mov r8, sl
 	add r7, sl, #0x5c
-	mov fp, r6
+	mov r11, r6
 	mov r4, #1
 _02120dd8:
 	mov r0, r7
@@ -1773,7 +1773,7 @@ _02120e18:
 	mov sb, r4
 	b _02120e24
 _02120e20:
-	mov sb, fp
+	mov sb, r11
 _02120e24:
 	add r6, r6, #1
 	cmp r6, #2
@@ -1782,7 +1782,7 @@ _02120e24:
 	blt _02120dd8
 _02120e38:
 	mov r0, sb
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02120cdc
 _02120e40: .word data_027e103c
@@ -2012,20 +2012,20 @@ _02121138: .word data_027e077c
 	.global func_ov15_0212113c
 	arm_func_start func_ov15_0212113c
 func_ov15_0212113c: ; 0x0212113c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x5c
 	ldr r1, _021216d4 ; =data_027e0618
 	mov sb, r0
 	ldrb r0, [r1, #0x101]
 	cmp r0, #0
 	addne sp, sp, #0x5c
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, _021216d8 ; =data_027e0cbc
 	mov r1, #0xb
 	bl func_0203d7e0
 	cmp r0, #0
 	addeq sp, sp, #0x5c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	mov r0, sb
 	bl func_ov15_02121700
 	cmp r0, #0
@@ -2230,7 +2230,7 @@ _02121424:
 _02121464:
 	cmp r7, #0
 	addeq sp, sp, #0x5c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r0, sb, #0x100
 	ldrsh r3, [r0, #0x14]
 	ldrsh r2, [r0, #0x16]
@@ -2272,7 +2272,7 @@ _021214b0:
 	ldrh r0, [r0, #0x4c]
 	cmp r0, #0
 	addne sp, sp, #0x5c
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	mov r5, #0
 	add r6, sb, #0x5c
 	mov r4, r5
@@ -2288,11 +2288,11 @@ _02121520:
 	add r6, r6, #0x18
 	blt _02121520
 	add sp, sp, #0x5c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02121550:
 	cmp r8, #0
 	addeq sp, sp, #0x5c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, _021216f8 ; =gItemManager
 	mov r1, #0x21
 	ldr r0, [r0]
@@ -2303,7 +2303,7 @@ _02121550:
 	mov r1, #0x23
 	bl _ZNK11ItemManager7HasItemEi
 	ldr r1, _021216f8 ; =gItemManager
-	mov fp, r0
+	mov r11, r0
 	ldr r0, [r1]
 	mov r1, #0x22
 	bl _ZNK11ItemManager7HasItemEi
@@ -2331,7 +2331,7 @@ _021215d4: ; jump table
 _021215e4:
 	cmp sl, #0
 	movne r5, #1
-	cmp fp, #0
+	cmp r11, #0
 	movne r8, #1
 	b _02121638
 _021215f8:
@@ -2349,7 +2349,7 @@ _02121610:
 	movne r7, #1
 	b _02121638
 _02121628:
-	cmp fp, #0
+	cmp r11, #0
 	movne r6, #1
 	cmp sl, #0
 	movne r7, #1
@@ -2386,7 +2386,7 @@ _02121680:
 _021216a4:
 	cmp r8, #0
 	addeq sp, sp, #0x5c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	mov r3, #0
 	str r3, [sp]
 	add r0, sb, #0x2c0
@@ -2395,7 +2395,7 @@ _021216a4:
 	str r3, [sp, #4]
 	bl func_02034b0c
 	add sp, sp, #0x5c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0212113c
 _021216d4: .word data_027e0618
@@ -3577,7 +3577,7 @@ _02122670: .word data_027e0fe8
 	.global func_ov15_02122674
 	arm_func_start func_ov15_02122674
 func_ov15_02122674: ; 0x02122674
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0xe4
 	ldr r1, _02122d9c ; =data_027e0f94
 	add r3, sp, #0xc0
@@ -3593,7 +3593,7 @@ func_ov15_02122674: ; 0x02122674
 	moveq r0, #0
 	addeq sp, sp, #0xe4
 	streq r0, [r4, #0x160]
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r3, [sp, #0xd8]
 	ldr r2, [sp, #0xdc]
 	ldr r1, [sp, #0xe0]
@@ -3612,7 +3612,7 @@ func_ov15_02122674: ; 0x02122674
 	movne r0, #0
 	addne sp, sp, #0xe4
 	strne r0, [r4, #0x160]
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r0, sp, #0xc0
 	add r1, sp, #0xd8
 	bl func_ov00_020ce2f0
@@ -3620,7 +3620,7 @@ func_ov15_02122674: ; 0x02122674
 	movlt r0, #0
 	addlt sp, sp, #0xe4
 	strlt r0, [r4, #0x160]
-	ldmltia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmltia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldrsh r5, [sp, #0x20]
 	ldr r2, [sp, #0xd8]
 	ldr r1, [sp, #0xdc]
@@ -3698,19 +3698,19 @@ _02122794:
 	sub r3, r6, #2
 	mov r0, r0, lsr #0x10
 	mov r0, r0, asr #0x4
-	mov fp, r0, lsl #0x1
+	mov r11, r0, lsl #0x1
 	add sb, r7, #1
 	mov sl, r7, lsl #0x1
-	add r8, fp, #1
+	add r8, r11, #1
 	ldr r2, [sp, #0xd8]
 	ldr r0, [sp, #0xe0]
 	mov ip, #0
 	ldr r5, _02122da4 ; =data_02050f54
-	mov r7, fp, lsl #0x1
-	ldrsh fp, [r5, sl]
+	mov r7, r11, lsl #0x1
+	ldrsh r11, [r5, sl]
 	mov sb, sb, lsl #0x1
 	ldrsh sb, [r5, sb]
-	mov sl, fp, asr #0x1f
+	mov sl, r11, asr #0x1f
 	mov sl, sl, lsl #0xd
 	str r1, [sp, #0x88]
 	str r1, [sp, #0x94]
@@ -3726,8 +3726,8 @@ _02122794:
 	str r3, [sp, #0x48]
 	str r3, [sp, #0x3c]
 	str r3, [sp, #0x40]
-	adds r3, r1, fp, lsl #13
-	orr sl, sl, fp, lsr #19
+	adds r3, r1, r11, lsl #13
+	orr sl, sl, r11, lsr #19
 	adc sl, sl, #0
 	mov r3, r3, lsr #0xc
 	orr r3, r3, sl, lsl #20
@@ -3775,7 +3775,7 @@ _02122794:
 	moveq r0, #0
 	addeq sp, sp, #0xe4
 	streq r0, [r4, #0x160]
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	mov r0, #1
 	strh r0, [sp, #0x5a]
 	add r1, sp, #0x3c
@@ -3799,7 +3799,7 @@ _02122794:
 	str r0, [r4, #0x160]
 	add sp, sp, #0xe4
 	strb r0, [r6, #0x118]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _021229e8:
 	ldr r0, _02122db0 ; =data_027e0fe4
 	add r1, sp, #0x3c
@@ -3816,7 +3816,7 @@ _021229e8:
 	strb r0, [r5, #0x118]
 	add sp, sp, #0xe4
 	str r0, [r4, #0x160]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02122a28:
 	ldr r0, [sp, #0x44]
 	add r1, sp, #0xcc
@@ -3832,7 +3832,7 @@ _02122a28:
 	str r0, [r6, #0x2dc]
 	add sp, sp, #0xe4
 	str r6, [r5, #0x2b0]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02122a64:
 	add r1, r5, #0x4000
 	mov r0, r0, asr #0x10
@@ -3860,14 +3860,14 @@ _02122a64:
 	ldrsh r0, [r3, sl]
 	ldrsh ip, [r3, sb]
 	ldrsh r3, [r3, r7]
-	mov fp, r8, asr #0x1f
+	mov r11, r8, asr #0x1f
 	mov sl, ip, asr #0x1f
 	mov lr, sl, lsl #0xe
-	mov r7, fp, lsl #0xc
+	mov r7, r11, lsl #0xc
 	strh r5, [sp, #0x58]
-	mov r5, fp, lsl #0xe
+	mov r5, r11, lsl #0xe
 	mov sl, r3, asr #0x1f
-	mov fp, sl, lsl #0xe
+	mov r11, sl, lsl #0xe
 	ldr sl, [sp, #0xd8]
 	mov r6, r0, asr #0x1f
 	mov sb, r6, lsl #0xc
@@ -3919,9 +3919,9 @@ _02122a64:
 	orr r5, r5, r0, lsl #20
 	add r0, sb, r5
 	adds r1, r1, r3, lsl #14
-	orr fp, fp, r3, lsr #18
+	orr r11, r11, r3, lsr #18
 	str r0, [sp, #0x90]
-	adc r0, fp, #0
+	adc r0, r11, #0
 	mov r1, r1, lsr #0xc
 	orr r1, r1, r0, lsl #20
 	add r0, r7, r1
@@ -3951,7 +3951,7 @@ _02122a64:
 	moveq r0, #0
 	addeq sp, sp, #0xe4
 	streq r0, [r4, #0x160]
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	mov r0, #1
 	strh r0, [sp, #0x5a]
 	add r1, sp, #0x2c
@@ -3975,7 +3975,7 @@ _02122a64:
 	str r0, [r4, #0x160]
 	add sp, sp, #0xe4
 	strb r0, [r5, #0x118]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02122c9c:
 	mov r0, #2
 	strh r0, [sp, #0x5a]
@@ -4001,7 +4001,7 @@ _02122c9c:
 	strb r0, [r5, #0x118]
 	add sp, sp, #0xe4
 	strb r0, [r6, #0x118]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02122d00:
 	ldr r0, _02122db0 ; =data_027e0fe4
 	add r1, sp, #0x24
@@ -4025,7 +4025,7 @@ _02122d3c:
 	strb r0, [r7, #0x118]
 	add sp, sp, #0xe4
 	str r0, [r4, #0x160]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02122d58:
 	ldr r0, [sp, #0x34]
 	add r1, sp, #0xcc
@@ -4043,7 +4043,7 @@ _02122d58:
 	str r6, [r7, #0x2b4]
 	str r7, [r6, #0x2b0]
 	add sp, sp, #0xe4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02122674
 _02122d9c: .word data_027e0f94
@@ -5164,7 +5164,7 @@ _02123c44: .word data_ov15_0218988c
 	.global func_ov15_02123c48
 	arm_func_start func_ov15_02123c48
 func_ov15_02123c48: ; 0x02123c48
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	mov r1, #0
 	mov r4, r0
 	bl func_ov15_02123474
@@ -5191,10 +5191,10 @@ func_ov15_02123c48: ; 0x02123c48
 	umull sb, r8, r7, r5
 	mla r8, r7, lr, r8
 	ldr r6, [r2, #0xc]
-	ldr fp, [r2, #0x10]
+	ldr r11, [r2, #0x10]
 	mla r8, r6, r5, r8
 	ldr sl, [r2, #0x14]
-	adds r6, fp, sb
+	adds r6, r11, sb
 	adc r5, sl, r8
 	str r6, [r2]
 	str r5, [r2, #4]
@@ -5223,7 +5223,7 @@ func_ov15_02123c48: ; 0x02123c48
 	str r1, [r4, #0x2a0]
 	mov r0, r4
 	str r1, [r4, #0x2a4]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02123c48
 _02123d38: .word data_ov15_021897c4
@@ -6162,7 +6162,7 @@ _02124a3c: .word data_027e10a4
 	.global func_ov15_02124a40
 	arm_func_start func_ov15_02124a40
 func_ov15_02124a40: ; 0x02124a40
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x1c
 	mov sl, r0
 	mov r5, r1
@@ -6190,7 +6190,7 @@ func_ov15_02124a40: ; 0x02124a40
 	ldrb r0, [sl, #0x118]
 	cmp r0, #0
 	addeq sp, sp, #0x1c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	mov r0, sl
 	bl func_ov15_02125210
 	cmp r0, #0
@@ -6252,7 +6252,7 @@ _02124b6c:
 	ldrb r0, [sl, #0x118]
 	cmp r0, #0
 	addeq sp, sp, #0x1c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02124b9c:
 	mov r1, r5
 	add r0, sl, #0xa4
@@ -6307,9 +6307,9 @@ _02124bbc:
 	orr r3, r3, r2, lsl #20
 	orr r5, r5, r4, lsl #20
 	add r4, r5, r3
-	smull fp, r8, r6, r7
+	smull r11, r8, r6, r7
 	adc ip, ip, #0
-	adds r6, fp, #0x800
+	adds r6, r11, #0x800
 	mov r0, r0, lsr #0xc
 	adc r8, r8, #0
 	mov r6, r6, lsr #0xc
@@ -6325,18 +6325,18 @@ _02124bbc:
 	bl func_01ff9bc4
 	mov r0, #0x800
 	ldr r3, _02125038 ; =0xfffffb33
-	mvn fp, #0
+	mvn r11, #0
 	umull r3, ip, sb, r3
 	adds r3, r3, #0x800
 	mov r4, r3, lsr #0xc
-	mla ip, sb, fp, ip
+	mla ip, sb, r11, ip
 	ldr r3, _02125038 ; =0xfffffb33
 	rsb r5, r0, #0xcd
 	mla ip, r8, r3, ip
 	adc r3, ip, #0
 	orr r4, r4, r3, lsl #20
 	umull ip, r3, r7, r5
-	mla r3, r7, fp, r3
+	mla r3, r7, r11, r3
 	adds ip, ip, #0x800
 	mla r3, r6, r5, r3
 	sub lr, r0, #0xcd
@@ -6352,25 +6352,25 @@ _02124bbc:
 	ldr r3, _02125038 ; =0xfffffb33
 	add r1, sl, #0x2bc
 	umull r5, r3, r7, r3
-	mla r3, r7, fp, r3
-	ldr fp, _02125038 ; =0xfffffb33
+	mla r3, r7, r11, r3
+	ldr r11, _02125038 ; =0xfffffb33
 	adds r5, r5, #0x800
-	mla r3, r6, fp, r3
+	mla r3, r6, r11, r3
 	adc r3, r3, #0
 	mov r5, r5, lsr #0xc
 	orr r5, r5, r3, lsl #20
-	umull ip, fp, sb, lr
+	umull ip, r11, sb, lr
 	mov r3, #0
-	mla fp, sb, r3, fp
-	mla fp, r8, lr, fp
+	mla r11, sb, r3, r11
+	mla r11, r8, lr, r11
 	adds ip, ip, #0x800
-	adc r3, fp, #0
-	mov fp, ip, lsr #0xc
-	orr fp, fp, r3, lsl #20
-	add r3, fp, r5
+	adc r3, r11, #0
+	mov r11, ip, lsr #0xc
+	orr r11, r11, r3, lsl #20
+	add r3, r11, r5
 	mov r3, r3, lsl #0x10
 	add r2, sp, #0x10
-	mov fp, r3, asr #0x10
+	mov r11, r3, asr #0x10
 	bl func_ov00_0207c474
 	ldr r0, _0212503c ; =data_027e0e58
 	add r1, sl, #0x2c8
@@ -6384,7 +6384,7 @@ _02124bbc:
 	ldr r1, _02125040 ; =0x00000d71
 	strh r0, [r2, #0x50]
 	strh r1, [r2, #0x52]
-	strh fp, [r2, #0x54]
+	strh r11, [r2, #0x54]
 _02124da4:
 	ldr r2, [sl, #0x2c8]
 	cmp r2, #0
@@ -6393,25 +6393,25 @@ _02124da4:
 	ldr r1, _02125040 ; =0x00000d71
 	strh r0, [r2, #0x50]
 	strh r1, [r2, #0x52]
-	strh fp, [r2, #0x54]
+	strh r11, [r2, #0x54]
 _02124dc4:
 	ldr r2, _02125030 ; =0x00000733
-	mov fp, #0
+	mov r11, #0
 	umull ip, r0, r7, r2
-	mla r0, r7, fp, r0
+	mla r0, r7, r11, r0
 	mla r0, r6, r2, r0
 	mov r1, #0x800
 	rsb r3, r1, #0xcd
 	adds r1, ip, #0x800
-	sub r2, fp, #1
-	umull fp, r7, sb, r3
+	sub r2, r11, #1
+	umull r11, r7, sb, r3
 	mla r7, sb, r2, r7
 	adc r0, r0, #0
 	mov r1, r1, lsr #0xc
 	orr r1, r1, r0, lsl #20
 	mla r7, r8, r3, r7
 	add r0, r1, r4
-	adds r2, fp, #0x800
+	adds r2, r11, #0x800
 	mov r3, r0, lsl #0x10
 	mov r1, r2, lsr #0xc
 	adc r0, r7, #0
@@ -6558,7 +6558,7 @@ _02124ffc:
 	strb r3, [sl, #0x2f8]
 	bl func_ov15_02184a40
 	add sp, sp, #0x1c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02124a40
 _0212502c: .word data_027e0e60
@@ -11825,7 +11825,7 @@ func_ov15_02129254: ; 0x02129254
 	.global func_ov15_0212925c
 	arm_func_start func_ov15_0212925c
 func_ov15_0212925c: ; 0x0212925c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x74
 	ldr r2, _021296c0 ; =data_027e0e60
 	mov sb, r0
@@ -11841,7 +11841,7 @@ func_ov15_0212925c: ; 0x0212925c
 	ldr r0, [r0]
 	bl func_ov00_02083374
 	ldr r1, _021296c0 ; =data_027e0e60
-	mov fp, r0
+	mov r11, r0
 	ldr r0, [r1]
 	bl func_ov00_02083384
 	ldr r3, [sp, #0x70]
@@ -12004,7 +12004,7 @@ _021294dc:
 	ldr r1, [sp, #0x5c]
 	str r0, [sp, #0x48]
 	str r0, [sp, #0x3c]
-	sub r0, r1, fp
+	sub r0, r1, r11
 	add r1, r1, #0xe800
 	str r4, [sp, #0x54]
 	str r4, [sp, #0x30]
@@ -12030,7 +12030,7 @@ _0212953c:
 	str r0, [sp, #0x48]
 	str r0, [sp, #0x3c]
 	sub r0, r1, #0xe800
-	add r1, r1, fp
+	add r1, r1, r11
 	str r4, [sp, #0x54]
 	str r4, [sp, #0x30]
 	str r0, [sp, #0x50]
@@ -12119,7 +12119,7 @@ _021296ac:
 	cmp r7, #4
 	blt _02129300
 	add sp, sp, #0x74
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0212925c
 _021296c0: .word data_027e0e60
@@ -13505,7 +13505,7 @@ _0212a76c:
 	.global func_ov15_0212a780
 	arm_func_start func_ov15_0212a780
 func_ov15_0212a780: ; 0x0212a780
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x7c
 	ldr r2, _0212ad74 ; =data_027e0f94
 	mov sl, r0
@@ -13796,7 +13796,7 @@ _0212ab94:
 	ldr r0, _0212adac ; =0x0007fc00
 	str r3, [r1]
 	str r0, [r1, #-0x7c]
-	mov fp, r2, lsr #0x10
+	mov r11, r2, lsr #0x10
 	mov r6, #0
 	sub r5, r1, #0x78
 	sub r4, r1, #0x74
@@ -13809,7 +13809,7 @@ _0212abf8:
 	mov r1, r1, asr #0x10
 	mov r1, r1, lsl #0x10
 	mov sb, r1, lsr #0x10
-	orr r1, sb, fp, lsl #16
+	orr r1, sb, r11, lsl #16
 	str r1, [r5]
 	ldr r3, [sl, #0x64]
 	add r0, sp, #0x24
@@ -13896,7 +13896,7 @@ _0212ad4c:
 	mov r1, #1
 	str r1, [r0]
 	add sp, sp, #0x7c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0212a780
 _0212ad74: .word data_027e0f94
@@ -15669,7 +15669,7 @@ _0212c4c8: .word data_027e0f64
 	.global func_ov15_0212c4cc
 	arm_func_start func_ov15_0212c4cc
 func_ov15_0212c4cc: ; 0x0212c4cc
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x18
 	ldr r1, _0212c6a4 ; =data_027e0d38
 	mov sl, r0
@@ -15709,10 +15709,10 @@ _0212c4fc:
 	mov r6, r8
 	add r5, sp, #0
 	add r4, sp, #0xc
-	mov fp, r8
+	mov r11, r8
 _0212c568:
 	rsb r0, r8, #0xc
-	mov r7, fp
+	mov r7, r11
 	mov sb, r0, lsl #0xc
 _0212c574:
 	rsb r0, r7, #0xc
@@ -15796,7 +15796,7 @@ _0212c684:
 	cmp r7, #0x19
 	blo _0212c5c0
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0212c4cc
 _0212c6a4: .word data_027e0d38
@@ -17823,7 +17823,7 @@ _0212e2bc: .word data_ov15_02190458
 	.global func_ov15_0212e2c0
 	arm_func_start func_ov15_0212e2c0
 func_ov15_0212e2c0: ; 0x0212e2c0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x88
 	mov r4, r0
 	bl _ZN5Actor14GetAngleToLinkEv
@@ -17836,7 +17836,7 @@ func_ov15_0212e2c0: ; 0x0212e2c0
 	ldr r0, [r4, #0x254]
 	cmp r0, #0
 	addne sp, sp, #0x88
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, _0212e770 ; =data_027e0f94
 	add r6, sp, #0x7c
 	ldmia r0, {r0, r1, r2}
@@ -17913,11 +17913,11 @@ func_ov15_0212e2c0: ; 0x0212e2c0
 	mla r6, r3, r2, r6
 	sub r2, r6, #0xa000
 	add r3, r2, #0x64000
-	mov fp, #0x28
-	umull r7, r6, r3, fp
+	mov r11, #0x28
+	umull r7, r6, r3, r11
 	mla r6, r3, r1, r6
 	mov r2, r3, asr #0x1f
-	mla r6, r2, fp, r6
+	mla r6, r2, r11, r6
 	adds r2, r7, #0x800
 	adc r1, r6, #0
 	mov r2, r2, lsr #0xc
@@ -17929,7 +17929,7 @@ func_ov15_0212e2c0: ; 0x0212e2c0
 	orr r7, r7, r0, lsl #20
 	cmp r7, #0x12c00
 	addgt sp, sp, #0x88
-	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	cmp r7, #0x2000
 	movle r6, #0xf6
 	ble _0212e494
@@ -18026,9 +18026,9 @@ _0212e4e0:
 	ldrsh r2, [r8, r2]
 	ldrsh r1, [r8, r1]
 	add r0, r4, #0x48
-	smull fp, sb, r2, r6
+	smull r11, sb, r2, r6
 	smull r8, r2, r1, r6
-	adds r6, fp, #0x800
+	adds r6, r11, #0x800
 	adc r1, sb, #0
 	mov r6, r6, lsr #0xc
 	orr r6, r6, r1, lsl #20
@@ -18089,7 +18089,7 @@ _0212e4e0:
 	bl _ZN12ActorManager8GetActorEP8ActorRef
 	cmp r0, #0
 	addeq sp, sp, #0x88
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	str r6, [r0, #0x60]
 	str r5, [r0, #0x64]
 	str r8, [r0, #0x68]
@@ -18126,7 +18126,7 @@ _0212e730:
 	mov r3, #0
 	bl func_ov00_020ceacc
 	add sp, sp, #0x88
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0212e2c0
 _0212e770: .word data_027e0f94
@@ -18245,7 +18245,7 @@ _0212e8d8:
 	.global func_ov15_0212e8e0
 	arm_func_start func_ov15_0212e8e0
 func_ov15_0212e8e0: ; 0x0212e8e0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	mov r6, r0
 	ldr r0, [r6, #0x130]
 	mov r4, r3
@@ -18269,8 +18269,8 @@ func_ov15_0212e8e0: ; 0x0212e8e0
 	ldrsh sb, [r1, #0x6a]
 	ldrb r8, [r6, #0x26c]
 	mov ip, #0
-	mov fp, sb, asr #0x1
-	mov r1, fp, lsl #0x10
+	mov r11, sb, asr #0x1
+	mov r1, r11, lsl #0x10
 	add r1, r7, r1, asr #16
 	mov r1, r1, lsl #0x10
 	mov r3, ip
@@ -18304,7 +18304,7 @@ _0212e9b0:
 	ldrb r1, [r6, #0x26d]
 	mov r0, #1
 	add r2, r2, #0x8000
-	add r2, fp, r2
+	add r2, r11, r2
 	mla r2, sb, ip, r2
 	orr r1, r1, r0, lsl ip
 	mov r0, r2, lsl #0x10
@@ -18358,10 +18358,10 @@ _0212ea44:
 	orr sl, sl, sb, lsl #20
 	mov sb, sl, asr #0x1f
 	mov sb, sb, lsl #0xd
-	adds fp, r8, sl, lsl #13
+	adds r11, r8, sl, lsl #13
 	orr sb, sb, sl, lsr #19
 	adc r8, sb, #0
-	mov sb, fp, lsr #0xc
+	mov sb, r11, lsr #0xc
 	orr sb, sb, r8, lsl #20
 	b _0212eae4
 _0212eaa4:
@@ -18376,10 +18376,10 @@ _0212eaa4:
 	orr sl, sl, sb, lsl #20
 	mov sb, sl, asr #0x1f
 	mov sb, sb, lsl #0xd
-	adds fp, r8, sl, lsl #13
+	adds r11, r8, sl, lsl #13
 	orr sb, sb, sl, lsr #19
 	adc r8, sb, #0
-	mov sb, fp, lsr #0xc
+	mov sb, r11, lsr #0xc
 	orr sb, sb, r8, lsl #20
 _0212eae4:
 	ldr r8, [sp, #0x28]
@@ -18389,20 +18389,20 @@ _0212eae4:
 	mov r4, r7, lsr #0x10
 	mov r4, r4, asr #0x4
 	mov r6, r6, asr #0x4
-	mov fp, r6, lsl #0x1
+	mov r11, r6, lsl #0x1
 	mov r7, r4, lsl #0x1
-	add r6, fp, #1
+	add r6, r11, #1
 	add sl, r7, #1
 	ldr r8, _0212eb8c ; =data_02050f54
-	mov r4, fp, lsl #0x1
+	mov r4, r11, lsl #0x1
 	mov r7, r7, lsl #0x1
 	ldrsh r4, [r8, r4]
 	mov r6, r6, lsl #0x1
 	ldrsh r7, [r8, r7]
-	mov fp, sl, lsl #0x1
+	mov r11, sl, lsl #0x1
 	ldrsh sl, [r8, r6]
 	mul r6, r4, sb
-	ldrsh r8, [r8, fp]
+	ldrsh r8, [r8, r11]
 	mul r4, r7, r0
 	mul r7, sl, sb
 	mul sb, r8, r0
@@ -18419,7 +18419,7 @@ _0212eae4:
 	str r2, [r5, #4]
 	add r0, r3, r0
 	str r0, [r5, #8]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0212e8e0
 _0212eb7c: .word data_027e0fac
@@ -19729,7 +19729,7 @@ _0212fd20: .word data_ov15_0218a5ac
 	.global func_ov15_0212fd24
 	arm_func_start func_ov15_0212fd24
 func_ov15_0212fd24: ; 0x0212fd24
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x274
 	mov r4, r1
 	mov r5, r0
@@ -19962,7 +19962,7 @@ _0212fe8c:
 	str r2, [sp, #0x238]
 	mov r2, #0x5c
 	str r1, [sp, #0x23c]
-	mov fp, #0
+	mov r11, #0
 	ldr r0, [r0]
 	add r1, sp, #0x1c4
 	str sl, [sp, #0x244]
@@ -19974,7 +19974,7 @@ _0212fe8c:
 	strb ip, [sp, #0x253]
 	strb r3, [sp, #0x254]
 	str r2, [sp, #0x258]
-	strb fp, [sp, #0x1da]
+	strb r11, [sp, #0x1da]
 	bl func_ov00_02097810
 	ldr r1, _02130540 ; =data_027e0e60
 	str r0, [r5, #0x488]
@@ -20044,7 +20044,7 @@ _02130188:
 	bl func_ov15_02141344
 	cmp r0, #0
 	addeq sp, sp, #0x274
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _021301f8:
 	mov r1, #0
 	strb r1, [r5, #0x490]
@@ -20250,7 +20250,7 @@ _02130510:
 	str r0, [r5, #0x138]
 	str r4, [r5, #0x130]
 	add sp, sp, #0x274
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0212fd24
 _02130524: .word data_027e0764
@@ -25980,15 +25980,15 @@ func_ov15_02135484: ; 0x02135484
 	.global func_ov15_021354a0
 	arm_func_start func_ov15_021354a0
 func_ov15_021354a0: ; 0x021354a0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x30
-	mov fp, r0
+	mov r11, r0
 	bl func_ov15_0213ce4c
 	bl func_ov15_0213d3b4
 	ldr r0, _02135548 ; =data_027e103c
 	ldr r0, [r0]
 	bl func_ov00_020cf2b8
-	mov r0, fp
+	mov r0, r11
 	bl func_ov15_021358f8
 	cmp r0, #0
 	beq _02135534
@@ -25996,7 +25996,7 @@ func_ov15_021354a0: ; 0x021354a0
 	ldr r6, _0213554c ; =0x534e4156
 	ldr r5, _02135550 ; =data_027e0f94
 	ldr r4, _02135554 ; =data_027e0fe8
-	str sl, [fp, #0x24]
+	str sl, [r11, #0x24]
 	add sb, sp, #4
 	mvn r8, #0
 	mov r7, sl
@@ -26019,11 +26019,11 @@ _021354f0:
 	cmp sl, #3
 	blt _021354f0
 _02135534:
-	mov r0, fp
+	mov r0, r11
 	mov r1, #1
 	bl func_ov15_02175d14
 	add sp, sp, #0x30
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_021354a0
 _02135548: .word data_027e103c
@@ -27823,7 +27823,7 @@ _02136d00: .word data_027e0fac
 	.global func_ov15_02136d04
 	arm_func_start func_ov15_02136d04
 func_ov15_02136d04: ; 0x02136d04
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x18
 	mov r4, r0
 	ldrb r0, [r4, #0x25f]
@@ -27863,9 +27863,9 @@ _02136d5c:
 	adc r5, r0, r6
 	stmia r2, {r3, r5}
 	umull r0, r3, r5, r1
-	mov fp, #0
-	mla r3, r5, fp, r3
-	mov r0, fp
+	mov r11, #0
+	mla r3, r5, r11, r3
+	mov r0, r11
 	mla r3, r0, r1, r3
 	ldr r5, [r4, #0xa4]
 	sub r0, r3, #0xcd
@@ -27885,8 +27885,8 @@ _02136d5c:
 	adc r6, r0, r6
 	str r5, [r2]
 	umull r0, r5, r6, r1
-	mla r5, r6, fp, r5
-	mov r0, fp
+	mla r5, r6, r11, r5
+	mov r0, r11
 	mla r5, r0, r1, r5
 	str r6, [r2, #4]
 	ldr r6, [r4, #0xa8]
@@ -27908,8 +27908,8 @@ _02136d5c:
 	adc r7, sb, r7
 	stmia r2, {r5, r7}
 	umull r2, r5, r7, r1
-	mla r5, r7, fp, r5
-	mov r2, fp
+	mla r5, r7, r11, r5
+	mov r2, r11
 	mla r5, r2, r1, r5
 	add r3, r1, #0x198
 	ldr r6, [r4, #0xac]
@@ -27922,7 +27922,7 @@ _02136d5c:
 	add r0, sp, #0
 	str r1, [sp, #8]
 	ldr r1, _0213712c ; =data_027e0fac
-	str fp, [sp]
+	str r11, [sp]
 	ldrsh r1, [r1]
 	str r3, [sp, #4]
 	bl func_ov00_020a61ac
@@ -28100,7 +28100,7 @@ _021370f8:
 	mov r0, r4
 	bl func_ov15_02136888
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02136d04
 _0213711c: .word data_027e0f94
@@ -29477,7 +29477,7 @@ _02138474: .word 0x00000ccc
 	.global func_ov15_02138478
 	arm_func_start func_ov15_02138478
 func_ov15_02138478: ; 0x02138478
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x78
 	ldr r2, _02138ba0 ; =data_027e10a4
 	ldr r4, _02138ba4 ; =data_027e0fa0
@@ -29650,7 +29650,7 @@ _021386b0:
 	adc r1, r2, r0
 	mov r0, r3, lsr #0xc
 	orr r0, r0, r1, lsl #20
-	mov fp, r0
+	mov r11, r0
 	b _02138750
 _02138730:
 	ldr r2, [sp, #0x70]
@@ -29660,7 +29660,7 @@ _02138730:
 	adc r1, r2, r0
 	mov r0, r3, lsr #0xc
 	orr r0, r0, r1, lsl #20
-	rsb fp, r0, #0
+	rsb r11, r0, #0
 _02138750:
 	cmp r7, r5
 	ble _0213877c
@@ -29757,7 +29757,7 @@ _02138894:
 	adc r0, r2, #0
 	mov r2, sl, lsr #0xc
 	orr r2, r2, r0, lsl #20
-	smull r2, r0, fp, r2
+	smull r2, r0, r11, r2
 	adds r3, r2, #0x800
 	adc r2, r0, #0
 	mov r0, r3, lsr #0xc
@@ -29936,7 +29936,7 @@ _02138b08:
 	add r0, r5, r0
 	str r0, [r1, #4]
 	add sp, sp, #0x78
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02138b78:
 	umull r3, r2, r5, r4
 	mla r2, r5, r0, r2
@@ -29947,7 +29947,7 @@ _02138b78:
 	sub r0, r5, r0
 	str r0, [r1, #4]
 	add sp, sp, #0x78
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02138478
 _02138ba0: .word data_027e10a4
@@ -32934,7 +32934,7 @@ _0213b454: .word 0x4b4d4741
 	.global func_ov15_0213b458
 	arm_func_start func_ov15_0213b458
 func_ov15_0213b458: ; 0x0213b458
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	ldr r1, _0213b63c ; =data_027e0fe4
 	mov r4, r0
 	ldr r0, [r1]
@@ -32950,10 +32950,10 @@ func_ov15_0213b458: ; 0x0213b458
 	bl func_ov15_021517a0
 	cmp r0, #0
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0213b49c:
 	ldr r2, _0213b644 ; =data_027e0764
-	mov fp, #0
+	mov r11, #0
 	ldr r3, [r2]
 	ldmib r2, {r1, r5}
 	umull r7, r6, r5, r3
@@ -32966,7 +32966,7 @@ _0213b49c:
 	ldr r0, [r2, #0x14]
 	adds r5, r8, r7
 	adc r3, r0, r6
-	mov r0, fp, lsl #0xc
+	mov r0, r11, lsl #0xc
 	str r5, [r2]
 	add r1, r1, #0x600
 	orr r0, r0, r3, lsr #20
@@ -32981,7 +32981,7 @@ _0213b49c:
 	mov r6, #0x80
 	str r1, [r4, #0x58]
 	ldr r1, [r4, #0x50]
-	mov sl, fp
+	mov sl, r11
 	str r1, [r4, #0x5c]
 	ldr r1, [r0]
 	mov r3, #0x1080
@@ -33024,7 +33024,7 @@ _0213b49c:
 	umull r2, r3, r5, r2
 	mla r3, r5, sl, r3
 	ldr r2, _0213b650 ; =0x0000ffff
-	mla r3, fp, r2, r3
+	mla r3, r11, r2, r3
 	strh r3, [r4, #0x78]
 	strh sl, [r1, #0x8e]
 	mov r1, #0x200
@@ -33034,7 +33034,7 @@ _0213b49c:
 	strb sl, [r4, #0x292]
 	bl func_ov15_0213b908
 	ldr r0, _0213b644 ; =data_027e0764
-	mov r1, fp
+	mov r1, r11
 	ldr r5, [r0]
 	ldmib r0, {r2, r3}
 	umull r7, r6, r3, r5
@@ -33043,7 +33043,7 @@ _0213b49c:
 	ldr r8, [r0, #0x14]
 	adds r7, r2, r7
 	ldr r2, [r0, #0xc]
-	mov r3, fp
+	mov r3, r11
 	mla r6, r2, r5, r6
 	adc r6, r8, r6
 	str r7, [r0]
@@ -33055,7 +33055,7 @@ _0213b49c:
 	add r0, r5, #0x5a
 	str r0, [r4, #0x284]
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0213b458
 _0213b63c: .word data_027e0fe4
@@ -34159,7 +34159,7 @@ _0213c5b8:
 	.global func_ov15_0213c5c4
 	arm_func_start func_ov15_0213c5c4
 func_ov15_0213c5c4: ; 0x0213c5c4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	mov r4, r0
 	add r0, r4, #0x158
 	mov r1, #1
@@ -34211,12 +34211,12 @@ func_ov15_0213c5c4: ; 0x0213c5c4
 	ldr r8, [lr]
 	ldr r6, [ip, #4]
 	ldmib lr, {r7, sl}
-	umull fp, ip, sl, r8
+	umull r11, ip, sl, r8
 	ldr r1, [lr, #0x10]
 	mla ip, sl, r7, ip
 	ldr sb, [lr, #0xc]
 	ldr r0, [lr, #0x14]
-	adds r1, r1, fp
+	adds r1, r1, r11
 	mla ip, sb, r8, ip
 	mov r5, r2, lsl #0xb
 	adc r0, r0, ip
@@ -34267,7 +34267,7 @@ func_ov15_0213c5c4: ; 0x0213c5c4
 	ldr r0, [r0, #0x34]
 	str r1, [r4, #0x274]
 	str r0, [r4, #0x278]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0213c5c4
 _0213c778: .word data_027e0764
@@ -34278,7 +34278,7 @@ _0213c784: .word data_ov15_0218ac90
 	.global func_ov15_0213c788
 	arm_func_start func_ov15_0213c788
 func_ov15_0213c788: ; 0x0213c788
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x10
 	mov r4, r0
 	bl _ZN5Actor16XzDistanceToLinkEv
@@ -34331,12 +34331,12 @@ _0213c7b4:
 	mla r5, r1, r2, r5
 	ldr r3, [r0, #0x14]
 	adds r6, r7, r6
-	ldr fp, _0213cb08 ; =0x00002001
+	ldr r11, _0213cb08 ; =0x00002001
 	adc r3, r3, r5
-	umull r1, r2, r3, fp
+	umull r1, r2, r3, r11
 	mov r1, sl
 	mla r2, r3, r1, r2
-	mla r2, sl, fp, r2
+	mla r2, sl, r11, r2
 	str r6, [r0]
 	str r3, [r0, #4]
 	sub r1, r2, #0x1000
@@ -34370,10 +34370,10 @@ _0213c7b4:
 	adds r1, sb, r7
 	adc r3, r8, r6
 	stmia r0, {r1, r3}
-	umull r1, r2, r3, fp
+	umull r1, r2, r3, r11
 	mov r1, sl
 	mla r2, r3, r1, r2
-	mla r2, sl, fp, r2
+	mla r2, sl, r11, r2
 	sub r1, r2, #0x1000
 	str r1, [r4, #0x270]
 	ldr r2, [r0]
@@ -34499,11 +34499,11 @@ _0213c9ec:
 	bl func_ov15_0213b8c4
 	cmp r0, #0
 	addeq sp, sp, #0x10
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	mov r0, r4
 	bl func_ov15_0213c27c
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0213c788
 _0213cb00: .word data_027e0fa0
@@ -36044,7 +36044,7 @@ _0213de48: .word data_027e0f94
 	arm_func_start func_ov15_0213de4c
 func_ov15_0213de4c: ; 0x0213de4c
 	stmdb sp!, {r0, r1, r2, r3}
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x80
 	add r1, sp, #0xac
 	mov r5, r0
@@ -36086,7 +36086,7 @@ func_ov15_0213de4c: ; 0x0213de4c
 	bl _ZN12ActorManager8GetActorEP8ActorRef
 	movs r4, r0
 	addeq sp, sp, #0x80
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	addeq sp, sp, #0x10
 	bxeq lr
 	ldr r0, _0213e3a8 ; =data_027e0f94
@@ -36141,12 +36141,12 @@ _0213df4c:
 	ldr r7, [r1, #0x10]
 	mla r3, lr, r0, r3
 	ldr ip, [r1, #0xc]
-	mov fp, #0
+	mov r11, #0
 	mla r3, ip, r2, r3
 	ldr r6, [r1, #0x14]
 	adds sb, r7, r8
 	adc r8, r6, r3
-	mov r0, fp, lsl #0x10
+	mov r0, r11, lsl #0x10
 	orr r0, r0, r8, lsr #16
 	str sb, [r1]
 	sub r0, r0, #0x8000
@@ -36154,7 +36154,7 @@ _0213df4c:
 	str r8, [r1, #4]
 	mov sl, r0, lsr #0x10
 	ldr r0, [r5, #0x194]
-	mov r2, fp
+	mov r2, r11
 	add r3, r0, #1
 	cmp r3, #0
 	ble _0213e048
@@ -36168,8 +36168,8 @@ _0213df4c:
 	cmp r3, #0
 	beq _0213e048
 	umull r1, r0, r2, r3
-	mla r0, r2, fp, r0
-	mla r0, fp, r3, r0
+	mla r0, r2, r11, r0
+	mla r0, r11, r3, r0
 	mov r2, r0
 _0213e048:
 	mov r0, sl, asr #0x4
@@ -36386,7 +36386,7 @@ _0213e360:
 	movge r0, #0
 	strge r0, [r5, #0x188]
 	add sp, sp, #0x80
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	add sp, sp, #0x10
 	bx lr
 	.align 2, 0
@@ -36903,7 +36903,7 @@ _0213ea4c: .word 0x00001555
 	.global func_ov15_0213ea50
 	arm_func_start func_ov15_0213ea50
 func_ov15_0213ea50: ; 0x0213ea50
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x1c8
 	str r1, [sp, #8]
 	ldr r2, [sp, #8]
@@ -36969,7 +36969,7 @@ _0213eac8:
 	bl func_ov15_02141344
 	cmp r0, #0
 	addeq sp, sp, #0x1c8
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	mov r1, #3
 	add r0, sp, #0x118
 	strh r1, [r4, #0x7a]
@@ -37099,7 +37099,7 @@ _0213eac8:
 	ldr r1, [sp, #0x108]
 	str ip, [sp, #0x188]
 	ldr ip, [sp, #0x100]
-	ldrb fp, [sp, #0x110]
+	ldrb r11, [sp, #0x110]
 	ldrb sl, [sp, #0x111]
 	ldrb sb, [sp, #0x112]
 	ldrb r8, [sp, #0x113]
@@ -37117,7 +37117,7 @@ _0213eac8:
 	ldr r0, [r1]
 	str ip, [sp, #0x1a0]
 	add r1, sp, #0x118
-	strb fp, [sp, #0x1a4]
+	strb r11, [sp, #0x1a4]
 	str r5, [sp, #0xc8]
 	str r3, [sp, #0xd0]
 	str r2, [sp, #0xd4]
@@ -37182,8 +37182,8 @@ _0213eac8:
 	str r1, [sp, #0xe0]
 	ldr r0, [r4, #0x37c]
 	str r0, [sp, #0xe4]
-	ldr fp, [r4, #0x380]
-	str fp, [sp, #0xe8]
+	ldr r11, [r4, #0x380]
+	str r11, [sp, #0xe8]
 	ldr sl, [r4, #0x384]
 	str sl, [sp, #0xc]
 	str sl, [sp, #0xec]
@@ -37275,7 +37275,7 @@ _0213eac8:
 	str r1, [sp, #0x190]
 	ldr r0, [r0]
 	add r1, sp, #0x118
-	str fp, [sp, #0x17c]
+	str r11, [sp, #0x17c]
 	str sb, [sp, #0x1a0]
 	strb r8, [sp, #0x1a4]
 	strb r7, [sp, #0x1a5]
@@ -37573,7 +37573,7 @@ _0213f47c:
 	ldr r0, [sp, #8]
 	str r0, [r4, #0x130]
 	add sp, sp, #0x1c8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0213ea50
 _0213f494: .word 0x0000ffff
@@ -43905,7 +43905,7 @@ _02144928:
 	.global func_ov15_021449b0
 	arm_func_start func_ov15_021449b0
 func_ov15_021449b0: ; 0x021449b0
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x1c4
 	mov sb, r0
 	ldr r0, [sb, #0x378]
@@ -44511,7 +44511,7 @@ _021452b0:
 	b _02145420
 _021452cc:
 	add sp, sp, #0x1c4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _021452d4:
 	bl func_ov15_021464fc
 	mov r5, r0
@@ -44771,18 +44771,18 @@ _02145524:
 	mov r1, #0x35
 	sub sl, r1, #0x36
 	sub r3, r1, #0x9f
-	umull ip, fp, r5, r1
-	mla fp, r5, lr, fp
-	mla fp, r4, r1, fp
+	umull ip, r11, r5, r1
+	mla r11, r5, lr, r11
+	mla r11, r4, r1, r11
 	adds ip, ip, #0x800
-	adc r1, fp, #0
-	mov fp, ip, lsr #0xc
-	orr fp, fp, r1, lsl #20
-	add r1, r8, fp
-	umull fp, r8, r7, r3
+	adc r1, r11, #0
+	mov r11, ip, lsr #0xc
+	orr r11, r11, r1, lsl #20
+	add r1, r8, r11
+	umull r11, r8, r7, r3
 	mla r8, r7, sl, r8
 	mla r8, r6, r3, r8
-	adds sl, fp, #0x800
+	adds sl, r11, #0x800
 	adc r3, r8, #0
 	mov r8, sl, lsr #0xc
 	orr r8, r8, r3, lsl #20
@@ -44809,12 +44809,12 @@ _02145524:
 	bl func_02002c14
 	mov r2, r0
 	add r0, sb, #0x4c0
-	mov fp, #0
+	mov r11, #0
 	mov r1, #0x35
 	sub ip, r1, #0x36
 	sub r3, r1, #0x9f
 	umull sl, lr, r7, r1
-	mla lr, r7, fp, lr
+	mla lr, r7, r11, lr
 	mla lr, r6, r1, lr
 	adds r6, sl, #0x800
 	adc r1, lr, #0
@@ -44843,7 +44843,7 @@ _02145798:
 	mov r2, #2
 	bl func_ov00_02089318
 	add sp, sp, #0x1c4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_021449b0
 _021457cc: .word data_027e0f64
@@ -47262,7 +47262,7 @@ func_ov15_02147604: ; 0x02147604
 	.global func_ov15_0214761c
 	arm_func_start func_ov15_0214761c
 func_ov15_0214761c: ; 0x0214761c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x1c
 	ldr r1, _02147bb0 ; =data_027e10a4
 	mov r4, r0
@@ -47308,7 +47308,7 @@ _02147670:
 	cmp r1, #2
 	beq _0214792c
 	add sp, sp, #0x1c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _021476d0:
 	ldr sl, _02147bb4 ; =data_027e0764
 	mov r1, #0
@@ -47322,16 +47322,16 @@ _021476d0:
 	mla r8, r2, r3, r8
 	adds sb, r7, sb
 	ldr r3, [sl, #0x14]
-	umull ip, fp, r0, sb
+	umull ip, r11, r0, sb
 	adc r8, r3, r8
 	str sb, [sl]
-	mla fp, r0, r8, fp
+	mla r11, r0, r8, r11
 	str r8, [sl, #4]
 	tst r8, #0x80000000
 	beq _0214775c
-	mla fp, r2, sb, fp
+	mla r11, r2, sb, r11
 	adds r0, r7, ip
-	adc r3, r3, fp
+	adc r3, r3, r11
 	mov r1, r1, lsl #0x2
 	orr r1, r1, r3, lsr #30
 	mov r1, r1, lsl #0x8
@@ -47346,9 +47346,9 @@ _021476d0:
 	add r0, r2, r1
 	b _02147798
 _0214775c:
-	mla fp, r2, sb, fp
+	mla r11, r2, sb, r11
 	adds r0, r7, ip
-	adc r3, r3, fp
+	adc r3, r3, r11
 	mov r1, r1, lsl #0x2
 	orr r1, r1, r3, lsr #30
 	mov r1, r1, lsl #0x8
@@ -47409,7 +47409,7 @@ _02147798:
 	mov r0, r0, lsl #0xb
 	add sp, sp, #0x1c
 	str r0, [r4, #0x3f4]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02147858:
 	mov r2, #0x100
 	add r0, r4, #0x3fc
@@ -47424,7 +47424,7 @@ _02147858:
 	bl func_ov15_021529f8
 	cmp r0, #0
 	addeq sp, sp, #0x1c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, [r4, #0x424]
 	cmp r0, #0
 	beq _021478c8
@@ -47438,7 +47438,7 @@ _02147858:
 	bl func_ov15_021529f0
 	cmp r0, #0x1e
 	addlt sp, sp, #0x1c
-	ldmltia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmltia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _021478c8:
 	mov r0, #2
 	ldr r2, _02147bb4 ; =data_027e0764
@@ -47464,7 +47464,7 @@ _021478c8:
 	mov r0, r0, lsl #0xb
 	add sp, sp, #0x1c
 	str r0, [r4, #0x3f4]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0214792c:
 	mov r0, #0
 	str r0, [r4, #0x3f0]
@@ -47481,7 +47481,7 @@ _0214792c:
 	bl func_ov15_02152a0c
 	cmp r0, #0
 	addeq sp, sp, #0x1c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r0, sp, #0x10
 	ldr r6, [r4, #0x420]
 	bl func_01ff9cec
@@ -47491,7 +47491,7 @@ _0214792c:
 	add r1, r1, #0xb00
 	cmp r0, r1
 	addge sp, sp, #0x1c
-	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r2, _02147bb4 ; =data_027e0764
 	mov r1, #0
 	ldr r3, [r2]
@@ -47512,7 +47512,7 @@ _0214792c:
 	cmp r6, #3
 	addge sp, sp, #0x1c
 	str r7, [r2, #4]
-	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	mov r1, #1
 	mov r0, r4
 	strb r1, [r4, #0x43c]
@@ -47615,19 +47615,19 @@ _02147acc:
 	ldr r8, [r2, #0x14]
 	adds r3, sb, r7
 	adc r5, r8, r6
-	mov fp, #0x3c
+	mov r11, #0x3c
 	stmia r2, {r3, r5}
-	umull r2, r3, r5, fp
+	umull r2, r3, r5, r11
 	mla r3, r5, sl, r3
 	mov r2, sl
-	mla r3, r2, fp, r3
+	mla r3, r2, r11, r3
 	add r2, r3, #0x1e
 	mov r0, r4
 	mov r1, #1
 	str r2, [r4, #0x428]
 	bl func_ov15_02148684
 	add sp, sp, #0x1c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0214761c
 _02147bb0: .word data_027e10a4
@@ -50572,7 +50572,7 @@ _0214a3ac: .word data_02050f54
 	.global func_ov15_0214a3b0
 	arm_func_start func_ov15_0214a3b0
 func_ov15_0214a3b0: ; 0x0214a3b0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x80
 	mov r6, r0
 	ldr r2, [r6, #0xe0]
@@ -50596,7 +50596,7 @@ func_ov15_0214a3b0: ; 0x0214a3b0
 	bl func_01fffb4c
 	cmp r0, #0
 	addeq sp, sp, #0x80
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r2, [r6, #0xc]
 	mov r0, #0x800
 	mov r1, r2, asr #0x1f
@@ -50614,10 +50614,10 @@ func_ov15_0214a3b0: ; 0x0214a3b0
 	add r0, r0, r2
 	cmp r1, r0
 	addge sp, sp, #0x80
-	ldmgeia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmgeia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	cmp r2, #0
 	addle sp, sp, #0x80
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r2, [r6, #0xf8]
 	ldr r1, [r6, #0xfc]
 	ldr r0, [r6, #0x100]
@@ -50764,8 +50764,8 @@ func_ov15_0214a3b0: ; 0x0214a3b0
 	bl func_01ffa9fc
 	ldr r0, _0214a86c ; =0x00000333
 	mov r7, #0x400
-	add fp, r0, #0xcc
-	mov r8, fp
+	add r11, r0, #0xcc
+	mov r8, r11
 	rsb r7, r7, #0
 _0214a6bc:
 	ldr lr, [sp, #0x74]
@@ -50813,7 +50813,7 @@ _0214a6bc:
 	mov r1, r1, lsl #0x10
 	mov r0, r0, asr #0x16
 	ldr r2, [sp, #0x54]
-	and r3, fp, r1, asr #22
+	and r3, r11, r1, asr #22
 	mov r1, r2, lsl #0x10
 	mov r1, r1, asr #0x16
 	mov r1, r1, lsl #0x16
@@ -50871,7 +50871,7 @@ _0214a82c:
 	str r2, [sp]
 	bl func_01ffa9fc
 	add sp, sp, #0x80
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0214a3b0
 _0214a858: .word 0x0000ffff
@@ -50885,7 +50885,7 @@ _0214a870: .word data_ov15_0218b704
 	.global func_ov15_0214a874
 	arm_func_start func_ov15_0214a874
 func_ov15_0214a874: ; 0x0214a874
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0xb4
 	mov sl, r0
 	ldr r3, [sl, #0xc]
@@ -50940,7 +50940,7 @@ _0214a8e8:
 	bl func_01fffb4c
 	cmp r0, #0
 	addeq sp, sp, #0xb4
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r0, sp, #0xa8
 	mov r1, r4
 	bl func_01fffbec
@@ -50951,10 +50951,10 @@ _0214a95c:
 	add r0, r0, r2
 	cmp r1, r0
 	addge sp, sp, #0xb4
-	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	cmp r2, #0
 	addle sp, sp, #0xb4
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r2, [sb]
 	ldr r1, [sb, #4]
 	ldr r0, [sb, #8]
@@ -51243,7 +51243,7 @@ _0214abd0:
 	mov r7, #0
 	ble _0214af2c
 	mov r4, #0x400
-	ldr fp, _0214af6c ; =0x000003ff
+	ldr r11, _0214af6c ; =0x000003ff
 	rsb r4, r4, #0
 _0214adf4:
 	cmp r6, #0x80000
@@ -51277,7 +51277,7 @@ _0214adf4:
 	mov r2, r2, lsl #0x16
 	sub r0, r3, r0
 	mov r0, r0, lsl #0x10
-	and r0, fp, r0, asr #22
+	and r0, r11, r0, asr #22
 	orr r0, r0, r2, lsr #12
 	orr r0, r0, r1, lsr #2
 	str r0, [sp, #0xc]
@@ -51301,7 +51301,7 @@ _0214adf4:
 	mov r1, r1, lsl #0x10
 	mov r0, r0, asr #0x16
 	ldr r2, [sp, #0x7c]
-	and r3, fp, r1, asr #22
+	and r3, r11, r1, asr #22
 	mov r1, r2, lsl #0x10
 	mov r1, r1, asr #0x16
 	mov r1, r1, lsl #0x16
@@ -51336,7 +51336,7 @@ _0214af2c:
 	str r2, [sp]
 	bl func_01ffa9fc
 	add sp, sp, #0xb4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0214a874
 _0214af58: .word data_027e10a4
@@ -51672,7 +51672,7 @@ _0214b3f4:
 	.global func_ov15_0214b408
 	arm_func_start func_ov15_0214b408
 func_ov15_0214b408: ; 0x0214b408
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x78
 	mov sb, r0
 	ldr r0, _0214b5f4 ; =0x0000019a
@@ -51725,7 +51725,7 @@ func_ov15_0214b408: ; 0x0214b408
 	rsb sl, sl, #0
 	add r6, sp, #0x3c
 	add r5, sp, #0x48
-	add fp, sp, #0x18
+	add r11, sp, #0x18
 _0214b4e0:
 	add r1, r7, #1
 	mul r0, r1, r1
@@ -51751,7 +51751,7 @@ _0214b4e0:
 	add r2, r4, r2, lsl #1
 	ldrsh r1, [r4, r1]
 	ldrsh r2, [r2, #2]
-	mov r0, fp
+	mov r0, r11
 	blx func_01ff8214
 	ldr r0, [sb, #0xb4]
 	add r7, r7, #1
@@ -51797,7 +51797,7 @@ _0214b59c:
 	str r2, [sp, #8]
 	bl func_ov15_0214b600
 	add sp, sp, #0x78
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0214b408
 _0214b5f4: .word 0x0000019a
@@ -55247,7 +55247,7 @@ func_ov15_0214e118: ; 0x0214e118
 	.global func_ov15_0214e138
 	arm_func_start func_ov15_0214e138
 func_ov15_0214e138: ; 0x0214e138
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0xbc
 	mov sl, r0
 	ldr r2, [sl, #0x1a0]
@@ -55259,7 +55259,7 @@ func_ov15_0214e138: ; 0x0214e138
 	ldr r0, [sl, #0x58]
 	add sp, sp, #0xbc
 	str r0, [sl, #0x4c]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0214e16c:
 	add r0, sl, #0x100
 	ldrh r1, [r0, #0x68]
@@ -55327,12 +55327,12 @@ _0214e16c:
 	str r0, [sp, #0x60]
 	ldr r0, [sl, #0x50]
 	str r0, [sp, #0x64]
-	ldr fp, [sl, #0x19c]
+	ldr r11, [sl, #0x19c]
 	ldr r4, [sl, #0x198]
-	mov r0, fp
+	mov r0, r11
 	bl func_01ff9e64
 	add r2, sp, #0x74
-	rsb r0, fp, #0
+	rsb r0, r11, #0
 	add r1, sp, #0x98
 	mov r3, r2
 	bl func_01ff9e64
@@ -55515,13 +55515,13 @@ _0214e3dc:
 	ldr r1, _0214eaac ; =data_02050f54
 	ldr ip, [sl, #0x68]
 	ldrsh r3, [r1, r2]
-	mov r1, fp, lsl #0x1
-	umull fp, r7, r3, r0
+	mov r1, r11, lsl #0x1
+	umull r11, r7, r3, r0
 	mla r7, r3, lr, r7
 	mov r2, r3, asr #0x1f
 	mla r7, r2, r0, r7
 	mov r0, #0x800
-	adds r2, fp, r0
+	adds r2, r11, r0
 	mov r0, #0
 	adc r0, r7, r0
 	mov r2, r2, lsr #0xc
@@ -55658,15 +55658,15 @@ _0214e738:
 	ldr r2, [sl, #0x188]
 	add r1, sl, #8
 	str r2, [sp, #0x14]
-	ldr fp, [sl, #0x18c]
+	ldr r11, [sl, #0x18c]
 	add r2, sl, #0x48
-	str fp, [sp, #0x18]
-	ldr fp, [sl, #0x190]
-	str fp, [sp, #0x1c]
+	str r11, [sp, #0x18]
+	ldr r11, [sl, #0x190]
+	str r11, [sp, #0x1c]
 	ldr ip, [sl, #0x194]
-	mov fp, ip, lsl #0x1
+	mov r11, ip, lsl #0x1
 	str ip, [sp, #0x20]
-	str fp, [sp, #0x24]
+	str r11, [sp, #0x24]
 	str r7, [sp]
 	ldrb r7, [sl, #0x1a8]
 	str r7, [sp, #4]
@@ -55859,7 +55859,7 @@ _0214ea14:
 	add r0, r4, r0
 	add sp, sp, #0xbc
 	str r0, [sl, #0x164]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0214ea84:
 	umull r2, r1, r4, r3
 	mla r1, r4, r0, r1
@@ -55870,7 +55870,7 @@ _0214ea84:
 	sub r0, r4, r0
 	str r0, [sl, #0x164]
 	add sp, sp, #0xbc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0214e138
 _0214eaac: .word data_02050f54
@@ -56802,7 +56802,7 @@ func_ov15_0214f754: ; 0x0214f754
 	.global func_ov15_0214f768
 	arm_func_start func_ov15_0214f768
 func_ov15_0214f768: ; 0x0214f768
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x4c
 	ldr r1, _0214f9c8 ; =data_027e0f94
 	mov sb, r0
@@ -56831,12 +56831,12 @@ _0214f7c4:
 	ldr r2, [r1, #4]
 	add r1, sp, #0x34
 	add r2, r2, sl
-	ldr fp, [r2, #0xc]
+	ldr r11, [r2, #0xc]
 	ldmib r2, {r3, ip}
 	mov r2, r4
 	str r3, [sp, #0x34]
 	str ip, [sp, #0x38]
-	str fp, [sp, #0x3c]
+	str r11, [sp, #0x3c]
 	bl func_01ff9bf8
 	mov r1, #0
 	mov r0, r4
@@ -56854,7 +56854,7 @@ _0214f81c:
 	ble _0214f92c
 	ldr sl, _0214f9cc ; =data_02050f54
 	mov r7, r8
-	add fp, sp, #0x28
+	add r11, sp, #0x28
 _0214f834:
 	ldr r1, [sb, #0x158]
 	add r0, sp, #0x40
@@ -56863,7 +56863,7 @@ _0214f834:
 	add r2, r2, r7
 	ldr r4, [r2, #0xc]
 	ldmib r2, {r3, ip}
-	mov r2, fp
+	mov r2, r11
 	str r3, [sp, #0x34]
 	str ip, [sp, #0x38]
 	str r4, [sp, #0x3c]
@@ -56877,7 +56877,7 @@ _0214f834:
 	add r0, sb, r8, lsl #1
 	add r0, r0, #0x100
 	ldrsh r2, [r0, #0x64]
-	mov r0, fp
+	mov r0, r11
 	rsb r1, r2, r1, asr #16
 	mov r1, r1, lsl #0x10
 	mov r4, r1, lsr #0x10
@@ -56960,7 +56960,7 @@ _0214f99c:
 _0214f9bc:
 	ldr r0, [sp]
 	add sp, sp, #0x4c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0214f768
 _0214f9c8: .word data_027e0f94
@@ -56970,7 +56970,7 @@ _0214f9d0: .word data_027e0ff0
 	.global func_ov15_0214f9d4
 	arm_func_start func_ov15_0214f9d4
 func_ov15_0214f9d4: ; 0x0214f9d4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x60
 	ldr r1, _0214fbdc ; =data_027e0f74
 	str r0, [sp]
@@ -56979,7 +56979,7 @@ func_ov15_0214f9d4: ; 0x0214f9d4
 	bl func_ov00_02097760
 	cmp r0, #0
 	addeq sp, sp, #0x60
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, [sp]
 	add r0, r0, #0x100
 	str r0, [sp, #8]
@@ -56987,7 +56987,7 @@ func_ov15_0214f9d4: ; 0x0214f9d4
 	ldrsb r0, [r0, #0xa4]
 	cmp r1, r0
 	addeq sp, sp, #0x60
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, _0214fbe4 ; =data_027e10a4
 	ldr r1, _0214fbe8 ; =data_027e0f94
 	ldr r3, [r0]
@@ -57006,12 +57006,12 @@ func_ov15_0214f9d4: ; 0x0214f9d4
 	str r0, [sp, #4]
 	cmp r0, #0
 	addle sp, sp, #0x60
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, [sp]
 	mov sl, r8
 	add r0, r0, #0xa5
 	add r4, r0, #0x100
-	add fp, sp, #0x3c
+	add r11, sp, #0x3c
 	add r6, sp, #0x54
 _0214fa80:
 	ldr r0, [r7, #4]
@@ -57023,7 +57023,7 @@ _0214fa80:
 	add r3, r8, #1
 	str r0, [sp, #0x3c]
 	ldr r0, [r2, #8]
-	mov r1, fp
+	mov r1, r11
 	str r0, [sp, #0x40]
 	ldr r0, [r2, #0xc]
 	mov r2, r6
@@ -57044,11 +57044,11 @@ _0214fa80:
 	add r1, sp, #0x48
 	bl func_01ff9d4c
 	add r0, sp, #0x18
-	mov r1, fp
+	mov r1, r11
 	add r2, sp, #0x30
 	bl func_01ff9bf8
 	add r0, sp, #0xc
-	mov r1, fp
+	mov r1, r11
 	add r2, sp, #0x24
 	bl func_01ff9bf8
 	mov r0, #0
@@ -57092,7 +57092,7 @@ _0214fb98:
 	mov r1, #0
 	strb r1, [r0, #0x1a5]
 	add sp, sp, #0x60
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0214fbb8:
 	add r0, r8, #1
 	mov r1, r0, lsl #0x18
@@ -57102,7 +57102,7 @@ _0214fbb8:
 	mov r8, r1, asr #0x18
 	bgt _0214fa80
 	add sp, sp, #0x60
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0214f9d4
 _0214fbdc: .word data_027e0f74
@@ -57548,7 +57548,7 @@ _021501a8: .word data_027e0f6c
 	.global func_ov15_021501ac
 	arm_func_start func_ov15_021501ac
 func_ov15_021501ac: ; 0x021501ac
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x8c
 	ldr r1, _02150848 ; =data_027e0dbc
 	add r6, sp, #0x7c
@@ -57686,7 +57686,7 @@ _0215036c:
 	cmp r0, #0
 	addne sp, sp, #0x8c
 	movne r0, #0
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r1, sp, #8
 	mov r0, sl
 	bl func_ov15_02151208
@@ -57725,7 +57725,7 @@ _02150408:
 	add sp, sp, #0x8c
 	strb r2, [r1, #0x28]
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02150460:
 	ldr r0, _02150868 ; =data_027e0f94
 	add r3, sp, #0x48
@@ -57801,7 +57801,7 @@ _02150560:
 	rsb r0, sb, #0
 	str r0, [sp, #4]
 	mov r0, r0, lsl #0x18
-	mov fp, r0, asr #0x18
+	mov r11, r0, asr #0x18
 _02150578:
 	ldr r0, _0215085c ; =data_027e0ff0
 	add r1, sp, #9
@@ -57813,7 +57813,7 @@ _02150578:
 	cmp sb, #0
 	movge r1, sb
 	ldrsb r0, [r4, #0x10]
-	movlt r1, fp
+	movlt r1, r11
 	cmp r0, r1
 	bne _021506e0
 	add r1, sp, #9
@@ -57912,7 +57912,7 @@ _021506e0:
 	add sp, sp, #0x8c
 	strb r2, [r1, #0x28]
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02150714:
 	ldr r0, [sl, #0x48]
 	str r0, [r5, #0x1c]
@@ -57994,7 +57994,7 @@ _021507b0:
 	strb r0, [sl, #0x2a8]
 	mov r0, #1
 	add sp, sp, #0x8c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_021501ac
 _02150848: .word data_027e0dbc
@@ -59231,7 +59231,7 @@ _021518f0: .word data_027e0764
 	.global func_ov15_021518f4
 	arm_func_start func_ov15_021518f4
 func_ov15_021518f4: ; 0x021518f4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x28
 	mov sl, r0
 	mov r0, #0
@@ -59248,7 +59248,7 @@ _02151908:
 	bge _02151a2c
 	add r5, sp, #4
 	add r6, sp, #0x1c
-	add fp, sp, #0x10
+	add r11, sp, #0x10
 _02151938:
 	add r0, sl, r7, lsl #2
 	ldr sb, [r0, #0x160]
@@ -59258,7 +59258,7 @@ _02151938:
 	mov r0, r6
 	str r1, [sp, #0x1c]
 	ldr r2, [r8, #0x4c]
-	mov r1, fp
+	mov r1, r11
 	str r2, [sp, #0x20]
 	ldr r3, [r8, #0x50]
 	mov r2, r5
@@ -59292,9 +59292,9 @@ _02151938:
 	mov r1, r5
 	mov r2, r6
 	bl func_01ff9bc4
-	mov r0, fp
+	mov r0, r11
 	mov r1, r5
-	mov r2, fp
+	mov r2, r11
 	bl func_01ff9bf8
 	ldr r0, [sp, #0x1c]
 	str r0, [r8, #0x48]
@@ -59319,7 +59319,7 @@ _02151a2c:
 	cmp r0, #4
 	blt _02151908
 	add sp, sp, #0x28
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	arm_func_end func_ov15_021518f4
 
 	.global func_ov15_02151a48
@@ -60564,7 +60564,7 @@ _02152a40:
 	.global func_ov15_02152a48
 	arm_func_start func_ov15_02152a48
 func_ov15_02152a48: ; 0x02152a48
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x1ac
 	ldr r1, _02153464 ; =data_027e0fe4
 	mov r5, r0
@@ -60666,7 +60666,7 @@ _02152b98:
 	cmp r0, #0
 	beq _02152d1c
 	ldr r1, _02153474 ; =data_027e0fac
-	ldr fp, _02153478 ; =data_02050f54
+	ldr r11, _02153478 ; =data_02050f54
 	ldrsh r3, [r1]
 	ldr r0, _0215347c ; =0xfffffd9a
 	mvn r1, #0
@@ -60674,10 +60674,10 @@ _02152b98:
 	mov r6, r2, lsl #0x1
 	add r2, r3, #0x2000
 	mov r3, r6, lsl #0x1
-	ldrsh r8, [fp, r3]
+	ldrsh r8, [r11, r3]
 	add r3, r6, #1
 	mov r3, r3, lsl #0x1
-	ldrsh r6, [fp, r3]
+	ldrsh r6, [r11, r3]
 	umull sl, sb, r8, r0
 	umull ip, r7, r6, r0
 	mov r2, r2, lsl #0x10
@@ -60686,16 +60686,16 @@ _02152b98:
 	mov r3, r2, lsl #0x1
 	add r2, r3, #1
 	mov r2, r2, lsl #0x1
-	ldrsh lr, [fp, r2]
+	ldrsh lr, [r11, r2]
 	adds sl, sl, #0x800
 	mla sb, r8, r1, sb
 	mla r7, r6, r1, r7
 	mov r1, r6, asr #0x1f
 	mov r3, r3, lsl #0x1
 	str ip, [sp, #8]
-	ldrsh ip, [fp, r3]
-	mov fp, r8, asr #0x1f
-	mla sb, fp, r0, sb
+	ldrsh ip, [r11, r3]
+	mov r11, r8, asr #0x1f
+	mla sb, r11, r0, sb
 	rsb r2, r0, #0x800
 	mla r7, r1, r0, r7
 	mov sl, sl, lsr #0xc
@@ -60706,7 +60706,7 @@ _02152b98:
 	sub r0, r0, #0x1b4
 	str r0, [r5, #0x4bc]
 	ldr r0, [sp, #8]
-	mov fp, #0
+	mov r11, #0
 	adds r1, r0, #0x800
 	umull sb, r8, lr, r2
 	adc r0, r7, #0
@@ -60715,7 +60715,7 @@ _02152b98:
 	add sl, r1, #0x3800
 	str sl, [r5, #0x4c0]
 	ldr r0, [r5, #0x4bc]
-	mla r8, lr, fp, r8
+	mla r8, lr, r11, r8
 	mov r7, lr, asr #0x1f
 	mla r8, r7, r2, r8
 	adds r7, sb, #0x800
@@ -60726,7 +60726,7 @@ _02152b98:
 	orr r7, r7, r2, lsl #20
 	add r2, sl, r7
 	umull r8, r7, ip, r3
-	mla r7, ip, fp, r7
+	mla r7, ip, r11, r7
 	mov r0, ip, asr #0x1f
 	mla r7, r0, r3, r7
 	adds r3, r8, #0x800
@@ -61235,7 +61235,7 @@ _02153454:
 	mov r0, r5
 	bl func_ov15_021548c4
 	add sp, sp, #0x1ac
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02152a48
 _02153464: .word data_027e0fe4
@@ -61667,7 +61667,7 @@ _02153a5c: .word data_ov15_0218f6c8
 	.global func_ov15_02153a60
 	arm_func_start func_ov15_02153a60
 func_ov15_02153a60: ; 0x02153a60
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0xc0
 	ldr r1, _02153f58 ; =data_027e0fe4
 	mov r5, r0
@@ -61676,7 +61676,7 @@ func_ov15_02153a60: ; 0x02153a60
 	bl _ZN12ActorManager8GetActorEP8ActorRef
 	movs r4, r0
 	addeq sp, sp, #0xc0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	mov r0, r5
 	bl func_ov15_0214325c
 	ldrb r0, [r5, #0x436]
@@ -61710,7 +61710,7 @@ _02153ae4:
 	cmp r1, r0
 	add sp, sp, #0xc0
 	strle r0, [r5, #0x280]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02153b04:
 	ldr r0, _02153f5c ; =data_027e1060
 	bl func_ov15_0217705c
@@ -61903,15 +61903,15 @@ _02153d74:
 	ldmia r3, {r0, r1, r2}
 	stmia r6, {r0, r1, r2}
 	ldr r8, [r4, #0x420]
-	mov fp, #0x3000
+	mov r11, #0x3000
 	ldr lr, _02153f88 ; =data_ov15_021863a8
 	ldr r0, [r4, #0x41c]
-	umull sl, sb, r8, fp
+	umull sl, sb, r8, r11
 	ldr r2, [lr, r0, lsl #2]
 	mov r0, #0
 	mla sb, r8, r0, sb
 	mov r7, r8, asr #0x1f
-	mla sb, r7, fp, sb
+	mla sb, r7, r11, sb
 	adds r7, sl, #0x800
 	adc r0, sb, #0
 	mov r7, r7, lsr #0xc
@@ -61995,7 +61995,7 @@ _02153d74:
 	ldrsh r1, [r1, #0x4c]
 	bl func_ov15_0216ea14
 	add sp, sp, #0xc0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02153a60
 _02153f58: .word data_027e0fe4
@@ -65147,7 +65147,7 @@ _02156b00: .word 0x00000285
 	.global func_ov15_02156b04
 	arm_func_start func_ov15_02156b04
 func_ov15_02156b04: ; 0x02156b04
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x38
 	mov r6, r0
 	add r0, r6, #0x200
@@ -65156,7 +65156,7 @@ func_ov15_02156b04: ; 0x02156b04
 	movne r0, #0
 	addne sp, sp, #0x38
 	strne r0, [r6, #0x2e0]
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r1, [r6, #0x2e4]
 	add r0, r6, #0x2e0
 	mov r2, #0xcd
@@ -65354,17 +65354,17 @@ _02156d4c:
 	mov sb, sl, asr #0x1f
 	mov r8, r5, asr #0x1f
 	mov r2, r7, asr #0x1f
-	mov fp, sb, lsl #0xd
+	mov r11, sb, lsl #0xd
 	mov sb, r8, lsl #0xd
 	mov r8, r2, lsl #0xd
 	mov r2, r1, asr #0x1f
 	mov r2, r2, lsl #0xd
 	adds ip, r0, sl, lsl #13
-	orr fp, fp, sl, lsr #19
-	adc sl, fp, #0
-	mov fp, ip, lsr #0xc
-	orr fp, fp, sl, lsl #20
-	add r4, r4, fp
+	orr r11, r11, sl, lsr #19
+	adc sl, r11, #0
+	mov r11, ip, lsr #0xc
+	orr r11, r11, sl, lsl #20
+	add r4, r4, r11
 	adds sl, r0, r5, lsl #13
 	orr sb, sb, r5, lsr #19
 	adc r5, sb, #0
@@ -65434,7 +65434,7 @@ _02156ed4:
 	mov r8, r3, asr #0x1f
 	mov ip, r8, lsl #0xe
 	mov r8, r2, asr #0x1f
-	mov fp, r8, lsl #0xe
+	mov r11, r8, lsl #0xe
 	mov r4, sl, asr #0x1f
 	mov r0, r4, lsl #0xc
 	ldr r8, [sp]
@@ -65476,9 +65476,9 @@ _02156ed4:
 	orr r8, r8, r3, lsl #20
 	str r0, [sp, #0x20]
 	add r0, r0, r8
-	orr fp, fp, r2, lsr #18
+	orr r11, r11, r2, lsr #18
 	str r0, [sp, #0x2c]
-	adc r0, fp, #0
+	adc r0, r11, #0
 	mov r1, r1, lsr #0xc
 	orr r1, r1, r0, lsl #20
 	add r0, r7, r1
@@ -65500,7 +65500,7 @@ _02157038:
 	ldr r0, [sp, #0x10]
 	str r0, [r6, #0x5c]
 	add sp, sp, #0x38
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02156b04
 _02157078: .word data_02050f54
@@ -65511,7 +65511,7 @@ _02157084: .word data_027e0f94
 	.global func_ov15_02157088
 	arm_func_start func_ov15_02157088
 func_ov15_02157088: ; 0x02157088
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x18
 	mov sl, r0
 	add r0, sl, #0x200
@@ -65545,11 +65545,11 @@ func_ov15_02157088: ; 0x02157088
 	add r0, r2, r1
 	add sp, sp, #0x18
 	str r0, [sl, #0x2d0]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02157114:
 	cmp r8, #0
 	addeq sp, sp, #0x18
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	bl func_ov15_0213ce4c
 	mov r1, #0xc
 	ldr r2, [r0, #4]
@@ -65566,7 +65566,7 @@ _02157114:
 	str r3, [sp, #0x14]
 	bl func_01ff9bf8
 	add r4, sl, #0x200
-	add fp, sp, #0xc
+	add r11, sp, #0xc
 	add r5, sp, #0
 	mov r6, #0
 _0215716c:
@@ -65617,7 +65617,7 @@ _021571ec:
 	str r0, [sl, #0x2d0]
 	bl func_ov15_0213ce4c
 	ldr r2, [r0, #4]
-	mov r0, fp
+	mov r0, r11
 	ldr r1, [r2, sb]
 	add r3, r2, sb
 	str r1, [sp, #0xc]
@@ -65637,7 +65637,7 @@ _02157264:
 	add r0, sl, #0x200
 	strh r7, [r0, #0xec]
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02157088
 _02157274: .word data_02050f54
@@ -65645,7 +65645,7 @@ _02157274: .word data_02050f54
 	.global func_ov15_02157278
 	arm_func_start func_ov15_02157278
 func_ov15_02157278: ; 0x02157278
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x24
 	ldr r2, [r1]
 	mov sl, r0
@@ -65666,7 +65666,7 @@ func_ov15_02157278: ; 0x02157278
 	str r1, [sl, #0x2cc]
 	ldr r0, [r0, #8]
 	str r0, [sl, #0x2d0]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _021572d0:
 	bne _02157308
 	bl func_ov15_0213ce4c
@@ -65681,7 +65681,7 @@ _021572d0:
 	str r0, [sl, #0x2cc]
 	ldr r0, [r1, #8]
 	str r0, [sl, #0x2d0]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02157308:
 	add r0, sl, #0x2bc
 	mov r3, #0xc
@@ -65690,13 +65690,13 @@ _02157308:
 	stmia r6, {r0, r1, r2}
 	smulbb sb, r7, r3
 	mov r8, #0x800
-	add fp, sp, #0
+	add r11, sp, #0
 	add r5, sp, #0x18
 	mov r4, #0
 _02157330:
 	bl func_ov15_0213ce4c
 	ldr r2, [r0, #4]
-	mov r0, fp
+	mov r0, r11
 	ldr r1, [r2, sb]
 	add r3, r2, sb
 	str r1, [sp]
@@ -65776,7 +65776,7 @@ _0215744c:
 	str r1, [sl, #0x2d0]
 	strh r7, [r0, #0xec]
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02157278
 _02157474: .word data_027e0f94
@@ -66134,10 +66134,10 @@ func_ov15_02157844: ; 0x02157844
 	.global func_ov15_021578e0
 	arm_func_start func_ov15_021578e0
 func_ov15_021578e0: ; 0x021578e0
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x5c
 	mov r4, r0
-	mov fp, r1
+	mov r11, r1
 	bl _ZN5Actor18func_ov00_020c313cEj
 	cmp r0, #0
 	beq _02157c08
@@ -66340,12 +66340,12 @@ _02157bf0:
 	ldr r0, [sp, #0x28]
 	str r0, [r4, #0x50]
 _02157c08:
-	mov r1, fp
+	mov r1, r11
 	add r0, r4, #0xa4
 	add r2, r4, #0x1d8
 	bl func_ov00_0207a1c8
 	add sp, sp, #0x5c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_021578e0
 _02157c20: .word data_ov15_0218c1d8
@@ -66542,13 +66542,13 @@ _02157e64: .word data_027e0d0c
 	.global func_ov15_02157e68
 	arm_func_start func_ov15_02157e68
 func_ov15_02157e68: ; 0x02157e68
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x5c
 	mov sl, r0
 	bl _ZN5Actor18func_ov00_020c313cEj
 	cmp r0, #0
 	addeq sp, sp, #0x5c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldrb r0, [sl, #0x176]
 	cmp r0, #0
 	bne _021580c4
@@ -66569,14 +66569,14 @@ func_ov15_02157e68: ; 0x02157e68
 	ldrne r0, [sl, #0x170]
 	addne r0, r0, #1
 	strne r0, [sl, #0x170]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02157ed8:
 	ldr r0, _021583a4 ; =data_027e10a4
 	ldr r0, [r0]
 	bl func_ov15_0213a54c
 	cmp r0, #0
 	addne sp, sp, #0x5c
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, _021583a8 ; =data_027e0e60
 	ldrh r1, [sl, #0x20]
 	ldr r0, [r0]
@@ -66584,7 +66584,7 @@ _02157ed8:
 	bl func_ov00_020836dc
 	cmp r0, #0
 	addeq sp, sp, #0x5c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r0, sl, #0x100
 	ldrh r1, [r0, #0x74]
 	sub r1, r1, #1
@@ -66592,7 +66592,7 @@ _02157ed8:
 	ldrh r1, [r0, #0x74]
 	cmp r1, #0
 	addne sp, sp, #0x5c
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	mov r1, #0x1e
 	ldr r2, _021583ac ; =data_027e0764
 	strh r1, [r0, #0x74]
@@ -66609,13 +66609,13 @@ _02157ed8:
 	mov r7, #0x64
 	str r6, [r2]
 	mov r8, #0
-	umull sb, fp, r5, r7
-	mla fp, r5, r8, fp
-	mla fp, r8, r7, fp
-	cmp fp, #0xa
+	umull sb, r11, r5, r7
+	mla r11, r5, r8, r11
+	mla r11, r8, r7, r11
+	cmp r11, #0xa
 	addge sp, sp, #0x5c
 	str r5, [r2, #4]
-	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	umull r8, r7, r1, r6
 	mla r7, r1, r5, r7
 	ldrh r5, [sl, #0x22]
@@ -66657,9 +66657,9 @@ _02157ed8:
 	ldr r2, [lr, #0xc]
 	ldr ip, [lr, #0x10]
 	mla r7, r2, r1, r7
-	ldr fp, [lr, #0x14]
+	ldr r11, [lr, #0x14]
 	adds r1, ip, r8
-	adc r0, fp, r7
+	adc r0, r11, r7
 	str r1, [lr]
 	str r0, [lr, #4]
 	mov r0, r0, asr #0x1f
@@ -66668,10 +66668,10 @@ _02157ed8:
 	strh r0, [sp, #0x18]
 	cmp sb, #0
 	addle sp, sp, #0x5c
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	mov r7, r6
 	add r8, sl, #0x158
-	mvn fp, #0
+	mvn r11, #0
 _0215806c:
 	add r0, r7, r4, asr #16
 	strh r0, [sp, #0x2c]
@@ -66685,7 +66685,7 @@ _0215806c:
 	add r0, sl, r6, lsl #3
 	ldr r0, [r0, #0x158]
 	add r6, r6, #1
-	cmp r0, fp
+	cmp r0, r11
 	ldrneb r0, [sl, #0x176]
 	add r7, r7, r5, asr #16
 	add r8, r8, #8
@@ -66694,20 +66694,20 @@ _0215806c:
 	cmp r6, sb
 	blt _0215806c
 	add sp, sp, #0x5c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _021580c4:
 	mov r6, #0
 	mov r7, r6
 	mov r8, r6
 	add sb, sl, #0x158
 	add r5, sp, #4
-	mov fp, r6
+	mov r11, r6
 	mvn r4, #0
 _021580e0:
 	add r0, sl, r8, lsl #3
 	ldr r0, [r0, #0x158]
 	mov r1, r8, lsl #0x1
-	strh fp, [r5, r1]
+	strh r11, [r5, r1]
 	cmp r0, r4
 	beq _02158134
 	ldr r0, _021583bc ; =data_027e0fe4
@@ -66812,26 +66812,26 @@ _02158260:
 	smull r3, r2, r0, r1
 	ldr r7, _021583c8 ; =0x55555556
 	add r0, r8, #2
-	smull fp, r3, r7, r0
+	smull r11, r3, r7, r0
 	add r3, r3, r0, lsr #31
 	mov r7, #3
-	smull r3, fp, r7, r3
+	smull r3, r11, r7, r3
 	sub r3, r0, r3
 	add r2, r2, r1, lsr #31
-	smull r2, fp, r7, r2
+	smull r2, r11, r7, r2
 	sub r2, r1, r2
 	mov r0, r8, lsl #0x1
 	mov r1, r2, lsl #0x1
 	mov r3, r3, lsl #0x1
 	ldrh r0, [r6, r0]
 	ldrh r7, [r6, r1]
-	ldrh fp, [r6, r3]
+	ldrh r11, [r6, r3]
 	sub r1, r7, r0
 	mov r1, r1, lsl #0x10
 	movs r1, r1, asr #0x10
 	mov r2, r1
 	smulbbmi r1, r1, r5
-	sub r3, fp, r0
+	sub r3, r11, r0
 	movmi r1, r1, lsl #0x10
 	mov r3, r3, lsl #0x10
 	movmi r1, r1, asr #0x10
@@ -66857,12 +66857,12 @@ _02158304:
 _02158318:
 	cmp r3, #0
 	ble _02158330
-	add r1, fp, r4
+	add r1, r11, r4
 	mov r1, r1, lsl #0x10
 	mov r7, r1, lsr #0x10
 	b _02158340
 _02158330:
-	add r1, fp, #0x55
+	add r1, r11, #0x55
 	add r1, r1, #0x5500
 	mov r1, r1, lsl #0x10
 	mov r7, r1, lsr #0x10
@@ -66893,7 +66893,7 @@ _02158394:
 	mov r0, sl
 	bl func_ov15_0215846c
 	add sp, sp, #0x5c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02157e68
 _021583a4: .word data_027e10a4
@@ -69306,7 +69306,7 @@ func_ov15_0215a440: ; 0x0215a440
 	.global func_ov15_0215a478
 	arm_func_start func_ov15_0215a478
 func_ov15_0215a478: ; 0x0215a478
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x30
 	ldr r1, _0215a748 ; =data_027e0f74
 	mov sl, r0
@@ -69319,7 +69319,7 @@ func_ov15_0215a478: ; 0x0215a478
 	cmp r0, #0
 	addne sp, sp, #0x30
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	mvn r0, #0
 	str r0, [sl, #0x98]
 	str r0, [sl, #0x88]
@@ -69364,7 +69364,7 @@ _0215a500:
 	cmp r0, #0
 	addlt sp, sp, #0x30
 	movlt r0, #0
-	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, _0215a75c ; =data_027e0e60
 	ldrh r1, [sl, #0x20]
 	ldr r0, [r0]
@@ -69394,7 +69394,7 @@ _0215a500:
 	ble _0215a6b0
 	mov sb, r8
 	add r5, sl, #0x1f0
-	mov fp, #0xc
+	mov r11, #0xc
 	mov r4, #0x24
 _0215a5d8:
 	ldr r0, [r6, #4]
@@ -69415,7 +69415,7 @@ _0215a5f8:
 	ldr r2, [r2, #0xc]
 	str r2, [sp, #0x14]
 	ldr ip, [sl, #0x1ec]
-	mul r2, ip, fp
+	mul r2, ip, r11
 	str r3, [r5, r2]
 	ldr r3, [sp, #0x10]
 	add ip, r5, r2
@@ -69492,7 +69492,7 @@ _0215a6b0:
 	strb r1, [sl, #0x239]
 	strb r1, [sl, #0x23a]
 	add sp, sp, #0x30
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0215a478
 _0215a748: .word data_027e0f74
@@ -69661,7 +69661,7 @@ func_ov15_0215a95c: ; 0x0215a95c
 	.global func_ov15_0215a970
 	arm_func_start func_ov15_0215a970
 func_ov15_0215a970: ; 0x0215a970
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x40
 	ldr r1, _0215b264 ; =data_027e0f94
 	add r3, sp, #0x34
@@ -69680,7 +69680,7 @@ func_ov15_0215a970: ; 0x0215a970
 	mov r0, r4
 	bl func_ov15_0215b790
 	add sp, sp, #0x40
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0215a9c0:
 	ldr r0, _0215b26c ; =data_027e0e60
 	mov r6, #0
@@ -69755,7 +69755,7 @@ _0215aa5c:
 	cmp r0, #0
 	addne sp, sp, #0x40
 	strneb r3, [r4, #0x238]
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r1, sp, #0x10
 	add r2, sp, #0xc
 	mov r0, r4
@@ -69855,7 +69855,7 @@ _0215ac10:
 	ldr r3, _0215b280 ; =data_ov15_021865e8
 	str r0, [sp, #8]
 	add r1, sp, #0x20
-	mov fp, r8
+	mov r11, r8
 _0215ac50:
 	ldr r6, [r7, r8, lsl #2]
 	ldr r2, [r3, r8, lsl #2]
@@ -69866,7 +69866,7 @@ _0215ac50:
 	mla lr, sl, r2, lr
 	adds r5, r5, #0x800
 	mla lr, sb, ip, lr
-	adc r2, lr, fp
+	adc r2, lr, r11
 	mov r5, r5, lsr #0xc
 	orr r5, r5, r2, lsl #20
 	add r2, r6, r5
@@ -69884,14 +69884,14 @@ _0215ac50:
 	mov r0, r3, lsr #0xc
 	adc r1, r2, #0
 	orr r0, r0, r1, lsl #20
-	mov fp, sl, lsl #0x2
-	cmp fp, #0x1000
-	movge fp, #0x1000
+	mov r11, sl, lsl #0x2
+	cmp r11, #0x1000
+	movge r11, #0x1000
 	mov ip, #0
 	ldr sb, _0215b284 ; =data_ov15_021865dc
 	ldr r3, _0215b288 ; =data_ov15_021865fc
 	str r0, [sp, #4]
-	mov sl, fp, asr #0x1f
+	mov sl, r11, asr #0x1f
 	add r1, sp, #0x14
 	mov lr, ip
 _0215ace4:
@@ -69900,8 +69900,8 @@ _0215ace4:
 	add r0, ip, #1
 	sub r5, r2, r8
 	mov r2, r5, asr #0x1f
-	umull r7, r6, fp, r5
-	mla r6, fp, r2, r6
+	umull r7, r6, r11, r5
+	mla r6, r11, r2, r6
 	mla r6, sl, r5, r6
 	adds r5, r7, #0x800
 	adc r2, r6, lr
@@ -70031,7 +70031,7 @@ _0215ae94:
 _0215aed4:
 	ldr r7, [r8, sl, lsl #2]
 	ldr r2, [r1, sl, lsl #2]
-	add fp, sl, #1
+	add r11, sl, #1
 	sub r2, r2, r7
 	umull ip, r3, r5, r2
 	adds r6, ip, #0x800
@@ -70042,9 +70042,9 @@ _0215aed4:
 	adc r2, r3, lr
 	orr r6, r6, r2, lsl #20
 	add r2, r7, r6
-	mov fp, fp, lsl #0x10
+	mov r11, r11, lsl #0x10
 	str r2, [r0, sl, lsl #2]
-	mov sl, fp, lsr #0x10
+	mov sl, r11, lsr #0x10
 	cmp sl, #5
 	blo _0215aed4
 	mov r0, #0x9000
@@ -70056,14 +70056,14 @@ _0215aed4:
 	mov r0, r3, lsr #0xc
 	adc r1, r2, #0
 	orr r0, r0, r1, lsl #20
-	mov fp, r5, lsl #0x2
-	cmp fp, #0x1000
-	movge fp, #0x1000
+	mov r11, r5, lsl #0x2
+	cmp r11, #0x1000
+	movge r11, #0x1000
 	mov ip, #0
 	ldr sb, _0215b284 ; =data_ov15_021865dc
 	ldr r3, _0215b288 ; =data_ov15_021865fc
 	str r0, [sp, #4]
-	mov sl, fp, asr #0x1f
+	mov sl, r11, asr #0x1f
 	add r1, sp, #0x14
 	mov lr, ip
 _0215af68:
@@ -70072,8 +70072,8 @@ _0215af68:
 	add r0, ip, #1
 	sub r5, r2, r8
 	mov r2, r5, asr #0x1f
-	umull r7, r6, fp, r5
-	mla r6, fp, r2, r6
+	umull r7, r6, r11, r5
+	mla r6, r11, r2, r6
 	mla r6, sl, r5, r6
 	adds r5, r7, #0x800
 	adc r2, r6, lr
@@ -70118,11 +70118,11 @@ _0215b004:
 	sub ip, r3, r2
 	umull r3, r2, ip, r8
 	mla r2, ip, r7, r2
-	mov fp, ip, asr #0x1f
-	mla r2, fp, r8, r2
-	adds fp, r3, #0x800
+	mov r11, ip, asr #0x1f
+	mla r2, r11, r8, r2
+	adds r11, r3, #0x800
 	adc r3, r2, #0
-	mov r2, fp, lsr #0xc
+	mov r2, r11, lsr #0xc
 	orr r2, r2, r3, lsl #20
 	bl Approach_thunk
 	tst sl, r0
@@ -70162,11 +70162,11 @@ _0215b0b0:
 	sub ip, r3, r2
 	umull r3, r2, ip, r8
 	mla r2, ip, r7, r2
-	mov fp, ip, asr #0x1f
-	mla r2, fp, r8, r2
-	adds fp, r3, #0x800
+	mov r11, ip, asr #0x1f
+	mla r2, r11, r8, r2
+	adds r11, r3, #0x800
 	adc r3, r2, #0
-	mov r2, fp, lsr #0xc
+	mov r2, r11, lsr #0xc
 	orr r2, r2, r3, lsl #20
 	bl Approach_thunk
 	tst sl, r0
@@ -70264,7 +70264,7 @@ _0215b248:
 	add r0, r4, #0x228
 	bl Approach_thunk
 	add sp, sp, #0x40
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0215a970
 _0215b264: .word data_027e0f94
@@ -70285,13 +70285,13 @@ _0215b298: .word 0x0005000e
 	.global func_ov15_0215b29c
 	arm_func_start func_ov15_0215b29c
 func_ov15_0215b29c: ; 0x0215b29c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x10
 	ldr r5, _0215b354 ; =data_027e0f94
 	add r4, sp, #4
 	mov sl, r0
 	mov r6, #0
-	mov fp, r1
+	mov r11, r1
 	str r2, [sp]
 	ldmia r5, {r0, r1, r2}
 	stmia r4, {r0, r1, r2}
@@ -70316,13 +70316,13 @@ _0215b2e0:
 	blo _0215b2e0
 _0215b30c:
 	ldr r0, [sp]
-	cmp fp, #0
-	strne r5, [fp]
+	cmp r11, #0
+	strne r5, [r11]
 	cmp r0, #0
 	strne r6, [r0]
 	cmp sb, #0
 	addeq sp, sp, #0x10
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	mov r0, #0xc
 	mla r1, r6, r0, sl
 	ldr r0, [r1, #0x1f0]
@@ -70332,7 +70332,7 @@ _0215b30c:
 	ldr r0, [r1, #0x1f8]
 	str r0, [sb, #8]
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0215b29c
 _0215b354: .word data_027e0f94
@@ -70340,7 +70340,7 @@ _0215b354: .word data_027e0f94
 	.global func_ov15_0215b358
 	arm_func_start func_ov15_0215b358
 func_ov15_0215b358: ; 0x0215b358
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	str r0, [sp]
 	ldr r0, _0215b620 ; =data_ov00_020ee0a0
 	mov r1, #0xa0
@@ -70460,7 +70460,7 @@ _0215b4b8:
 	and r2, r2, #0xff
 	bl func_ov00_0209cd40
 	ldr r0, _0215b624 ; =data_ov15_021865c8
-	ldr fp, _0215b620 ; =data_ov00_020ee0a0
+	ldr r11, _0215b620 ; =data_ov00_020ee0a0
 	ldr r0, [r0, #0x10]
 	ldr r4, _0215b628 ; =0x00000249
 	sub r8, r0, sb
@@ -70481,7 +70481,7 @@ _0215b54c:
 	orr r1, r1, r0, lsl #20
 	add r0, sb, r1
 	mov r1, r0, asr #0xc
-	mov r0, fp
+	mov r0, r11
 	and r2, r1, #0xff
 	mov r1, sl
 	bl func_ov00_0209cd40
@@ -70521,7 +70521,7 @@ _0215b54c:
 	mov r1, #0
 	ldr r0, [r0]
 	bl func_ov00_020823a4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0215b358
 _0215b620: .word data_ov00_020ee0a0
@@ -70652,7 +70652,7 @@ _0215b78c: .word data_027e10a8
 	.global func_ov15_0215b790
 	arm_func_start func_ov15_0215b790
 func_ov15_0215b790: ; 0x0215b790
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x14
 	ldr r1, _0215b840 ; =data_027e10a8
 	mov r2, #1
@@ -70670,7 +70670,7 @@ func_ov15_0215b790: ; 0x0215b790
 	strb r2, [sl, #0x23a]
 	add r4, sl, #0x3a
 	add sb, sl, #0x1c8
-	mov fp, r8
+	mov r11, r8
 	mov r5, r2
 	add r7, sp, #0
 	mov r6, #0x2000
@@ -70684,7 +70684,7 @@ _0215b7e8:
 	add sb, sb, #4
 	tst r1, r0
 	movne r0, r5
-	moveq r0, fp
+	moveq r0, r11
 	strb r0, [r4, #0x200]
 	cmp r8, #5
 	blt _0215b7e8
@@ -70696,7 +70696,7 @@ _0215b7e8:
 	mov r0, sl
 	bl func_ov15_0215b84c
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0215b790
 _0215b840: .word data_027e10a8
@@ -71752,7 +71752,7 @@ _0215c6c4:
 	.global func_ov15_0215c6d4
 	arm_func_start func_ov15_0215c6d4
 func_ov15_0215c6d4: ; 0x0215c6d4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x44
 	ldr r4, _0215c7d8 ; =data_027e0ff0
 	mov r7, #0
@@ -71766,7 +71766,7 @@ func_ov15_0215c6d4: ; 0x0215c6d4
 	ble _0215c7c0
 	add r6, sp, #0x20
 	add r5, sp, #4
-	add fp, sp, #8
+	add r11, sp, #8
 _0215c710:
 	ldr r0, [r3]
 	ldr r2, [r0, r8, lsl #3]
@@ -71789,7 +71789,7 @@ _0215c710:
 	str r1, [sp, #0x3c]
 	str r0, [sp, #0x40]
 	ldr r1, [sl]
-	mov r0, fp
+	mov r0, r11
 	str r1, [sp, #8]
 	ldr r2, [sl, #4]
 	add r1, sp, #0x38
@@ -71819,7 +71819,7 @@ _0215c7c0:
 	ldmia r0, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
 	add sp, sp, #0x44
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0215c6d4
 _0215c7d8: .word data_027e0ff0
@@ -71827,7 +71827,7 @@ _0215c7d8: .word data_027e0ff0
 	.global func_ov15_0215c7dc
 	arm_func_start func_ov15_0215c7dc
 func_ov15_0215c7dc: ; 0x0215c7dc
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x34
 	ldr r3, _0215c8b0 ; =data_027e0ff0
 	mov r7, #0
@@ -71844,7 +71844,7 @@ func_ov15_0215c7dc: ; 0x0215c7dc
 	ble _0215c898
 	mov sb, r7
 	add r4, sp, #4
-	add fp, sp, #0x28
+	add r11, sp, #0x28
 _0215c824:
 	ldr r1, [r8, #4]
 	mov r0, r4
@@ -71855,7 +71855,7 @@ _0215c824:
 	str r3, [sp, #0x30]
 	str r2, [sp, #0x28]
 	ldr r2, [sl]
-	mov r1, fp
+	mov r1, r11
 	str r2, [sp, #4]
 	ldr r2, [sl, #4]
 	str r2, [sp, #8]
@@ -71882,7 +71882,7 @@ _0215c898:
 	ldmia r0, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
 	add sp, sp, #0x34
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0215c7dc
 _0215c8b0: .word data_027e0ff0
@@ -71890,7 +71890,7 @@ _0215c8b0: .word data_027e0ff0
 	.global func_ov15_0215c8b4
 	arm_func_start func_ov15_0215c8b4
 func_ov15_0215c8b4: ; 0x0215c8b4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x60
 	ldr r3, _0215cb1c ; =data_027e0ff0
 	ldrb r1, [r1]
@@ -71914,7 +71914,7 @@ func_ov15_0215c8b4: ; 0x0215c8b4
 	str r1, [sp, #0x5c]
 	blt _0215cb10
 	mov sb, #0x24
-	add fp, sp, #0x30
+	add r11, sp, #0x30
 _0215c918:
 	cmp r6, r7
 	ldr r0, [r8, #4]
@@ -71937,14 +71937,14 @@ _0215c940:
 _0215c95c:
 	add r0, sp, #0x48
 	add r1, sp, #0x54
-	mov r2, fp
+	mov r2, r11
 	bl func_01ff9bf8
 	mov r0, #0
 	str r0, [sp, #0x34]
-	mov r0, fp
+	mov r0, r11
 	bl func_01ff9cec
 	str r0, [sp, #8]
-	mov r0, fp
+	mov r0, r11
 	bl func_01fffb4c
 	cmp r0, #0
 	beq _0215cb00
@@ -71959,7 +71959,7 @@ _0215c95c:
 	str r3, [sp, #0x14]
 	bl func_01ff9bf8
 	add r0, sp, #0x3c
-	mov r1, fp
+	mov r1, r11
 	bl func_01ff9c2c
 	movs r4, r0
 	bmi _0215ca60
@@ -72052,7 +72052,7 @@ _0215cb00:
 _0215cb10:
 	mov r0, r5
 	add sp, sp, #0x60
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0215c8b4
 _0215cb1c: .word data_027e0ff0
@@ -72140,11 +72140,11 @@ _0215cc2c: .word data_027e0f94
 	.global func_ov15_0215cc30
 	arm_func_start func_ov15_0215cc30
 func_ov15_0215cc30: ; 0x0215cc30
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x24
 	ldr r6, _0215cee4 ; =data_027e0f94
 	add r4, sp, #0xc
-	mov fp, r0
+	mov r11, r0
 	mov r7, r1
 	mov r5, r2
 	ldmia r6, {r0, r1, r2}
@@ -72313,9 +72313,9 @@ _0215cda8:
 _0215ced0:
 	add r0, sp, #0x18
 	ldmia r0, {r0, r1, r2}
-	stmia fp, {r0, r1, r2}
+	stmia r11, {r0, r1, r2}
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0215cc30
 _0215cee4: .word data_027e0f94
@@ -74315,7 +74315,7 @@ _0215e884:
 	.global func_ov15_0215e890
 	arm_func_start func_ov15_0215e890
 func_ov15_0215e890: ; 0x0215e890
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0xd0
 	mov sb, r0
 	ldr r1, [sb, #0x3b8]
@@ -75092,12 +75092,12 @@ _0215f40c:
 	cmp r0, #0
 	ble _0215f464
 	ldr r8, _0215f80c ; =data_ov15_0218f81c
-	ldr fp, _0215f810 ; =data_027e0fe4
+	ldr r11, _0215f810 ; =data_027e0fe4
 	mov r4, r8
 	mov sl, #1
 	mvn r5, #0
 _0215f430:
-	ldr r0, [fp]
+	ldr r0, [r11]
 	mov r1, r8
 	bl _ZN12ActorManager8GetActorEP8ActorRef
 	cmp r0, #0
@@ -75226,9 +75226,9 @@ _0215f50c:
 	ldr r5, [r3, #0xc]
 	ldr ip, [r3, #0x10]
 	mla r8, r5, r4, r8
-	ldr fp, [r3, #0x14]
+	ldr r11, [r3, #0x14]
 	adds r4, ip, sl
-	adc r8, fp, r8
+	adc r8, r11, r8
 	umull r5, r7, r8, r0
 	mov r5, #0
 	mla r7, r8, r5, r7
@@ -75248,9 +75248,9 @@ _0215f50c:
 	ldr r5, [r3, #0xc]
 	ldr ip, [r3, #0x10]
 	mla r8, r5, r4, r8
-	ldr fp, [r3, #0x14]
+	ldr r11, [r3, #0x14]
 	adds r0, ip, sl
-	adc r7, fp, r8
+	adc r7, r11, r8
 	stmia r3, {r0, r7}
 	umull r0, r4, r7, r1
 	mov r0, #0
@@ -75267,10 +75267,10 @@ _0215f50c:
 	umull r8, r7, r5, r1
 	mla r7, r5, r0, r7
 	ldr r4, [r3, #0xc]
-	ldr fp, [r3, #0x10]
+	ldr r11, [r3, #0x10]
 	mla r7, r4, r1, r7
 	ldr sl, [r3, #0x14]
-	adds r0, fp, r8
+	adds r0, r11, r8
 	adc r4, sl, r7
 	stmia r3, {r0, r4}
 	umull r0, r1, r4, r2
@@ -75318,7 +75318,7 @@ _0215f770:
 	ldr r3, [sb, #0x1ec]
 	cmp r3, #0
 	addeq sp, sp, #0xd0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	cmp r2, #0
 	moveq r0, #1
 	ldr r1, [r3, #0x24]
@@ -75328,12 +75328,12 @@ _0215f770:
 	orr r0, r1, r0, lsr #30
 	add sp, sp, #0xd0
 	str r0, [r3, #0x24]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0215f7a8:
 	add r0, sb, #0x1ec
 	bl func_ov00_020b7e6c
 	add sp, sp, #0xd0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0215e890
 _0215f7b8: .word data_027e0e60
@@ -78102,7 +78102,7 @@ _02161c84: .word data_027e0e2c
 	.global func_ov15_02161c88
 	arm_func_start func_ov15_02161c88
 func_ov15_02161c88: ; 0x02161c88
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x6c
 	ldr r1, _02162424 ; =data_027e0f74
 	mov sl, r0
@@ -78120,7 +78120,7 @@ func_ov15_02161c88: ; 0x02161c88
 _02161cc4:
 	add sp, sp, #0x6c
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02161cd0:
 	mov r1, #2
 	ldr r0, _02162428 ; =data_027e0fec
@@ -78270,7 +78270,7 @@ _02161f00:
 	ldr r1, [r1]
 	mov r0, #0
 	strb r5, [r1, #0x38]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02161f18:
 	ldr r0, _02162424 ; =data_027e0f74
 	mov r1, #0x62
@@ -78300,7 +78300,7 @@ _02161f2c:
 	add sp, sp, #0x6c
 	strb r2, [r1, #0x38]
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02161f88:
 	ldrb r0, [sl, #0x2a]
 	cmp r0, #0
@@ -78320,7 +78320,7 @@ _02161f88:
 	bl func_ov15_02162688
 	add sp, sp, #0x6c
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02161fd4:
 	ldr r0, _02162438 ; =data_027e0fe4
 	add r3, sp, #0x60
@@ -78381,7 +78381,7 @@ _0216204c:
 _021620b0:
 	add sp, sp, #0x6c
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _021620bc:
 	ldr r0, _0216244c ; =data_027e0f94
 	add r3, sp, #0x44
@@ -78453,7 +78453,7 @@ _021621b4:
 	rsb r0, sb, #0
 	str r0, [sp]
 	mov r0, r0, lsl #0x18
-	mov fp, r0, asr #0x18
+	mov r11, r0, asr #0x18
 _021621c4:
 	ldr r0, _02162440 ; =data_027e0ff0
 	add r1, sp, #4
@@ -78465,7 +78465,7 @@ _021621c4:
 	cmp sb, #0
 	movge r1, sb
 	ldrsb r0, [r5, #0x10]
-	movlt r1, fp
+	movlt r1, r11
 	cmp r0, r1
 	bne _0216232c
 	add r1, sp, #4
@@ -78572,7 +78572,7 @@ _0216232c:
 _02162370:
 	add sp, sp, #0x6c
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0216237c:
 	ldr r0, [sl, #0x48]
 	str r0, [r4, #0x2c]
@@ -78618,7 +78618,7 @@ _021623c4:
 	mov r0, #1
 	strh r1, [sl, #0x78]
 	add sp, sp, #0x6c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02161c88
 _02162424: .word data_027e0f74
@@ -78795,7 +78795,7 @@ _02162684: .word data_ov15_021867d4
 	.global func_ov15_02162688
 	arm_func_start func_ov15_02162688
 func_ov15_02162688: ; 0x02162688
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x394
 	mov r4, r1
 	mov r5, r0
@@ -79039,37 +79039,37 @@ _021629c0:
 	bl func_ov00_02087d34
 	mov r1, #5
 	ldr r2, [sp, #0x27c]
-	ldr fp, [sp, #0x284]
+	ldr r11, [sp, #0x284]
 	ldr sl, [sp, #0x288]
 	ldr r0, [sp, #0x28c]
 	str r2, [sp, #0x310]
 	ldr r2, [sp, #0x290]
-	str fp, [sp, #0x318]
-	ldr fp, [sp, #0x294]
+	str r11, [sp, #0x318]
+	ldr r11, [sp, #0x294]
 	str sl, [sp, #0x31c]
 	ldr sl, [sp, #0x298]
 	str r0, [sp, #0x320]
 	ldr r0, [sp, #0x29c]
 	str r2, [sp, #0x324]
 	ldr r2, [sp, #0x2a0]
-	str fp, [sp, #0x328]
-	ldr fp, [sp, #0x2a4]
+	str r11, [sp, #0x328]
+	ldr r11, [sp, #0x2a4]
 	str sl, [sp, #0x32c]
 	ldr sl, [sp, #0x2a8]
 	str r0, [sp, #0x330]
 	ldr r0, [sp, #0x2ac]
 	str r2, [sp, #0x334]
 	ldr r2, [sp, #0x2b0]
-	str fp, [sp, #0x338]
-	ldr fp, [sp, #0x2b4]
+	str r11, [sp, #0x338]
+	ldr r11, [sp, #0x2b4]
 	str sl, [sp, #0x33c]
 	ldr sl, [sp, #0x2b8]
 	str r0, [sp, #0x340]
 	ldr r0, [sp, #0x2bc]
 	str r2, [sp, #0x344]
 	ldr r2, [sp, #0x2c0]
-	str fp, [sp, #0x348]
-	ldr fp, [sp, #0x2c4]
+	str r11, [sp, #0x348]
+	ldr r11, [sp, #0x2c4]
 	str sl, [sp, #0x34c]
 	ldr sl, [sp, #0x2c8]
 	ldrb sb, [sp, #0x2dc]
@@ -79081,15 +79081,15 @@ _021629c0:
 	ldr r0, [sp, #0x2cc]
 	str r2, [sp, #0x354]
 	ldr r2, [sp, #0x2d0]
-	str fp, [sp, #0x358]
-	ldr fp, [sp, #0x2d4]
+	str r11, [sp, #0x358]
+	ldr r11, [sp, #0x2d4]
 	str sl, [sp, #0x35c]
 	ldr sl, [sp, #0x2d8]
 	str r0, [sp, #0x360]
 	mov r0, #1
 	str r2, [sp, #0x364]
 	mov r2, #0x5c
-	str fp, [sp, #0x368]
+	str r11, [sp, #0x368]
 	strb r0, [sp, #0x2f8]
 	str sl, [sp, #0x36c]
 	strb sb, [sp, #0x370]
@@ -79251,7 +79251,7 @@ _02162b58:
 	ldr r8, [sp, #0x1bc]
 	str r7, [sp, #0x240]
 	ldr r7, [sp, #0x1c0]
-	mov fp, #0x5c
+	mov r11, #0x5c
 	str r1, [sp, #0x244]
 	ldr r0, [r0]
 	add r1, sp, #0x1cc
@@ -79263,7 +79263,7 @@ _02162b58:
 	strb ip, [sp, #0x25a]
 	strb r3, [sp, #0x25b]
 	strb r2, [sp, #0x25c]
-	str fp, [sp, #0x260]
+	str r11, [sp, #0x260]
 	strb sl, [sp, #0x1e2]
 	bl func_ov00_02097810
 	str r0, [r5, #0x240]
@@ -79279,7 +79279,7 @@ _02162dc4:
 	str r4, [r5, #0x130]
 	strb r0, [r5, #0x255]
 	add sp, sp, #0x394
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02162688
 _02162ddc: .word 0x0000ffff
@@ -86785,7 +86785,7 @@ _021694f0: .word data_027e0f6c
 	.global func_ov15_021694f4
 	arm_func_start func_ov15_021694f4
 func_ov15_021694f4: ; 0x021694f4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x20
 	mov sl, r0
 	str r1, [sp, #4]
@@ -86825,7 +86825,7 @@ _02169544:
 	ldr r4, _02169674 ; =data_027e0ffc
 	ldr r5, _02169678 ; =data_ov15_02186918
 	mov sb, r7
-	add fp, sp, #0x14
+	add r11, sp, #0x14
 _02169594:
 	add r0, sl, r7
 	ldrb r6, [r0, #0x23c]
@@ -86858,7 +86858,7 @@ _02169594:
 	ldr r3, [sl, #8]
 	mov r0, r4
 	mov r1, #0x358
-	mov r2, fp
+	mov r2, r11
 	add r3, r7, r3
 	bl func_ov00_020cec60
 	b _02169638
@@ -86866,7 +86866,7 @@ _02169620:
 	ldr r3, [sl, #8]
 	ldr r1, _02169680 ; =0x00000359
 	mov r0, r4
-	mov r2, fp
+	mov r2, r11
 	add r3, r7, r3
 	bl func_ov00_020cec60
 _02169638:
@@ -86883,7 +86883,7 @@ _02169650:
 	add r2, sl, #0x48
 	bl func_ov00_0207a1c8
 	add sp, sp, #0x20
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_021694f4
 _02169668: .word data_ov15_021868f0
@@ -86973,7 +86973,7 @@ _02169778: .word data_027e0194
 	.global func_ov15_0216977c
 	arm_func_start func_ov15_0216977c
 func_ov15_0216977c: ; 0x0216977c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x44
 	ldrh r1, [r1]
 	mov sl, r0
@@ -86981,7 +86981,7 @@ func_ov15_0216977c: ; 0x0216977c
 	bne _021697a0
 	tst r1, #8
 	addeq sp, sp, #0x44
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _021697a0:
 	add r1, sp, #0x14
 	str r1, [sp]
@@ -86996,7 +86996,7 @@ _021697a0:
 	bl func_ov00_02079470
 	cmp r0, #0
 	addeq sp, sp, #0x44
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r0, sp, #0x24
 	bl func_01ffbe34
 	ldr r0, _02169928 ; =data_027e0d3c
@@ -87020,7 +87020,7 @@ _021697a0:
 	bl func_020313c8
 	ldr r8, _02169930 ; =data_ov15_021869b8
 	ldr r4, _02169934 ; =data_ov15_02186998
-	ldr fp, _02169928 ; =data_027e0d3c
+	ldr r11, _02169928 ; =data_027e0d3c
 	mov sb, #0
 	add r7, sp, #0x14
 	add r6, sp, #0x10
@@ -87045,7 +87045,7 @@ _02169848:
 	str r0, [sp, #8]
 	str r0, [sp, #0xc]
 	mov r2, #0
-	ldr r0, [fp]
+	ldr r0, [r11]
 	add r1, sp, #0x18
 	mov r3, r2
 	bl func_ov00_02079470
@@ -87062,10 +87062,10 @@ _021698c0:
 	add r8, r8, #8
 	blt _02169848
 	add sp, sp, #0x44
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _021698d8:
 	addne sp, sp, #0x44
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r0, sl, #0x100
 	ldrh r0, [r0, #0xb4]
 	cmp r0, #1
@@ -87076,14 +87076,14 @@ _021698d8:
 	movne r0, #0
 	cmp r0, #0
 	addne sp, sp, #0x44
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r1, [sp, #0x14]
 	ldr r2, [sp, #0x10]
 	add r3, sp, #0x24
 	add r0, sl, #0x158
 	bl func_02034a1c
 	add sp, sp, #0x44
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0216977c
 _02169928: .word data_027e0d3c
@@ -87831,15 +87831,15 @@ _0216a398: .word data_027e0fe4
 	.global func_ov15_0216a39c
 	arm_func_start func_ov15_0216a39c
 func_ov15_0216a39c: ; 0x0216a39c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0xc
 	mov ip, #0xf000
 	rsb ip, ip, #0
 	add r3, ip, #0x3000
-	add fp, ip, #0xc000
+	add r11, ip, #0xc000
 	str r3, [sp]
 	str r3, [sp, #8]
-	mov r3, fp
+	mov r3, r11
 	str r3, [sp, #4]
 	add r1, r0, #0x23c
 	ldr r3, _0216a554 ; =data_027e0764
@@ -87875,7 +87875,7 @@ _0216a3d4:
 	str r5, [r0, r2, lsl #2]
 	cmp r5, r4
 	bgt _0216a540
-	str fp, [r0, r2, lsl #2]
+	str r11, [r0, r2, lsl #2]
 	mov r4, #2
 	strb r4, [r1, r2]
 	b _0216a540
@@ -87944,7 +87944,7 @@ _0216a540:
 	cmp r2, #0x10
 	blt _0216a3d4
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0216a39c
 _0216a554: .word data_027e0764
@@ -87976,7 +87976,7 @@ func_ov15_0216a574: ; 0x0216a574
 	.global func_ov15_0216a590
 	arm_func_start func_ov15_0216a590
 func_ov15_0216a590: ; 0x0216a590
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #8
 	mov r0, #1
 	ldr r1, _0216a734 ; =data_027e0f74
@@ -87984,14 +87984,14 @@ func_ov15_0216a590: ; 0x0216a590
 	ldr r0, [r1]
 	ldr r1, [sp, #4]
 	str r1, [sp]
-	ldr fp, [sp, #4]
-	mov r4, fp
-	mov r5, fp
-	mov r6, fp
-	mov r7, fp
-	mov r8, fp
-	mov sb, fp
-	mov sl, fp
+	ldr r11, [sp, #4]
+	mov r4, r11
+	mov r5, r11
+	mov r6, r11
+	mov r7, r11
+	mov r8, r11
+	mov sb, r11
+	mov sl, r11
 	bl func_ov00_02097738
 	cmp r0, #0
 	bne _0216a614
@@ -88058,9 +88058,9 @@ _0216a6a8:
 	ldr r0, [r0]
 	bl func_ov00_020848b8
 	cmp r0, #0
-	moveq fp, #0
+	moveq r11, #0
 _0216a6c4:
-	cmp fp, #0
+	cmp r11, #0
 	bne _0216a704
 	ldr r0, _0216a734 ; =data_027e0f74
 	mov r1, #0x1f
@@ -88090,7 +88090,7 @@ _0216a704:
 _0216a728:
 	ldr r0, [sp, #4]
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0216a590
 _0216a734: .word data_027e0f74
@@ -89229,7 +89229,7 @@ _0216b588: .word 0x000011c7
 	.global func_ov15_0216b58c
 	arm_func_start func_ov15_0216b58c
 func_ov15_0216b58c: ; 0x0216b58c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x80
 	mov sb, r0
 	ldr r4, [sb, #0x88]
@@ -89257,7 +89257,7 @@ _0216b5e8:
 	cmp r0, #0
 	addeq sp, sp, #0x80
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, [sb, #0x48]
 	mov r2, #1
 	str r0, [sp, #0x3c]
@@ -89274,7 +89274,7 @@ _0216b5e8:
 	add r3, sp, #0x54
 	bl func_01ffe468
 	mov r6, #0
-	ldr fp, _0216b9bc ; =data_027e0f64
+	ldr r11, _0216b9bc ; =data_027e0f64
 	add r7, sp, #0x54
 	add r8, sp, #0x64
 	add r4, sp, #0x48
@@ -89332,7 +89332,7 @@ _0216b6cc:
 	str r3, [sp, #0x38]
 	bl func_01ff9bc4
 	str sl, [sp]
-	ldr r0, [fp]
+	ldr r0, [r11]
 	mov r1, r4
 	ldr r0, [r0, #4]
 	mov r2, r8
@@ -89341,7 +89341,7 @@ _0216b6cc:
 	cmp r0, #0
 	addeq sp, sp, #0x80
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r6, r6, #1
 	cmp r6, #4
 	add r7, r7, #4
@@ -89351,16 +89351,16 @@ _0216b6cc:
 	ldrb r1, [r0, #0xc]
 	cmp r1, #0
 	ldrne r3, [r0, #0x10]
-	ldrne fp, [r0, #0x14]
+	ldrne r11, [r0, #0x14]
 	bne _0216b778
 	ldrh r1, [r0, #0x34]
 	tst r1, #2
 	ldrne r3, [r0, #0x1c]
-	ldrne fp, [r0, #0x20]
+	ldrne r11, [r0, #0x20]
 	bne _0216b778
 	add sp, sp, #0x80
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0216b778:
 	ldr r1, [sp, #0x64]
 	ldr r0, [sp, #0x68]
@@ -89402,22 +89402,22 @@ _0216b7e0:
 	sub sl, r3, r5
 	ldr r4, [sp, #0x6c]
 	ldr r7, [sp, #0x70]
-	sub r5, fp, r6
+	sub r5, r11, r6
 	sub r2, r2, #8
-	sub r6, fp, r2
+	sub r6, r11, r2
 	sub sb, r3, sb
 	sub r8, r3, r4
 	add r1, r1, #8
-	sub r4, fp, r1
+	sub r4, r11, r1
 	sub r7, r3, r7
 	add r0, r0, #8
-	sub r3, fp, r0
+	sub r3, r11, r0
 	smull r1, r0, sb, r6
-	smull fp, r2, sl, r5
+	smull r11, r2, sl, r5
 	smull lr, ip, sb, r4
 	str r0, [sp, #4]
 	str ip, [sp, #0x24]
-	subs fp, fp, r1
+	subs r11, r11, r1
 	ldr ip, [sp, #4]
 	str r6, [sp, #0x54]
 	sbc r2, r2, ip
@@ -89465,7 +89465,7 @@ _0216b7e0:
 	subs r4, r6, r4
 	ldr r6, [sp, #0x20]
 	sbc r6, r5, r6
-	subs r5, fp, #0
+	subs r5, r11, #0
 	sbcs r5, r2, #0
 	mov r5, #0
 	blt _0216b92c
@@ -89477,8 +89477,8 @@ _0216b7e0:
 	bge _0216b9a4
 _0216b92c:
 	mov r5, #0
-	subs fp, r5, fp
-	sbcs fp, r5, r2
+	subs r11, r5, r11
+	sbcs r11, r5, r2
 	blt _0216b954
 	subs r2, r5, r8
 	sbcs r2, r5, r7
@@ -89511,11 +89511,11 @@ _0216b97c:
 _0216b9a4:
 	add sp, sp, #0x80
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0216b9b0:
 	mov r0, #0
 	add sp, sp, #0x80
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0216b58c
 _0216b9bc: .word data_027e0f64
@@ -92821,7 +92821,7 @@ _0216e698: .word 0x000001df
 	.global func_ov15_0216e69c
 	arm_func_start func_ov15_0216e69c
 func_ov15_0216e69c: ; 0x0216e69c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x50
 	mov r4, r1
 	mvn ip, #0
@@ -92845,7 +92845,7 @@ func_ov15_0216e69c: ; 0x0216e69c
 	mov r3, #0
 	mla sb, r8, r3, sb
 	ldr r3, _0216e96c ; =0x0000152d
-	mov fp, r2
+	mov r11, r2
 	mla sb, r7, r3, sb
 	adds r7, sl, #0x800
 	add r0, sp, #0x44
@@ -92862,7 +92862,7 @@ func_ov15_0216e69c: ; 0x0216e69c
 	adc r3, r7, #0
 	mov r6, r6, lsr #0xc
 	orr r6, r6, r3, lsl #20
-	mov r1, fp
+	mov r1, r11
 	mov r2, r0
 	str r6, [sp, #0x44]
 	bl func_01ff88b0
@@ -92882,7 +92882,7 @@ func_ov15_0216e69c: ; 0x0216e69c
 	ldrsh r2, [r3, r2]
 	blx func_01ff8214
 	add r1, sp, #0x20
-	mov r0, fp
+	mov r0, r11
 	mov r2, r1
 	bl func_01ff8690
 	ldr r0, _0216e978 ; =gItemManager
@@ -92996,7 +92996,7 @@ _0216e930:
 	add r2, r5, #0x64
 	cmp r3, r2
 	addeq sp, sp, #0x50
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0216e944:
 	ldr r1, [r3]
 	add r3, r3, #4
@@ -93007,7 +93007,7 @@ _0216e944:
 	cmp r3, r2
 	bne _0216e944
 	add sp, sp, #0x50
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0216e69c
 _0216e96c: .word 0x0000152d
@@ -93477,7 +93477,7 @@ func_ov15_0216ef0c: ; 0x0216ef0c
 	.global func_ov15_0216ef4c
 	arm_func_start func_ov15_0216ef4c
 func_ov15_0216ef4c: ; 0x0216ef4c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	mov r4, r0
 	add r1, r4, #0x200
 	mov r2, #0
@@ -93505,8 +93505,8 @@ func_ov15_0216ef4c: ; 0x0216ef4c
 	str r5, [r2, #4]
 	mov r2, r5, lsr #0x10
 	strh r2, [r0, #0xb8]
-	mov fp, #2
-	str fp, [sp]
+	mov r11, #2
+	str r11, [sp]
 	ldr r0, _0216eff0 ; =data_027e0e58
 	add r1, r4, #0x158
 	add r3, r4, #0x48
@@ -93516,7 +93516,7 @@ func_ov15_0216ef4c: ; 0x0216ef4c
 	ldr r2, [r2, r4, lsl #2]
 	bl func_ov00_0207c1f8
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0216ef4c
 _0216efec: .word data_027e0764
@@ -94579,7 +94579,7 @@ _0216fdfc: .word data_027e0764
 	.global func_ov15_0216fe00
 	arm_func_start func_ov15_0216fe00
 func_ov15_0216fe00: ; 0x0216fe00
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x338
 	mov r4, r1
 	mov r5, r0
@@ -94705,7 +94705,7 @@ _0216fe54:
 	ldr r8, [sp, #0x278]
 	ldr r7, [sp, #0x27c]
 	str r1, [sp, #0x300]
-	mov fp, #0x5c
+	mov r11, #0x5c
 	ldr r0, [r0]
 	add r1, sp, #0x288
 	str sb, [sp, #0x308]
@@ -94716,7 +94716,7 @@ _0216fe54:
 	strb ip, [sp, #0x316]
 	strb r3, [sp, #0x317]
 	strb r2, [sp, #0x318]
-	str fp, [sp, #0x31c]
+	str r11, [sp, #0x31c]
 	strb sl, [sp, #0x29e]
 	bl func_ov00_02097810
 	add r1, r5, #0xf8
@@ -94964,7 +94964,7 @@ _021703c8:
 	mov r1, #4
 	bl func_ov15_0216fe00
 	add sp, sp, #0x338
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _021703e8:
 	ldr r0, _0217063c ; =data_027e10a4
 	mov r6, #0
@@ -95066,7 +95066,7 @@ _021703e8:
 	ldrb r3, [sp, #0xbb]
 	ldrb r2, [sp, #0xbc]
 	ldr r1, [sp, #0xa4]
-	ldr fp, [sp, #0xac]
+	ldr r11, [sp, #0xac]
 	ldr sl, [sp, #0xb0]
 	str sb, [sp, #0x134]
 	ldr sb, [sp, #0xb4]
@@ -95074,7 +95074,7 @@ _021703e8:
 	mov lr, #0x5c
 	ldr r0, [r0]
 	add r1, sp, #0xc0
-	str fp, [sp, #0x140]
+	str r11, [sp, #0x140]
 	str sl, [sp, #0x144]
 	str sb, [sp, #0x148]
 	strb r8, [sp, #0x14c]
@@ -95109,7 +95109,7 @@ _0217060c:
 	str r4, [r5, #0x130]
 	strb r0, [r5, #0x56c]
 	add sp, sp, #0x338
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0216fe00
 _02170624: .word 0x0000ffff
@@ -95401,7 +95401,7 @@ _02170a00: .word 0x4852434e
 	.global func_ov15_02170a04
 	arm_func_start func_ov15_02170a04
 func_ov15_02170a04: ; 0x02170a04
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x294
 	mov r4, r0
 	ldrb r1, [r4, #0x56c]
@@ -95430,11 +95430,11 @@ _02170a5c:
 	bl func_ov15_021733b0
 	cmp r0, #0
 	addeq sp, sp, #0x294
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, [r4, #0x138]
 	cmp r0, #0x5a
 	addlt sp, sp, #0x294
-	ldmltia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmltia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r1, r4, #0x9c
 	ldr r0, _02170fe4 ; =data_027e0c68
 	ldr r2, _02170fe8 ; =0x00050027
@@ -95442,7 +95442,7 @@ _02170a5c:
 	bl func_02036ce4
 	cmp r0, #0
 	addeq sp, sp, #0x294
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	mov r0, r4
 	mov r1, #1
 	bl _ZN5Actor10SetUnk_11cEc
@@ -95452,7 +95452,7 @@ _02170a5c:
 	ldr r0, [r0]
 	bl func_ov15_021413d4
 	add sp, sp, #0x294
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02170ac8:
 	ldr r0, _02170fec ; =data_027e0f64
 	add r1, sp, #0x22c
@@ -95485,7 +95485,7 @@ _02170ac8:
 	and r0, r1, r0
 	cmp r0, #0x1000000
 	addeq sp, sp, #0x294
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r0, r4, #0x9c
 	add r0, r0, #0x400
 	ldr r1, [r0]
@@ -95497,7 +95497,7 @@ _02170ac8:
 	and r0, r1, r0
 	cmp r0, #0x1000000
 	addne sp, sp, #0x294
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r0, sp, #0x17c
 	bl func_ov00_0209a4f4
 	mvn r5, #0
@@ -95615,7 +95615,7 @@ _02170ac8:
 	ldr r7, [sp, #0x16c]
 	str r6, [sp, #0x1ec]
 	ldr r6, [sp, #0x170]
-	mov fp, #0x5c
+	mov r11, #0x5c
 	str r1, [sp, #0x1f0]
 	ldr r0, [r0]
 	add r1, sp, #0x17c
@@ -95628,7 +95628,7 @@ _02170ac8:
 	strb ip, [sp, #0x20a]
 	strb r3, [sp, #0x20b]
 	strb r2, [sp, #0x20c]
-	str fp, [sp, #0x210]
+	str r11, [sp, #0x210]
 	strb sl, [sp, #0x192]
 	bl func_ov00_02097810
 	str r0, [r4, #0x540]
@@ -95662,7 +95662,7 @@ _02170db8:
 	strb r1, [r4, #0x575]
 	bl func_ov00_0209a508
 	add sp, sp, #0x294
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02170e08:
 	ldr r0, _02170fec ; =data_027e0f64
 	ldr r0, [r0]
@@ -95670,13 +95670,13 @@ _02170e08:
 	bl func_ov00_02089a2c
 	cmp r0, #0
 	addne sp, sp, #0x294
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	mov r0, #3
 	strb r0, [r4, #0x56c]
 	mov r0, #0
 	add sp, sp, #0x294
 	str r0, [r4, #0x138]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02170e3c:
 	add r0, r4, #0x4c
 	mov r1, #0x2000
@@ -95706,7 +95706,7 @@ _02170e3c:
 	ldr r0, [r4, #0x138]
 	cmp r0, #0x3c
 	addlt sp, sp, #0x294
-	ldmltia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmltia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r1, r4, #0x9c
 	ldr r0, _02170fe4 ; =data_027e0c68
 	ldr r2, _02171004 ; =0x00050028
@@ -95714,14 +95714,14 @@ _02170e3c:
 	bl func_02036ce4
 	cmp r0, #0
 	addeq sp, sp, #0x294
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	mov r0, r4
 	mov r1, #1
 	bl _ZN5Actor10SetUnk_11cEc
 	mov r0, #4
 	add sp, sp, #0x294
 	strb r0, [r4, #0x56c]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02170eec:
 	add r0, r4, #0x4c
 	mov r1, #0x2000
@@ -95754,7 +95754,7 @@ _02170eec:
 	and r0, r1, r0
 	cmp r0, #0x1000000
 	addeq sp, sp, #0x294
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r0, r4, #0x9c
 	add r0, r0, #0x400
 	ldr r1, [r0]
@@ -95766,7 +95766,7 @@ _02170eec:
 	and r0, r1, r0
 	cmp r0, #0x1000000
 	addne sp, sp, #0x294
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, _02170ff8 ; =data_027e0f74
 	ldr r1, [r4, #0x540]
 	ldr r0, [r0]
@@ -95785,7 +95785,7 @@ _02170fc4:
 	bl func_ov15_0216fe00
 _02170fd8:
 	add sp, sp, #0x294
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02170a04
 _02170fe0: .word data_027e10a4
@@ -97081,7 +97081,7 @@ func_ov15_02172238: ; 0x02172238
 	.global func_ov15_02172260
 	arm_func_start func_ov15_02172260
 func_ov15_02172260: ; 0x02172260
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x40
 	mov r4, r0
 	str r1, [sp]
@@ -97097,7 +97097,7 @@ func_ov15_02172260: ; 0x02172260
 	cmp r1, r0
 	addge sp, sp, #0x40
 	movge r0, #0
-	ldmgeia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmgeia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr sl, [r4, #0x48]
 	mov r1, #0x800
 	str sl, [sp, #0x28]
@@ -97105,7 +97105,7 @@ func_ov15_02172260: ; 0x02172260
 	sub ip, r1, #0x2800
 	str r0, [sp, #0x2c]
 	ldr sb, [r4, #0x50]
-	ldr fp, _021724c4 ; =0x00001266
+	ldr r11, _021724c4 ; =0x00001266
 	str r0, [sp, #0x38]
 	str sb, [sp, #0x30]
 	mov r0, #0
@@ -97125,22 +97125,22 @@ func_ov15_02172260: ; 0x02172260
 	ldr r0, _021724c8 ; =data_02050f54
 	add r1, sp, #0x34
 	ldrsh r6, [r0, r2]
-	umull r0, r5, r3, fp
+	umull r0, r5, r3, r11
 	adds r0, r0, #0x800
 	mov r7, r0, lsr #0xc
 	mov r0, #0
 	mla r5, r3, r0, r5
 	mov r2, r3, asr #0x1f
-	mla r5, r2, fp, r5
+	mla r5, r2, r11, r5
 	adc r0, r5, #0
 	orr r7, r7, r0, lsl #20
 	add r0, sl, r7
 	mov r3, #0
-	umull r8, r7, r6, fp
+	umull r8, r7, r6, r11
 	str r0, [sp, #0x34]
 	mla r7, r6, r3, r7
 	mov r5, r6, asr #0x1f
-	mla r7, r5, fp, r7
+	mla r7, r5, r11, r7
 	adds r5, r8, #0x800
 	adc r3, r7, #0
 	mov r5, r5, lsr #0xc
@@ -97160,7 +97160,7 @@ func_ov15_02172260: ; 0x02172260
 	mov r5, r3, lsl #0x1
 	ldr r3, _021724c8 ; =data_02050f54
 	umull r8, r7, r6, ip
-	ldrsh fp, [r3, r5]
+	ldrsh r11, [r3, r5]
 	ldr r3, [sp, #0xc]
 	mov r5, r6, asr #0x1f
 	mla r7, r6, r3, r7
@@ -97172,9 +97172,9 @@ func_ov15_02172260: ; 0x02172260
 	add r3, sl, r5
 	str r3, [sp, #0x28]
 	ldr r3, [sp, #8]
-	umull r7, r6, fp, lr
-	mla r6, fp, r3, r6
-	mov r5, fp, asr #0x1f
+	umull r7, r6, r11, lr
+	mla r6, r11, r3, r6
+	mov r5, r11, asr #0x1f
 	mla r6, r5, lr, r6
 	adds r5, r7, #0x800
 	adc r3, r6, #0
@@ -97230,11 +97230,11 @@ func_ov15_02172260: ; 0x02172260
 	cmp r1, r0
 	addlt sp, sp, #0x40
 	movlt r0, #1
-	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _021724b8:
 	mov r0, #0
 	add sp, sp, #0x40
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02172260
 _021724c4: .word 0x00001266
@@ -98995,7 +98995,7 @@ func_ov15_02173c84: ; 0x02173c84
 	.global func_ov15_02173cb4
 	arm_func_start func_ov15_02173cb4
 func_ov15_02173cb4: ; 0x02173cb4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x78
 	mov r4, r0
 	add r0, r4, #0x48
@@ -99043,7 +99043,7 @@ func_ov15_02173cb4: ; 0x02173cb4
 	bl _ZN12ActorManager8GetActorEP8ActorRef
 	movs r4, r0
 	addeq sp, sp, #0x78
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, _02173fdc ; =data_027e0ffc
 	ldr r1, _02173fe0 ; =0x000002eb
 	add r2, sp, #0x6c
@@ -99060,30 +99060,30 @@ func_ov15_02173cb4: ; 0x02173cb4
 	ldr r6, [r0, #8]
 	ldr sl, [r0]
 	ldr sb, [r0, #4]
-	umull ip, fp, r6, sl
-	mla fp, r6, sb, fp
+	umull ip, r11, r6, sl
+	mla r11, r6, sb, r11
 	ldr r5, [r0, #0xc]
 	ldr r8, [r0, #0x10]
-	mla fp, r5, sl, fp
+	mla r11, r5, sl, r11
 	ldr r7, [r0, #0x14]
 	mov r0, #0
 	adds sl, r8, ip
-	adc sb, r7, fp
+	adc sb, r7, r11
 	mov r3, r0, lsl #0x10
 	orr r3, r3, sb, lsr #16
 	sub r3, r3, #0x8000
-	ldr fp, _02173fe8 ; =data_027e0764
+	ldr r11, _02173fe8 ; =data_027e0764
 	mov r3, r3, lsl #0x10
 	mov r3, r3, lsr #0x10
-	str sl, [fp]
+	str sl, [r11]
 	mov r3, r3, asr #0x4
-	str sb, [fp, #4]
-	mov fp, r3, lsl #0x1
-	mov r3, fp, lsl #0x1
-	add fp, fp, #1
-	mov fp, fp, lsl #0x1
+	str sb, [r11, #4]
+	mov r11, r3, lsl #0x1
+	mov r3, r11, lsl #0x1
+	add r11, r11, #1
+	mov r11, r11, lsl #0x1
 	ldrsh r3, [lr, r3]
-	ldrsh fp, [lr, fp]
+	ldrsh r11, [lr, r11]
 	umull lr, ip, r6, sl
 	mla ip, r6, sb, ip
 	mla ip, r5, sl, ip
@@ -99105,7 +99105,7 @@ func_ov15_02173cb4: ; 0x02173cb4
 	mla r8, r6, r5, r8
 	smull r7, r6, r3, r8
 	adds r7, r7, #0x800
-	smull r5, r3, fp, r8
+	smull r5, r3, r11, r8
 	adc r6, r6, #0
 	adds r5, r5, #0x800
 	mov r7, r7, lsr #0xc
@@ -99192,7 +99192,7 @@ func_ov15_02173cb4: ; 0x02173cb4
 	str r0, [r4, #0x64]
 	str r7, [r4, #0x68]
 	add sp, sp, #0x78
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02173cb4
 _02173fcc: .word data_027e0e58
@@ -101692,14 +101692,14 @@ _02176114: .word func_ov15_02176300
 	.global func_ov15_02176118
 	arm_func_start func_ov15_02176118
 func_ov15_02176118: ; 0x02176118
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	bl func_ov15_0213ce4c
 	bl func_ov15_0213d1ec
 	ldr r4, _021762cc ; =0x04000488
 	mov r0, r0, lsl #0x10
 	mov r5, r0, lsr #0x10
 	mov r6, #0
-	sub fp, r4, #0x88
+	sub r11, r4, #0x88
 _02176138:
 	ldr r0, _021762d0 ; =0x0000ffff
 	str r0, [r4, #0x38]
@@ -101731,7 +101731,7 @@ _02176138:
 	mov r0, r0, lsr #0x10
 	mov r1, r7, lsl #0x10
 	mov r0, r0, lsl #0x10
-	str fp, [r4]
+	str r11, [r4]
 	orr r0, r0, r1, lsr #16
 	str r0, [r4, #4]
 	mov r0, #0
@@ -101801,7 +101801,7 @@ _02176138:
 	cmp r6, #4
 	mov r5, r0, lsr #0x10
 	blt _02176138
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02176118
 _021762cc: .word 0x04000488
@@ -102655,13 +102655,13 @@ _02176e30:
 	.global func_ov15_02176ed8
 	arm_func_start func_ov15_02176ed8
 func_ov15_02176ed8: ; 0x02176ed8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	ldr r2, _02177050 ; =data_027e0618
 	mov sl, r0
 	ldrb r0, [r2, #0x101]
 	mov r4, r1
 	cmp r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, _02177054 ; =data_027e0c54
 	bl func_020360a8
 	mov r1, r0
@@ -102670,7 +102670,7 @@ func_ov15_02176ed8: ; 0x02176ed8
 	cmp r0, #0
 	ldrne r8, [sl, #0x318]
 	cmpne r8, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, _02177058 ; =data_027e0c38
 	mov sb, #0
 	ldr r0, [r0, #0x10]
@@ -102679,7 +102679,7 @@ func_ov15_02176ed8: ; 0x02176ed8
 	addeq r8, r8, #0x28
 	add r4, sl, #0x300
 	mov r6, sb
-	mov fp, #0x62
+	mov r11, #0x62
 	mov r7, sb
 _02176f40:
 	ldrsh r0, [r4, #0x28]
@@ -102692,7 +102692,7 @@ _02176f40:
 	b _02176f74
 _02176f60:
 	str r6, [sp]
-	mov r0, fp
+	mov r0, r11
 	mov r1, #0xa
 	ldmia r8, {r2, r3}
 	bl func_02034984
@@ -102741,17 +102741,17 @@ _02176f74:
 	bl func_02034984
 	ldrb r0, [sl, #0x351]
 	cmp r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, [sl, #0x324]
 	cmp r0, #1
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r0, sl, #0x204
 	ldr r1, [r4, #0x70]
 	ldr r2, [r4, #0x74]
 	add r0, r0, #0x400
 	mov r3, #0
 	bl func_02034a1c
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02176ed8
 _02177050: .word data_027e0618
@@ -102791,19 +102791,19 @@ _02177088: .word func_ov09_0211372c
 	.global func_ov15_0217708c
 	arm_func_start func_ov15_0217708c
 func_ov15_0217708c: ; 0x0217708c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	mov r0, #1
 	str r0, [sp]
-	ldr fp, [sp]
+	ldr r11, [sp]
 	ldr r1, _021771fc ; =data_027e0f74
-	mov r4, fp
+	mov r4, r11
 	ldr r0, [r1]
-	mov r5, fp
-	mov r6, fp
-	mov r7, fp
-	mov r8, fp
-	mov sb, fp
-	mov sl, fp
+	mov r5, r11
+	mov r6, r11
+	mov r7, r11
+	mov r8, r11
+	mov sb, r11
+	mov sl, r11
 	bl func_ov00_02097738
 	cmp r0, #0
 	bne _02177104
@@ -102879,9 +102879,9 @@ _02177198:
 	cmp r0, #0
 	beq _021771d4
 _021771d0:
-	mov fp, #0
+	mov r11, #0
 _021771d4:
-	cmp fp, #0
+	cmp r11, #0
 	bne _021771f4
 	ldr r0, _0217720c ; =data_027e10a4
 	ldr r0, [r0]
@@ -102891,7 +102891,7 @@ _021771d4:
 	strne r0, [sp]
 _021771f4:
 	ldr r0, [sp]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0217708c
 _021771fc: .word data_027e0f74
@@ -103487,7 +103487,7 @@ _02177960: .word data_027e10b0
 	.global func_ov15_02177964
 	arm_func_start func_ov15_02177964
 func_ov15_02177964: ; 0x02177964
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x7c
 	ldr r1, _02177ef4 ; =data_027e10b0
 	mov r4, r0
@@ -103546,7 +103546,7 @@ func_ov15_02177964: ; 0x02177964
 	mov r3, #2
 	str sb, [r4, #0x1d0]
 	ldrsh sb, [r4, #0x78]
-	ldr fp, _02177f00 ; =0x0000a332
+	ldr r11, _02177f00 ; =0x0000a332
 	strh sb, [r1, #0xd4]
 	str r8, [r4, #0x44c]
 	str r7, [r4, #0x198]
@@ -103577,7 +103577,7 @@ func_ov15_02177964: ; 0x02177964
 	strb r8, [r4, #0x124]
 	str r8, [r4, #0x12c]
 	ldr r5, _02177f04 ; =0x00003666
-	str fp, [r4, #0x158]
+	str r11, [r4, #0x158]
 	str r5, [r4, #0x15c]
 	strh r8, [r1, #0x68]
 	ldrsh r6, [r1, #0x68]
@@ -103603,20 +103603,20 @@ func_ov15_02177964: ; 0x02177964
 	str r3, [r4, #0x3a4]
 	str r5, [r4, #0x3ac]
 	str r3, [r4, #0x3b0]
-	ldr fp, [r2]
+	ldr r11, [r2]
 	ldmib r2, {sb, ip}
-	umull r5, r3, ip, fp
+	umull r5, r3, ip, r11
 	mla r3, ip, sb, r3
 	ldr sb, [r2, #0xc]
 	ldr ip, [r2, #0x10]
-	mla r3, sb, fp, r3
+	mla r3, sb, r11, r3
 	ldr sb, [r2, #0x14]
 	adds r5, ip, r5
-	adc fp, sb, r3
-	umull r3, sb, fp, r6
-	mla sb, fp, r8, sb
+	adc r11, sb, r3
+	umull r3, sb, r11, r6
+	mla sb, r11, r8, sb
 	mla sb, sl, r6, sb
-	stmia r2, {r5, fp}
+	stmia r2, {r5, r11}
 	add r2, sb, #0x3c
 	strh r2, [r0, #0x64]
 	strh r7, [r1, #0x20]
@@ -103663,7 +103663,7 @@ _02177bd4:
 _02177c14:
 	add sp, sp, #0x7c
 	mov r0, r8
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02177c20:
 	ldr r3, [r4, #0x4c]
 	ldr r2, [r4, #0x50]
@@ -103738,7 +103738,7 @@ _02177c84:
 	cmp r0, #5
 	addeq sp, sp, #0x7c
 	moveq r0, #1
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r0, sp, #0x44
 	bl func_ov00_020c1500
 	mvn r1, #0
@@ -103770,7 +103770,7 @@ _02177c84:
 	cmp r1, r0
 	addeq sp, sp, #0x7c
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, _02177f20 ; =data_027e0fe4
 	add r1, sp, #4
 	ldr r0, [r0]
@@ -103791,7 +103791,7 @@ _02177c84:
 	cmp r1, r0
 	addeq sp, sp, #0x7c
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, _02177f20 ; =data_027e0fe4
 	add r1, sp, #4
 	ldr r0, [r0]
@@ -103812,7 +103812,7 @@ _02177c84:
 	cmp r1, r0
 	addeq sp, sp, #0x7c
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, _02177f20 ; =data_027e0fe4
 	add r1, sp, #4
 	ldr r0, [r0]
@@ -103835,7 +103835,7 @@ _02177c84:
 	cmp r1, r0
 	addeq sp, sp, #0x7c
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, _02177f20 ; =data_027e0fe4
 	add r1, sp, #4
 	ldr r0, [r0]
@@ -103847,7 +103847,7 @@ _02177c84:
 	str r0, [r4, #0x3bc]
 	mov r0, #1
 	add sp, sp, #0x7c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02177964
 _02177ef4: .word data_027e10b0
@@ -105054,7 +105054,7 @@ _02178ff4: .word 0xffffe99a
 	.global func_ov15_02178ff8
 	arm_func_start func_ov15_02178ff8
 func_ov15_02178ff8: ; 0x02178ff8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0xa0
 	ldrh r1, [r1]
 	mov sl, r0
@@ -105063,7 +105063,7 @@ func_ov15_02178ff8: ; 0x02178ff8
 	bne _02179020
 	tst r1, #8
 	addeq sp, sp, #0xa0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02179020:
 	cmp r4, #0x69
 	beq _021790c8
@@ -105080,7 +105080,7 @@ _02179020:
 	bl func_ov00_02079470
 	cmp r0, #0
 	addeq sp, sp, #0xa0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r0, sp, #0x80
 	bl func_01ffbe34
 	mov r0, #1
@@ -105108,7 +105108,7 @@ _021790a4:
 	mov r3, r4
 	bl func_020313c8
 	add sp, sp, #0xa0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _021790c8:
 	add r0, sp, #0x60
 	bl func_01ffbe34
@@ -105122,7 +105122,7 @@ _021790c8:
 	mov sb, #0
 	str r0, [sp, #0x60]
 	add r4, sl, #0x400
-	add fp, sp, #0x44
+	add r11, sp, #0x44
 	add r5, sp, #0x60
 	mov r8, #1
 _02179104:
@@ -105130,7 +105130,7 @@ _02179104:
 	tst r0, r8, lsl sb
 	bne _0217916c
 	ldr r2, [r7, sb, lsl #2]
-	mov r0, fp
+	mov r0, r11
 	add r1, r6, r2, lsl #3
 	ldr r2, [r6, r2, lsl #3]
 	ldr r1, [r1, #4]
@@ -105190,13 +105190,13 @@ _0217916c:
 	mov r4, sb, lsl #0x1
 	ldrsh r5, [r3, r4]
 	add r4, sb, #1
-	umull fp, sb, r8, r0
+	umull r11, sb, r8, r0
 	mov r4, r4, lsl #0x1
 	ldrsh r4, [r3, r4]
 	mla sb, r8, r2, sb
 	mov r7, r8, asr #0x1f
 	mla sb, r7, r0, sb
-	adds r7, fp, #0x800
+	adds r7, r11, #0x800
 	adc r0, sb, #0
 	mov sb, r7, lsr #0xc
 	orr sb, sb, r0, lsl #20
@@ -105264,7 +105264,7 @@ _0217916c:
 	str r5, [sp]
 	bl func_020313c8
 	add sp, sp, #0xa0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02178ff8
 _0217932c: .word data_027e0d3c
@@ -105279,7 +105279,7 @@ _02179348: .word data_02051f54
 	.global func_ov15_0217934c
 	arm_func_start func_ov15_0217934c
 func_ov15_0217934c: ; 0x0217934c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0xc8
 	mov r5, r1
 	ldr r3, [r5, #0x14]
@@ -105289,7 +105289,7 @@ func_ov15_0217934c: ; 0x0217934c
 	cmp r2, r1
 	addne sp, sp, #0xc8
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r0, r3, #0x48
 	add r8, sp, #0xbc
 	ldmia r0, {r0, r1, r2}
@@ -105306,12 +105306,12 @@ func_ov15_0217934c: ; 0x0217934c
 	ldr r3, [r4, #0x4c]
 	ldr r2, [r4, #0x448]
 	add r0, r0, #0x5b00
-	sub fp, r3, r2
-	sub r1, r1, fp
+	sub r11, r3, r2
+	sub r1, r1, r11
 	cmp r1, r0
 	addge sp, sp, #0xc8
 	movge r0, #0
-	ldmgeia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmgeia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r0, r4, #0x48
 	add sb, sp, #0xa0
 	ldmia r0, {r0, r1, r2}
@@ -105374,7 +105374,7 @@ func_ov15_0217934c: ; 0x0217934c
 	stmia r5!, {r0, r1, r2, r3}
 	ldmia r7, {r0, r1, r2, r3}
 	stmia r5, {r0, r1, r2, r3}
-	add r5, fp, #0x33
+	add r5, r11, #0x33
 	ldr r3, _021796b0 ; =data_ov15_0218ddc4
 	mov r0, r6
 	mov r1, r6
@@ -105486,14 +105486,14 @@ func_ov15_0217934c: ; 0x0217934c
 	cmpge r0, #0
 	addlt sp, sp, #0xc8
 	movlt r0, #0
-	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0217968c:
 	add r0, r4, #0x1d8
 	mov r1, #1
 	bl func_ov00_020c5d74
 	mov r0, #1
 	add sp, sp, #0xc8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0217934c
 _021796a4: .word 0x434e424c
@@ -105581,7 +105581,7 @@ _021797cc: .word data_027e0f94
 	.global func_ov15_021797d0
 	arm_func_start func_ov15_021797d0
 func_ov15_021797d0: ; 0x021797d0
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0xc
 	mov r7, r0
 	add r1, r7, #0x400
@@ -105590,7 +105590,7 @@ func_ov15_021797d0: ; 0x021797d0
 	subne r0, r0, #1
 	strneh r0, [r1, #0x64]
 	addne sp, sp, #0xc
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r2, _02179ac0 ; =data_027e0764
 	mov r5, #0
 	ldr r3, [r2]
@@ -105629,10 +105629,10 @@ _0217987c:
 	add r2, sp, #0
 	mov r0, r6
 	bl func_ov15_0217bb6c
-	ldrb fp, [sp]
-	cmp fp, #0
+	ldrb r11, [sp]
+	cmp r11, #0
 	addeq sp, sp, #0xc
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldrh r2, [sp, #8]
 	ldr r3, _02179ac0 ; =data_027e0764
 	mov ip, #1
@@ -105702,7 +105702,7 @@ _02179988:
 	beq _02179a20
 	cmp r4, #7
 	bgt _02179a20
-	cmp fp, #1
+	cmp r11, #1
 	bls _02179a20
 	mov r3, #0
 	ldr r4, _02179ac0 ; =data_027e0764
@@ -105712,12 +105712,12 @@ _02179988:
 _021799bc:
 	ldr sb, [r4, #8]
 	ldr r3, [r4, #0xc]
-	umull fp, sl, sb, r1
+	umull r11, sl, sb, r1
 	mla sl, sb, r0, sl
 	mla sl, r3, r1, sl
 	ldr r1, [r4, #0x10]
 	ldr r0, [r4, #0x14]
-	adds r1, r1, fp
+	adds r1, r1, r11
 	adc r0, r0, sl
 	mov r3, r7, lsl #0x2
 	orr r3, r3, r0, lsr #30
@@ -105768,7 +105768,7 @@ _02179a78:
 	strneh r0, [sp, #4]
 	bne _02179aa8
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02179aa0:
 	mov r0, #0
 	strh r0, [sp, #4]
@@ -105778,7 +105778,7 @@ _02179aa8:
 	mov r0, r6
 	bl func_ov15_0217bbb0
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_021797d0
 _02179ac0: .word data_027e0764
@@ -106744,7 +106744,7 @@ _0217a84c: .word data_027e0e58
 	.global func_ov15_0217a850
 	arm_func_start func_ov15_0217a850
 func_ov15_0217a850: ; 0x0217a850
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x130
 	mov r4, r0
 	add r0, sp, #0x80
@@ -106838,7 +106838,7 @@ func_ov15_0217a850: ; 0x0217a850
 	ldr r8, [sp, #0x6c]
 	ldr r7, [sp, #0x70]
 	ldr r6, [sp, #0x74]
-	mov fp, #0x5c
+	mov r11, #0x5c
 	ldr r1, _0217aa2c ; =data_027e0f74
 	str r0, [sp, #0xf4]
 	ldr r0, [r1]
@@ -106853,13 +106853,13 @@ func_ov15_0217a850: ; 0x0217a850
 	strb ip, [sp, #0x10e]
 	strb r3, [sp, #0x10f]
 	strb r2, [sp, #0x110]
-	str fp, [sp, #0x114]
+	str r11, [sp, #0x114]
 	bl func_ov00_02097810
 	str r0, [r4, #0x370]
 	add r0, sp, #0x80
 	bl func_ov00_0209a508
 	add sp, sp, #0x130
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0217a850
 _0217aa20: .word data_027e0e60
@@ -107936,12 +107936,12 @@ func_ov15_0217b848: ; 0x0217b848
 	.global func_ov15_0217b84c
 	arm_func_start func_ov15_0217b84c
 func_ov15_0217b84c: ; 0x0217b84c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x12c
 	mov r4, r0
 	ldrh r5, [r4, #0x20]
 	str r1, [sp, #4]
-	mov fp, r2
+	mov r11, r2
 	cmp r5, #3
 	ldrh r8, [r4, #0x22]
 	mov r1, #0xc
@@ -108006,7 +108006,7 @@ _0217b91c:
 	str sl, [sp]
 	bl func_01ff8988
 	add r0, sp, #0xfc
-	mov r1, fp
+	mov r1, r11
 	add r2, sp, #0xcc
 	bl func_01ff8e84
 	mov r0, r5, asr #0x4
@@ -108067,7 +108067,7 @@ _0217ba30:
 	cmp r3, #9
 	blt _0217ba30
 	add r2, sp, #0x9c
-	mov r1, fp
+	mov r1, r11
 	bl func_01ff8e84
 	add r0, sp, #0x9c
 	add r1, r4, #0x288
@@ -108082,12 +108082,12 @@ _0217ba78:
 	ldr r0, [r4, #0x284]
 	cmp r0, #0
 	addeq sp, sp, #0x12c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r1, [sp, #4]
-	mov r2, fp
+	mov r2, r11
 	bl func_ov15_0217b84c
 	add sp, sp, #0x12c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0217b84c
 _0217ba9c: .word data_ov15_0218e010
@@ -109572,17 +109572,17 @@ _0217ced8: .word data_027e0d0c
 	.global func_ov15_0217cedc
 	arm_func_start func_ov15_0217cedc
 func_ov15_0217cedc: ; 0x0217cedc
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x20
 	mov sl, r0
 	ldr r1, [sl, #0x2e0]
 	cmp r1, #0
 	addge sp, sp, #0x20
-	ldmgeia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmgeia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	bl _ZN5Actor16XzDistanceToLinkEv
 	cmp r0, #0x6000
 	addlt sp, sp, #0x20
-	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r0, sl, #0x48
 	add r3, sp, #0x14
 	ldmia r0, {r0, r1, r2}
@@ -109628,7 +109628,7 @@ func_ov15_0217cedc: ; 0x0217cedc
 	add sb, sl, #0x2a0
 	mov r7, r8
 	add r5, sp, #0x14
-	mov fp, #2
+	mov r11, #2
 _0217cfc0:
 	str r7, [sp]
 	mov r0, r8, lsl #0x1
@@ -109636,7 +109636,7 @@ _0217cfc0:
 	ldrsh r1, [r6, r0]
 	ldr r0, [r4]
 	mov r2, r5
-	mov r3, fp
+	mov r3, r11
 	bl func_ov00_0207c1b0
 	mov r0, sb
 	bl func_ov00_020b7e6c
@@ -109647,7 +109647,7 @@ _0217cfc0:
 	mov r0, #0
 	strb r0, [sl, #0x118]
 	add sp, sp, #0x20
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0217cedc
 _0217d008: .word data_027e0e60
@@ -109912,12 +109912,12 @@ _0217d3b8: .word 0x53485254
 	.global func_ov15_0217d3bc
 	arm_func_start func_ov15_0217d3bc
 func_ov15_0217d3bc: ; 0x0217d3bc
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x34
 	ldr r1, [sp, #0x58]
 	ldr r6, [sp, #0x5c]
 	ldr r4, [r1]
-	ldr fp, _0217d538 ; =0x0000010a
+	ldr r11, _0217d538 ; =0x0000010a
 	str r1, [sp, #0x58]
 	str r0, [sp, #4]
 	mov r8, r2
@@ -109925,11 +109925,11 @@ func_ov15_0217d3bc: ; 0x0217d3bc
 	mov r5, #0
 _0217d3e8:
 	mov ip, #0
-	umull sl, sb, r4, fp
+	umull sl, sb, r4, r11
 	mla sb, r4, ip, sb
 	mov lr, r4, asr #0x1f
 	adds sl, sl, #0x800
-	mla sb, lr, fp, sb
+	mla sb, lr, r11, sb
 	mov sl, sl, lsr #0xc
 	adc sb, sb, #0
 	orr sl, sl, sb, lsl #20
@@ -109992,7 +109992,7 @@ _0217d3e8:
 	ldmia r1, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
 	add sp, sp, #0x34
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0217d4fc:
 	sub r1, r4, #0x1000
 	cmp r0, r1
@@ -110009,7 +110009,7 @@ _0217d50c:
 	ldmia r2, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
 	add sp, sp, #0x34
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0217d3bc
 _0217d538: .word 0x0000010a
@@ -110803,7 +110803,7 @@ _0217def8: .word func_ov15_0217e1c8
 	.global func_ov15_0217defc
 	arm_func_start func_ov15_0217defc
 func_ov15_0217defc: ; 0x0217defc
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x24
 	mov sl, r0
 	mov sb, r1
@@ -110814,7 +110814,7 @@ func_ov15_0217defc: ; 0x0217defc
 	ldrnesb r0, [sl, #0x14]
 	cmpne r0, #0
 	addeq sp, sp, #0x24
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r0, sp, #4
 	bl func_01ffbe34
 	mov r0, sl
@@ -110840,8 +110840,8 @@ func_ov15_0217defc: ; 0x0217defc
 	mov r7, #0
 	cmp r0, #0
 	addle sp, sp, #0x24
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
-	mov fp, r4
+	ldmleia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	mov r11, r4
 	ldr r4, _0217e000 ; =gItemManager
 	mov r8, r7
 	mov r5, r7
@@ -110859,7 +110859,7 @@ _0217dfc4:
 	ldr r0, [sl, #0x20]
 	mov r1, sb
 	mov r2, r5
-	mov r3, fp
+	mov r3, r11
 	add r0, r0, r8
 	bl func_ov00_020d00c4
 _0217dfe0:
@@ -110869,7 +110869,7 @@ _0217dfe0:
 	cmp r7, r0
 	blt _0217dfa8
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0217defc
 _0217dffc: .word data_027e0cbc
@@ -111702,7 +111702,7 @@ _0217eb08: .word data_027e104c
 	.global func_ov15_0217eb0c
 	arm_func_start func_ov15_0217eb0c
 func_ov15_0217eb0c: ; 0x0217eb0c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x14
 	mov r4, r0
 	str r1, [r4, #0xc]
@@ -111798,7 +111798,7 @@ _0217ec5c:
 	str r7, [sp, #0x10]
 	bl func_ov09_0211a604
 	ldr sl, _0217ee20 ; =data_ov15_0218e6d8
-	ldr fp, _0217ee1c ; =data_027e104c
+	ldr r11, _0217ee1c ; =data_027e104c
 	mov r8, #6
 	mov sb, r7
 	mov r6, #3
@@ -111811,7 +111811,7 @@ _0217ec88:
 	beq _0217ece0
 	str r6, [sp]
 	str r5, [sp, #4]
-	ldr r0, [fp]
+	ldr r0, [r11]
 	ldr r1, [sl, #0x1c]
 	ldr r2, [sl, #0x20]
 	ldr r3, [sl, #0x24]
@@ -111910,7 +111910,7 @@ _0217ede8:
 _0217ee04:
 	mov r0, #1
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0217eb0c
 _0217ee10: .word data_ov15_0218e688
@@ -111944,7 +111944,7 @@ _0217ee60: .word func_ov15_0217ee64
 	.global func_ov15_0217ee64
 	arm_func_start func_ov15_0217ee64
 func_ov15_0217ee64: ; 0x0217ee64
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x14c
 	ldr r3, _0217f3a0 ; =0x0000ffff
 	ldr r2, _0217f3a4 ; =0x040004c0
@@ -112135,7 +112135,7 @@ func_ov15_0217ee64: ; 0x0217ee64
 	mov r6, #0x50000
 	add r5, sp, #0x7c
 	mov r4, #0x20000
-	mov fp, #0x30000
+	mov r11, #0x30000
 _0217f164:
 	ldr r0, [sp, #4]
 	mov r8, #0
@@ -112148,7 +112148,7 @@ _0217f174:
 	str sl, [sp, #0x80]
 	str r7, [sp, #0x84]
 	str r7, [sp, #0x88]
-	mov r2, fp
+	mov r2, r11
 	mov r3, #0x40000
 	str r6, [sp]
 	bl func_ov05_0210e2c4
@@ -112172,11 +112172,11 @@ _0217f174:
 	mov r6, #0x10
 	mov r5, #0x50000
 	add r4, sp, #0x6c
-	mov fp, #0x20000
+	mov r11, #0x20000
 _0217f1f0:
 	mov r2, #0x40000
 	mov r0, r4
-	mov r1, fp
+	mov r1, r11
 	mov r3, r2
 	str r8, [sp, #0x6c]
 	str sb, [sp, #0x70]
@@ -112281,7 +112281,7 @@ _0217f1f0:
 	str r4, [sp]
 	bl func_ov05_0210e2c4
 	add sp, sp, #0x14c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0217ee64
 _0217f3a0: .word 0x0000ffff
@@ -113201,7 +113201,7 @@ _0217fe8c: .word data_027e10a4
 	.global func_ov15_0217fe90
 	arm_func_start func_ov15_0217fe90
 func_ov15_0217fe90: ; 0x0217fe90
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x50
 	mov r4, r0
 	mov sl, #0
@@ -113239,7 +113239,7 @@ func_ov15_0217fe90: ; 0x0217fe90
 	mov r2, #0xb1
 	str r0, [r4, #0x8c]
 	ldr r0, [r4, #0x80]
-	mov fp, #0xb2
+	mov r11, #0xb2
 	str r0, [r4, #0x90]
 	ldr r0, [r4, #0x84]
 	str r0, [r4, #0x94]
@@ -113264,7 +113264,7 @@ func_ov15_0217fe90: ; 0x0217fe90
 	str lr, [r4, #0x424]
 	str r2, [r4, #0x42c]
 	str lr, [r4, #0x430]
-	str fp, [r4, #0x438]
+	str r11, [r4, #0x438]
 	str lr, [r4, #0x43c]
 	mov r1, #0xb3
 	str r1, [r4, #0x444]
@@ -113288,7 +113288,7 @@ func_ov15_0217fe90: ; 0x0217fe90
 	bl func_ov15_021803ac
 	add sp, sp, #0x50
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0217fff0:
 	cmp r0, #8
 	bne _02180038
@@ -113302,14 +113302,14 @@ _0217fff0:
 _02180014:
 	add sp, sp, #0x50
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02180020:
 	mov r0, r4
 	mov r1, #0xa
 	bl func_ov15_021803ac
 	add sp, sp, #0x50
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02180038:
 	cmp r0, #9
 	bne _02180058
@@ -113318,7 +113318,7 @@ _02180038:
 	bl func_ov15_021803ac
 	add sp, sp, #0x50
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02180058:
 	ldrh r0, [r4, #0x24]
 	cmp r0, #0
@@ -113337,7 +113337,7 @@ _02180078:
 	beq _021800fc
 	add sp, sp, #0x50
 	mov r0, sl
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0218009c:
 	ldr r0, _02180334 ; =data_027e0f74
 	mov r1, #0x33
@@ -113347,7 +113347,7 @@ _0218009c:
 	beq _021800fc
 	add sp, sp, #0x50
 	mov r0, sl
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _021800c0:
 	ldr r0, _02180334 ; =data_027e0f74
 	mov r1, #0x33
@@ -113356,14 +113356,14 @@ _021800c0:
 	cmp r0, #0
 	addeq sp, sp, #0x50
 	moveq r0, sl
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	mov r0, r4
 	mov r1, sl
 	bl _ZN5Actor18func_Ov00_020c1bfcEi
 	cmp r0, #0
 	addne sp, sp, #0x50
 	movne r0, sl
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _021800fc:
 	ldr r0, [r4, #8]
 	mov r1, #0
@@ -113522,7 +113522,7 @@ _0218031c:
 _02180324:
 	mov r0, #1
 	add sp, sp, #0x50
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 _02180330: .word data_027e0d0c
 _02180334: .word data_027e0f74
@@ -113565,7 +113565,7 @@ _021803a8: .word 0x53424f53
 	.global func_ov15_021803ac
 	arm_func_start func_ov15_021803ac
 func_ov15_021803ac: ; 0x021803ac
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x31c
 	mov r5, r0
 	mov r4, r1
@@ -113612,7 +113612,7 @@ _02180424:
 	bl func_ov15_02141344
 	cmp r0, #0
 	addeq sp, sp, #0x31c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r0, r5, #0x300
 	mov r1, #0
 	strh r1, [r0, #0x9a]
@@ -113754,7 +113754,7 @@ _0218064c:
 	bl func_ov15_02141344
 	cmp r0, #0
 	addeq sp, sp, #0x31c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	mov r2, #0
 	str r2, [r5, #0x37c]
 	strb r2, [r5, #0x39e]
@@ -113888,7 +113888,7 @@ _021806b8:
 	ldr r0, [r1, #0x260]
 	str r0, [r5, #0x324]
 	ldr r0, [r1, #0x264]
-	mov fp, #0x5c
+	mov r11, #0x5c
 	str r0, [r5, #0x328]
 	ldr r0, [r1, #0x268]
 	str r0, [r5, #0x32c]
@@ -113953,7 +113953,7 @@ _021806b8:
 	strb ip, [sp, #0x1e2]
 	strb r3, [sp, #0x1e3]
 	strb r2, [sp, #0x1e4]
-	str fp, [sp, #0x1e8]
+	str r11, [sp, #0x1e8]
 	bl func_ov00_02097810
 	str r0, [r5, #0x38c]
 	mov r0, #1
@@ -114032,7 +114032,7 @@ _02180ab8:
 	str r0, [r5, #0x138]
 	str r4, [r5, #0x130]
 	add sp, sp, #0x31c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_021803ac
 _02180acc: .word data_027e0d0c
@@ -114858,13 +114858,13 @@ _02181614: .word data_027e0f94
 	.global func_ov15_02181618
 	arm_func_start func_ov15_02181618
 func_ov15_02181618: ; 0x02181618
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x118
 	mov r4, r0
 	bl _ZN5Actor18func_ov00_020c198cEv
 	cmp r0, #0
 	addeq sp, sp, #0x118
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r0, sp, #0x68
 	bl func_ov00_0209a4f4
 	ldr r1, _021818c0 ; =data_027e0f94
@@ -114998,7 +114998,7 @@ func_ov15_02181618: ; 0x02181618
 	str r6, [sp, #0xd4]
 	ldr r6, [sp, #0x5c]
 	str r1, [sp, #0xd8]
-	mov fp, #0x5c
+	mov r11, #0x5c
 	ldr r0, [r0]
 	add r1, sp, #0x68
 	str sl, [sp, #0xe0]
@@ -115011,7 +115011,7 @@ func_ov15_02181618: ; 0x02181618
 	strb ip, [sp, #0xf6]
 	strb r3, [sp, #0xf7]
 	strb r2, [sp, #0xf8]
-	str fp, [sp, #0xfc]
+	str r11, [sp, #0xfc]
 	bl func_ov00_02097810
 	mvn r1, #0
 	str r0, [r4, #0x38c]
@@ -115028,7 +115028,7 @@ _021818b0:
 	add r0, sp, #0x68
 	bl func_ov00_0209a508
 	add sp, sp, #0x118
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02181618
 _021818c0: .word data_027e0f94
@@ -115620,7 +115620,7 @@ _0218210c: .word 0x4647474e
 	.global func_ov15_02182110
 	arm_func_start func_ov15_02182110
 func_ov15_02182110: ; 0x02182110
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x150
 	mov r4, r0
 	ldrb r1, [r4, #0x39e]
@@ -115781,7 +115781,7 @@ _02182140:
 	ldr r7, [sp, #0x94]
 	str r2, [sp, #0x110]
 	mov r2, #0x5c
-	mov fp, #0
+	mov r11, #0
 	str r1, [sp, #0x114]
 	ldr r0, [r0]
 	add r1, sp, #0xa0
@@ -115795,7 +115795,7 @@ _02182140:
 	strb ip, [sp, #0x12f]
 	strb r3, [sp, #0x130]
 	str r2, [sp, #0x134]
-	strb fp, [sp, #0xb6]
+	strb r11, [sp, #0xb6]
 	bl func_ov00_02097810
 	str r0, [r4, #0x38c]
 	mov r1, #1
@@ -115903,13 +115903,13 @@ _02182548:
 	and r0, r1, r0
 	cmp r0, #0x1000000
 	addeq sp, sp, #0x150
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r0, r4, #0x3a4
 	ldr r1, [r0]
 	ldr r1, [r1, #0x10]
 	blx r1
 	add sp, sp, #0x150
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02182110
 _0218257c: .word data_027e0e60
@@ -117355,32 +117355,32 @@ func_ov15_02183898: ; 0x02183898
 	.global func_ov15_021838b8
 	arm_func_start func_ov15_021838b8
 func_ov15_021838b8: ; 0x021838b8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	mov sl, r0
 	ldrb r0, [sl, #0x48]
 	cmp r0, #0
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, [sl, #0x14]
 	ldrb r0, [r0, #5]
 	cmp r0, #0
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldrsh r1, [sl]
 	ldrsh r0, [sl, #2]
 	cmp r1, r0
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, _02183990 ; =data_027e077c
 	ldr r0, [r0]
 	cmp r0, #0x3b
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	mov sb, #0
 	mov r6, sb
 	mov r8, sl
 	add r7, sl, #0x18
-	mov fp, sb
+	mov r11, sb
 	mov r4, #1
 	mov r5, sb
 _02183928:
@@ -117404,7 +117404,7 @@ _02183968:
 	mov sb, r4
 	b _02183974
 _02183970:
-	mov sb, fp
+	mov sb, r11
 _02183974:
 	add r6, r6, #1
 	cmp r6, #2
@@ -117412,7 +117412,7 @@ _02183974:
 	add r8, r8, #0x18
 	blt _02183928
 	mov r0, sb
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_021838b8
 _02183990: .word data_027e077c
@@ -118886,7 +118886,7 @@ _02184c0c: .word func_ov15_02184c10
 	.global func_ov15_02184c10
 	arm_func_start func_ov15_02184c10
 func_ov15_02184c10: ; 0x02184c10
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x5c
 	ldr r1, _02184eb8 ; =data_027e0f64
 	mov r2, #0x60
@@ -118903,17 +118903,17 @@ func_ov15_02184c10: ; 0x02184c10
 	str r2, [sp, #8]
 	cmp r5, r1
 	addlt sp, sp, #0x5c
-	ldmltia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmltia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	cmp r5, #0x110
 	addgt sp, sp, #0x5c
-	ldmgtia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmgtia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	mov r0, r1
 	cmp r4, r0
 	addlt sp, sp, #0x5c
-	ldmltia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmltia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	cmp r4, #0xd0
 	addgt sp, sp, #0x5c
-	ldmgtia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmgtia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	sub r1, r3, r5
 	mov r3, r1, lsl #0xc
 	sub r0, r2, r4
@@ -118929,7 +118929,7 @@ func_ov15_02184c10: ; 0x02184c10
 	bl func_01fffb4c
 	cmp r4, #0xa0000
 	addge sp, sp, #0x5c
-	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	cmp r4, #0x50000
 	movle r7, #0x1000
 	ble _02184cec
@@ -118946,7 +118946,7 @@ _02184cec:
 	ldr r1, _02184ec0 ; =0xfffff4cd
 	cmp r0, r1
 	addle sp, sp, #0x5c
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	cmp r0, #0
 	bgt _02184d2c
 	rsb r0, r0, #0
@@ -118970,7 +118970,7 @@ _02184d2c:
 	ldr r5, _02184ec8 ; =data_ov15_0218727c
 	str r0, [r4]
 	ldr sl, [sp, #0x10]
-	ldr fp, [sp, #0xc]
+	ldr r11, [sp, #0xc]
 	mov r6, r7, asr #0x1f
 	mov r4, #0
 _02184d64:
@@ -119038,7 +119038,7 @@ _02184d64:
 	adc r0, r2, r0
 	mov r1, r1, lsr #0xc
 	orr r1, r1, r0, lsl #20
-	add r0, r1, fp, lsl #12
+	add r0, r1, r11, lsl #12
 	bl func_ov05_0210e184
 	str r0, [sp, #0x44]
 	mov r0, #0
@@ -119058,7 +119058,7 @@ _02184d64:
 	blt _02184d64
 	bl func_01ffa8d4
 	add sp, sp, #0x5c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02184c10
 _02184eb8: .word data_027e0f64
@@ -119326,7 +119326,7 @@ _021851fc: .word data_ov00_020ee734
 	.global func_ov15_02185200
 	arm_func_start func_ov15_02185200
 func_ov15_02185200: ; 0x02185200
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0xc
 	mov sl, r0
 	ldrb r4, [sl, #0xc]
@@ -119369,7 +119369,7 @@ _02185284:
 	ldrlt r1, [sl, #4]
 	cmplt r1, #7
 	addge sp, sp, #0xc
-	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	cmp r0, #0
 	bne _02185354
 	mov r0, sl
@@ -119387,13 +119387,13 @@ _02185284:
 	mov r3, #0x3c
 	bl func_ov15_0218588c
 	mov r5, #0
-	ldr fp, _0218541c ; =data_ov15_021872e4
+	ldr r11, _0218541c ; =data_ov15_021872e4
 	mov r7, r5
 	add r4, sl, #0x10
 _021852ec:
 	mov r6, #0
 	mov r8, r4
-	add sb, fp, r7
+	add sb, r11, r7
 _021852f8:
 	ldr r0, [sl, #4]
 	ldr r2, [r4, #0x14]
@@ -119417,17 +119417,17 @@ _021852f8:
 	mov r0, #1
 	add sp, sp, #0xc
 	strb r0, [sl, #0xc]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02185354:
-	mov fp, #0
-	mov r6, fp
-	mov r7, fp
+	mov r11, #0
+	mov r6, r11
+	mov r7, r11
 	add r4, sl, #0x10
 _02185364:
 	ldr r1, [sl]
 	ldr r0, _02185420 ; =data_ov15_021872c4
 	add r2, r0, r1, lsl #4
-	ldr r0, [r2, fp, lsl #3]
+	ldr r0, [r2, r11, lsl #3]
 	cmp r0, #0
 	beq _021853c8
 	ldr r3, [sp, #8]
@@ -119451,8 +119451,8 @@ _021853a0:
 	cmp r5, #2
 	blt _021853a0
 _021853c8:
-	add fp, fp, #1
-	cmp fp, #2
+	add r11, r11, #1
+	cmp r11, #2
 	add r4, r4, #0x18
 	add r6, r6, #8
 	add r7, r7, #2
@@ -119462,16 +119462,16 @@ _021853c8:
 	ldr r0, [sp]
 	cmp r0, #0
 	addne sp, sp, #0xc
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, [sp, #4]
 	cmp r0, #1
 	addhi sp, sp, #0xc
-	ldmhiia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmhiia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, [sl, #0x24]
 	mov r1, #0xfa
 	bl func_0201f8ac
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02185200
 _0218541c: .word data_ov15_021872e4

--- a/asm/ov15.s
+++ b/asm/ov15.s
@@ -575,19 +575,19 @@ func_ov15_0211fd64: ; 0x0211fd64
 	.global func_ov15_0211fd88
 	arm_func_start func_ov15_0211fd88
 func_ov15_0211fd88: ; 0x0211fd88
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #0x19c
 	ldr r3, _02120598 ; =data_027e0d78
-	mov sb, r0
+	mov r9, r0
 	ldr r4, [r3, #0x24]
 	ldr r2, [r3, #0x28]
-	ldr r0, [sb, #0x30]
+	ldr r0, [r9, #0x30]
 	mov r6, #0
-	str r0, [sb, #0x38]
-	ldr r0, [sb, #0x34]
+	str r0, [r9, #0x38]
+	ldr r0, [r9, #0x34]
 	mov r8, r1
-	str r0, [sb, #0x3c]
-	ldrb r0, [sb, #0x58]
+	str r0, [r9, #0x3c]
+	ldrb r0, [r9, #0x58]
 	mov r7, r6
 	mov r4, r4, lsl #0xc
 	cmp r0, #0
@@ -596,12 +596,12 @@ func_ov15_0211fd88: ; 0x0211fd88
 	ldrb r0, [r3, #0xc]
 	cmp r0, #0
 	beq _02120184
-	ldr r0, [sb, #0x40]
-	ldr r1, [sb, #0x44]
+	ldr r0, [r9, #0x40]
+	ldr r1, [r9, #0x44]
 	add r0, r4, r0
-	str r0, [sb, #0x30]
+	str r0, [r9, #0x30]
 	add r0, r5, r1
-	str r0, [sb, #0x34]
+	str r0, [r9, #0x34]
 	mov r5, #5
 	ldr r6, [r3, #0x10]
 	ldr r4, [r3, #0x1c]
@@ -627,14 +627,14 @@ _0211fe30:
 	mov r3, r3, asr #0x7
 	add r5, r3, #5
 _0211fe50:
-	ldr r4, [sb, #0x40]
+	ldr r4, [r9, #0x40]
 	rsb r3, r5, #0x64
 	mul r6, r4, r3
 	ldr r5, _0212059c ; =0x51eb851f
 	mov r3, r6, lsr #0x1f
 	smull r4, r6, r5, r6
 	add r6, r3, r6, asr #5
-	str r6, [sb, #0x40]
+	str r6, [r9, #0x40]
 _0211fe70:
 	cmp r1, #0
 	beq _0211fed4
@@ -655,14 +655,14 @@ _0211fe90:
 	add r3, r0, r3, asr #4
 	add r0, r3, #5
 _0211feb4:
-	ldr r1, [sb, #0x44]
+	ldr r1, [r9, #0x44]
 	rsb r0, r0, #0x64
 	mul r3, r1, r0
 	ldr r2, _0212059c ; =0x51eb851f
 	mov r0, r3, lsr #0x1f
 	smull r1, r3, r2, r3
 	add r3, r0, r3, asr #5
-	str r3, [sb, #0x44]
+	str r3, [r9, #0x44]
 _0211fed4:
 	ldr r0, _021205a4 ; =data_ov15_0218ec30
 	ldr r0, [r0]
@@ -671,7 +671,7 @@ _0211fed4:
 	ldr r0, _021205a8 ; =data_ov15_0218ec40
 	ldr r1, _021205ac ; =data_ov15_0218946c
 	mov r3, #2
-	stmia r0, {r1, sb}
+	stmia r0, {r1, r9}
 	str r3, [r0, #8]
 	ldr r1, _021205b0 ; =func_ov15_0211fc6c
 	ldr r2, _021205b4 ; =data_ov15_0218ec34
@@ -707,16 +707,16 @@ _0211ff18:
 	strb r3, [sp, #0x191]
 	str r2, [sp, #0x194]
 	str r2, [sp, #0x198]
-	ldr r0, [sb, #0x30]
+	ldr r0, [r9, #0x30]
 	mov r4, #0x1000
 	str r0, [sp, #0x44]
-	ldr r0, [sb, #0x34]
+	ldr r0, [r9, #0x34]
 	mov r3, #7
 	str r0, [sp, #0x48]
-	ldr r0, [sb, #0x38]
+	ldr r0, [r9, #0x38]
 	mov r2, #0x49
 	str r0, [sp, #0x3c]
-	ldr r5, [sb, #0x3c]
+	ldr r5, [r9, #0x3c]
 	ldr r0, _021205bc ; =data_027e0e60
 	str r5, [sp, #0x40]
 	str r4, [sp]
@@ -732,19 +732,19 @@ _0211ff18:
 	beq _02120018
 	ldr r1, [sp, #0x194]
 	ldr r0, _021205a8 ; =data_ov15_0218ec40
-	str r1, [sb, #0x30]
+	str r1, [r9, #0x30]
 	ldr r1, [sp, #0x198]
-	str r1, [sb, #0x34]
+	str r1, [r9, #0x34]
 	ldr r1, [r0, #8]
 	cmp r1, #1
 	bne _02120058
 	mov r1, #0
-	strb r1, [sb, #0x58]
+	strb r1, [r9, #0x58]
 	ldr r1, [r0, #0x10]
 	mov r7, #1
-	str r1, [sb, #0x30]
+	str r1, [r9, #0x30]
 	ldr r0, [r0, #0x14]
-	str r0, [sb, #0x34]
+	str r0, [r9, #0x34]
 	b _02120058
 _02120018:
 	ldr r0, _021205a8 ; =data_ov15_0218ec40
@@ -752,23 +752,23 @@ _02120018:
 	cmp r1, #1
 	bne _02120048
 	mov r1, #0
-	strb r1, [sb, #0x58]
+	strb r1, [r9, #0x58]
 	ldr r1, [r0, #0x10]
 	mov r7, #1
-	str r1, [sb, #0x30]
+	str r1, [r9, #0x30]
 	ldr r0, [r0, #0x14]
-	str r0, [sb, #0x34]
+	str r0, [r9, #0x34]
 	b _02120058
 _02120048:
 	ldr r0, [sp, #0x194]
-	str r0, [sb, #0x30]
+	str r0, [r9, #0x30]
 	ldr r0, [sp, #0x198]
-	str r0, [sb, #0x34]
+	str r0, [r9, #0x34]
 _02120058:
 	ldr r10, _021205c0 ; =data_ov15_02189420
 	mov r2, #0
-	ldr r6, [sb, #0x34]
-	ldr r5, [sb, #0x30]
+	ldr r6, [r9, #0x34]
+	ldr r5, [r9, #0x30]
 	ldr ip, [r10]
 	mov r3, r2
 	mov r4, r2
@@ -826,22 +826,22 @@ _02120104:
 	cmp r6, r0
 	movlt r6, r0
 _02120138:
-	str r5, [sb, #0x30]
-	str r6, [sb, #0x34]
+	str r5, [r9, #0x30]
+	str r6, [r9, #0x34]
 _02120140:
 	mov r0, #3
 	str r0, [sp]
 	mov r0, #0x3e
 	str r0, [sp, #4]
-	ldr r1, [sb, #0x30]
-	mov r0, sb
+	ldr r1, [r9, #0x30]
+	mov r0, r9
 	mov r1, r1, asr #0xc
 	str r1, [sp, #8]
-	ldr r1, [sb, #0x34]
+	ldr r1, [r9, #0x34]
 	mov r2, r8
 	mov r1, r1, asr #0xc
 	str r1, [sp, #0xc]
-	ldrb r3, [sb, #0x59]
+	ldrb r3, [r9, #0x59]
 	mov r1, #0
 	bl func_ov05_0210d0e4
 	mov r6, #1
@@ -866,16 +866,16 @@ _02120184:
 	strb r6, [sp, #0x129]
 	str r0, [sp, #0x12c]
 	str r0, [sp, #0x130]
-	ldr r0, [sb, #0x30]
+	ldr r0, [r9, #0x30]
 	mov r3, #0x1000
 	str r0, [sp, #0x34]
-	ldr r0, [sb, #0x34]
+	ldr r0, [r9, #0x34]
 	mov r2, #7
 	str r0, [sp, #0x38]
-	ldr r0, [sb, #0x38]
+	ldr r0, [r9, #0x38]
 	mov r1, #0x49
 	str r0, [sp, #0x2c]
-	ldr r4, [sb, #0x3c]
+	ldr r4, [r9, #0x3c]
 	ldr r0, _021205bc ; =data_027e0e60
 	str r4, [sp, #0x30]
 	str r3, [sp]
@@ -890,16 +890,16 @@ _02120184:
 	cmp r0, #0
 	beq _0212023c
 	ldr r0, [sp, #0x12c]
-	str r0, [sb, #0x30]
+	str r0, [r9, #0x30]
 	ldr r0, [sp, #0x130]
-	str r0, [sb, #0x34]
+	str r0, [r9, #0x34]
 _0212023c:
 	add r1, sp, #0x58
 	str r1, [sp]
 	ldr r0, _021205c4 ; =data_027e0d3c
-	ldr r2, [sb, #0x30]
+	ldr r2, [r9, #0x30]
 	ldr r0, [r0]
-	ldr r3, [sb, #0x34]
+	ldr r3, [r9, #0x34]
 	mov r1, #0
 	bl func_ov00_020792a0
 	bl func_ov15_0213ce4c
@@ -916,25 +916,25 @@ _02120280:
 	str r0, [sp]
 	mov r0, #0x3e
 	str r0, [sp, #4]
-	ldr r1, [sb, #0x30]
-	mov r0, sb
+	ldr r1, [r9, #0x30]
+	mov r0, r9
 	mov r1, r1, asr #0xc
 	str r1, [sp, #8]
-	ldr r1, [sb, #0x34]
+	ldr r1, [r9, #0x34]
 	mov r2, r8
 	mov r1, r1, asr #0xc
 	str r1, [sp, #0xc]
-	ldrb r3, [sb, #0x59]
+	ldrb r3, [r9, #0x59]
 	mov r1, #0
 	bl func_ov05_0210d0e4
 _021202bc:
 	mov r0, #0
-	strb r0, [sb, #0x58]
+	strb r0, [r9, #0x58]
 	add sp, sp, #0x19c
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 _021202d0:
-	ldr r0, [sb, #0x2c]
+	ldr r0, [r9, #0x2c]
 	bl func_ov15_02121998
 	cmp r0, #0
 	bne _02120548
@@ -983,7 +983,7 @@ _02120354:
 	add r0, r2, r3, lsl #4
 	cmp r1, #0
 	beq _02120548
-	ldr r2, [sb, #0x30]
+	ldr r2, [r9, #0x30]
 	ldr r1, [r0]
 	add r2, r2, r1
 	cmp r4, r2
@@ -992,7 +992,7 @@ _02120354:
 	add r1, r1, r2
 	cmp r4, r1
 	bgt _02120548
-	ldr r2, [sb, #0x34]
+	ldr r2, [r9, #0x34]
 	ldr r1, [r0, #4]
 	add r1, r2, r1
 	cmp r5, r1
@@ -1008,7 +1008,7 @@ _02120354:
 	mov r1, #0x3f
 	bl func_ov00_020d77e4
 	mov r0, #1
-	strb r0, [sb, #0x58]
+	strb r0, [r9, #0x58]
 	rsb r0, r0, #0x10000
 	strh r0, [sp, #0x88]
 	strh r0, [sp, #0x8a]
@@ -1029,16 +1029,16 @@ _02120354:
 	strb r0, [sp, #0xc1]
 	str r1, [sp, #0xc4]
 	str r1, [sp, #0xc8]
-	ldr r1, [sb, #0x30]
+	ldr r1, [r9, #0x30]
 	mov r10, #0x1000
 	str r1, [sp, #0x24]
-	ldr r1, [sb, #0x34]
+	ldr r1, [r9, #0x34]
 	mov r3, #7
 	str r1, [sp, #0x28]
-	ldr r1, [sb, #0x30]
+	ldr r1, [r9, #0x30]
 	mov r2, #0x49
 	str r1, [sp, #0x1c]
-	ldr ip, [sb, #0x34]
+	ldr ip, [r9, #0x34]
 	ldr r1, _021205bc ; =data_027e0e60
 	str ip, [sp, #0x20]
 	str r10, [sp]
@@ -1053,22 +1053,22 @@ _02120354:
 	cmp r0, #0
 	beq _021204ac
 	ldr r0, [sp, #0xc4]
-	str r0, [sb, #0x30]
+	str r0, [r9, #0x30]
 	ldr r0, [sp, #0xc8]
-	str r0, [sb, #0x34]
+	str r0, [r9, #0x34]
 _021204ac:
-	ldr r0, [sb, #0x30]
-	ldr r1, [sb, #0x34]
+	ldr r0, [r9, #0x30]
+	ldr r1, [r9, #0x34]
 	sub r0, r0, r4
-	str r0, [sb, #0x40]
+	str r0, [r9, #0x40]
 	sub r0, r1, r5
-	str r0, [sb, #0x44]
-	ldrb r0, [sb, #4]
+	str r0, [r9, #0x44]
+	ldrb r0, [r9, #4]
 	cmp r0, #0
 	beq _02120548
 	mov r1, #0
 	add r0, sp, #0x14
-	strh r1, [sb, #0x5a]
+	strh r1, [r9, #0x5a]
 	bl func_ov15_0211fcc0
 	mov r0, #0x3e
 	str r0, [sp]
@@ -1079,21 +1079,21 @@ _021204ac:
 	add r0, r0, r1, asr #12
 	str r0, [sp, #4]
 	ldr r1, [sp, #0x18]
-	mov r0, sb
+	mov r0, r9
 	add r1, r1, #0x800
 	mov r1, r1, asr #0xc
 	str r1, [sp, #8]
-	ldr r2, [sb, #0x40]
+	ldr r2, [r9, #0x40]
 	mov r1, r8
 	add r2, r2, #0x800
 	mov r2, r2, asr #0xc
 	str r2, [sp, #0xc]
-	ldr r2, [sb, #0x44]
+	ldr r2, [r9, #0x44]
 	mov r3, #3
 	add r2, r2, #0x800
 	mov r2, r2, asr #0xc
 	str r2, [sp, #0x10]
-	ldrb r2, [sb, #0x59]
+	ldrb r2, [r9, #0x59]
 	bl func_ov05_0210d374
 	mov r6, #1
 _02120548:
@@ -1102,9 +1102,9 @@ _02120548:
 	add r1, sp, #0x4c
 	str r1, [sp]
 	ldr r0, _021205c4 ; =data_027e0d3c
-	ldr r2, [sb, #0x30]
+	ldr r2, [r9, #0x30]
 	ldr r0, [r0]
-	ldr r3, [sb, #0x34]
+	ldr r3, [r9, #0x34]
 	mov r1, #0
 	bl func_ov00_020792a0
 	bl func_ov15_0213ce4c
@@ -1113,11 +1113,11 @@ _02120548:
 	bl func_ov15_0213d40c
 	cmp r0, #1
 	moveq r0, #0
-	streqb r0, [sb, #0x58]
+	streqb r0, [r9, #0x58]
 _0212058c:
 	mov r0, r6
 	add sp, sp, #0x19c
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0211fd88
 _02120598: .word data_027e0d78
@@ -1489,7 +1489,7 @@ _02120a64: .word func_ov15_021208e0
 	.global func_ov15_02120a68
 	arm_func_start func_ov15_02120a68
 func_ov15_02120a68: ; 0x02120a68
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #8
 	mov r4, r0
 	add r0, r4, #0x100
@@ -1521,7 +1521,7 @@ func_ov15_02120a68: ; 0x02120a68
 	str r1, [sp]
 	bl func_020351b8
 	mov r7, #0
-	add sb, r4, #0x128
+	add r9, r4, #0x128
 	ldr r8, _02120b50 ; =data_ov15_02185b58
 	mov r6, r7
 	mov r5, #7
@@ -1530,11 +1530,11 @@ _02120afc:
 	str r6, [sp]
 	str r6, [sp, #4]
 	ldrb r2, [r8], #1
-	mov r0, sb
+	mov r0, r9
 	mov r1, r5
 	mov r3, r6
 	bl func_020350b4
-	mov r0, sb
+	mov r0, r9
 	mov r1, r4
 	mov r2, r4
 	mov r3, r4
@@ -1542,10 +1542,10 @@ _02120afc:
 	bl func_020351b8
 	add r7, r7, #1
 	cmp r7, #4
-	add sb, sb, #0x88
+	add r9, r9, #0x88
 	blt _02120afc
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02120a68
 _02120b48: .word data_027e0c38
@@ -1687,7 +1687,7 @@ _02120cd8: .word data_027e0cbc
 	.global func_ov15_02120cdc
 	arm_func_start func_ov15_02120cdc
 func_ov15_02120cdc: ; 0x02120cdc
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	ldr r1, _02120e40 ; =data_027e103c
 	mov r10, r0
 	ldr r0, [r1]
@@ -1701,7 +1701,7 @@ func_ov15_02120cdc: ; 0x02120cdc
 	strb r0, [r10, #0x20]
 _02120d0c:
 	ldrsb r0, [r10, #0x14]
-	mov sb, #0
+	mov r9, #0
 	cmp r0, #0
 	beq _02120e38
 	ldr r0, _02120e44 ; =data_027e0c68
@@ -1722,7 +1722,7 @@ _02120d0c:
 	mov r0, #0x18
 	mla r0, r1, r0, r3
 	ldr r4, [r0]
-	mov r2, sb
+	mov r2, r9
 	ldr r4, [r4]
 	mov r1, r5
 	mov r3, r2
@@ -1734,10 +1734,10 @@ _02120d0c:
 	mov r0, r10
 	mla r1, r2, r1, r10
 	ldrh r1, [r1, #0x36]
-	mov sb, #1
+	mov r9, #1
 	bl func_ov15_02120e4c
 	cmp r0, #0
-	moveq sb, #0
+	moveq r9, #0
 _02120da4:
 	mov r0, r10
 	bl func_ov15_02120b6c
@@ -1762,7 +1762,7 @@ _02120dd8:
 	blx ip
 	tst r0, #8
 	beq _02120e24
-	cmp sb, #0
+	cmp r9, #0
 	bne _02120e18
 	ldrh r1, [r8, #0x66]
 	mov r0, r10
@@ -1770,10 +1770,10 @@ _02120dd8:
 	cmp r0, #0
 	beq _02120e20
 _02120e18:
-	mov sb, r4
+	mov r9, r4
 	b _02120e24
 _02120e20:
-	mov sb, r11
+	mov r9, r11
 _02120e24:
 	add r6, r6, #1
 	cmp r6, #2
@@ -1781,8 +1781,8 @@ _02120e24:
 	add r8, r8, #0x18
 	blt _02120dd8
 _02120e38:
-	mov r0, sb
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	mov r0, r9
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02120cdc
 _02120e40: .word data_027e103c
@@ -2012,24 +2012,24 @@ _02121138: .word data_027e077c
 	.global func_ov15_0212113c
 	arm_func_start func_ov15_0212113c
 func_ov15_0212113c: ; 0x0212113c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x5c
 	ldr r1, _021216d4 ; =data_027e0618
-	mov sb, r0
+	mov r9, r0
 	ldrb r0, [r1, #0x101]
 	cmp r0, #0
 	addne sp, sp, #0x5c
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, _021216d8 ; =data_027e0cbc
 	mov r1, #0xb
 	bl func_0203d7e0
 	cmp r0, #0
 	addeq sp, sp, #0x5c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
-	mov r0, sb
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
+	mov r0, r9
 	bl func_ov15_02121700
 	cmp r0, #0
-	ldrnesb r0, [sb, #0x14]
+	ldrnesb r0, [r9, #0x14]
 	cmpne r0, #0
 	ldr r0, _021216dc ; =data_027e103c
 	movne r7, #1
@@ -2043,13 +2043,13 @@ func_ov15_0212113c: ; 0x0212113c
 	ldr r0, [r0]
 	cmp r0, #0x11
 	bne _02121270
-	mov r0, sb
+	mov r0, r9
 	bl func_ov15_02120b6c
 	cmp r0, #0
 	bne _02121270
 	add r0, sp, #0x3c
 	bl func_01ffbe34
-	mov r0, sb
+	mov r0, r9
 	bl func_ov15_02121998
 	cmp r0, #0
 	movne r0, #1
@@ -2071,7 +2071,7 @@ func_ov15_0212113c: ; 0x0212113c
 	add r1, r1, #0x800
 	add r2, r0, #0x800
 	add r3, sp, #0x3c
-	add r0, sb, #0x8c
+	add r0, r9, #0x8c
 	mov r1, r1, asr #0xc
 	mov r2, r2, asr #0xc
 	bl func_02034a1c
@@ -2141,7 +2141,7 @@ _021212d4:
 	add r2, sp, #0x18
 	add r3, sp, #0x14
 	bl func_ov00_0207914c
-	ldrb r0, [sb, #0x20]
+	ldrb r0, [r9, #0x20]
 	mov r4, #0
 	cmp r0, #4
 	addls pc, pc, r0, lsl #2
@@ -2166,7 +2166,7 @@ _02121358:
 	str r0, [sp, #0x20]
 	cmp r4, #0
 	bne _02121394
-	mov r0, sb
+	mov r0, r9
 	bl func_ov15_0212179c
 	cmp r0, #0
 	beq _0212139c
@@ -2191,18 +2191,18 @@ _021213b8:
 	ldrb r0, [r0, #0x101]
 	cmp r0, #0
 	bne _02121424
-	ldrb r0, [sb, #0x20]
+	ldrb r0, [r9, #0x20]
 	cmp r0, #1
 	blo _02121424
 	cmp r0, #4
 	bhi _02121424
-	mov r0, sb
+	mov r0, r9
 	bl func_ov15_0212179c
 	cmp r0, #0
 	beq _02121424
 	mov r0, #0
 	str r0, [sp]
-	ldrb r1, [sb, #0x20]
+	ldrb r1, [r9, #0x20]
 	ldr r0, _021216f4 ; =data_ov15_02185b5c
 	ldr r2, [sp, #0x18]
 	sub r1, r1, #1
@@ -2211,7 +2211,7 @@ _021213b8:
 	mov r0, #0xcf
 	bl func_02034984
 _02121424:
-	mov r0, sb
+	mov r0, r9
 	bl func_ov15_02121998
 	cmp r0, #0
 	beq _02121464
@@ -2222,7 +2222,7 @@ _02121424:
 	mov r0, #8
 	str r0, [sp, #8]
 	mov r4, #0x20
-	add r0, sb, #0x348
+	add r0, r9, #0x348
 	mov r1, #0xcf
 	mov r2, #9
 	str r4, [sp, #0xc]
@@ -2230,8 +2230,8 @@ _02121424:
 _02121464:
 	cmp r7, #0
 	addeq sp, sp, #0x5c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
-	add r0, sb, #0x100
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
+	add r0, r9, #0x100
 	ldrsh r3, [r0, #0x14]
 	ldrsh r2, [r0, #0x16]
 	cmp r3, r2
@@ -2248,14 +2248,14 @@ _02121464:
 	bl Divide
 	mov r3, r0
 _021214b0:
-	ldrb r0, [sb, #0x124]
-	ldr r1, [sb, #0x11c]
-	ldr r2, [sb, #0x120]
+	ldrb r0, [r9, #0x124]
+	ldr r1, [r9, #0x11c]
+	ldr r2, [r9, #0x120]
 	bl func_ov00_020d02bc
-	ldrb r3, [sb, #0x1c]
+	ldrb r3, [r9, #0x1c]
 	add r0, r0, #0x800
 	mov r1, r0, asr #0xc
-	add r2, sb, #0x2c
+	add r2, r9, #0x2c
 	mov r0, #0x18
 	mla r0, r3, r0, r2
 	mov r2, #0
@@ -2264,17 +2264,17 @@ _021214b0:
 	mov r3, r2
 	str r2, [sp]
 	bl func_ov00_020d00c4
-	mov r0, sb
+	mov r0, r9
 	bl func_ov15_02120b6c
 	cmp r0, #0
 	beq _02121550
-	add r0, sb, #0x300
+	add r0, r9, #0x300
 	ldrh r0, [r0, #0x4c]
 	cmp r0, #0
 	addne sp, sp, #0x5c
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	mov r5, #0
-	add r6, sb, #0x5c
+	add r6, r9, #0x5c
 	mov r4, r5
 _02121520:
 	mov r0, r6
@@ -2288,11 +2288,11 @@ _02121520:
 	add r6, r6, #0x18
 	blt _02121520
 	add sp, sp, #0x5c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02121550:
 	cmp r8, #0
 	addeq sp, sp, #0x5c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, _021216f8 ; =gItemManager
 	mov r1, #0x21
 	ldr r0, [r0]
@@ -2358,7 +2358,7 @@ _02121638:
 	beq _0212165c
 	mov r3, #0
 	str r3, [sp]
-	add r0, sb, #0x128
+	add r0, r9, #0x128
 	mov r1, #0xcf
 	mov r2, #4
 	str r3, [sp, #4]
@@ -2368,7 +2368,7 @@ _0212165c:
 	beq _02121680
 	mov r3, #0
 	str r3, [sp]
-	add r0, sb, #0x1b0
+	add r0, r9, #0x1b0
 	mov r1, #0xcf
 	mov r2, #5
 	str r3, [sp, #4]
@@ -2378,7 +2378,7 @@ _02121680:
 	beq _021216a4
 	mov r3, #0
 	str r3, [sp]
-	add r0, sb, #0x238
+	add r0, r9, #0x238
 	mov r1, #0xcf
 	mov r2, #6
 	str r3, [sp, #4]
@@ -2386,16 +2386,16 @@ _02121680:
 _021216a4:
 	cmp r8, #0
 	addeq sp, sp, #0x5c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	mov r3, #0
 	str r3, [sp]
-	add r0, sb, #0x2c0
+	add r0, r9, #0x2c0
 	mov r1, #0xcf
 	mov r2, #7
 	str r3, [sp, #4]
 	bl func_02034b0c
 	add sp, sp, #0x5c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0212113c
 _021216d4: .word data_027e0618
@@ -2490,21 +2490,21 @@ _021217e0: .word data_02056be4
 	.global func_ov15_021217e4
 	arm_func_start func_ov15_021217e4
 func_ov15_021217e4: ; 0x021217e4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
-	mov sb, r1
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
+	mov r9, r1
 	mov r6, r0
-	mov r0, sb
+	mov r0, r9
 	mov r5, r2
 	mov r4, r3
 	bl func_ov00_020a5e9c
 	movs r7, r0
 	mov r8, #0
 	bne _021218b0
-	ldrb r7, [sb, #0x12]
+	ldrb r7, [r9, #0x12]
 	ldr r0, _02121970 ; =data_027e0e60
 	add r1, r7, #0xa6
 	ldr r0, [r0]
-	add sb, r1, #0x50000
+	add r9, r1, #0x50000
 	bl func_ov00_02082d08
 	cmp r0, #3
 	addls pc, pc, r0, lsl #2
@@ -2557,18 +2557,18 @@ _021218b0:
 	bl func_ov00_0209d748
 	mvn r1, #0
 	cmp r0, r1
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	cmp r0, #0x11
 	bne _021218f0
 	ldr r1, _02121978 ; =data_027e0fe4
 	ldr r1, [r1]
 	ldrb r1, [r1, #0x29]
 	cmp r1, #0
-	ldrne sb, _0212197c ; =0x000500aa
-	addeq sb, r0, #0xb7
+	ldrne r9, _0212197c ; =0x000500aa
+	addeq r9, r0, #0xb7
 	b _021218f4
 _021218f0:
-	add sb, r0, #0xb7
+	add r9, r0, #0xb7
 _021218f4:
 	ldr r0, _02121974 ; =data_027e0f7c
 	mov r1, r7
@@ -2587,11 +2587,11 @@ _021218f4:
 	bgt _0212193c
 	bl func_ov00_020a3fc0
 	cmp r0, #0
-	ldreq sb, _02121980 ; =0x000500a5
+	ldreq r9, _02121980 ; =0x000500a5
 _0212193c:
 	mov r8, #5
 _02121940:
-	mov r1, sb
+	mov r1, r9
 	cmp r4, #0
 	mov r2, r5
 	add r0, r6, #0x348
@@ -2602,7 +2602,7 @@ _02121940:
 	ldr r0, [r0]
 	mov r2, #1
 	bl func_ov00_020cfc9c
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov15_021217e4
 _02121970: .word data_027e0e60
@@ -3326,7 +3326,7 @@ _021222b8: .word data_027e0764
 	.global func_ov15_021222bc
 	arm_func_start func_ov15_021222bc
 func_ov15_021222bc: ; 0x021222bc
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #0x60
 	ldr r2, _02122638 ; =data_027e0f90
 	mov r4, r1
@@ -3335,13 +3335,13 @@ func_ov15_021222bc: ; 0x021222bc
 	ldrsh r1, [r2, #0xa]
 	cmp r1, #0
 	addle sp, sp, #0x60
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	ldr r1, _0212263c ; =0x42554949
 	cmp r4, r1
 	bne _021222fc
 	bl func_ov15_02122674
 	add sp, sp, #0x60
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _021222fc:
 	ldr r0, _02122640 ; =data_027e0f94
 	add r3, sp, #0x48
@@ -3382,21 +3382,21 @@ _02122384:
 	cmp r4, r0
 	bne _021224dc
 	ldr r0, [r5, #0x48]
-	ldr sb, _02122658 ; =data_027e0764
+	ldr r9, _02122658 ; =data_027e0764
 	str r0, [sp, #0x54]
 	ldr r0, [r5, #0x4c]
-	ldr r1, [sb]
+	ldr r1, [r9]
 	str r0, [sp, #0x58]
 	ldr r0, [r5, #0x50]
 	mov r3, #0
 	str r0, [sp, #0x5c]
-	ldmib sb, {r0, r7}
+	ldmib r9, {r0, r7}
 	umull r10, r2, r7, r1
 	mla r2, r7, r0, r2
-	ldr r6, [sb, #0xc]
-	ldr ip, [sb, #0x10]
+	ldr r6, [r9, #0xc]
+	ldr ip, [r9, #0x10]
 	mla r2, r6, r1, r2
-	ldr r8, [sb, #0x14]
+	ldr r8, [r9, #0x14]
 	adds r1, ip, r10
 	adc r0, r8, r2
 	mov r2, r3, lsl #0x2
@@ -3404,8 +3404,8 @@ _02122384:
 	add r2, r2, #3
 	and r2, r2, #0xff
 	mov lr, r3
-	str r1, [sb]
-	str r0, [sb, #4]
+	str r1, [r9]
+	str r0, [r9, #4]
 	strh lr, [sp, #0x1e]
 	strh r2, [sp, #0x1c]
 	cmp r2, #4
@@ -3421,9 +3421,9 @@ _02122384:
 	moveq lr, r0
 	umullne r6, lr, r0, r2
 	mlane lr, r0, r3, lr
-	str r1, [sb]
+	str r1, [r9]
 	mlane lr, r3, r2, lr
-	str r0, [sb, #4]
+	str r0, [r9, #4]
 _0212243c:
 	and r2, lr, #0xff
 	strh r2, [sp, #0x20]
@@ -3442,24 +3442,24 @@ _02122450:
 	mla r6, ip, r1, r6
 	adds r8, r7, r8
 	ldr r0, [r3, #0x14]
-	umull r10, sb, lr, r8
+	umull r10, r9, lr, r8
 	adc r1, r0, r6
-	mla sb, lr, r1, sb
+	mla r9, lr, r1, r9
 	str r8, [r3]
-	mla sb, ip, r8, sb
+	mla r9, ip, r8, r9
 	adds r6, r7, r10
-	adc sb, r0, sb
+	adc r9, r0, r9
 	mov r0, #3
 	umull r7, r10, r1, r0
 	str r1, [r3, #4]
 	str r6, [r3]
 	mov r6, #0
-	umull r7, r8, sb, r2
-	str sb, [r3, #4]
+	umull r7, r8, r9, r2
+	str r9, [r3, #4]
 	mla r10, r1, r6, r10
 	mov r3, r6
 	mla r10, r3, r0, r10
-	mla r8, sb, r6, r8
+	mla r8, r9, r6, r8
 	and r1, r10, #0xff
 	mla r8, r3, r2, r8
 	sub r0, r2, #0x8000
@@ -3482,12 +3482,12 @@ _021224dc:
 	mov r0, #0
 	ldr r3, _02122664 ; =0x00001001
 	adc r1, r1, r8
-	umull r8, sb, r1, r3
+	umull r8, r9, r1, r3
 	str r2, [r7]
-	mla sb, r1, r0, sb
+	mla r9, r1, r0, r9
 	mov r8, r0
-	mla sb, r8, r3, sb
-	add r3, sb, #0x2000
+	mla r9, r8, r3, r9
+	add r3, r9, #0x2000
 	rsb r8, r3, #0
 	ldr r3, [r6]
 	ldr r6, _02122658 ; =data_027e0764
@@ -3497,21 +3497,21 @@ _021224dc:
 	str r8, [sp, #0x18]
 	ldr r8, [r6, #8]
 	ldr r0, [r3, #4]
-	umull ip, sb, r8, r2
-	mla sb, r8, r1, sb
+	umull ip, r9, r8, r2
+	mla r9, r8, r1, r9
 	ldr r3, [r0, #0x160]
 	ldr r7, [r6, #0xc]
 	add r0, r0, #0x200
 	cmp r3, #3
 	ldrsh r0, [r0, #0x26]
-	mla sb, r7, r2, sb
+	mla r9, r7, r2, r9
 	subeq r0, r0, #0x8000
 	moveq r0, r0, lsl #0x10
 	ldr r8, [r6, #0x10]
 	moveq r0, r0, asr #0x10
 	ldr r1, [r6, #0x14]
 	adds ip, r8, ip
-	adc r2, r1, sb
+	adc r2, r1, r9
 	ldr r3, _02122668 ; =0x00002aab
 	str ip, [r6]
 	mov r1, #0
@@ -3545,7 +3545,7 @@ _021225f0:
 	ldreq r0, [r5, #0x164]
 	addeq sp, sp, #0x60
 	streq r0, [r5, #0x160]
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	add r1, r5, #0x168
 	str r1, [sp]
 	ldr r0, _02122670 ; =data_027e0fe8
@@ -3555,7 +3555,7 @@ _021225f0:
 	mov r1, r4
 	bl func_ov00_020c4048
 	add sp, sp, #0x60
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov15_021222bc
 _02122638: .word data_027e0f90
@@ -3577,7 +3577,7 @@ _02122670: .word data_027e0fe8
 	.global func_ov15_02122674
 	arm_func_start func_ov15_02122674
 func_ov15_02122674: ; 0x02122674
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0xe4
 	ldr r1, _02122d9c ; =data_027e0f94
 	add r3, sp, #0xc0
@@ -3593,7 +3593,7 @@ func_ov15_02122674: ; 0x02122674
 	moveq r0, #0
 	addeq sp, sp, #0xe4
 	streq r0, [r4, #0x160]
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r3, [sp, #0xd8]
 	ldr r2, [sp, #0xdc]
 	ldr r1, [sp, #0xe0]
@@ -3612,7 +3612,7 @@ func_ov15_02122674: ; 0x02122674
 	movne r0, #0
 	addne sp, sp, #0xe4
 	strne r0, [r4, #0x160]
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r0, sp, #0xc0
 	add r1, sp, #0xd8
 	bl func_ov00_020ce2f0
@@ -3620,7 +3620,7 @@ func_ov15_02122674: ; 0x02122674
 	movlt r0, #0
 	addlt sp, sp, #0xe4
 	strlt r0, [r4, #0x160]
-	ldmltia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmltia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldrsh r5, [sp, #0x20]
 	ldr r2, [sp, #0xd8]
 	ldr r1, [sp, #0xdc]
@@ -3699,7 +3699,7 @@ _02122794:
 	mov r0, r0, lsr #0x10
 	mov r0, r0, asr #0x4
 	mov r11, r0, lsl #0x1
-	add sb, r7, #1
+	add r9, r7, #1
 	mov r10, r7, lsl #0x1
 	add r8, r11, #1
 	ldr r2, [sp, #0xd8]
@@ -3708,8 +3708,8 @@ _02122794:
 	ldr r5, _02122da4 ; =data_02050f54
 	mov r7, r11, lsl #0x1
 	ldrsh r11, [r5, r10]
-	mov sb, sb, lsl #0x1
-	ldrsh sb, [r5, sb]
+	mov r9, r9, lsl #0x1
+	ldrsh r9, [r5, r9]
 	mov r10, r11, asr #0x1f
 	mov r10, r10, lsl #0xd
 	str r1, [sp, #0x88]
@@ -3719,7 +3719,7 @@ _02122794:
 	mov r8, r8, lsl #0x1
 	ldrsh r7, [r5, r7]
 	ldrsh r5, [r5, r8]
-	mov r8, sb, asr #0x1f
+	mov r8, r9, asr #0x1f
 	mov r8, r8, lsl #0xd
 	strh r6, [sp, #0x58]
 	str r3, [sp, #0x44]
@@ -3732,8 +3732,8 @@ _02122794:
 	mov r3, r3, lsr #0xc
 	orr r3, r3, r10, lsl #20
 	add r3, r2, r3
-	adds r10, r1, sb, lsl #13
-	orr r8, r8, sb, lsr #19
+	adds r10, r1, r9, lsl #13
+	orr r8, r8, r9, lsr #19
 	str r3, [sp, #0x9c]
 	adc r3, r8, #0
 	mov r8, r10, lsr #0xc
@@ -3775,7 +3775,7 @@ _02122794:
 	moveq r0, #0
 	addeq sp, sp, #0xe4
 	streq r0, [r4, #0x160]
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	mov r0, #1
 	strh r0, [sp, #0x5a]
 	add r1, sp, #0x3c
@@ -3799,7 +3799,7 @@ _02122794:
 	str r0, [r4, #0x160]
 	add sp, sp, #0xe4
 	strb r0, [r6, #0x118]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _021229e8:
 	ldr r0, _02122db0 ; =data_027e0fe4
 	add r1, sp, #0x3c
@@ -3816,7 +3816,7 @@ _021229e8:
 	strb r0, [r5, #0x118]
 	add sp, sp, #0xe4
 	str r0, [r4, #0x160]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02122a28:
 	ldr r0, [sp, #0x44]
 	add r1, sp, #0xcc
@@ -3832,7 +3832,7 @@ _02122a28:
 	str r0, [r6, #0x2dc]
 	add sp, sp, #0xe4
 	str r6, [r5, #0x2b0]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02122a64:
 	add r1, r5, #0x4000
 	mov r0, r0, asr #0x10
@@ -3850,7 +3850,7 @@ _02122a64:
 	sub r2, r5, #3
 	ldr r1, [sp, #0xdc]
 	ldr r3, _02122da4 ; =data_02050f54
-	mov sb, r0, lsl #0x1
+	mov r9, r0, lsl #0x1
 	add r7, r8, #1
 	mov r10, r8, lsl #0x1
 	add r6, r0, #1
@@ -3858,7 +3858,7 @@ _02122a64:
 	ldrsh r8, [r3, r8]
 	mov r7, r6, lsl #0x1
 	ldrsh r0, [r3, r10]
-	ldrsh ip, [r3, sb]
+	ldrsh ip, [r3, r9]
 	ldrsh r3, [r3, r7]
 	mov r11, r8, asr #0x1f
 	mov r10, ip, asr #0x1f
@@ -3870,7 +3870,7 @@ _02122a64:
 	mov r11, r10, lsl #0xe
 	ldr r10, [sp, #0xd8]
 	mov r6, r0, asr #0x1f
-	mov sb, r6, lsl #0xc
+	mov r9, r6, lsl #0xc
 	str r10, [sp, #8]
 	mov r10, #0
 	mov r6, r6, lsl #0xe
@@ -3880,14 +3880,14 @@ _02122a64:
 	mov r1, #0x800
 	strh r10, [sp, #0x5a]
 	adds r10, r1, r0, lsl #12
-	orr sb, sb, r0, lsr #20
+	orr r9, r9, r0, lsr #20
 	str r10, [sp, #0xc]
-	adc sb, sb, #0
+	adc r9, r9, #0
 	mov r10, r10, lsr #0xc
-	orr sb, r10, sb, lsl #20
+	orr r9, r10, r9, lsl #20
 	ldr r10, [sp, #8]
-	str sb, [sp, #0x18]
-	add sb, r10, sb
+	str r9, [sp, #0x18]
+	add r9, r10, r9
 	ldr r10, [sp, #0xe0]
 	orr r7, r7, r8, lsr #20
 	str r10, [sp, #0x1c]
@@ -3903,7 +3903,7 @@ _02122a64:
 	add r7, r7, r10
 	mov r0, r0, lsr #0xc
 	orr r0, r0, r6, lsl #20
-	add r0, sb, r0
+	add r0, r9, r0
 	orr r5, r5, r8, lsr #18
 	adds r6, r1, r8, lsl #14
 	str r0, [sp, #0x9c]
@@ -3917,7 +3917,7 @@ _02122a64:
 	adc r0, lr, #0
 	mov r5, r5, lsr #0xc
 	orr r5, r5, r0, lsl #20
-	add r0, sb, r5
+	add r0, r9, r5
 	adds r1, r1, r3, lsl #14
 	orr r11, r11, r3, lsr #18
 	str r0, [sp, #0x90]
@@ -3929,8 +3929,8 @@ _02122a64:
 	str r2, [sp, #0x38]
 	str r2, [sp, #0x2c]
 	str r2, [sp, #0x30]
-	str sb, [sp, #0xd8]
-	str sb, [sp, #0x84]
+	str r9, [sp, #0xd8]
+	str r9, [sp, #0x84]
 	str r10, [sp, #0x10]
 	str r7, [sp, #0xe0]
 	str r7, [sp, #0x8c]
@@ -3951,7 +3951,7 @@ _02122a64:
 	moveq r0, #0
 	addeq sp, sp, #0xe4
 	streq r0, [r4, #0x160]
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	mov r0, #1
 	strh r0, [sp, #0x5a]
 	add r1, sp, #0x2c
@@ -3975,7 +3975,7 @@ _02122a64:
 	str r0, [r4, #0x160]
 	add sp, sp, #0xe4
 	strb r0, [r5, #0x118]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02122c9c:
 	mov r0, #2
 	strh r0, [sp, #0x5a]
@@ -4001,7 +4001,7 @@ _02122c9c:
 	strb r0, [r5, #0x118]
 	add sp, sp, #0xe4
 	strb r0, [r6, #0x118]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02122d00:
 	ldr r0, _02122db0 ; =data_027e0fe4
 	add r1, sp, #0x24
@@ -4025,7 +4025,7 @@ _02122d3c:
 	strb r0, [r7, #0x118]
 	add sp, sp, #0xe4
 	str r0, [r4, #0x160]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02122d58:
 	ldr r0, [sp, #0x34]
 	add r1, sp, #0xcc
@@ -4043,7 +4043,7 @@ _02122d58:
 	str r6, [r7, #0x2b4]
 	str r7, [r6, #0x2b0]
 	add sp, sp, #0xe4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02122674
 _02122d9c: .word data_027e0f94
@@ -4851,7 +4851,7 @@ func_ov15_02123848: ; 0x02123848
 	.global func_ov15_02123878
 	arm_func_start func_ov15_02123878
 func_ov15_02123878: ; 0x02123878
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	ldr r7, _02123910 ; =data_027e0764
 	mov r0, #0
 	ldr r4, [r7]
@@ -4865,17 +4865,17 @@ func_ov15_02123878: ; 0x02123878
 	adds r5, lr, r5
 	adc r4, ip, r6
 	mov r6, #0x64
-	umull r8, sb, r4, r6
+	umull r8, r9, r4, r6
 	cmp r1, #0
 	str r5, [r7]
-	mla sb, r4, r0, sb
+	mla r9, r4, r0, r9
 	mov r1, r0
-	mla sb, r1, r6, sb
+	mla r9, r1, r6, r9
 	str r4, [r7, #4]
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
-	cmp sb, #0x1e
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
+	cmp r9, #0x1e
 	movlt r0, #8
-	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmltia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	umull r8, r6, r3, r5
 	mla r6, r3, r4, r6
 	mla r6, r2, r5, r6
@@ -4888,7 +4888,7 @@ func_ov15_02123878: ; 0x02123878
 	str r8, [r7]
 	str r5, [r7, #4]
 	add r0, r4, #2
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02123878
 _02123910: .word data_027e0764
@@ -5164,7 +5164,7 @@ _02123c44: .word data_ov15_0218988c
 	.global func_ov15_02123c48
 	arm_func_start func_ov15_02123c48
 func_ov15_02123c48: ; 0x02123c48
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	mov r1, #0
 	mov r4, r0
 	bl func_ov15_02123474
@@ -5188,13 +5188,13 @@ func_ov15_02123c48: ; 0x02123c48
 	rsb ip, r3, #0x8000
 	ldr r7, [r2, #8]
 	ldmia r2, {r5, lr}
-	umull sb, r8, r7, r5
+	umull r9, r8, r7, r5
 	mla r8, r7, lr, r8
 	ldr r6, [r2, #0xc]
 	ldr r11, [r2, #0x10]
 	mla r8, r6, r5, r8
 	ldr r10, [r2, #0x14]
-	adds r6, r11, sb
+	adds r6, r11, r9
 	adc r5, r10, r8
 	str r6, [r2]
 	str r5, [r2, #4]
@@ -5223,7 +5223,7 @@ func_ov15_02123c48: ; 0x02123c48
 	str r1, [r4, #0x2a0]
 	mov r0, r4
 	str r1, [r4, #0x2a4]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02123c48
 _02123d38: .word data_ov15_021897c4
@@ -6162,7 +6162,7 @@ _02124a3c: .word data_027e10a4
 	.global func_ov15_02124a40
 	arm_func_start func_ov15_02124a40
 func_ov15_02124a40: ; 0x02124a40
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x1c
 	mov r10, r0
 	mov r5, r1
@@ -6190,7 +6190,7 @@ func_ov15_02124a40: ; 0x02124a40
 	ldrb r0, [r10, #0x118]
 	cmp r0, #0
 	addeq sp, sp, #0x1c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	mov r0, r10
 	bl func_ov15_02125210
 	cmp r0, #0
@@ -6252,7 +6252,7 @@ _02124b6c:
 	ldrb r0, [r10, #0x118]
 	cmp r0, #0
 	addeq sp, sp, #0x1c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02124b9c:
 	mov r1, r5
 	add r0, r10, #0xa4
@@ -6292,15 +6292,15 @@ _02124bbc:
 	mov r2, r2, lsl #0x1
 	mov r4, r4, lsl #0x1
 	ldrsh r7, [r3, r2]
-	ldrsh sb, [r3, r4]
+	ldrsh r9, [r3, r4]
 	rsb r2, r0, #0
 	smull r5, r4, r0, r7
 	adds r0, r5, #0x800
 	mov r5, r0, lsr #0xc
 	adc r4, r4, #0
-	smull r3, r8, r6, sb
+	smull r3, r8, r6, r9
 	adds r3, r3, #0x800
-	smull r0, ip, r2, sb
+	smull r0, ip, r2, r9
 	adc r2, r8, #0
 	adds r0, r0, #0x800
 	mov r3, r3, lsr #0xc
@@ -6320,16 +6320,16 @@ _02124bbc:
 	add r0, r10, #0x48
 	str r4, [sp, #0x10]
 	str r3, [sp, #0x18]
-	mov r8, sb, asr #0x1f
+	mov r8, r9, asr #0x1f
 	mov r6, r7, asr #0x1f
 	bl func_01ff9bc4
 	mov r0, #0x800
 	ldr r3, _02125038 ; =0xfffffb33
 	mvn r11, #0
-	umull r3, ip, sb, r3
+	umull r3, ip, r9, r3
 	adds r3, r3, #0x800
 	mov r4, r3, lsr #0xc
-	mla ip, sb, r11, ip
+	mla ip, r9, r11, ip
 	ldr r3, _02125038 ; =0xfffffb33
 	rsb r5, r0, #0xcd
 	mla ip, r8, r3, ip
@@ -6359,9 +6359,9 @@ _02124bbc:
 	adc r3, r3, #0
 	mov r5, r5, lsr #0xc
 	orr r5, r5, r3, lsl #20
-	umull ip, r11, sb, lr
+	umull ip, r11, r9, lr
 	mov r3, #0
-	mla r11, sb, r3, r11
+	mla r11, r9, r3, r11
 	mla r11, r8, lr, r11
 	adds ip, ip, #0x800
 	adc r3, r11, #0
@@ -6404,8 +6404,8 @@ _02124dc4:
 	rsb r3, r1, #0xcd
 	adds r1, ip, #0x800
 	sub r2, r11, #1
-	umull r11, r7, sb, r3
-	mla r7, sb, r2, r7
+	umull r11, r7, r9, r3
+	mla r7, r9, r2, r7
 	adc r0, r0, #0
 	mov r1, r1, lsr #0xc
 	orr r1, r1, r0, lsl #20
@@ -6558,7 +6558,7 @@ _02124ffc:
 	strb r3, [r10, #0x2f8]
 	bl func_ov15_02184a40
 	add sp, sp, #0x1c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02124a40
 _0212502c: .word data_027e0e60
@@ -6913,7 +6913,7 @@ func_ov15_02125444: ; 0x02125444
 	.global func_ov15_02125474
 	arm_func_start func_ov15_02125474
 func_ov15_02125474: ; 0x02125474
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0xc
 	mov r1, #0x2000
 	mov r4, r0
@@ -6951,11 +6951,11 @@ func_ov15_02125474: ; 0x02125474
 	ldr r1, [r4, #0x88]
 	add r2, sp, #0
 	str r1, [r4, #0x98]
-	ldr sb, [lr]
+	ldr r9, [lr]
 	add r1, r4, #0x48
-	str sb, [r4, #0xa8]
-	ldr sb, [lr, #4]
-	str sb, [r4, #0xac]
+	str r9, [r4, #0xa8]
+	ldr r9, [lr, #4]
+	str r9, [r4, #0xac]
 	ldr lr, [lr, #8]
 	str lr, [r4, #0xb0]
 	str r8, [r4, #0xb4]
@@ -6998,7 +6998,7 @@ _021255b4:
 	strb r0, [r4, #0x2a4]
 	mov r0, #1
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02125474
 _021255c8: .word 0x00000333
@@ -11825,10 +11825,10 @@ func_ov15_02129254: ; 0x02129254
 	.global func_ov15_0212925c
 	arm_func_start func_ov15_0212925c
 func_ov15_0212925c: ; 0x0212925c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x74
 	ldr r2, _021296c0 ; =data_027e0e60
-	mov sb, r0
+	mov r9, r0
 	ldr r0, [r2]
 	mov r8, r1
 	add r1, sp, #0x68
@@ -11891,7 +11891,7 @@ _02129300:
 	ldr r1, _021296cc ; =data_ov00_020e2dd8
 	str r1, [r0]
 _0212935c:
-	add r1, sb, r7, lsl #2
+	add r1, r9, r7, lsl #2
 	str r0, [r1, #0x188]
 	mov r0, r8
 	mov r1, r7
@@ -11925,7 +11925,7 @@ _0212935c:
 	bl func_ov00_0207d634
 	cmp r0, #0
 	beq _021293f8
-	mov r0, sb
+	mov r0, r9
 	ldrb r1, [sp, #0x26]
 	bl func_ov15_021296d4
 	cmp r0, #0
@@ -12047,12 +12047,12 @@ _02129598:
 	bl func_ov00_0207d634
 	cmp r0, #0
 	beq _021295ec
-	mov r0, sb
+	mov r0, r9
 	ldrb r1, [sp, #0x26]
 	bl func_ov15_021296d4
 	cmp r0, #0
 	beq _021295ec
-	mov r0, sb
+	mov r0, r9
 	add r1, sp, #0x14
 	mov r5, #4
 	bl func_ov00_02080140
@@ -12076,7 +12076,7 @@ _0212960c:
 	mov r0, #0
 	str r0, [sp]
 	ldr r1, [sp, #0x10]
-	add r0, sb, r7, lsl #2
+	add r0, r9, r7, lsl #2
 	bic r1, r1, #0x1f
 	orr r1, r1, #2
 	orr r1, r1, #0x8000
@@ -12090,7 +12090,7 @@ _0212960c:
 	str r3, [sp, #0x10]
 	blx r5
 	ldr r0, _021296d0 ; =data_027e0f6c
-	add r1, sb, r7, lsl #2
+	add r1, r9, r7, lsl #2
 	ldr r0, [r0]
 	ldr r1, [r1, #0x188]
 	bl func_ov00_02093a5c
@@ -12099,18 +12099,18 @@ _0212960c:
 	bl func_ov00_0207d634
 	cmp r0, #0
 	beq _0212969c
-	mov r0, sb
+	mov r0, r9
 	ldrb r1, [sp, #0x26]
 	bl func_ov15_021296d4
 	cmp r0, #0
 	beq _0212969c
-	add r0, sb, r7, lsl #2
+	add r0, r9, r7, lsl #2
 	ldr r1, [r0, #0x188]
 	mov r0, #0
 	strb r0, [r1, #4]
 	b _021296ac
 _0212969c:
-	add r0, sb, r7, lsl #2
+	add r0, r9, r7, lsl #2
 	ldr r1, [r0, #0x188]
 	mov r0, #1
 	strb r0, [r1, #4]
@@ -12119,7 +12119,7 @@ _021296ac:
 	cmp r7, #4
 	blt _02129300
 	add sp, sp, #0x74
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0212925c
 _021296c0: .word data_027e0e60
@@ -12474,18 +12474,18 @@ _02129a68: .word func_ov00_0208cd1c
 	.global func_ov15_02129a6c
 	arm_func_start func_ov15_02129a6c
 func_ov15_02129a6c: ; 0x02129a6c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x1c
 	mov r7, r2
 	mov r8, r1
 	ldr r2, _02129b14 ; =data_027e0e60
-	mov sb, r0
+	mov r9, r0
 	ldrb r1, [r7, #1]
 	ldr r0, [r2]
 	mov r6, r3
 	bl func_ov00_02083c50
 	mov r5, r0
-	mov r0, sb
+	mov r0, r9
 	ldr r2, [r0]
 	mov r1, r7
 	ldr r2, [r2, #0x60]
@@ -12508,7 +12508,7 @@ func_ov15_02129a6c: ; 0x02129a6c
 	stmib sp, {r1, r6}
 	str r0, [sp, #0xc]
 	ldr r0, _02129b18 ; =data_027e0f68
-	ldrb r2, [sb, #0x13]
+	ldrb r2, [r9, #0x13]
 	ldrb r3, [r7]
 	ldr r0, [r0]
 	mov r1, r8
@@ -12516,7 +12516,7 @@ func_ov15_02129a6c: ; 0x02129a6c
 _02129b08:
 	mov r0, #1
 	add sp, sp, #0x1c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02129a6c
 _02129b14: .word data_027e0e60
@@ -13505,7 +13505,7 @@ _0212a76c:
 	.global func_ov15_0212a780
 	arm_func_start func_ov15_0212a780
 func_ov15_0212a780: ; 0x0212a780
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x7c
 	ldr r2, _0212ad74 ; =data_027e0f94
 	mov r10, r0
@@ -13556,7 +13556,7 @@ _0212a7f8:
 	sub r3, r0, #0x21000
 	mov r2, #0x800
 	sub r4, r1, #4
-	umull sb, r0, r8, r3
+	umull r9, r0, r8, r3
 	mla r0, r8, r4, r0
 	mov r4, r8, asr #0x1f
 	sub r6, r2, #0x20800
@@ -13564,16 +13564,16 @@ _0212a7f8:
 	ldr r7, [sp, #0x70]
 	sub r3, r1, #4
 	umull r4, r8, r7, r6
-	adds r2, sb, #0x800
+	adds r2, r9, #0x800
 	adc r1, r0, #0
-	adds sb, r4, #0x800
+	adds r9, r4, #0x800
 	mov r4, r2, lsr #0xc
 	orr r4, r4, r1, lsl #20
 	mla r8, r7, r3, r8
 	mov r0, r7, asr #0x1f
 	mla r8, r0, r6, r8
 	adc r2, r8, #0
-	mov r0, sb, lsr #0xc
+	mov r0, r9, lsr #0xc
 	orr r0, r0, r2, lsl #20
 	mov r1, #0x800000
 	bl func_01ff9b88
@@ -13808,8 +13808,8 @@ _0212abf8:
 	mov r1, r1, lsl #0x14
 	mov r1, r1, asr #0x10
 	mov r1, r1, lsl #0x10
-	mov sb, r1, lsr #0x10
-	orr r1, sb, r11, lsl #16
+	mov r9, r1, lsr #0x10
+	orr r1, r9, r11, lsl #16
 	str r1, [r5]
 	ldr r3, [r10, #0x64]
 	add r0, sp, #0x24
@@ -13848,7 +13848,7 @@ _0212abf8:
 	mov r2, r2, asr #0x10
 	mov r2, r2, lsl #0x10
 	mov r2, r2, lsr #0x10
-	orr r2, sb, r2, lsl #16
+	orr r2, r9, r2, lsl #16
 	str r2, [r5]
 	ldr r3, [r10, #0x64]
 	ldr r2, [sp, #8]
@@ -13896,7 +13896,7 @@ _0212ad4c:
 	mov r1, #1
 	str r1, [r0]
 	add sp, sp, #0x7c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0212a780
 _0212ad74: .word data_027e0f94
@@ -13986,14 +13986,14 @@ func_ov15_0212ae5c: ; 0x0212ae5c
 	.global func_ov15_0212ae90
 	arm_func_start func_ov15_0212ae90
 func_ov15_0212ae90: ; 0x0212ae90
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x60
 	mov r4, r0
 	ldr r0, [r4, #0x70]
 	mov r6, r1
 	cmp r0, #8
 	addhs sp, sp, #0x60
-	ldmhsia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmhsia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	ldr r0, _0212b2e8 ; =data_027e0f64
 	mov r1, #0
 	ldr r0, [r0]
@@ -14026,12 +14026,12 @@ func_ov15_0212ae90: ; 0x0212ae90
 	str r5, [sp, #0x50]
 	ldr r7, [r2, #8]
 	ldr r5, [r2, #0xc]
-	umull sb, r8, r7, r3
+	umull r9, r8, r7, r3
 	mla r8, r7, r1, r8
 	mla r8, r5, r3, r8
 	ldr r7, [r2, #0x10]
 	ldr r1, [r2, #0x14]
-	adds r3, r7, sb
+	adds r3, r7, r9
 	adc r7, r1, r8
 	str r3, [r2]
 	mov r1, #0
@@ -14068,13 +14068,13 @@ _0212afa0:
 	ldr r2, _0212b2f0 ; =data_027e0764
 	ldr r5, [r2]
 	ldmib r2, {r3, r7}
-	umull sb, r8, r7, r5
+	umull r9, r8, r7, r5
 	mla r8, r7, r3, r8
 	ldr r3, [r2, #0xc]
 	ldr r7, [r2, #0x10]
 	mla r8, r3, r5, r8
 	ldr r3, [r2, #0x14]
-	adds r5, r7, sb
+	adds r5, r7, r9
 	adc r7, r3, r8
 	stmia r2, {r5, r7}
 	cmp r0, #0
@@ -14150,7 +14150,7 @@ _0212b08c:
 	cmp r0, #1
 	cmpne r0, #2
 	addeq sp, sp, #0x60
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	ldr r3, _0212b2f0 ; =data_027e0764
 	mov r2, #0
 	ldr r1, [r3]
@@ -14166,10 +14166,10 @@ _0212b08c:
 	mov r1, #0x33
 	umull r5, r6, r7, r1
 	mla r6, r7, r2, r6
-	ldr sb, [r4, #0x48]
+	ldr r9, [r4, #0x48]
 	mla r6, r2, r1, r6
 	mov r0, #0xc
-	mul r1, sb, r0
+	mul r1, r9, r0
 	ldr r0, _0212b300 ; =data_ov15_02185d00
 	str r8, [r3]
 	ldr r5, [r0, r1]
@@ -14186,7 +14186,7 @@ _0212b08c:
 	orr r2, r2, r1, lsl #20
 	add r8, r5, r2
 	mov r2, #0x29
-	umull r1, sb, r8, r2
+	umull r1, r9, r8, r2
 	mov lr, #0
 	adds r1, r1, #0x800
 	ldr r3, [r4, #0x48]
@@ -14195,10 +14195,10 @@ _0212b08c:
 	mul r1, r3, r1
 	mov r3, #1
 	strb r3, [sp, #0xc]
-	mla sb, r8, lr, sb
+	mla r9, r8, lr, r9
 	mov r3, r8, asr #0x1f
-	mla sb, r3, r2, sb
-	adc r2, sb, #0
+	mla r9, r3, r2, r9
+	adc r2, r9, #0
 	orr ip, ip, r2, lsl #20
 	ldr r3, _0212b304 ; =data_ov15_02185d04
 	ldr r2, _0212b308 ; =data_ov15_02185d06
@@ -14257,7 +14257,7 @@ _0212b08c:
 	str r2, [r0, #0x28]
 	ldr r1, [r1, #0x2c]
 	str r1, [r0, #0x2c]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _0212b2c4:
 	strb lr, [sp]
 	sub r2, sp, #4
@@ -14267,7 +14267,7 @@ _0212b2c4:
 	add r0, r4, #0x6c
 	bl func_ov15_0212b7b4
 	add sp, sp, #0x60
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0212ae90
 _0212b2e8: .word data_027e0f64
@@ -15669,7 +15669,7 @@ _0212c4c8: .word data_027e0f64
 	.global func_ov15_0212c4cc
 	arm_func_start func_ov15_0212c4cc
 func_ov15_0212c4cc: ; 0x0212c4cc
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x18
 	ldr r1, _0212c6a4 ; =data_027e0d38
 	mov r10, r0
@@ -15713,7 +15713,7 @@ _0212c4fc:
 _0212c568:
 	rsb r0, r8, #0xc
 	mov r7, r11
-	mov sb, r0, lsl #0xc
+	mov r9, r0, lsl #0xc
 _0212c574:
 	rsb r0, r7, #0xc
 	mov r3, r0, lsl #0xc
@@ -15722,7 +15722,7 @@ _0212c574:
 	mov r2, r5
 	str r3, [sp]
 	str r6, [sp, #4]
-	str sb, [sp, #8]
+	str r9, [sp, #8]
 	bl func_01ff9bc4
 	ldr r0, [r10, #4]
 	mov r1, r5
@@ -15796,7 +15796,7 @@ _0212c684:
 	cmp r7, #0x19
 	blo _0212c5c0
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0212c4cc
 _0212c6a4: .word data_027e0d38
@@ -17448,7 +17448,7 @@ _0212dd8c: .word 0xffffeccd
 	.global func_ov15_0212dd90
 	arm_func_start func_ov15_0212dd90
 func_ov15_0212dd90: ; 0x0212dd90
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0xb8
 	mov r4, r0
 	ldr r1, [r4, #0x264]
@@ -17599,13 +17599,13 @@ _0212df28:
 	ldrb ip, [sp, #0x3f]
 	ldrb r3, [sp, #0x40]
 	ldrb r2, [sp, #0x41]
-	ldr sb, [sp, #0x2c]
+	ldr r9, [sp, #0x2c]
 	ldr r8, [sp, #0x30]
 	ldr r7, [sp, #0x34]
 	ldr r6, [sp, #0x38]
 	ldr r0, [r0]
 	add r1, sp, #8
-	str sb, [sp, #8]
+	str r9, [sp, #8]
 	str r8, [sp, #0xc]
 	str r7, [sp, #0x10]
 	str r6, [sp, #0x14]
@@ -17630,7 +17630,7 @@ _0212e03c:
 	ldr r1, [r1]
 	strb r0, [r1, #0x4d4]
 	add sp, sp, #0xb8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0212dd90
 _0212e054: .word data_027e0f64
@@ -17823,7 +17823,7 @@ _0212e2bc: .word data_ov15_02190458
 	.global func_ov15_0212e2c0
 	arm_func_start func_ov15_0212e2c0
 func_ov15_0212e2c0: ; 0x0212e2c0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x88
 	mov r4, r0
 	bl _ZN5Actor14GetAngleToLinkEv
@@ -17836,7 +17836,7 @@ func_ov15_0212e2c0: ; 0x0212e2c0
 	ldr r0, [r4, #0x254]
 	cmp r0, #0
 	addne sp, sp, #0x88
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, _0212e770 ; =data_027e0f94
 	add r6, sp, #0x7c
 	ldmia r0, {r0, r1, r2}
@@ -17900,9 +17900,9 @@ func_ov15_0212e2c0: ; 0x0212e2c0
 	mla r7, r6, r3, r7
 	ldr r10, [r2, #0x10]
 	mla r7, lr, ip, r7
-	ldr sb, [r2, #0x14]
+	ldr r9, [r2, #0x14]
 	adds r6, r10, r8
-	adc r3, sb, r7
+	adc r3, r9, r7
 	str r6, [r2]
 	str r3, [r2, #4]
 	mov r2, #0x14000
@@ -17929,7 +17929,7 @@ func_ov15_0212e2c0: ; 0x0212e2c0
 	orr r7, r7, r0, lsl #20
 	cmp r7, #0x12c00
 	addgt sp, sp, #0x88
-	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	cmp r7, #0x2000
 	movle r6, #0xf6
 	ble _0212e494
@@ -17966,14 +17966,14 @@ _0212e4e0:
 	ldr r3, _0212e784 ; =0x0000014a
 	ldr r1, [r8]
 	ldmib r8, {r0, r2}
-	umull r10, sb, r2, r1
-	mla sb, r2, r0, sb
+	umull r10, r9, r2, r1
+	mla r9, r2, r0, r9
 	ldr r0, [r8, #0xc]
 	ldr r2, [r8, #0x10]
-	mla sb, r0, r1, sb
+	mla r9, r0, r1, r9
 	ldr r0, [r8, #0x14]
 	adds r1, r2, r10
-	adc r0, r0, sb
+	adc r0, r0, r9
 	str r1, [r8]
 	mov r2, r0, lsr #0x10
 	mov r2, r2, lsl #0x10
@@ -17983,13 +17983,13 @@ _0212e4e0:
 	mov r2, r2, lsl #0x10
 	mov r2, r2, lsr #0x10
 	mov r1, #0
-	umull r10, sb, r2, r3
+	umull r10, r9, r2, r3
 	str r0, [r8, #4]
-	mla sb, r2, r1, sb
+	mla r9, r2, r1, r9
 	mov r0, r1
 	adds r8, r10, #0x800
-	mla sb, r0, r3, sb
-	adc r0, sb, #0
+	mla r9, r0, r3, r9
+	adc r0, r9, #0
 	mov r1, r8, lsr #0xc
 	orr r1, r1, r0, lsl #20
 	mov r0, r1, lsl #0x10
@@ -18026,10 +18026,10 @@ _0212e4e0:
 	ldrsh r2, [r8, r2]
 	ldrsh r1, [r8, r1]
 	add r0, r4, #0x48
-	smull r11, sb, r2, r6
+	smull r11, r9, r2, r6
 	smull r8, r2, r1, r6
 	adds r6, r11, #0x800
-	adc r1, sb, #0
+	adc r1, r9, #0
 	mov r6, r6, lsr #0xc
 	orr r6, r6, r1, lsl #20
 	adds r8, r8, #0x800
@@ -18038,10 +18038,10 @@ _0212e4e0:
 	orr r2, r2, r1, lsl #20
 	add r8, r2, #0
 	ldmia r0, {r0, r1, r2}
-	ldr sb, _0212e790 ; =0x000004cd
+	ldr r9, _0212e790 ; =0x000004cd
 	add r10, sp, #0x58
 	stmia r10, {r0, r1, r2}
-	str sb, [sp, #0x54]
+	str r9, [sp, #0x54]
 	ldr r1, [sp, #8]
 	mov r3, #0
 	add r0, sp, #0x4c
@@ -18089,7 +18089,7 @@ _0212e4e0:
 	bl _ZN12ActorManager8GetActorEP8ActorRef
 	cmp r0, #0
 	addeq sp, sp, #0x88
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	str r6, [r0, #0x60]
 	str r5, [r0, #0x64]
 	str r8, [r0, #0x68]
@@ -18126,7 +18126,7 @@ _0212e730:
 	mov r3, #0
 	bl func_ov00_020ceacc
 	add sp, sp, #0x88
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0212e2c0
 _0212e770: .word data_027e0f94
@@ -18245,7 +18245,7 @@ _0212e8d8:
 	.global func_ov15_0212e8e0
 	arm_func_start func_ov15_0212e8e0
 func_ov15_0212e8e0: ; 0x0212e8e0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	mov r6, r0
 	ldr r0, [r6, #0x130]
 	mov r4, r3
@@ -18266,10 +18266,10 @@ func_ov15_0212e8e0: ; 0x0212e8e0
 	add r1, r1, #0x48
 	bl _ZN5Actor10GetAngleToEP5Vec3p
 	add r1, r6, #0x200
-	ldrsh sb, [r1, #0x6a]
+	ldrsh r9, [r1, #0x6a]
 	ldrb r8, [r6, #0x26c]
 	mov ip, #0
-	mov r11, sb, asr #0x1
+	mov r11, r9, asr #0x1
 	mov r1, r11, lsl #0x10
 	add r1, r7, r1, asr #16
 	mov r1, r1, lsl #0x10
@@ -18293,7 +18293,7 @@ _0212e96c:
 	movlt r2, r10
 	movlt ip, r3
 _0212e998:
-	add r7, r7, sb
+	add r7, r7, r9
 	mov r7, r7, lsl #0x10
 	mov r7, r7, asr #0x10
 	add r3, r3, #1
@@ -18305,7 +18305,7 @@ _0212e9b0:
 	mov r0, #1
 	add r2, r2, #0x8000
 	add r2, r11, r2
-	mla r2, sb, ip, r2
+	mla r2, r9, ip, r2
 	orr r1, r1, r0, lsl ip
 	mov r0, r2, lsl #0x10
 	strb r1, [r6, #0x26d]
@@ -18334,8 +18334,8 @@ _0212e9e4:
 	orr r1, r1, r2, lsr #19
 	ldr r3, _0212eb88 ; =data_027e0f94
 	adc r0, r1, #0
-	mov sb, r8, lsr #0xc
-	orr sb, sb, r0, lsl #20
+	mov r9, r8, lsr #0xc
+	orr r9, r9, r0, lsl #20
 	ldmia r3, {r1, r2, r3}
 	mov r0, #0x9000
 	b _0212eae4
@@ -18349,38 +18349,38 @@ _0212ea44:
 	beq _0212eaa4
 	ldr r8, _0212eb84 ; =data_ov15_0218a464
 	ldr r6, [r6, #0x250]
-	ldr sb, [r8, #0x18]
+	ldr r9, [r8, #0x18]
 	mov r8, #0x800
-	smull r10, sb, r6, sb
+	smull r10, r9, r6, r9
 	adds r10, r10, #0x800
-	adc sb, sb, #0
+	adc r9, r9, #0
 	mov r10, r10, lsr #0xc
-	orr r10, r10, sb, lsl #20
-	mov sb, r10, asr #0x1f
-	mov sb, sb, lsl #0xd
+	orr r10, r10, r9, lsl #20
+	mov r9, r10, asr #0x1f
+	mov r9, r9, lsl #0xd
 	adds r11, r8, r10, lsl #13
-	orr sb, sb, r10, lsr #19
-	adc r8, sb, #0
-	mov sb, r11, lsr #0xc
-	orr sb, sb, r8, lsl #20
+	orr r9, r9, r10, lsr #19
+	adc r8, r9, #0
+	mov r9, r11, lsr #0xc
+	orr r9, r9, r8, lsl #20
 	b _0212eae4
 _0212eaa4:
 	ldr r8, _0212eb84 ; =data_ov15_0218a464
 	ldr r6, [r6, #0x250]
-	ldr sb, [r8, #0x1c]
+	ldr r9, [r8, #0x1c]
 	mov r8, #0x800
-	smull r10, sb, r6, sb
+	smull r10, r9, r6, r9
 	adds r10, r10, #0x800
-	adc sb, sb, #0
+	adc r9, r9, #0
 	mov r10, r10, lsr #0xc
-	orr r10, r10, sb, lsl #20
-	mov sb, r10, asr #0x1f
-	mov sb, sb, lsl #0xd
+	orr r10, r10, r9, lsl #20
+	mov r9, r10, asr #0x1f
+	mov r9, r9, lsl #0xd
 	adds r11, r8, r10, lsl #13
-	orr sb, sb, r10, lsr #19
-	adc r8, sb, #0
-	mov sb, r11, lsr #0xc
-	orr sb, sb, r8, lsl #20
+	orr r9, r9, r10, lsr #19
+	adc r8, r9, #0
+	mov r9, r11, lsr #0xc
+	orr r9, r9, r8, lsl #20
 _0212eae4:
 	ldr r8, [sp, #0x28]
 	mov r7, r7, lsl #0x10
@@ -18401,11 +18401,11 @@ _0212eae4:
 	ldrsh r7, [r8, r7]
 	mov r11, r10, lsl #0x1
 	ldrsh r10, [r8, r6]
-	mul r6, r4, sb
+	mul r6, r4, r9
 	ldrsh r8, [r8, r11]
 	mul r4, r7, r0
-	mul r7, r10, sb
-	mul sb, r8, r0
+	mul r7, r10, r9
+	mul r9, r8, r0
 	add r6, r6, #0x800
 	add r0, r7, #0x800
 	add r7, r4, #0x800
@@ -18413,13 +18413,13 @@ _0212eae4:
 	add r4, r4, r7, asr #12
 	add r1, r1, r4
 	str r1, [r5]
-	add r1, sb, #0x800
+	add r1, r9, #0x800
 	mov r0, r0, asr #0xc
 	add r0, r0, r1, asr #12
 	str r2, [r5, #4]
 	add r0, r3, r0
 	str r0, [r5, #8]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0212e8e0
 _0212eb7c: .word data_027e0fac
@@ -18573,9 +18573,9 @@ _0212ed74: .word data_ov15_02185d4a
 	.global func_ov15_0212ed78
 	arm_func_start func_ov15_0212ed78
 func_ov15_0212ed78: ; 0x0212ed78
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #0xc
-	mov sb, r0
+	mov r9, r0
 	mov r10, r1
 	mov r8, r2
 	mov r7, r3
@@ -18584,15 +18584,15 @@ func_ov15_0212ed78: ; 0x0212ed78
 	bl _ZN5Actor12XzDistanceToEP5Vec3p
 	mov r4, r0
 	mov r2, r10
-	add r0, sb, #0x48
+	add r0, r9, #0x48
 	mov r1, #0x2000
 	bl func_ov00_020ce284
 	cmp r0, #0
-	mov r0, sb
+	mov r0, r9
 	mov r1, r10
 	beq _0212ee3c
 	bl _ZN5Actor10GetAngleToEP5Vec3p
-	ldrsh r1, [sb, #0x78]
+	ldrsh r1, [r9, #0x78]
 	sub r0, r0, r1
 	mov r0, r0, lsl #0x10
 	movs r2, r0, asr #0x10
@@ -18600,7 +18600,7 @@ func_ov15_0212ed78: ; 0x0212ed78
 	movmi r0, r0, lsl #0x10
 	movmi r2, r0, asr #0x10
 	ldrsh r1, [r8]
-	add r0, sb, #0x100
+	add r0, r9, #0x100
 	cmp r2, #0x4000
 	strh r1, [r0, #0xd4]
 	ldr r1, [r7]
@@ -18620,12 +18620,12 @@ func_ov15_0212ed78: ; 0x0212ed78
 	orr r1, r1, r0, lsl #20
 _0212ee2c:
 	ldr r2, [r5]
-	add r0, sb, #0x24c
+	add r0, r9, #0x24c
 	bl Approach_thunk
 	b _0212ee94
 _0212ee3c:
 	bl _ZN5Actor10GetAngleToEP5Vec3p
-	add r1, sb, #0x100
+	add r1, r9, #0x100
 	strh r0, [r1, #0xd4]
 	cmp r4, #0x4000
 	ldrge r1, [r6]
@@ -18645,17 +18645,17 @@ _0212ee3c:
 	orr r1, r1, r0, lsl #20
 _0212ee88:
 	ldr r2, [r5]
-	add r0, sb, #0x24c
+	add r0, r9, #0x24c
 	bl Approach_thunk
 _0212ee94:
-	add r0, sb, #0x100
+	add r0, r9, #0x100
 	ldrsh r1, [r0, #0xd4]
-	add r0, sb, #0x78
+	add r0, r9, #0x78
 	mov r2, #0x2d8
 	bl func_0202b154
-	ldrh r0, [sb, #0x78]
+	ldrh r0, [r9, #0x78]
 	ldr r2, _0212ef24 ; =data_02050f54
-	ldr r6, [sb, #0x24c]
+	ldr r6, [r9, #0x24c]
 	mov r0, r0, asr #0x4
 	mov r1, r0, lsl #0x1
 	add r0, r1, #1
@@ -18674,7 +18674,7 @@ _0212ee94:
 	adc r0, r1, #0
 	mov r3, r2, lsr #0xc
 	orr r3, r3, r0, lsl #20
-	add r0, sb, #0x48
+	add r0, r9, #0x48
 	add r1, sp, #0
 	mov r2, r0
 	str r5, [sp]
@@ -18682,7 +18682,7 @@ _0212ee94:
 	str r3, [sp, #8]
 	bl func_01ff9bc4
 	add sp, sp, #0xc
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0212ed78
 _0212ef20: .word data_ov15_0218a464
@@ -19729,7 +19729,7 @@ _0212fd20: .word data_ov15_0218a5ac
 	.global func_ov15_0212fd24
 	arm_func_start func_ov15_0212fd24
 func_ov15_0212fd24: ; 0x0212fd24
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x274
 	mov r4, r1
 	mov r5, r0
@@ -19771,11 +19771,11 @@ _0212fd5c:
 	umull r8, r7, r6, r2
 	mla r7, r6, r1, r7
 	ldr r1, [r3, #0xc]
-	ldr sb, [r3, #0x10]
+	ldr r9, [r3, #0x10]
 	mla r7, r1, r2, r7
 	mov r1, r0, lsl #0x2
 	ldr r6, [r3, #0x14]
-	adds r8, sb, r8
+	adds r8, r9, r8
 	adc r2, r6, r7
 	str r8, [r3]
 	ldr r0, _02130528 ; =data_ov15_02185dc8
@@ -19831,14 +19831,14 @@ _0212fe8c:
 	strh r1, [r5, #0x7a]
 	bl func_ov00_0209a4f4
 	ldr r1, _02130534 ; =data_027e0f94
-	mvn sb, #0
+	mvn r9, #0
 	ldr r3, [r1]
 	ldr r2, [r1, #4]
 	mov r8, #0x32
 	mov r7, #2
 	mov r6, #3
 	ldr r0, _02130538 ; =data_027e0f64
-	str sb, [sp, #0x1c8]
+	str r9, [sp, #0x1c8]
 	strb r8, [sp, #0x1cd]
 	strb r7, [sp, #0x1ce]
 	strb r6, [sp, #0x1cf]
@@ -19851,7 +19851,7 @@ _0212fe8c:
 	add r1, sp, #0x15c
 	bl func_ov00_02087d34
 	ldr r0, [sp, #0x15c]
-	mov sb, #1
+	mov r9, #1
 	str r0, [r5, #0x35c]
 	ldr r0, [sp, #0x160]
 	str r0, [r5, #0x360]
@@ -19916,7 +19916,7 @@ _0212fe8c:
 	ldr r2, [sp, #0x16c]
 	ldr r1, [sp, #0x170]
 	ldr r0, [sp, #0x174]
-	strb sb, [sp, #0x1d8]
+	strb r9, [sp, #0x1d8]
 	str r8, [sp, #0x1f0]
 	str r7, [sp, #0x1f4]
 	str r6, [sp, #0x1f8]
@@ -19929,7 +19929,7 @@ _0212fe8c:
 	str r0, [sp, #0x210]
 	ldr r0, [sp, #0x194]
 	ldr r10, [sp, #0x180]
-	ldr sb, [sp, #0x184]
+	ldr r9, [sp, #0x184]
 	ldr r8, [sp, #0x188]
 	str r0, [sp, #0x228]
 	ldr r0, [sp, #0x1ac]
@@ -19938,8 +19938,8 @@ _0212fe8c:
 	ldr r1, [sp, #0x190]
 	str r10, [sp, #0x214]
 	ldr r10, [sp, #0x198]
-	str sb, [sp, #0x218]
-	ldr sb, [sp, #0x19c]
+	str r9, [sp, #0x218]
+	ldr r9, [sp, #0x19c]
 	str r8, [sp, #0x21c]
 	ldr r8, [sp, #0x1a0]
 	str r0, [sp, #0x240]
@@ -19955,8 +19955,8 @@ _0212fe8c:
 	ldr r1, [sp, #0x1a8]
 	str r10, [sp, #0x22c]
 	ldr r10, [sp, #0x1b0]
-	str sb, [sp, #0x230]
-	ldr sb, [sp, #0x1b4]
+	str r9, [sp, #0x230]
+	ldr r9, [sp, #0x1b4]
 	str r8, [sp, #0x234]
 	ldr r8, [sp, #0x1b8]
 	str r2, [sp, #0x238]
@@ -19966,7 +19966,7 @@ _0212fe8c:
 	ldr r0, [r0]
 	add r1, sp, #0x1c4
 	str r10, [sp, #0x244]
-	str sb, [sp, #0x248]
+	str r9, [sp, #0x248]
 	str r8, [sp, #0x24c]
 	strb r7, [sp, #0x250]
 	strb r6, [sp, #0x251]
@@ -20044,7 +20044,7 @@ _02130188:
 	bl func_ov15_02141344
 	cmp r0, #0
 	addeq sp, sp, #0x274
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _021301f8:
 	mov r1, #0
 	strb r1, [r5, #0x490]
@@ -20170,36 +20170,36 @@ _02130220:
 	ldr r1, [sp, #0x10]
 	ldr r0, [sp, #0x14]
 	ldr r10, [sp, #0x44]
-	ldr sb, [sp, #0x48]
+	ldr r9, [sp, #0x48]
 	ldr r8, [sp, #0x4c]
 	str r10, [sp, #0xd8]
 	ldr r10, [sp, #0x50]
-	str sb, [sp, #0xdc]
-	ldr sb, [sp, #0x54]
+	str r9, [sp, #0xdc]
+	ldr r9, [sp, #0x54]
 	str r8, [sp, #0xe0]
 	ldr r8, [sp, #0x58]
 	str r10, [sp, #0xe4]
 	ldr r10, [sp, #0x5c]
-	str sb, [sp, #0xe8]
-	ldr sb, [sp, #0x6c]
+	str r9, [sp, #0xe8]
+	ldr r9, [sp, #0x6c]
 	str r8, [sp, #0xec]
 	ldr r8, [sp, #0x70]
 	str r10, [sp, #0xf0]
 	ldr r10, [sp, #0x74]
-	str sb, [sp, #0x100]
-	ldr sb, [sp, #0x78]
+	str r9, [sp, #0x100]
+	ldr r9, [sp, #0x78]
 	str r8, [sp, #0x104]
 	ldr r8, [sp, #0x7c]
 	str r10, [sp, #0x108]
 	ldr r10, [sp, #0x80]
-	str sb, [sp, #0x10c]
-	ldr sb, [sp, #0x84]
+	str r9, [sp, #0x10c]
+	ldr r9, [sp, #0x84]
 	str r8, [sp, #0x110]
 	ldr r8, [sp, #0x88]
 	str r10, [sp, #0x114]
 	ldr r10, [sp, #0x8c]
-	str sb, [sp, #0x118]
-	ldr sb, [sp, #0x90]
+	str r9, [sp, #0x118]
+	ldr r9, [sp, #0x90]
 	str r8, [sp, #0x11c]
 	ldr r8, [sp, #0x94]
 	ldrb r7, [sp, #0xa4]
@@ -20207,8 +20207,8 @@ _02130220:
 	ldrb r3, [sp, #0xa6]
 	str r10, [sp, #0x120]
 	ldr r10, [sp, #0x98]
-	str sb, [sp, #0x124]
-	ldr sb, [sp, #0x9c]
+	str r9, [sp, #0x124]
+	ldr r9, [sp, #0x9c]
 	str r8, [sp, #0x128]
 	ldr r8, [sp, #0xa0]
 	str r10, [sp, #0x12c]
@@ -20218,7 +20218,7 @@ _02130220:
 	str r0, [sp, #0xf4]
 	str r1, [sp, #0xf8]
 	str r2, [sp, #0xfc]
-	str sb, [sp, #0x130]
+	str r9, [sp, #0x130]
 	str r8, [sp, #0x134]
 	strb r7, [sp, #0x138]
 	strb r6, [sp, #0x139]
@@ -20250,7 +20250,7 @@ _02130510:
 	str r0, [r5, #0x138]
 	str r4, [r5, #0x130]
 	add sp, sp, #0x274
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0212fd24
 _02130524: .word data_027e0764
@@ -21176,7 +21176,7 @@ _021311c4: .word 0x0000010f
 	.global func_ov15_021311c8
 	arm_func_start func_ov15_021311c8
 func_ov15_021311c8: ; 0x021311c8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x284
 	mov r4, r0
 	ldr r5, [r4, #0x4c]
@@ -21445,15 +21445,15 @@ _021315c0:
 	stmia r6, {r0, r1}
 	ldr r2, [sp, #0x54]
 	ldr r1, [sp, #0x58]
-	ldr sb, [sp, #0x5c]
+	ldr r9, [sp, #0x5c]
 	ldr r8, [sp, #0x60]
 	ldr r3, [sp, #0x64]
 	str r2, [sp, #0xe8]
 	ldr r2, [sp, #0x68]
 	str r1, [sp, #0xec]
 	ldr r1, [sp, #0x6c]
-	str sb, [sp, #0xf0]
-	ldr sb, [sp, #0x70]
+	str r9, [sp, #0xf0]
+	ldr r9, [sp, #0x70]
 	str r8, [sp, #0xf4]
 	ldr r8, [sp, #0x74]
 	str r3, [sp, #0xf8]
@@ -21462,8 +21462,8 @@ _021315c0:
 	ldr r2, [sp, #0x7c]
 	str r1, [sp, #0x100]
 	ldr r1, [sp, #0x80]
-	str sb, [sp, #0x104]
-	ldr sb, [sp, #0x84]
+	str r9, [sp, #0x104]
+	ldr r9, [sp, #0x84]
 	str r8, [sp, #0x108]
 	ldr r8, [sp, #0x88]
 	str r3, [sp, #0x10c]
@@ -21472,8 +21472,8 @@ _021315c0:
 	ldr r2, [sp, #0x90]
 	str r1, [sp, #0x114]
 	ldr r1, [sp, #0x94]
-	str sb, [sp, #0x118]
-	ldr sb, [sp, #0x98]
+	str r9, [sp, #0x118]
+	ldr r9, [sp, #0x98]
 	str r8, [sp, #0x11c]
 	ldr r8, [sp, #0x9c]
 	str r3, [sp, #0x120]
@@ -21488,8 +21488,8 @@ _021315c0:
 	ldr r2, [sp, #0xa4]
 	str r1, [sp, #0x128]
 	ldr r1, [sp, #0xa8]
-	str sb, [sp, #0x12c]
-	ldr sb, [sp, #0xac]
+	str r9, [sp, #0x12c]
+	ldr r9, [sp, #0xac]
 	str r8, [sp, #0x130]
 	ldr r8, [sp, #0xb0]
 	str r3, [sp, #0x134]
@@ -21501,7 +21501,7 @@ _021315c0:
 	str r1, [sp, #0x13c]
 	ldr r0, [r0]
 	add r1, sp, #0xbc
-	str sb, [sp, #0x140]
+	str r9, [sp, #0x140]
 	str r8, [sp, #0x144]
 	strb r7, [sp, #0x148]
 	strb r6, [sp, #0x149]
@@ -21655,7 +21655,7 @@ _021318fc:
 	mov r0, r4
 	bl func_ov15_021327dc
 	add sp, sp, #0x284
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov15_021311c8
 _0213190c: .word data_027e0f94
@@ -22071,36 +22071,36 @@ _02131f08: .word data_027e0e60
 	.global func_ov15_02131f0c
 	arm_func_start func_ov15_02131f0c
 func_ov15_02131f0c: ; 0x02131f0c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x50
-	mov sb, r0
-	ldrb r0, [sb, #0x490]
+	mov r9, r0
+	ldrb r0, [r9, #0x490]
 	cmp r0, #3
 	bne _02131fd8
 	ldr r0, _021321b8 ; =data_027e0f64
-	add r1, sb, #0x35c
+	add r1, r9, #0x35c
 	ldr r0, [r0]
 	ldr r0, [r0, #4]
 	bl func_ov00_02087d34
 	mov r0, #0x2800
-	str r0, [sb, #0x374]
+	str r0, [r9, #0x374]
 	mov r0, #0x3000
-	str r0, [sb, #0x36c]
+	str r0, [r9, #0x36c]
 	ldr r1, _021321bc ; =0x00001770
 	ldr r0, _021321c0 ; =data_027e0fac
-	str r1, [sb, #0x368]
+	str r1, [r9, #0x368]
 	ldrsh r0, [r0]
 	mov r2, #0
-	mov r1, sb
+	mov r1, r9
 	add r0, r0, #0xff
 	add r0, r0, #0xff00
 	mov r0, r0, lsl #0x10
 	mov r0, r0, asr #0x10
-	str r0, [sb, #0x370]
-	str r2, [sb, #0x378]
-	str r2, [sb, #0x37c]
+	str r0, [r9, #0x370]
+	str r2, [r9, #0x378]
+	str r2, [r9, #0x37c]
 	add r0, sp, #0x44
-	str r2, [sb, #0x380]
+	str r2, [r9, #0x380]
 	bl func_ov15_021321c4
 	ldr r2, [sp, #0x44]
 	ldr r1, [sp, #0x48]
@@ -22115,38 +22115,38 @@ func_ov15_02131f0c: ; 0x02131f0c
 	ldr r0, _021321b8 ; =data_027e0f64
 	add r1, sp, #0x38
 	ldr r0, [r0]
-	add r3, sb, #0x35c
+	add r3, r9, #0x35c
 	ldr r0, [r0, #4]
 	mov r2, #2
 	bl func_ov00_02089318
 	add sp, sp, #0x50
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _02131fd8:
-	ldr r0, [sb, #0x138]
+	ldr r0, [r9, #0x138]
 	cmp r0, #0x78
 	bgt _0213215c
-	ldr r2, [sb, #0x36c]
+	ldr r2, [r9, #0x36c]
 	rsb r3, r0, #0x78
-	ldr r1, [sb, #0x368]
-	ldr r0, [sb, #0x370]
+	ldr r1, [r9, #0x368]
+	ldr r0, [r9, #0x370]
 	mov r4, r2, lsl #0x10
 	mov r7, r3, lsl #0xc
-	ldr r2, [sb, #0x3dc]
+	ldr r2, [r9, #0x3dc]
 	cmp r7, #0x1000
 	mov r5, r1, lsl #0x10
 	mov r6, r0, lsl #0x10
-	strle r2, [sb, #0x374]
+	strle r2, [r9, #0x374]
 	ble _02132030
-	ldr r0, [sb, #0x374]
+	ldr r0, [r9, #0x374]
 	mov r1, r7
 	sub r0, r2, r0
 	bl Divide
-	ldr r1, [sb, #0x374]
+	ldr r1, [r9, #0x374]
 	add r0, r1, r0
-	str r0, [sb, #0x374]
+	str r0, [r9, #0x374]
 _02132030:
-	ldr r0, [sb, #0x3d4]
+	ldr r0, [r9, #0x3d4]
 	cmp r7, #0x1000
 	mov r0, r0, lsl #0x10
 	mov r8, r0, asr #0x10
@@ -22162,7 +22162,7 @@ _02132030:
 	mov r0, r0, lsl #0x10
 	mov r8, r0, asr #0x10
 _0213206c:
-	ldr r0, [sb, #0x3d0]
+	ldr r0, [r9, #0x3d0]
 	cmp r7, #0x1000
 	mov r0, r0, lsl #0x10
 	mov r4, r0, asr #0x10
@@ -22178,7 +22178,7 @@ _0213206c:
 	mov r0, r0, lsl #0x10
 	mov r4, r0, asr #0x10
 _021320a8:
-	ldr r0, [sb, #0x3d8]
+	ldr r0, [r9, #0x3d8]
 	cmp r7, #0x1000
 	mov r0, r0, lsl #0x10
 	mov r2, r0, asr #0x10
@@ -22195,14 +22195,14 @@ _021320a8:
 	mov r2, r0, asr #0x10
 _021320e4:
 	mov r0, #0
-	str r0, [sb, #0x378]
-	str r0, [sb, #0x37c]
-	str r0, [sb, #0x380]
-	str r8, [sb, #0x36c]
-	str r4, [sb, #0x368]
+	str r0, [r9, #0x378]
+	str r0, [r9, #0x37c]
+	str r0, [r9, #0x380]
+	str r8, [r9, #0x36c]
+	str r4, [r9, #0x368]
 	add r0, sp, #0x2c
-	mov r1, sb
-	str r2, [sb, #0x370]
+	mov r1, r9
+	str r2, [r9, #0x370]
 	bl func_ov15_021321c4
 	ldr r2, [sp, #0x2c]
 	ldr r1, [sp, #0x30]
@@ -22217,16 +22217,16 @@ _021320e4:
 	ldr r0, _021321b8 ; =data_027e0f64
 	add r1, sp, #0x20
 	ldr r0, [r0]
-	add r3, sb, #0x35c
+	add r3, r9, #0x35c
 	ldr r0, [r0, #4]
 	mov r2, #2
 	bl func_ov00_02089318
 	add sp, sp, #0x50
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _0213215c:
 	add r0, sp, #0x14
-	mov r1, sb
+	mov r1, r9
 	bl func_ov15_021321c4
 	ldr r2, [sp, #0x14]
 	ldr r1, [sp, #0x18]
@@ -22241,13 +22241,13 @@ _0213215c:
 	ldr r0, _021321b8 ; =data_027e0f64
 	add r1, sp, #8
 	ldr r0, [r0]
-	add r3, sb, #0x35c
+	add r3, r9, #0x35c
 	ldr r0, [r0, #4]
 	mov r2, #2
 	bl func_ov00_02089318
 	mov r0, #1
 	add sp, sp, #0x50
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02131f0c
 _021321b8: .word data_027e0f64
@@ -22304,7 +22304,7 @@ _02132264: .word data_027e0f94
 	.global func_ov15_02132268
 	arm_func_start func_ov15_02132268
 func_ov15_02132268: ; 0x02132268
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0xa4
 	mov r4, r0
 	ldrb r0, [r4, #0x490]
@@ -22361,7 +22361,7 @@ _021322e8:
 	ldrsh r7, [r2, r4]
 	ldrsh r4, [r2, r0]
 	mov r0, #0x52
-	umull sb, r8, r7, r0
+	umull r9, r8, r7, r0
 	mov r2, #0
 	umull r6, r5, r4, r0
 	mla r8, r7, r2, r8
@@ -22369,9 +22369,9 @@ _021322e8:
 	mov r7, r7, asr #0x1f
 	mov r4, r4, asr #0x1f
 	mla r8, r7, r0, r8
-	adds sb, sb, #0x800
+	adds r9, r9, #0x800
 	adc r7, r8, #0
-	mov r8, sb, lsr #0xc
+	mov r8, r9, lsr #0xc
 	mla r5, r4, r0, r5
 	adds r6, r6, #0x800
 	adc r0, r5, #0
@@ -22403,7 +22403,7 @@ _021322e8:
 	str r2, [sp, #0xa0]
 	bl func_ov15_0214138c
 	add sp, sp, #0xa4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _021323ec:
 	add r5, sp, #0x70
 	add r1, sp, #0x80
@@ -22476,12 +22476,12 @@ _0213246c:
 	str r2, [sp, #0x80]
 	bl func_ov15_0214138c
 	add sp, sp, #0xa4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _02132504:
 	ldr r0, [r4, #0x138]
 	cmp r0, #0x32
 	addle sp, sp, #0xa4
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	mov r3, #0
 	sub r2, r3, #2
 	mov r5, #0x47
@@ -22502,20 +22502,20 @@ _02132504:
 	bl func_ov00_020838e8
 	cmp r0, #0
 	addeq sp, sp, #0xa4
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	ldr r0, _021325f0 ; =data_027e10a4
 	ldrsh r5, [sp, #0x5c]
 	ldrb lr, [sp, #0x5e]
 	ldrb ip, [sp, #0x5f]
 	ldrb r3, [sp, #0x60]
 	ldrb r2, [sp, #0x61]
-	ldr sb, [sp, #0x4c]
+	ldr r9, [sp, #0x4c]
 	ldr r8, [sp, #0x50]
 	ldr r7, [sp, #0x54]
 	ldr r6, [sp, #0x58]
 	ldr r0, [r0]
 	add r1, sp, #4
-	str sb, [sp, #4]
+	str r9, [sp, #4]
 	str r8, [sp, #8]
 	str r7, [sp, #0xc]
 	str r6, [sp, #0x10]
@@ -22531,7 +22531,7 @@ _02132504:
 	strneb r0, [r4, #0x490]
 _021325d0:
 	add sp, sp, #0xa4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02132268
 _021325d8: .word data_027e0f94
@@ -25980,7 +25980,7 @@ func_ov15_02135484: ; 0x02135484
 	.global func_ov15_021354a0
 	arm_func_start func_ov15_021354a0
 func_ov15_021354a0: ; 0x021354a0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x30
 	mov r11, r0
 	bl func_ov15_0213ce4c
@@ -25997,13 +25997,13 @@ func_ov15_021354a0: ; 0x021354a0
 	ldr r5, _02135550 ; =data_027e0f94
 	ldr r4, _02135554 ; =data_027e0fe8
 	str r10, [r11, #0x24]
-	add sb, sp, #4
+	add r9, sp, #4
 	mvn r8, #0
 	mov r7, r10
 _021354f0:
-	mov r0, sb
+	mov r0, r9
 	bl func_ov00_020c1500
-	mov r0, sb
+	mov r0, r9
 	str r8, [sp, #0x20]
 	str r8, [sp, #0x24]
 	bl func_ov00_020c3348
@@ -26013,7 +26013,7 @@ _021354f0:
 	ldr r0, [r4]
 	mov r1, r6
 	mov r2, r5
-	mov r3, sb
+	mov r3, r9
 	bl func_ov00_020c4048
 	add r10, r10, #1
 	cmp r10, #3
@@ -26023,7 +26023,7 @@ _02135534:
 	mov r1, #1
 	bl func_ov15_02175d14
 	add sp, sp, #0x30
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_021354a0
 _02135548: .word data_027e103c
@@ -27823,7 +27823,7 @@ _02136d00: .word data_027e0fac
 	.global func_ov15_02136d04
 	arm_func_start func_ov15_02136d04
 func_ov15_02136d04: ; 0x02136d04
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x18
 	mov r4, r0
 	ldrb r0, [r4, #0x25f]
@@ -27903,9 +27903,9 @@ _02136d5c:
 	ldr r5, [r2, #0xc]
 	ldr r10, [r2, #0x10]
 	mla r7, r5, lr, r7
-	ldr sb, [r2, #0x14]
+	ldr r9, [r2, #0x14]
 	adds r5, r10, r8
-	adc r7, sb, r7
+	adc r7, r9, r7
 	stmia r2, {r5, r7}
 	umull r2, r5, r7, r1
 	mla r5, r7, r11, r5
@@ -28100,7 +28100,7 @@ _021370f8:
 	mov r0, r4
 	bl func_ov15_02136888
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02136d04
 _0213711c: .word data_027e0f94
@@ -29477,7 +29477,7 @@ _02138474: .word 0x00000ccc
 	.global func_ov15_02138478
 	arm_func_start func_ov15_02138478
 func_ov15_02138478: ; 0x02138478
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x78
 	ldr r2, _02138ba0 ; =data_027e10a4
 	ldr r4, _02138ba4 ; =data_027e0fa0
@@ -29506,7 +29506,7 @@ func_ov15_02138478: ; 0x02138478
 	ldrsh r5, [r5, r1]
 	rsb r4, r6, #0
 	ldr r1, _02138bb4 ; =data_027e0fac
-	mov sb, r0
+	mov r9, r0
 	ldrsh r0, [r1]
 	add r1, sp, #0x54
 	str r3, [sp, #0x6c]
@@ -29538,7 +29538,7 @@ func_ov15_02138478: ; 0x02138478
 	mov r3, r2
 	mov r0, #0x800
 	bl func_01ff9e64
-	mov r0, sb
+	mov r0, r9
 	add r1, sp, #0x3c
 	bl func_ov15_02138408
 	ldr r1, _02138bb8 ; =data_027e0f94
@@ -29555,7 +29555,7 @@ func_ov15_02138478: ; 0x02138478
 	add r1, sp, #0x54
 	mov r3, r2
 	bl func_01ff9e64
-	mov r0, sb
+	mov r0, r9
 	add r1, sp, #0x30
 	bl func_ov15_02138408
 	mov r4, r0
@@ -29572,7 +29572,7 @@ func_ov15_02138478: ; 0x02138478
 	str r5, [sp, #0x2c]
 	bl func_01ff9e64
 	add r1, sp, #0x24
-	mov r0, sb
+	mov r0, r9
 	bl func_ov15_02138408
 	ldr r1, _02138bb8 ; =data_027e0f94
 	mov r7, r0
@@ -29588,11 +29588,11 @@ func_ov15_02138478: ; 0x02138478
 	add r1, sp, #0x48
 	mov r3, r2
 	bl func_01ff9e64
-	mov r0, sb
+	mov r0, r9
 	add r1, sp, #0x18
 	bl func_ov15_02138408
 	mov r5, r0
-	ldrb r0, [sb, #0x27c]
+	ldrb r0, [r9, #0x27c]
 	cmp r0, #0
 	bne _021386b0
 	ldr r1, _02138bb8 ; =data_027e0f94
@@ -29620,10 +29620,10 @@ func_ov15_02138478: ; 0x02138478
 	cmp r2, r1
 	strlt r1, [r0, #4]
 _021386b0:
-	mov r0, sb
+	mov r0, r9
 	bl func_ov15_021366b0
 	add r8, r8, r0
-	mov r0, sb
+	mov r0, r9
 	bl func_ov15_021366c4
 	add r4, r4, r0
 	mov r0, #0
@@ -29717,13 +29717,13 @@ _0213879c:
 	str r0, [ip, #4]
 	str r3, [ip]
 	str r3, [ip, #8]
-	ldrb r0, [sb, #0x26e]
+	ldrb r0, [r9, #0x26e]
 	cmp r0, #0
 	beq _02138894
 	ldr r0, _02138bb4 ; =data_027e0fac
 	ldr r10, _02138bb0 ; =data_02050f54
 	ldrh r0, [r0]
-	ldr r2, [sb, #0x78]
+	ldr r2, [r9, #0x78]
 	mov r0, r0, asr #0x4
 	mov r0, r0, lsl #0x1
 	mov r1, r0, lsl #0x1
@@ -29764,7 +29764,7 @@ _02138894:
 	orr r0, r0, r2, lsl #20
 	bl Divide
 	ldr r2, _02138ba8 ; =data_ov15_0218aa28
-	ldrsh r10, [sb, #0x96]
+	ldrsh r10, [r9, #0x96]
 	ldr r3, [r2, #0x24]
 	mov r1, #0x800
 	mov r2, r3, asr #0x1f
@@ -29772,7 +29772,7 @@ _02138894:
 	add r0, r10, r0
 	orr r2, r2, r3, lsr #26
 	adds r3, r1, r3, lsl #6
-	strh r0, [sb, #0x96]
+	strh r0, [r9, #0x96]
 	adc r0, r2, #0
 	mov r2, r3, lsr #0xc
 	orr r2, r2, r0, lsl #20
@@ -29782,19 +29782,19 @@ _02138894:
 	mov r0, r3, lsr #0xc
 	orr r0, r0, r2, lsl #20
 	bl Divide
-	ldrsh r3, [sb, #0x98]
+	ldrsh r3, [r9, #0x98]
 	ldr r1, _02138bac ; =data_027e0fb0
 	ldr r2, _02138bc0 ; =0xffffc71c
 	add r0, r3, r0
-	strh r0, [sb, #0x98]
+	strh r0, [r9, #0x98]
 	ldrsh r3, [r1]
-	ldrsh r0, [sb, #0x96]
+	ldrsh r0, [r9, #0x96]
 	add r0, r3, r0, lsl #1
 	strh r0, [r1]
-	ldrsh r3, [sb, #0x90]
-	ldrsh r0, [sb, #0x98]
+	ldrsh r3, [r9, #0x90]
+	ldrsh r0, [r9, #0x98]
 	add r0, r3, r0
-	strh r0, [sb, #0x90]
+	strh r0, [r9, #0x90]
 	ldrsh r3, [r1]
 	cmp r3, r2
 	strlth r2, [r1]
@@ -29803,14 +29803,14 @@ _02138894:
 	cmp r3, r0
 	strgth r0, [r1]
 _02138974:
-	ldrsh r2, [sb, #0x90]
+	ldrsh r2, [r9, #0x90]
 	ldr r1, _02138bc0 ; =0xffffc71c
 	cmp r2, r1
-	strlth r1, [sb, #0x90]
+	strlth r1, [r9, #0x90]
 	blt _02138994
 	rsb r0, r1, #0
 	cmp r2, r0
-	strgth r0, [sb, #0x90]
+	strgth r0, [r9, #0x90]
 _02138994:
 	cmp r8, r4
 	movgt r0, r8
@@ -29841,7 +29841,7 @@ _02138994:
 	adc r0, r5, #0
 	mov r3, r4, lsr #0xc
 	orr r3, r3, r0, lsl #20
-	ldrsh r0, [sb, #0x96]
+	ldrsh r0, [r9, #0x96]
 	add r3, r3, #0xcd
 	add r6, r3, #0x400
 	mov r1, r1, asr #0x1
@@ -29869,7 +29869,7 @@ _02138a50:
 	mov r3, r3, lsl #0x10
 	sub r0, r0, r3, asr #16
 _02138a70:
-	strh r0, [sb, #0x96]
+	strh r0, [r9, #0x96]
 	cmp r2, #0x800
 	ldr r0, _02138bc4 ; =0x000004cd
 	movge r2, #0x800
@@ -29882,7 +29882,7 @@ _02138a70:
 	adc r0, r4, #0
 	mov r2, r3, lsr #0xc
 	orr r2, r2, r0, lsl #20
-	ldrsh r0, [sb, #0x98]
+	ldrsh r0, [r9, #0x98]
 	add r2, r2, #0xcd
 	add r5, r2, #0x400
 	cmp r0, #0
@@ -29909,7 +29909,7 @@ _02138ae8:
 	mov r2, r2, lsl #0x10
 	sub r0, r0, r2, asr #16
 _02138b08:
-	strh r0, [sb, #0x98]
+	strh r0, [r9, #0x98]
 	mov r0, #0x214
 	umull r4, r3, r1, r0
 	mov r2, #0
@@ -29936,7 +29936,7 @@ _02138b08:
 	add r0, r5, r0
 	str r0, [r1, #4]
 	add sp, sp, #0x78
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02138b78:
 	umull r3, r2, r5, r4
 	mla r2, r5, r0, r2
@@ -29947,7 +29947,7 @@ _02138b78:
 	sub r0, r5, r0
 	str r0, [r1, #4]
 	add sp, sp, #0x78
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02138478
 _02138ba0: .word data_027e10a4
@@ -32934,7 +32934,7 @@ _0213b454: .word 0x4b4d4741
 	.global func_ov15_0213b458
 	arm_func_start func_ov15_0213b458
 func_ov15_0213b458: ; 0x0213b458
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	ldr r1, _0213b63c ; =data_027e0fe4
 	mov r4, r0
 	ldr r0, [r1]
@@ -32950,7 +32950,7 @@ func_ov15_0213b458: ; 0x0213b458
 	bl func_ov15_021517a0
 	cmp r0, #0
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0213b49c:
 	ldr r2, _0213b644 ; =data_027e0764
 	mov r11, #0
@@ -33014,10 +33014,10 @@ _0213b49c:
 	ldmib r2, {r3, r5, lr}
 	umull r7, r6, r5, ip
 	mla r6, r5, r3, r6
-	ldr sb, [r2, #0x10]
+	ldr r9, [r2, #0x10]
 	mla r6, lr, ip, r6
 	ldr r8, [r2, #0x14]
-	adds r3, sb, r7
+	adds r3, r9, r7
 	adc r5, r8, r6
 	stmia r2, {r3, r5}
 	ldr r2, _0213b650 ; =0x0000ffff
@@ -33055,7 +33055,7 @@ _0213b49c:
 	add r0, r5, #0x5a
 	str r0, [r4, #0x284]
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0213b458
 _0213b63c: .word data_027e0fe4
@@ -34159,7 +34159,7 @@ _0213c5b8:
 	.global func_ov15_0213c5c4
 	arm_func_start func_ov15_0213c5c4
 func_ov15_0213c5c4: ; 0x0213c5c4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	mov r4, r0
 	add r0, r4, #0x158
 	mov r1, #1
@@ -34214,10 +34214,10 @@ func_ov15_0213c5c4: ; 0x0213c5c4
 	umull r11, ip, r10, r8
 	ldr r1, [lr, #0x10]
 	mla ip, r10, r7, ip
-	ldr sb, [lr, #0xc]
+	ldr r9, [lr, #0xc]
 	ldr r0, [lr, #0x14]
 	adds r1, r1, r11
-	mla ip, sb, r8, ip
+	mla ip, r9, r8, ip
 	mov r5, r2, lsl #0xb
 	adc r0, r0, ip
 	str r1, [lr]
@@ -34231,10 +34231,10 @@ func_ov15_0213c5c4: ; 0x0213c5c4
 	umull r8, r7, r6, r1
 	mla r7, r6, r0, r7
 	ldr r5, [lr, #0xc]
-	ldr sb, [lr, #0x10]
+	ldr r9, [lr, #0x10]
 	mla r7, r5, r1, r7
 	ldr ip, [lr, #0x14]
-	adds r0, sb, r8
+	adds r0, r9, r8
 	adc r5, ip, r7
 	stmia lr, {r0, r5}
 	umull r0, r1, r5, r3
@@ -34267,7 +34267,7 @@ func_ov15_0213c5c4: ; 0x0213c5c4
 	ldr r0, [r0, #0x34]
 	str r1, [r4, #0x274]
 	str r0, [r4, #0x278]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0213c5c4
 _0213c778: .word data_027e0764
@@ -34278,7 +34278,7 @@ _0213c784: .word data_ov15_0218ac90
 	.global func_ov15_0213c788
 	arm_func_start func_ov15_0213c788
 func_ov15_0213c788: ; 0x0213c788
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x10
 	mov r4, r0
 	bl _ZN5Actor16XzDistanceToLinkEv
@@ -34346,12 +34346,12 @@ _0213c7b4:
 	ldmib r0, {r3, r5, lr}
 	umull r7, r6, r5, ip
 	mla r6, r5, r3, r6
-	ldr sb, [r0, #0x10]
+	ldr r9, [r0, #0x10]
 	ldr r1, [r1, #4]
 	mla r6, lr, ip, r6
 	add r2, r1, #0x1600
 	ldr r8, [r0, #0x14]
-	adds r5, sb, r7
+	adds r5, r9, r7
 	mov r1, r10, lsl #0xb
 	adc r3, r8, r6
 	str r5, [r0]
@@ -34364,10 +34364,10 @@ _0213c7b4:
 	umull r7, r6, r5, r2
 	mla r6, r5, r1, r6
 	ldr r3, [r0, #0xc]
-	ldr sb, [r0, #0x10]
+	ldr r9, [r0, #0x10]
 	mla r6, r3, r2, r6
 	ldr r8, [r0, #0x14]
-	adds r1, sb, r7
+	adds r1, r9, r7
 	adc r3, r8, r6
 	stmia r0, {r1, r3}
 	umull r1, r2, r3, r11
@@ -34381,10 +34381,10 @@ _0213c7b4:
 	umull r7, r6, r5, r2
 	mla r6, r5, r1, r6
 	ldr r3, [r0, #0xc]
-	ldr sb, [r0, #0x10]
+	ldr r9, [r0, #0x10]
 	mla r6, r3, r2, r6
 	ldr r8, [r0, #0x14]
-	adds r1, sb, r7
+	adds r1, r9, r7
 	adc r2, r8, r6
 	stmia r0, {r1, r2}
 	mov r0, #0x3f
@@ -34499,11 +34499,11 @@ _0213c9ec:
 	bl func_ov15_0213b8c4
 	cmp r0, #0
 	addeq sp, sp, #0x10
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	mov r0, r4
 	bl func_ov15_0213c27c
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0213c788
 _0213cb00: .word data_027e0fa0
@@ -34897,10 +34897,10 @@ _0213cfe4: .word data_027e0fb8
 	.global func_ov15_0213cfe8
 	arm_func_start func_ov15_0213cfe8
 func_ov15_0213cfe8: ; 0x0213cfe8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x30
-	mov sb, r0
-	ldrsh r4, [sb, #0xe]
+	mov r9, r0
+	ldrsh r4, [r9, #0xe]
 	mov r8, r1
 	mov r7, r2
 	mov r6, r3
@@ -34911,9 +34911,9 @@ func_ov15_0213cfe8: ; 0x0213cfe8
 	strneh r0, [r6]
 	add sp, sp, #0x30
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _0213d024:
-	ldr r1, [sb, #4]
+	ldr r1, [r9, #4]
 	mov r0, #0xc
 	smlabb r0, r4, r0, r1
 	ldr r3, _0213d1a8 ; =data_027e0f94
@@ -34931,7 +34931,7 @@ _0213d024:
 	bl func_01ff9ec0
 	subs r8, r8, r0
 	bmi _0213d09c
-	ldrh r1, [sb, #0xc]
+	ldrh r1, [r9, #0xc]
 _0213d070:
 	add r0, r4, #1
 	mov r0, r0, lsl #0x10
@@ -34939,15 +34939,15 @@ _0213d070:
 	mov r4, r0, asr #0x10
 	addle sp, sp, #0x30
 	movle r0, #0
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
-	ldr r0, [sb, #8]
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
+	ldr r0, [r9, #8]
 	ldr r0, [r0, r4, lsl #2]
 	subs r8, r8, r0
 	bpl _0213d070
 _0213d09c:
 	mov r0, #0xc
 	mul r5, r4, r0
-	ldr r2, [sb, #4]
+	ldr r2, [r9, #4]
 	cmp r4, #0
 	ldr r1, [r2, r5]
 	add r2, r2, r5
@@ -34959,7 +34959,7 @@ _0213d09c:
 	ble _0213d108
 	sub r1, r4, #1
 	mul r2, r1, r0
-	ldr r3, [sb, #4]
+	ldr r3, [r9, #4]
 	add r0, sp, #0xc
 	ldr r1, [r3, r2]
 	add r3, r3, r2
@@ -34978,15 +34978,15 @@ _0213d108:
 	mov r2, r0
 	bl func_01ff9bf8
 _0213d118:
-	ldr r1, [sb, #4]
+	ldr r1, [r9, #4]
 	add r0, sp, #0xc
 	ldr r1, [r1, r5]
 	str r1, [r7]
-	ldr r1, [sb, #4]
+	ldr r1, [r9, #4]
 	add r1, r1, r5
 	ldr r1, [r1, #4]
 	str r1, [r7, #4]
-	ldr r1, [sb, #4]
+	ldr r1, [r9, #4]
 	add r1, r1, r5
 	ldr r1, [r1, #8]
 	str r1, [r7, #8]
@@ -35014,7 +35014,7 @@ _0213d190:
 	strneh r0, [r6]
 	mov r0, #1
 	add sp, sp, #0x30
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0213cfe8
 _0213d1a8: .word data_027e0f94
@@ -35384,10 +35384,10 @@ _0213d5ec: .word data_027e10a4
 	.global func_ov15_0213d5f0
 	arm_func_start func_ov15_0213d5f0
 func_ov15_0213d5f0: ; 0x0213d5f0
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	mov r10, r0
 	ldrsh r5, [r10, #0xe]
-	mov sb, r1
+	mov r9, r1
 	cmp r5, #0
 	blt _0213d614
 	ldrh r0, [r10, #0xc]
@@ -35399,7 +35399,7 @@ _0213d614:
 	sub r0, r0, #1
 	strh r0, [r10, #0xe]
 	ldrsh r0, [r10, #0xe]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _0213d62c:
 	mov r6, r5
 	cmp r5, r0
@@ -35454,13 +35454,13 @@ _0213d6dc:
 	ldr r2, [r10, #4]
 	ldr r0, [r2, r1]
 	add r1, r2, r1
-	str r0, [sb]
+	str r0, [r9]
 	ldr r0, [r1, #4]
-	str r0, [sb, #4]
+	str r0, [r9, #4]
 	ldr r0, [r1, #8]
-	str r0, [sb, #8]
+	str r0, [r9, #8]
 	mov r0, r6
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0213d5f0
 _0213d70c: .word data_027e0f94
@@ -36044,7 +36044,7 @@ _0213de48: .word data_027e0f94
 	arm_func_start func_ov15_0213de4c
 func_ov15_0213de4c: ; 0x0213de4c
 	stmdb sp!, {r0, r1, r2, r3}
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x80
 	add r1, sp, #0xac
 	mov r5, r0
@@ -36086,7 +36086,7 @@ func_ov15_0213de4c: ; 0x0213de4c
 	bl _ZN12ActorManager8GetActorEP8ActorRef
 	movs r4, r0
 	addeq sp, sp, #0x80
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	addeq sp, sp, #0x10
 	bxeq lr
 	ldr r0, _0213e3a8 ; =data_027e0f94
@@ -36144,11 +36144,11 @@ _0213df4c:
 	mov r11, #0
 	mla r3, ip, r2, r3
 	ldr r6, [r1, #0x14]
-	adds sb, r7, r8
+	adds r9, r7, r8
 	adc r8, r6, r3
 	mov r0, r11, lsl #0x10
 	orr r0, r0, r8, lsr #16
-	str sb, [r1]
+	str r9, [r1]
 	sub r0, r0, #0x8000
 	mov r0, r0, lsl #0x10
 	str r8, [r1, #4]
@@ -36158,10 +36158,10 @@ _0213df4c:
 	add r3, r0, #1
 	cmp r3, #0
 	ble _0213e048
-	umull r2, r0, lr, sb
+	umull r2, r0, lr, r9
 	mla r0, lr, r8, r0
 	adds r7, r7, r2
-	mla r0, ip, sb, r0
+	mla r0, ip, r9, r0
 	adc r2, r6, r0
 	str r7, [r1]
 	str r2, [r1, #4]
@@ -36247,12 +36247,12 @@ _0213e130:
 	ldrsh r2, [r3, r2]
 	ldrsh r0, [r3, r0]
 	mov r3, #0
-	smull sb, r6, r2, r1
-	adds sb, sb, #0x800
+	smull r9, r6, r2, r1
+	adds r9, r9, #0x800
 	smull r2, r1, r0, r1
 	adc r0, r6, #0
 	adds r2, r2, #0x800
-	mov r6, sb, lsr #0xc
+	mov r6, r9, lsr #0xc
 	orr r6, r6, r0, lsl #20
 	adc r0, r1, #0
 	mov r1, r2, lsr #0xc
@@ -36277,12 +36277,12 @@ _0213e1ac:
 	ldrsh r2, [r3, r2]
 	ldrsh r0, [r3, r0]
 	mov r3, #0
-	smull sb, r6, r2, r1
-	adds sb, sb, #0x800
+	smull r9, r6, r2, r1
+	adds r9, r9, #0x800
 	smull r2, r1, r0, r1
 	adc r0, r6, #0
 	adds r2, r2, #0x800
-	mov r6, sb, lsr #0xc
+	mov r6, r9, lsr #0xc
 	orr r6, r6, r0, lsl #20
 	adc r0, r1, #0
 	mov r1, r2, lsr #0xc
@@ -36347,11 +36347,11 @@ _0213e2cc:
 	mov r2, r2, lsl #0x1
 	mov r1, r1, lsl #0x1
 	ldrsh r2, [r3, r2]
-	ldr sb, [r5, #0x198]
+	ldr r9, [r5, #0x198]
 	ldrsh r1, [r3, r1]
-	smull r3, r7, r2, sb
+	smull r3, r7, r2, r9
 	adds r8, r3, #0x800
-	smull r3, r2, r1, sb
+	smull r3, r2, r1, r9
 	adc r1, r7, #0
 	adds r7, r3, #0x800
 	mov r3, r8, lsr #0xc
@@ -36363,14 +36363,14 @@ _0213e2cc:
 	adds r10, r1, #0x800
 	orr r2, r2, r0, lsl #20
 	mov r1, r6
-	adc sb, r8, #0
+	adc r9, r8, #0
 	mov r6, r10, lsr #0xc
 	ldr r7, [sp, #0x40]
 	ldr r0, [sp, #0x78]
 	add r8, r2, #0
 	sub r0, r7, r0
 	add r7, r3, #0
-	orr r6, r6, sb, lsl #20
+	orr r6, r6, r9, lsl #20
 	bl Divide
 	add r1, r6, r6, lsr #31
 	add r6, r0, r1, asr #1
@@ -36386,7 +36386,7 @@ _0213e360:
 	movge r0, #0
 	strge r0, [r5, #0x188]
 	add sp, sp, #0x80
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	add sp, sp, #0x10
 	bx lr
 	.align 2, 0
@@ -36903,7 +36903,7 @@ _0213ea4c: .word 0x00001555
 	.global func_ov15_0213ea50
 	arm_func_start func_ov15_0213ea50
 func_ov15_0213ea50: ; 0x0213ea50
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x1c8
 	str r1, [sp, #8]
 	ldr r2, [sp, #8]
@@ -36969,7 +36969,7 @@ _0213eac8:
 	bl func_ov15_02141344
 	cmp r0, #0
 	addeq sp, sp, #0x1c8
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	mov r1, #3
 	add r0, sp, #0x118
 	strh r1, [r4, #0x7a]
@@ -37101,7 +37101,7 @@ _0213eac8:
 	ldr ip, [sp, #0x100]
 	ldrb r11, [sp, #0x110]
 	ldrb r10, [sp, #0x111]
-	ldrb sb, [sp, #0x112]
+	ldrb r9, [sp, #0x112]
 	ldrb r8, [sp, #0x113]
 	ldrb r7, [sp, #0x114]
 	str r6, [sp, #0x18c]
@@ -37127,7 +37127,7 @@ _0213eac8:
 	str r3, [sp, #0x164]
 	str r2, [sp, #0x168]
 	strb r10, [sp, #0x1a5]
-	strb sb, [sp, #0x1a6]
+	strb r9, [sp, #0x1a6]
 	strb r8, [sp, #0x1a7]
 	strb r7, [sp, #0x1a8]
 	str r6, [sp, #0x1ac]
@@ -37154,8 +37154,8 @@ _0213eac8:
 	str r2, [sp, #0x140]
 	strb r1, [sp, #0x12c]
 	str r0, [r4, #0x35c]
-	ldr sb, [r4, #0x348]
-	str sb, [sp, #0xb0]
+	ldr r9, [r4, #0x348]
+	str r9, [sp, #0xb0]
 	ldr r0, [r4, #0x34c]
 	str r0, [sp, #0xb4]
 	ldr r8, [r4, #0x350]
@@ -37232,7 +37232,7 @@ _0213eac8:
 	str r5, [sp, #0xc0]
 	str r5, [sp, #0x154]
 	mov r5, #0x1000
-	str sb, [sp, #0x144]
+	str r9, [sp, #0x144]
 	str r8, [sp, #0x14c]
 	str r7, [sp, #0x150]
 	str r6, [sp, #0x158]
@@ -37252,22 +37252,22 @@ _0213eac8:
 	str r0, [sp, #0x180]
 	and r7, r1, #0xff
 	ldr r0, [sp, #0x10]
-	ldr sb, [sp, #0x20]
+	ldr r9, [sp, #0x20]
 	ldr r1, [sp, #0x38]
 	str r0, [sp, #0x184]
 	and r6, r1, #0xff
 	ldr r0, [sp, #0x14]
-	str sb, [sp, #0x194]
-	ldr sb, [sp, #0x24]
+	str r9, [sp, #0x194]
+	ldr r9, [sp, #0x24]
 	ldr r1, [sp, #0x3c]
 	str r0, [sp, #0x188]
 	and r5, r1, #0xff
 	ldr r0, _0213f4b0 ; =data_027e0f74
-	str sb, [sp, #0x198]
-	ldr sb, [sp, #0x28]
+	str r9, [sp, #0x198]
+	ldr r9, [sp, #0x28]
 	ldr r1, [sp, #0x1c]
-	str sb, [sp, #0x19c]
-	ldr sb, [sp, #0x2c]
+	str r9, [sp, #0x19c]
+	ldr r9, [sp, #0x2c]
 	str r3, [sp, #0x16c]
 	str r2, [sp, #0x170]
 	and r3, r10, #0xff
@@ -37276,7 +37276,7 @@ _0213eac8:
 	ldr r0, [r0]
 	add r1, sp, #0x118
 	str r11, [sp, #0x17c]
-	str sb, [sp, #0x1a0]
+	str r9, [sp, #0x1a0]
 	strb r8, [sp, #0x1a4]
 	strb r7, [sp, #0x1a5]
 	strb r6, [sp, #0x1a6]
@@ -37573,7 +37573,7 @@ _0213f47c:
 	ldr r0, [sp, #8]
 	str r0, [r4, #0x130]
 	add sp, sp, #0x1c8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0213ea50
 _0213f494: .word 0x0000ffff
@@ -39017,14 +39017,14 @@ func_ov15_02140854: ; 0x02140854
 	.global func_ov15_021408bc
 	arm_func_start func_ov15_021408bc
 func_ov15_021408bc: ; 0x021408bc
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #0x138
 	mov r4, r0
 	bl _ZN5Actor18func_ov00_020c198cEv
 	cmp r0, #0
 	addeq sp, sp, #0x138
 	mov r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	add r5, sp, #0xc
 	add r1, sp, #0x1c
 	mov r2, #4
@@ -39040,7 +39040,7 @@ func_ov15_021408bc: ; 0x021408bc
 	cmp r0, #0
 	addeq sp, sp, #0x138
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	mov r1, #3
 	add r0, sp, #0x88
 	strh r1, [r4, #0x7a]
@@ -39176,7 +39176,7 @@ func_ov15_021408bc: ; 0x021408bc
 	ldr r1, [sp, #0x78]
 	str r10, [sp, #0xf8]
 	ldr r10, [sp, #0x70]
-	ldrb sb, [sp, #0x80]
+	ldrb r9, [sp, #0x80]
 	ldrb r8, [sp, #0x81]
 	ldrb r7, [sp, #0x82]
 	ldrb r6, [sp, #0x83]
@@ -39194,7 +39194,7 @@ func_ov15_021408bc: ; 0x021408bc
 	ldr r0, [r1]
 	str r10, [sp, #0x110]
 	add r1, sp, #0x88
-	strb sb, [sp, #0x114]
+	strb r9, [sp, #0x114]
 	str ip, [sp, #0x38]
 	str r3, [sp, #0x40]
 	str r2, [sp, #0x44]
@@ -39219,7 +39219,7 @@ func_ov15_021408bc: ; 0x021408bc
 	bl func_ov00_0209a508
 	mov r0, #1
 	add sp, sp, #0x138
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov15_021408bc
 _02140be8: .word data_027e10a4
@@ -40467,7 +40467,7 @@ _02141b58: .word data_02050f54
 	.global func_ov15_02141b5c
 	arm_func_start func_ov15_02141b5c
 func_ov15_02141b5c: ; 0x02141b5c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x38
 	ldr r3, [r1]
 	mov r4, r0
@@ -40488,12 +40488,12 @@ func_ov15_02141b5c: ; 0x02141b5c
 	str lr, [sp, #0x20]
 	ldr r5, [r4, #0x28]
 	sub r1, r7, #0x1000
-	sub sb, r1, r5
+	sub r9, r1, r5
 	rsb r5, r5, #0
 	add r1, sp, #0x2c
 	add ip, sp, #8
 	str r8, [sp, #0x2c]
-	str sb, [sp, #0x30]
+	str r9, [sp, #0x30]
 	str r0, [sp, #0x34]
 	ldmia r1, {r0, r1, r2}
 	stmia ip, {r0, r1, r2}
@@ -40522,7 +40522,7 @@ func_ov15_02141b5c: ; 0x02141b5c
 	ldr r1, [r4, #4]
 	bl func_ov00_02093a5c
 	add sp, sp, #0x38
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02141b5c
 _02141c3c: .word data_027e0f6c
@@ -43905,19 +43905,19 @@ _02144928:
 	.global func_ov15_021449b0
 	arm_func_start func_ov15_021449b0
 func_ov15_021449b0: ; 0x021449b0
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x1c4
-	mov sb, r0
-	ldr r0, [sb, #0x378]
+	mov r9, r0
+	ldr r0, [r9, #0x378]
 	cmp r0, #0
 	subne r0, r0, #1
-	strne r0, [sb, #0x378]
-	ldr r0, [sb, #0x37c]
+	strne r0, [r9, #0x378]
+	ldr r0, [r9, #0x37c]
 	cmp r0, #0
 	subne r0, r0, #1
-	strne r0, [sb, #0x37c]
-	ldr r1, [sb, #0x20]
-	ldrb r0, [sb, #0x34d]
+	strne r0, [r9, #0x37c]
+	ldr r1, [r9, #0x20]
+	ldrb r0, [r9, #0x34d]
 	ldr r6, [r1, #0xc0]
 	ldr r4, [r1, #0xc4]
 	cmp r0, #0x11
@@ -43945,7 +43945,7 @@ _021449f8: ; jump table
 _02144a40:
 	bl func_ov15_02146308
 	ldr r0, _021457cc ; =data_027e0f64
-	add r1, sb, #0x450
+	add r1, r9, #0x450
 	ldr r0, [r0]
 	ldr r0, [r0, #4]
 	bl func_ov00_02087d34
@@ -43957,10 +43957,10 @@ _02144a40:
 	ldr r5, [r2, #0x270]
 	ldr r3, [r2, #0x274]
 	ldr r2, [r2, #0x26c]
-	str r2, [sb, #0x4b8]
-	str r5, [sb, #0x4bc]
-	str r3, [sb, #0x4c0]
-	str r1, [sb, #0x454]
+	str r2, [r9, #0x4b8]
+	str r5, [r9, #0x4bc]
+	str r3, [r9, #0x4c0]
+	str r1, [r9, #0x454]
 	bl func_ov00_0209a4f4
 	mov r0, #1
 	mvn r3, #0
@@ -43972,85 +43972,85 @@ _02144a40:
 	strb r0, [sp, #0x128]
 	strb r0, [sp, #0x12a]
 	strb r1, [sp, #0x11e]
-	ldr r1, [sb, #0x450]
+	ldr r1, [r9, #0x450]
 	ldr r0, _021457d0 ; =data_027e0f74
 	str r1, [sp, #0x140]
-	ldr r1, [sb, #0x454]
+	ldr r1, [r9, #0x454]
 	ldr r0, [r0]
 	str r1, [sp, #0x144]
-	ldr r2, [sb, #0x458]
+	ldr r2, [r9, #0x458]
 	add r1, sp, #0x114
 	str r2, [sp, #0x148]
-	ldr r3, [sb, #0x45c]
+	ldr r3, [r9, #0x45c]
 	mov r2, #0x5c
 	str r3, [sp, #0x14c]
-	ldr r3, [sb, #0x460]
+	ldr r3, [r9, #0x460]
 	str r3, [sp, #0x150]
-	ldr r3, [sb, #0x464]
+	ldr r3, [r9, #0x464]
 	str r3, [sp, #0x154]
-	ldr r3, [sb, #0x468]
+	ldr r3, [r9, #0x468]
 	str r3, [sp, #0x158]
-	ldr r3, [sb, #0x46c]
+	ldr r3, [r9, #0x46c]
 	str r3, [sp, #0x15c]
-	ldr r3, [sb, #0x470]
+	ldr r3, [r9, #0x470]
 	str r3, [sp, #0x160]
-	ldr r3, [sb, #0x474]
+	ldr r3, [r9, #0x474]
 	str r3, [sp, #0x164]
-	ldr r3, [sb, #0x478]
+	ldr r3, [r9, #0x478]
 	str r3, [sp, #0x168]
-	ldr r3, [sb, #0x47c]
+	ldr r3, [r9, #0x47c]
 	str r3, [sp, #0x16c]
-	ldr r3, [sb, #0x480]
+	ldr r3, [r9, #0x480]
 	str r3, [sp, #0x170]
-	ldr r3, [sb, #0x484]
+	ldr r3, [r9, #0x484]
 	str r3, [sp, #0x174]
-	ldr r3, [sb, #0x488]
+	ldr r3, [r9, #0x488]
 	str r3, [sp, #0x178]
-	ldr r3, [sb, #0x48c]
+	ldr r3, [r9, #0x48c]
 	str r3, [sp, #0x17c]
-	ldr r3, [sb, #0x490]
+	ldr r3, [r9, #0x490]
 	str r3, [sp, #0x180]
-	ldr r3, [sb, #0x494]
+	ldr r3, [r9, #0x494]
 	str r3, [sp, #0x184]
-	ldr r3, [sb, #0x498]
+	ldr r3, [r9, #0x498]
 	str r3, [sp, #0x188]
-	ldr r3, [sb, #0x49c]
+	ldr r3, [r9, #0x49c]
 	str r3, [sp, #0x18c]
-	ldr r3, [sb, #0x4a0]
+	ldr r3, [r9, #0x4a0]
 	str r3, [sp, #0x190]
-	ldr r3, [sb, #0x4a4]
+	ldr r3, [r9, #0x4a4]
 	str r3, [sp, #0x194]
-	ldr r3, [sb, #0x4a8]
+	ldr r3, [r9, #0x4a8]
 	str r3, [sp, #0x198]
-	ldr r3, [sb, #0x4ac]
+	ldr r3, [r9, #0x4ac]
 	str r3, [sp, #0x19c]
-	ldrb r3, [sb, #0x4b0]
+	ldrb r3, [r9, #0x4b0]
 	strb r3, [sp, #0x1a0]
-	ldrb r3, [sb, #0x4b1]
+	ldrb r3, [r9, #0x4b1]
 	strb r3, [sp, #0x1a1]
-	ldrb r3, [sb, #0x4b2]
+	ldrb r3, [r9, #0x4b2]
 	strb r3, [sp, #0x1a2]
-	ldrb r3, [sb, #0x4b3]
+	ldrb r3, [r9, #0x4b3]
 	strb r3, [sp, #0x1a3]
-	ldrb r3, [sb, #0x4b4]
+	ldrb r3, [r9, #0x4b4]
 	strb r3, [sp, #0x1a4]
 	str r2, [sp, #0x1a8]
 	bl func_ov00_02097810
-	str r0, [sb, #0x348]
+	str r0, [r9, #0x348]
 	mov r0, #1
-	strb r0, [sb, #0x34d]
-	add r0, sb, #0x300
+	strb r0, [r9, #0x34d]
+	add r0, r9, #0x300
 	mov r1, #0x4000
 	strh r1, [r0, #0x2a]
-	ldr r0, [sb, #0x20]
+	ldr r0, [r9, #0x20]
 	bl func_ov15_02149af0
-	add r2, sb, #0x300
-	ldr r0, [sb, #0x20]
+	add r2, r9, #0x300
+	ldr r0, [r9, #0x20]
 	ldrsh r3, [r2, #0x2a]
 	add r1, r0, #0x100
-	mov r0, sb
+	mov r0, r9
 	strh r3, [r1, #0xb0]
-	ldr r1, [sb, #0x20]
+	ldr r1, [r9, #0x20]
 	ldrsh r3, [r2, #0x2a]
 	add r1, r1, #0x100
 	mov r2, #1
@@ -44059,7 +44059,7 @@ _02144a40:
 	str r2, [r1, #0x11c]
 	bl func_ov15_0214325c
 	add r1, sp, #0xf0
-	mov r0, sb
+	mov r0, r9
 	bl func_ov15_02175ba8
 	mov r0, #0x1ec
 	str r0, [sp, #0xe8]
@@ -44073,59 +44073,59 @@ _02144a40:
 	bl func_01ff88b0
 	ldr r1, _021457d4 ; =data_027e0f94
 	add r0, sp, #0xe4
-	add r2, sb, #0x358
+	add r2, r9, #0x358
 	bl func_01ff9bc4
 	ldr r0, _021457d8 ; =data_027e0fac
-	add r1, sb, #0x300
+	add r1, r9, #0x300
 	ldrsh r0, [r0]
 	ldr r3, _021457dc ; =0xfffffccd
 	mov r2, #0x1000
 	add r0, r0, #0xab
 	add r0, r0, #0x2a00
 	strh r0, [r1, #0x84]
-	str r3, [sb, #0x298]
-	ldr r1, [sb, #0x2a0]
+	str r3, [r9, #0x298]
+	ldr r1, [r9, #0x2a0]
 	mov r0, #0
-	str r1, [sb, #0x294]
-	ldr r3, [sb, #0x2a8]
-	add r1, sb, #0xc4
-	str r3, [sb, #0x29c]
-	str r2, [sb, #0x4c4]
-	str r0, [sb, #0x4c8]
-	str r0, [sb, #0x4cc]
+	str r1, [r9, #0x294]
+	ldr r3, [r9, #0x2a8]
+	add r1, r9, #0xc4
+	str r3, [r9, #0x29c]
+	str r2, [r9, #0x4c4]
+	str r0, [r9, #0x4c8]
+	str r0, [r9, #0x4cc]
 	add r0, r1, #0x400
 	mov r2, r0
 	add r1, sp, #0xf0
 	bl func_01ff88b0
-	add r1, sb, #0xc4
+	add r1, r9, #0xc4
 	add r0, r1, #0x400
 	ldr r1, _021457d4 ; =data_027e0f94
 	mov r2, r0
 	bl func_01ff9bc4
-	ldr r1, [sb, #0x294]
+	ldr r1, [r9, #0x294]
 	ldr r0, _021457e0 ; =data_027e0e60
-	str r1, [sb, #0x4b8]
-	ldr r2, [sb, #0x298]
-	add r1, sb, #0x2a0
-	str r2, [sb, #0x4bc]
-	ldr r3, [sb, #0x29c]
+	str r1, [r9, #0x4b8]
+	ldr r2, [r9, #0x298]
+	add r1, r9, #0x2a0
+	str r2, [r9, #0x4bc]
+	ldr r3, [r9, #0x29c]
 	mov r2, #0
-	str r3, [sb, #0x4c0]
+	str r3, [r9, #0x4c0]
 	ldr r0, [r0]
 	bl func_ov00_02083ee0
 	ldr r1, _021457e4 ; =0xfffffe66
 	mov r2, #0
 	add r0, r0, r1
-	str r0, [sb, #0x4bc]
-	str r2, [sb, #0x374]
+	str r0, [r9, #0x4bc]
+	str r2, [r9, #0x374]
 	mov r0, #0x2000
 	str r0, [r4, #0x17c]
-	mov r0, sb
+	mov r0, r9
 	bl func_ov15_02144774
 	add r0, sp, #0x114
 	bl func_ov00_0209a508
 _02144d14:
-	add r0, sb, #0x364
+	add r0, r9, #0x364
 	add r3, sp, #0xd8
 	ldmia r0, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
@@ -44141,12 +44141,12 @@ _02144d14:
 	str r3, [sp, #0x2c]
 	bl func_ov00_02083ee0
 	str r0, [sp, #0xdc]
-	ldr r0, [sb, #0x298]
+	ldr r0, [r9, #0x298]
 	cmp r0, #0x2b8
 	blt _02144de4
 	ldr r0, _021457e8 ; =data_027e0ffc
 	ldr r1, _021457ec ; =0x000003e2
-	add r2, sb, #0x294
+	add r2, r9, #0x294
 	mov r3, #0
 	bl func_ov00_020ceacc
 	mov r2, #0
@@ -44157,99 +44157,99 @@ _02144d14:
 	mov r1, #1
 	str r1, [sp]
 	ldr r0, _021457f4 ; =data_027e0e58
-	add r1, sb, #0x184
+	add r1, r9, #0x184
 	ldr r0, [r0]
-	add r3, sb, #0x364
+	add r3, r9, #0x364
 	mov r2, #2
 	bl func_ov00_0207c1f8
 	mov r0, #1
 	str r0, [sp]
 	ldr r0, _021457f4 ; =data_027e0e58
-	add r1, sb, #0x188
+	add r1, r9, #0x188
 	ldr r0, [r0]
 	mov r2, #3
-	add r3, sb, #0x364
+	add r3, r9, #0x364
 	bl func_ov00_0207c1f8
 	mov r0, #0
-	str r0, [sb, #0x380]
+	str r0, [r9, #0x380]
 	mov r0, #0x1e
-	str r0, [sb, #0x378]
+	str r0, [r9, #0x378]
 	mov r0, #2
-	strb r0, [sb, #0x34d]
+	strb r0, [r9, #0x34d]
 	b _02144e00
 _02144de4:
 	mov r4, #0
 	add r1, sp, #0xd8
-	add r0, sb, #0x2f0
+	add r0, r9, #0x2f0
 	mov r2, #0x148
 	mov r3, #0xf
 	str r4, [sp]
 	bl func_ov00_020c7734
 _02144e00:
-	ldr r1, [sb, #0x298]
+	ldr r1, [r9, #0x298]
 	ldr r0, _021457f8 ; =0x000004cd
 	cmp r1, r0
 	blt _02144e40
-	ldr r1, [sb, #0x294]
-	add r0, sb, #0x374
-	str r1, [sb, #0x4b8]
-	ldr r2, [sb, #0x29c]
+	ldr r1, [r9, #0x294]
+	add r0, r9, #0x374
+	str r1, [r9, #0x4b8]
+	ldr r2, [r9, #0x29c]
 	mov r1, #0x14
-	str r2, [sb, #0x4c0]
-	ldr r4, [sb, #0x4bc]
-	ldr r3, [sb, #0x374]
+	str r2, [r9, #0x4c0]
+	ldr r4, [r9, #0x4bc]
+	ldr r3, [r9, #0x374]
 	mov r2, #1
 	add r3, r4, r3
-	str r3, [sb, #0x4bc]
+	str r3, [r9, #0x4bc]
 	bl Approach_thunk
 _02144e40:
-	ldr r0, [sb, #0x298]
+	ldr r0, [r9, #0x298]
 	mov r3, #0
 	add r1, r0, #0x18
-	str r1, [sb, #0x298]
-	ldr r0, [sb, #0x2a4]
+	str r1, [r9, #0x298]
+	ldr r0, [r9, #0x2a4]
 	cmp r1, r0
 	blt _02144ea0
 	ldr r0, _021457e8 ; =data_027e0ffc
-	add r2, sb, #0x294
+	add r2, r9, #0x294
 	mov r1, #0x3e4
 	bl func_ov00_020ceacc
-	ldr r0, [sb, #0x2a0]
+	ldr r0, [r9, #0x2a0]
 	mov r1, #3
-	str r0, [sb, #0x294]
-	ldr r2, [sb, #0x2a4]
+	str r0, [r9, #0x294]
+	ldr r2, [r9, #0x2a4]
 	mov r0, #0xa
-	str r2, [sb, #0x298]
-	ldr r2, [sb, #0x2a8]
-	str r2, [sb, #0x29c]
-	strb r1, [sb, #0x34d]
-	str r0, [sb, #0x378]
-	ldr r0, [sb, #0x20]
+	str r2, [r9, #0x298]
+	ldr r2, [r9, #0x2a8]
+	str r2, [r9, #0x29c]
+	strb r1, [r9, #0x34d]
+	str r0, [r9, #0x378]
+	ldr r0, [r9, #0x20]
 	bl func_ov15_02149e80
 	b _02144eb0
 _02144ea0:
 	ldr r0, _021457e8 ; =data_027e0ffc
 	ldr r1, _021457fc ; =0x000003e3
-	add r2, sb, #0x294
+	add r2, r9, #0x294
 	bl func_ov00_020cec08
 _02144eb0:
-	mov r0, sb
+	mov r0, r9
 	bl func_ov15_02144774
-	mov r0, sb
+	mov r0, r9
 	bl func_ov15_021448f8
 	b _02145420
 _02144ec4:
-	ldr r0, [sb, #0x378]
+	ldr r0, [r9, #0x378]
 	cmp r0, #0
 	moveq r0, #4
-	streqb r0, [sb, #0x34d]
-	mov r0, sb
+	streqb r0, [r9, #0x34d]
+	mov r0, r9
 	bl func_ov15_02144774
-	mov r0, sb
+	mov r0, r9
 	bl func_ov15_021448f8
 	b _02145420
 _02144ee8:
-	add r0, sb, #0x300
+	add r0, r9, #0x300
 	ldrsh r1, [r0, #0x2a]
 	mov r3, #0
 	sub r1, r1, #0x16c
@@ -44259,68 +44259,68 @@ _02144ee8:
 	bgt _02144f40
 	ldr r0, _021457e8 ; =data_027e0ffc
 	ldr r1, _02145800 ; =0x000003e6
-	add r2, sb, #0x2c4
+	add r2, r9, #0x2c4
 	bl func_ov00_020ceacc
-	add r0, sb, #0x300
+	add r0, r9, #0x300
 	mov r1, #0
 	strh r1, [r0, #0x2a]
 	mov r0, #5
-	strb r0, [sb, #0x34d]
+	strb r0, [r9, #0x34d]
 	mov r0, #0x14
-	str r0, [sb, #0x378]
-	ldr r0, [sb, #0x20]
+	str r0, [r9, #0x378]
+	ldr r0, [r9, #0x20]
 	bl func_ov15_02149e68
 	b _02144f50
 _02144f40:
 	ldr r0, _021457e8 ; =data_027e0ffc
 	ldr r1, _02145804 ; =0x000003e5
-	add r2, sb, #0x2c4
+	add r2, r9, #0x2c4
 	bl func_ov00_020cec08
 _02144f50:
-	add r0, sb, #0x300
-	ldr r1, [sb, #0x20]
+	add r0, r9, #0x300
+	ldr r1, [r9, #0x20]
 	ldrsh r2, [r0, #0x2a]
 	add r1, r1, #0x100
-	mov r0, sb
+	mov r0, r9
 	strh r2, [r1, #0xb0]
-	ldr r1, [sb, #0x2a0]
-	str r1, [sb, #0x2ac]
-	ldr r1, [sb, #0x2a4]
-	str r1, [sb, #0x2b0]
-	ldr r1, [sb, #0x2a8]
-	str r1, [sb, #0x2b4]
-	ldr r1, [sb, #0x2ac]
-	str r1, [sb, #0x294]
-	ldr r1, [sb, #0x2b0]
-	str r1, [sb, #0x298]
-	ldr r1, [sb, #0x2b4]
-	str r1, [sb, #0x29c]
+	ldr r1, [r9, #0x2a0]
+	str r1, [r9, #0x2ac]
+	ldr r1, [r9, #0x2a4]
+	str r1, [r9, #0x2b0]
+	ldr r1, [r9, #0x2a8]
+	str r1, [r9, #0x2b4]
+	ldr r1, [r9, #0x2ac]
+	str r1, [r9, #0x294]
+	ldr r1, [r9, #0x2b0]
+	str r1, [r9, #0x298]
+	ldr r1, [r9, #0x2b4]
+	str r1, [r9, #0x29c]
 	bl func_ov15_02144774
-	ldr r1, [sb, #0x294]
-	mov r0, sb
-	str r1, [sb, #0x4b8]
-	ldr r1, [sb, #0x29c]
-	str r1, [sb, #0x4c0]
+	ldr r1, [r9, #0x294]
+	mov r0, r9
+	str r1, [r9, #0x4b8]
+	ldr r1, [r9, #0x29c]
+	str r1, [r9, #0x4c0]
 	bl func_ov15_021448f8
 	b _02145420
 _02144fb8:
-	ldr r0, [sb, #0x378]
+	ldr r0, [r9, #0x378]
 	cmp r0, #0
 	moveq r0, #6
-	streqb r0, [sb, #0x34d]
-	mov r0, sb
+	streqb r0, [r9, #0x34d]
+	mov r0, r9
 	bl func_ov15_02144774
-	mov r0, sb
+	mov r0, r9
 	bl func_ov15_021448f8
 	b _02145420
 _02144fdc:
 	add r1, sp, #0xb4
-	mov r0, sb
+	mov r0, r9
 	bl func_ov15_02175ba8
 	ldr r0, [r6, #4]
 	mov r1, #0
 	str r1, [r0, #0x11c]
-	ldr r0, [sb, #0x20]
+	ldr r0, [r9, #0x20]
 	bl func_ov15_02149b34
 	ldr r1, _02145808 ; =0x000003d7
 	add r0, sp, #0xa8
@@ -44334,10 +44334,10 @@ _02144fdc:
 	bl func_01ff88b0
 	ldr r1, _021457d4 ; =data_027e0f94
 	add r0, sp, #0xa8
-	add r2, sb, #0x358
+	add r2, r9, #0x358
 	bl func_01ff9bc4
 	ldr r1, _021457d8 ; =data_027e0fac
-	add r0, sb, #0x300
+	add r0, r9, #0x300
 	ldrsh r3, [r1]
 	ldr r1, _02145808 ; =0x000003d7
 	mov r2, #0
@@ -44358,21 +44358,21 @@ _02144fdc:
 	ldr r2, [sp, #0xb0]
 	ldr r0, [sp, #0xa8]
 	mvn r1, #0xcc
-	str r0, [sb, #0x364]
-	str r3, [sb, #0x368]
-	str r2, [sb, #0x36c]
-	ldr r2, [sb, #0x368]
+	str r0, [r9, #0x364]
+	str r3, [r9, #0x368]
+	str r2, [r9, #0x36c]
+	ldr r2, [r9, #0x368]
 	mov r0, #0x1000
 	add r2, r2, #0x1000
-	str r2, [sb, #0x368]
-	str r1, [sb, #0x370]
+	str r2, [r9, #0x368]
+	str r1, [r9, #0x370]
 	str r0, [r4, #0x17c]
 	ldr r0, _021457f4 ; =data_027e0e58
-	add r1, sb, #0x184
+	add r1, r9, #0x184
 	ldr r0, [r0]
 	bl func_ov00_0207c444
 	ldr r0, _021457f4 ; =data_027e0e58
-	add r1, sb, #0x188
+	add r1, r9, #0x188
 	ldr r0, [r0]
 	bl func_ov00_0207c444
 	ldr r0, _021457e8 ; =data_027e0ffc
@@ -44384,30 +44384,30 @@ _02144fdc:
 	ldr r2, [sp, #0xb0]
 	ldr r1, [sp, #0xa8]
 	ldr r0, _021457e4 ; =0xfffffe66
-	str r1, [sb, #0x4b8]
-	str r3, [sb, #0x4bc]
-	str r2, [sb, #0x4c0]
-	ldr r1, [sb, #0x4bc]
+	str r1, [r9, #0x4b8]
+	str r3, [r9, #0x4bc]
+	str r2, [r9, #0x4c0]
+	ldr r1, [r9, #0x4bc]
 	add r0, r1, r0
-	str r0, [sb, #0x4bc]
+	str r0, [r9, #0x4bc]
 	ldr r0, _02145810 ; =0x00000333
 	mov r1, #0x180
-	str r0, [sb, #0x468]
-	str r1, [sb, #0x460]
+	str r0, [r9, #0x468]
+	str r1, [r9, #0x460]
 	ldr r0, _021457d8 ; =data_027e0fac
 	mov r1, #7
 	ldrsh r2, [r0]
 	mov r0, #0x14
 	sub r2, r2, #0x7800
-	str r2, [sb, #0x464]
-	strb r1, [sb, #0x34d]
-	str r0, [sb, #0x378]
+	str r2, [r9, #0x464]
+	strb r1, [r9, #0x34d]
+	str r0, [r9, #0x378]
 	b _02145420
 _02145140:
 	cmp r0, #7
 	bne _021451e4
 	add r1, sp, #0x84
-	mov r0, sb
+	mov r0, r9
 	bl func_ov15_02175ba8
 	ldr r4, _02145808 ; =0x000003d7
 	add r0, sp, #0x78
@@ -44419,58 +44419,58 @@ _02145140:
 	str r4, [sp, #0x7c]
 	str r3, [sp, #0x80]
 	bl func_01ff88b0
-	ldr r2, [sb, #0x368]
-	ldr r1, [sb, #0x370]
+	ldr r2, [r9, #0x368]
+	ldr r1, [r9, #0x370]
 	ldr r0, _021457d4 ; =data_027e0f94
 	add r2, r2, r1
-	str r2, [sb, #0x368]
+	str r2, [r9, #0x368]
 	ldr r1, [sp, #0x7c]
 	ldr r0, [r0, #4]
 	add r1, r1, r0
 	cmp r2, r1
 	bge _021451e4
 	ldr r0, _021457e8 ; =data_027e0ffc
-	str r1, [sb, #0x368]
+	str r1, [r9, #0x368]
 	mov r4, #8
-	add r2, sb, #0x364
+	add r2, r9, #0x364
 	mov r1, #0x3e8
 	mov r3, r5
-	strb r4, [sb, #0x34d]
+	strb r4, [r9, #0x34d]
 	bl func_ov00_020ceacc
 	mov r1, r5
 	str r1, [sp]
 	ldr r0, _021457f4 ; =data_027e0e58
 	str r1, [sp, #4]
 	ldr r0, [r0]
-	add r2, sb, #0x364
+	add r2, r9, #0x364
 	mov r3, #1
 	bl func_ov00_0207c1b0
 _021451e4:
-	ldr r0, [sb, #0x378]
+	ldr r0, [r9, #0x378]
 	cmp r0, #0
 	bne _02145420
 	mov r0, #9
-	strb r0, [sb, #0x34d]
+	strb r0, [r9, #0x34d]
 	mov r0, #0x28
-	str r0, [sb, #0x378]
+	str r0, [r9, #0x378]
 	b _02145420
 _02145204:
-	ldr r0, [sb, #0x378]
+	ldr r0, [r9, #0x378]
 	cmp r0, #0xa
 	bgt _02145230
 	bne _02145230
 	ldr r0, _021457e8 ; =data_027e0ffc
 	ldr r1, _02145814 ; =0x000003e9
-	add r2, sb, #0x364
+	add r2, r9, #0x364
 	mov r3, #0
 	bl func_ov00_020ceacc
 	mov r0, #1
 	strb r0, [r4, #0x180]
 _02145230:
-	ldr r0, [sb, #0x378]
+	ldr r0, [r9, #0x378]
 	cmp r0, #0
 	moveq r0, #0xa
-	streqb r0, [sb, #0x34d]
+	streqb r0, [r9, #0x34d]
 	beq _02145420
 	cmp r0, #0xa
 	bne _0214525c
@@ -44481,7 +44481,7 @@ _02145230:
 _0214525c:
 	cmp r0, #0x1e
 	moveq r0, #0x46
-	streq r0, [sb, #0x37c]
+	streq r0, [r9, #0x37c]
 	b _02145420
 _0214526c:
 	ldr r0, [r4, #0x10]
@@ -44497,9 +44497,9 @@ _0214526c:
 	blx _ZN4Item18func_ov00_020ad020Ei
 	cmp r0, #0
 	movne r0, #0xb
-	strneb r0, [sb, #0x34d]
+	strneb r0, [r9, #0x34d]
 	moveq r0, #0xd
-	streqb r0, [sb, #0x34d]
+	streqb r0, [r9, #0x34d]
 	b _02145420
 _021452b0:
 	bl func_ov15_021464fc
@@ -44507,11 +44507,11 @@ _021452b0:
 	ldr r0, _02145818 ; =data_ov09_0211f5dc
 	blx func_ov03_020fb0b0
 	mov r0, #0xc
-	strb r0, [sb, #0x34d]
+	strb r0, [r9, #0x34d]
 	b _02145420
 _021452cc:
 	add sp, sp, #0x1c4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _021452d4:
 	bl func_ov15_021464fc
 	mov r5, r0
@@ -44548,13 +44548,13 @@ _02145334:
 	mov r1, #1
 	bl func_ov15_0216e168
 	mov r0, #0xe
-	strb r0, [sb, #0x34d]
+	strb r0, [r9, #0x34d]
 _02145358:
 	mov r0, r6
 	bl func_ov15_0216e9d0
 	cmp r0, #0
 	movne r0, #0xf
-	strneb r0, [sb, #0x34d]
+	strneb r0, [r9, #0x34d]
 	b _02145420
 _02145370:
 	bl func_ov15_021464fc
@@ -44563,7 +44563,7 @@ _02145370:
 	mov r0, r4
 	blx _ZN11ItemManager18func_ov00_020ae648Ejjj
 	mov r0, #0x10
-	strb r0, [sb, #0x34d]
+	strb r0, [r9, #0x34d]
 	b _02145420
 _02145390:
 	ldr r0, _02145820 ; =data_ov00_020eec68
@@ -44573,7 +44573,7 @@ _02145390:
 	bl func_ov00_02097750
 	cmp r0, #0
 	bne _02145420
-	mov r0, sb
+	mov r0, r9
 	bl func_ov15_021428c4
 	bl func_ov15_02146578
 	mov r1, r0
@@ -44595,7 +44595,7 @@ _021453d4:
 	bl func_ov15_02184728
 _021453f8:
 	mov r0, #0x11
-	strb r0, [sb, #0x34d]
+	strb r0, [r9, #0x34d]
 	bl func_ov15_021464fc
 	cmp r0, #0x26
 	bne _0214541c
@@ -44606,22 +44606,22 @@ _021453f8:
 _0214541c:
 	bl func_ov15_021465e8
 _02145420:
-	ldr r2, [sb, #0x20]
-	ldr r1, [sb, #0x364]
-	add r0, sb, #0x300
+	ldr r2, [r9, #0x20]
+	ldr r1, [r9, #0x364]
+	add r0, r9, #0x300
 	str r1, [r2, #0x180]
-	ldr r1, [sb, #0x368]
+	ldr r1, [r9, #0x368]
 	str r1, [r2, #0x184]
-	ldr r1, [sb, #0x36c]
+	ldr r1, [r9, #0x36c]
 	str r1, [r2, #0x188]
-	ldr r2, [sb, #0x20]
-	ldr r1, [sb, #0x358]
+	ldr r2, [r9, #0x20]
+	ldr r1, [r9, #0x358]
 	str r1, [r2, #0x170]
-	ldr r1, [sb, #0x35c]
+	ldr r1, [r9, #0x35c]
 	str r1, [r2, #0x174]
-	ldr r1, [sb, #0x360]
+	ldr r1, [r9, #0x360]
 	str r1, [r2, #0x178]
-	ldr r1, [sb, #0x20]
+	ldr r1, [r9, #0x20]
 	ldrh r2, [r0, #0x84]
 	add r0, r1, #0x100
 	strh r2, [r0, #0x7c]
@@ -44630,13 +44630,13 @@ _02145420:
 	tst r0, #1
 	beq _02145500
 	add r2, sp, #0x6c
-	add r0, sb, #0x364
-	add r1, sb, #0x358
+	add r0, r9, #0x364
+	add r1, r9, #0x358
 	bl func_01ff9bf8
 	ldr r0, [sp, #0x6c]
 	ldr r1, [sp, #0x74]
 	bl func_01ffa0f4
-	add r1, sb, #0x300
+	add r1, r9, #0x300
 	ldrh r1, [r1, #0x84]
 	ldr r5, [sp, #0x70]
 	mov r2, #0
@@ -44663,21 +44663,21 @@ _02145420:
 	mov r0, r6
 	bl func_ov15_0216ea14
 _02145500:
-	ldrb r0, [sb, #0x34d]
+	ldrb r0, [r9, #0x34d]
 	cmp r0, #3
 	blo _02145524
-	ldr r0, [sb, #0x2a0]
-	str r0, [sb, #0x294]
-	ldr r0, [sb, #0x2a4]
-	str r0, [sb, #0x298]
-	ldr r0, [sb, #0x2a8]
-	str r0, [sb, #0x29c]
+	ldr r0, [r9, #0x2a0]
+	str r0, [r9, #0x294]
+	ldr r0, [r9, #0x2a4]
+	str r0, [r9, #0x298]
+	ldr r0, [r9, #0x2a8]
+	str r0, [r9, #0x29c]
 _02145524:
-	ldr r0, [sb, #0x37c]
+	ldr r0, [r9, #0x37c]
 	cmp r0, #0
 	beq _02145798
 	add r1, sp, #0x48
-	mov r0, sb
+	mov r0, r9
 	bl func_ov15_02175ba8
 	ldr r4, _02145830 ; =0x0000023d
 	add r0, sp, #0x3c
@@ -44693,62 +44693,62 @@ _02145524:
 	ldr r1, _021457d4 ; =data_027e0f94
 	mov r2, r0
 	bl func_01ff9bc4
-	ldr r1, [sb, #0x45c]
+	ldr r1, [r9, #0x45c]
 	ldr r0, _02145834 ; =0x00000e39
 	sub r0, r0, r1
 	bl func_02042f74
-	ldr r1, [sb, #0x37c]
+	ldr r1, [r9, #0x37c]
 	bl func_02002c14
 	mov r0, r0, lsl #0x10
 	mov r2, r0, asr #0x10
-	add r0, sb, #0x5c
+	add r0, r9, #0x5c
 	ldr r1, _02145834 ; =0x00000e39
 	add r0, r0, #0x400
 	bl Approach_thunk
-	ldr r1, [sb, #0x460]
+	ldr r1, [r9, #0x460]
 	ldr r0, _02145838 ; =0x000023b0
 	sub r0, r0, r1
 	bl func_02042f74
-	ldr r1, [sb, #0x37c]
+	ldr r1, [r9, #0x37c]
 	bl func_02002c14
 	mov r0, r0, lsl #0x10
 	mov r2, r0, asr #0x10
 	ldr r1, _02145838 ; =0x000023b0
-	add r0, sb, #0x460
+	add r0, r9, #0x460
 	bl func_0202b154
 	ldr r0, _021457d8 ; =data_027e0fac
-	ldr r1, [sb, #0x464]
+	ldr r1, [r9, #0x464]
 	ldrsh r4, [r0]
 	ldr r0, _0214583c ; =0xffff86dc
 	sub r1, r1, r4
 	sub r0, r0, r1
 	bl func_02042f74
-	ldr r1, [sb, #0x37c]
+	ldr r1, [r9, #0x37c]
 	bl func_02002c14
 	ldr r1, _0214583c ; =0xffff86dc
 	mov r0, r0, lsl #0x10
 	add r1, r4, r1
 	mov r2, r0, asr #0x10
-	add r0, sb, #0x64
+	add r0, r9, #0x64
 	mov r1, r1, lsl #0x10
 	add r0, r0, #0x400
 	mov r1, r1, asr #0x10
 	bl func_0202b154
-	ldr r1, [sb, #0x468]
+	ldr r1, [r9, #0x468]
 	ldr r0, _021457f0 ; =0x0000028f
 	sub r0, r0, r1
 	bl func_02042f74
-	ldr r1, [sb, #0x37c]
+	ldr r1, [r9, #0x37c]
 	bl func_02002c14
 	mov r2, r0
-	add r0, sb, #0x68
+	add r0, r9, #0x68
 	ldr r1, _021457f0 ; =0x0000028f
 	add r0, r0, #0x400
 	bl Approach_thunk
 	ldr r0, _021457d8 ; =data_027e0fac
 	ldr r8, [sp, #0x3c]
 	ldrh r2, [r0]
-	ldr r0, [sb, #0x4b8]
+	ldr r0, [r9, #0x4b8]
 	add r1, r8, #0x35
 	mov r2, r2, asr #0x4
 	mov r4, r2, lsl #0x1
@@ -44760,12 +44760,12 @@ _02145524:
 	mov r1, r1, lsl #0x1
 	ldrsh r7, [r2, r3]
 	ldrsh r5, [r2, r1]
-	ldr r1, [sb, #0x37c]
+	ldr r1, [r9, #0x37c]
 	mov r6, r7, asr #0x1f
 	mov r4, r5, asr #0x1f
 	bl func_02002c14
 	mov r2, r0
-	add r0, sb, #0xb8
+	add r0, r9, #0xb8
 	add r0, r0, #0x400
 	mov lr, #0
 	mov r1, #0x35
@@ -44789,26 +44789,26 @@ _02145524:
 	add r1, r1, r8
 	bl Approach_thunk
 	ldr r1, [sp, #0x40]
-	ldr r0, [sb, #0x4bc]
+	ldr r0, [r9, #0x4bc]
 	add r8, r1, #0xe9
 	sub r0, r8, r0
 	bl func_02042f74
-	ldr r1, [sb, #0x37c]
+	ldr r1, [r9, #0x37c]
 	bl func_02002c14
 	mov r1, r8
 	mov r2, r0
-	add r0, sb, #0xbc
+	add r0, r9, #0xbc
 	add r0, r0, #0x400
 	bl Approach_thunk
 	ldr r8, [sp, #0x44]
-	ldr r0, [sb, #0x4c0]
+	ldr r0, [r9, #0x4c0]
 	sub r1, r8, #0x6a
 	sub r0, r1, r0
 	bl func_02042f74
-	ldr r1, [sb, #0x37c]
+	ldr r1, [r9, #0x37c]
 	bl func_02002c14
 	mov r2, r0
-	add r0, sb, #0x4c0
+	add r0, r9, #0x4c0
 	mov r11, #0
 	mov r1, #0x35
 	sub ip, r1, #0x36
@@ -44836,14 +44836,14 @@ _02145798:
 	ldr r0, _021457cc ; =data_027e0f64
 	str r1, [sp, #4]
 	ldr r0, [r0]
-	add r1, sb, #0xb8
+	add r1, r9, #0xb8
 	ldr r0, [r0, #4]
 	add r1, r1, #0x400
-	add r3, sb, #0x450
+	add r3, r9, #0x450
 	mov r2, #2
 	bl func_ov00_02089318
 	add sp, sp, #0x1c4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_021449b0
 _021457cc: .word data_027e0f64
@@ -47262,7 +47262,7 @@ func_ov15_02147604: ; 0x02147604
 	.global func_ov15_0214761c
 	arm_func_start func_ov15_0214761c
 func_ov15_0214761c: ; 0x0214761c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x1c
 	ldr r1, _02147bb0 ; =data_027e10a4
 	mov r4, r0
@@ -47308,28 +47308,28 @@ _02147670:
 	cmp r1, #2
 	beq _0214792c
 	add sp, sp, #0x1c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _021476d0:
 	ldr r10, _02147bb4 ; =data_027e0764
 	mov r1, #0
 	ldr r0, [r10, #8]
 	ldr r3, [r10]
 	ldr r2, [r10, #4]
-	umull sb, r8, r0, r3
+	umull r9, r8, r0, r3
 	mla r8, r0, r2, r8
 	ldr r2, [r10, #0xc]
 	ldr r7, [r10, #0x10]
 	mla r8, r2, r3, r8
-	adds sb, r7, sb
+	adds r9, r7, r9
 	ldr r3, [r10, #0x14]
-	umull ip, r11, r0, sb
+	umull ip, r11, r0, r9
 	adc r8, r3, r8
-	str sb, [r10]
+	str r9, [r10]
 	mla r11, r0, r8, r11
 	str r8, [r10, #4]
 	tst r8, #0x80000000
 	beq _0214775c
-	mla r11, r2, sb, r11
+	mla r11, r2, r9, r11
 	adds r0, r7, ip
 	adc r3, r3, r11
 	mov r1, r1, lsl #0x2
@@ -47346,7 +47346,7 @@ _021476d0:
 	add r0, r2, r1
 	b _02147798
 _0214775c:
-	mla r11, r2, sb, r11
+	mla r11, r2, r9, r11
 	adds r0, r7, ip
 	adc r3, r3, r11
 	mov r1, r1, lsl #0x2
@@ -47394,10 +47394,10 @@ _02147798:
 	umull r8, r7, r6, r5
 	mla r7, r6, r2, r7
 	ldr r2, [r3, #0xc]
-	ldr sb, [r3, #0x10]
+	ldr r9, [r3, #0x10]
 	mla r7, r2, r5, r7
 	ldr r6, [r3, #0x14]
-	adds r8, sb, r8
+	adds r8, r9, r8
 	adc r7, r6, r7
 	mov r2, #5
 	umull r5, r6, r7, r2
@@ -47409,7 +47409,7 @@ _02147798:
 	mov r0, r0, lsl #0xb
 	add sp, sp, #0x1c
 	str r0, [r4, #0x3f4]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02147858:
 	mov r2, #0x100
 	add r0, r4, #0x3fc
@@ -47424,7 +47424,7 @@ _02147858:
 	bl func_ov15_021529f8
 	cmp r0, #0
 	addeq sp, sp, #0x1c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, [r4, #0x424]
 	cmp r0, #0
 	beq _021478c8
@@ -47438,7 +47438,7 @@ _02147858:
 	bl func_ov15_021529f0
 	cmp r0, #0x1e
 	addlt sp, sp, #0x1c
-	ldmltia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmltia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _021478c8:
 	mov r0, #2
 	ldr r2, _02147bb4 ; =data_027e0764
@@ -47464,7 +47464,7 @@ _021478c8:
 	mov r0, r0, lsl #0xb
 	add sp, sp, #0x1c
 	str r0, [r4, #0x3f4]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0214792c:
 	mov r0, #0
 	str r0, [r4, #0x3f0]
@@ -47481,7 +47481,7 @@ _0214792c:
 	bl func_ov15_02152a0c
 	cmp r0, #0
 	addeq sp, sp, #0x1c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r0, sp, #0x10
 	ldr r6, [r4, #0x420]
 	bl func_01ff9cec
@@ -47491,7 +47491,7 @@ _0214792c:
 	add r1, r1, #0xb00
 	cmp r0, r1
 	addge sp, sp, #0x1c
-	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmgeia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r2, _02147bb4 ; =data_027e0764
 	mov r1, #0
 	ldr r3, [r2]
@@ -47512,7 +47512,7 @@ _0214792c:
 	cmp r6, #3
 	addge sp, sp, #0x1c
 	str r7, [r2, #4]
-	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmgeia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	mov r1, #1
 	mov r0, r4
 	strb r1, [r4, #0x43c]
@@ -47610,10 +47610,10 @@ _02147acc:
 	ldmib r2, {r3, r5, lr}
 	umull r7, r6, r5, ip
 	mla r6, r5, r3, r6
-	ldr sb, [r2, #0x10]
+	ldr r9, [r2, #0x10]
 	mla r6, lr, ip, r6
 	ldr r8, [r2, #0x14]
-	adds r3, sb, r7
+	adds r3, r9, r7
 	adc r5, r8, r6
 	mov r11, #0x3c
 	stmia r2, {r3, r5}
@@ -47627,7 +47627,7 @@ _02147acc:
 	str r2, [r4, #0x428]
 	bl func_ov15_02148684
 	add sp, sp, #0x1c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0214761c
 _02147bb0: .word data_027e10a4
@@ -47646,7 +47646,7 @@ func_ov15_02147bb8: ; 0x02147bb8
 	.global func_ov15_02147bcc
 	arm_func_start func_ov15_02147bcc
 func_ov15_02147bcc: ; 0x02147bcc
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x1c
 	mov r6, r0
 	ldr r0, _02148070 ; =data_027e10a4
@@ -47667,13 +47667,13 @@ func_ov15_02147bcc: ; 0x02147bcc
 	umull r8, r7, r3, r2
 	mla r7, r3, r0, r7
 	ldr r0, [r1, #0xc]
-	ldr sb, [r1, #0x10]
+	ldr r9, [r1, #0x10]
 	mla r7, r0, r2, r7
 	ldr r3, [r1, #0x14]
-	adds sb, sb, r8
+	adds r9, r9, r8
 	adc r8, r3, r7
 	mov r0, #0x28
-	str sb, [r1]
+	str r9, [r1]
 	umull r3, r7, r8, r0
 	mov r2, #0
 	mla r7, r8, r2, r7
@@ -47695,17 +47695,17 @@ func_ov15_02147bcc: ; 0x02147bcc
 	mov ip, r2, lsr #0xc
 	orr ip, ip, r0, lsl #20
 	mov r0, #0xa00
-	mov sb, ip, asr #0x1f
+	mov r9, ip, asr #0x1f
 	mov r2, #0
 	umull r7, r3, ip, r0
 	mla r3, ip, r2, r3
-	mov r8, sb, lsl #0xa
+	mov r8, r9, lsl #0xa
 	mov r1, #0x800
 	adds r1, r1, ip, lsl #10
 	orr r8, r8, ip, lsr #22
 	adc r8, r8, #0
 	adds r7, r7, #0x800
-	mla r3, sb, r0, r3
+	mla r3, r9, r0, r3
 	mov r1, r1, lsr #0xc
 	adc r0, r3, #0
 	mov r3, r7, lsr #0xc
@@ -47718,14 +47718,14 @@ func_ov15_02147bcc: ; 0x02147bcc
 	ldr r3, _02148074 ; =data_027e0764
 	ldr r7, [r3]
 	ldmib r3, {r2, r8}
-	umull ip, sb, r8, r7
-	mla sb, r8, r2, sb
+	umull ip, r9, r8, r7
+	mla r9, r8, r2, r9
 	ldr r2, [r3, #0xc]
 	ldr r8, [r3, #0x10]
-	mla sb, r2, r7, sb
+	mla r9, r2, r7, r9
 	ldr r2, [r3, #0x14]
 	adds r7, r8, ip
-	adc r2, r2, sb
+	adc r2, r2, r9
 	str r7, [r3]
 	str r2, [r3, #4]
 	cmp r0, #0
@@ -47762,29 +47762,29 @@ _02147d38:
 	sub r0, r0, r1, asr #10
 	add r0, r0, #1
 	cmp r0, #0
-	movle sb, #0
+	movle r9, #0
 	ble _02147de8
 	ldr r3, _02148074 ; =data_027e0764
 	ldr r8, [r3]
 	ldmib r3, {r7, ip}
-	umull sb, lr, ip, r8
+	umull r9, lr, ip, r8
 	mla lr, ip, r7, lr
 	ldr r7, [r3, #0xc]
 	ldr ip, [r3, #0x10]
 	mla lr, r7, r8, lr
 	ldr r7, [r3, #0x14]
-	adds r8, ip, sb
-	adc sb, r7, lr
-	stmia r3, {r8, sb}
+	adds r8, ip, r9
+	adc r9, r7, lr
+	stmia r3, {r8, r9}
 	cmp r0, #0
 	beq _02147de8
 	mov r8, #0
-	umull r7, r3, sb, r0
-	mla r3, sb, r8, r3
+	umull r7, r3, r9, r0
+	mla r3, r9, r8, r3
 	mla r3, r8, r0, r3
-	mov sb, r3
+	mov r9, r3
 _02147de8:
-	add r0, sb, r1, asr #10
+	add r0, r9, r1, asr #10
 	add r0, r0, #0x1e0
 	smull r2, r1, r0, r2
 	adds r2, r2, #0x800
@@ -47868,7 +47868,7 @@ _02147f18:
 	ldr r0, [r6, #0x428]
 	cmp r0, #0
 	addne sp, sp, #0x1c
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	ldr r2, _02148074 ; =data_027e0764
 	mov r0, #0
 	ldr r3, [r2]
@@ -47895,22 +47895,22 @@ _02147f18:
 	ldrb r2, [r3, #0x293]
 	cmp r2, #0
 	addne sp, sp, #0x1c
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	sub r0, r0, #0xf000
 	cmp r4, r0
 	addlt sp, sp, #0x1c
-	ldmltia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmltia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	ldr r0, [r3, #0x3d0]
 	cmp r0, #0
 	addeq sp, sp, #0x1c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	mov r0, r5, asr #0xb
 	add r0, r5, r0, lsr #20
 	mov r0, r0, asr #0xc
 	sub r4, r0, #3
 	cmp r4, #1
 	addle sp, sp, #0x1c
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	ldr r0, _0214807c ; =data_027e0f74
 	add r1, r1, #0xf3
 	ldr r0, [r0]
@@ -47920,7 +47920,7 @@ _02147f18:
 	cmp r4, #0xf
 	ble _02148000
 	add sp, sp, #0x1c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _02147ff8:
 	cmp r4, #0x19
 	movgt r4, #0x19
@@ -47947,12 +47947,12 @@ _02148000:
 	cmp r5, r4
 	str ip, [r2, #4]
 	addle sp, sp, #0x1c
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	mov r0, r6
 	mov r1, #2
 	bl func_ov15_02148684
 	add sp, sp, #0x1c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02147bcc
 _02148070: .word data_027e10a4
@@ -48013,7 +48013,7 @@ _0214812c: .word data_ov15_02186220
 	.global func_ov15_02148130
 	arm_func_start func_ov15_02148130
 func_ov15_02148130: ; 0x02148130
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #4
 	mov r4, r0
 	ldrb r1, [r4, #0x439]
@@ -48128,56 +48128,56 @@ _02148274:
 	strb r0, [r4, #0x43b]
 	ldr r7, [r8]
 	ldmib r8, {r0, r2}
-	umull r5, sb, r2, r7
-	mla sb, r2, r0, sb
+	umull r5, r9, r2, r7
+	mla r9, r2, r0, r9
 	ldr r1, [r8, #0xc]
 	ldr ip, [r8, #0x10]
-	mla sb, r1, r7, sb
+	mla r9, r1, r7, r9
 	ldr r3, [r8, #0x14]
 	adds r5, ip, r5
-	adc lr, r3, sb
+	adc lr, r3, r9
 	mov r7, #0xa
-	umull sb, r10, lr, r7
+	umull r9, r10, lr, r7
 	mla r10, lr, r6, r10
 	mov r0, r6
 	mla r10, r0, r7, r10
-	umull sb, r7, r2, r5
+	umull r9, r7, r2, r5
 	mla r7, r2, lr, r7
 	stmia r8, {r5, lr}
 	cmp r10, #2
 	bge _02148358
 	mla r7, r1, r5, r7
-	adds sb, ip, sb
+	adds r9, ip, r9
 	adc r5, r3, r7
 	mov r1, #0x1e
 	umull r2, r3, r5, r1
 	mla r3, r5, r6, r3
 	mla r3, r0, r1, r3
-	str sb, [r8]
+	str r9, [r8]
 	str r5, [r8, #4]
 	add r0, r3, #0x1e
 	b _02148380
 _02148358:
 	mla r7, r1, r5, r7
-	adds sb, ip, sb
+	adds r9, ip, r9
 	adc r5, r3, r7
 	mov r1, #0x1e
 	umull r2, r3, r5, r1
 	mla r3, r5, r6, r3
 	mla r3, r0, r1, r3
-	str sb, [r8]
+	str r9, [r8]
 	str r5, [r8, #4]
 	add r0, r3, #0x5a
 _02148380:
 	add sp, sp, #4
 	str r0, [r4, #0x428]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 _0214838c:
 	ldr r0, [r4, #0x42c]
 	add r0, r0, #1
 	str r0, [r4, #0x42c]
 	add sp, sp, #4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02148130
 _021483a0: .word data_ov15_0218b588
@@ -50572,7 +50572,7 @@ _0214a3ac: .word data_02050f54
 	.global func_ov15_0214a3b0
 	arm_func_start func_ov15_0214a3b0
 func_ov15_0214a3b0: ; 0x0214a3b0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x80
 	mov r6, r0
 	ldr r2, [r6, #0xe0]
@@ -50596,7 +50596,7 @@ func_ov15_0214a3b0: ; 0x0214a3b0
 	bl func_01fffb4c
 	cmp r0, #0
 	addeq sp, sp, #0x80
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r2, [r6, #0xc]
 	mov r0, #0x800
 	mov r1, r2, asr #0x1f
@@ -50614,10 +50614,10 @@ func_ov15_0214a3b0: ; 0x0214a3b0
 	add r0, r0, r2
 	cmp r1, r0
 	addge sp, sp, #0x80
-	ldmgeia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmgeia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	cmp r2, #0
 	addle sp, sp, #0x80
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r2, [r6, #0xf8]
 	ldr r1, [r6, #0xfc]
 	ldr r0, [r6, #0x100]
@@ -50771,22 +50771,22 @@ _0214a6bc:
 	ldr lr, [sp, #0x74]
 	ldr r3, _0214a86c ; =0x00000333
 	cmp r5, #0x80000
-	umull r10, sb, lr, r3
+	umull r10, r9, lr, r3
 	mov r3, #0
-	mla sb, lr, r3, sb
+	mla r9, lr, r3, r9
 	moveq r5, #0
 	movne r5, #0x80000
 	add r0, sp, #0x50
 	ldr r3, _0214a86c ; =0x00000333
 	mov ip, lr, asr #0x1f
-	mla sb, ip, r3, sb
+	mla r9, ip, r3, r9
 	adds r10, r10, #0x800
-	adc r3, sb, #0
-	mov sb, r10, lsr #0xc
-	orr sb, sb, r3, lsl #20
+	adc r3, r9, #0
+	mov r9, r10, lsr #0xc
+	orr r9, r9, r3, lsl #20
 	add r1, sp, #0x74
 	mov r2, r0
-	str sb, [sp, #0x74]
+	str r9, [sp, #0x74]
 	bl func_01ff9bc4
 	ldr r1, [r6, #0xfc]
 	ldr r0, [sp, #0x54]
@@ -50797,11 +50797,11 @@ _0214a6bc:
 	mov r0, r0, asr #0x10
 	mov r0, r0, lsl #0x10
 	mov r0, r0, lsr #0x10
-	mov sb, r0, lsl #0x10
+	mov r9, r0, lsl #0x10
 	mov r0, #0x22
 	add r1, sp, #0x10
 	add r4, r4, #1
-	str sb, [sp, #0x10]
+	str r9, [sp, #0x10]
 	bl func_01ffa9fc
 	ldr r1, [sp, #0x58]
 	ldr r0, [sp, #0x64]
@@ -50825,7 +50825,7 @@ _0214a6bc:
 	add r1, sp, #0xc
 	mov r2, #1
 	bl func_01ffa9fc
-	orr r0, sb, #0x200
+	orr r0, r9, #0x200
 	str r0, [sp, #8]
 	mov r0, #0x22
 	add r1, sp, #8
@@ -50871,7 +50871,7 @@ _0214a82c:
 	str r2, [sp]
 	bl func_01ffa9fc
 	add sp, sp, #0x80
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0214a3b0
 _0214a858: .word 0x0000ffff
@@ -50885,7 +50885,7 @@ _0214a870: .word data_ov15_0218b704
 	.global func_ov15_0214a874
 	arm_func_start func_ov15_0214a874
 func_ov15_0214a874: ; 0x0214a874
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0xb4
 	mov r10, r0
 	ldr r3, [r10, #0xc]
@@ -50897,7 +50897,7 @@ func_ov15_0214a874: ; 0x0214a874
 	ldrb r0, [r10, #0x1c5]
 	adc r2, r2, #0
 	mov r4, r4, lsr #0xc
-	mov sb, r1
+	mov r9, r1
 	cmp r0, #0
 	orr r4, r4, r2, lsl #20
 	beq _0214a8e8
@@ -50915,13 +50915,13 @@ func_ov15_0214a874: ; 0x0214a874
 	str r0, [sp, #0xb0]
 	b _0214a95c
 _0214a8e8:
-	ldr r1, [sb]
+	ldr r1, [r9]
 	add r0, sp, #0xa8
 	str r1, [sp, #0xa8]
-	ldr r2, [sb, #4]
+	ldr r2, [r9, #4]
 	add r1, sp, #0x6c
 	str r2, [sp, #0xac]
-	ldr r3, [sb, #8]
+	ldr r3, [r9, #8]
 	mov r2, r0
 	str r3, [sp, #0xb0]
 	ldr r3, [r10, #0xf8]
@@ -50940,24 +50940,24 @@ _0214a8e8:
 	bl func_01fffb4c
 	cmp r0, #0
 	addeq sp, sp, #0xb4
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r0, sp, #0xa8
 	mov r1, r4
 	bl func_01fffbec
 _0214a95c:
 	ldr r2, [sp, #0xac]
-	ldr r0, [sb, #4]
+	ldr r0, [r9, #4]
 	ldr r1, [r10, #0xfc]
 	add r0, r0, r2
 	cmp r1, r0
 	addge sp, sp, #0xb4
-	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmgeia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	cmp r2, #0
 	addle sp, sp, #0xb4
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
-	ldr r2, [sb]
-	ldr r1, [sb, #4]
-	ldr r0, [sb, #8]
+	ldmleia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
+	ldr r2, [r9]
+	ldr r1, [r9, #4]
+	ldr r0, [r9, #8]
 	str r2, [sp, #0x9c]
 	str r1, [sp, #0xa0]
 	str r0, [sp, #0xa4]
@@ -51011,13 +51011,13 @@ _0214a95c:
 	add r1, sp, #0x48
 	mov r2, #3
 	bl func_01ffa9fc
-	ldr r1, [sb]
+	ldr r1, [r9]
 	ldr r0, _0214af58 ; =data_027e10a4
 	str r1, [sp, #0x90]
 	ldr r1, [r0]
-	ldr r0, [sb, #4]
+	ldr r0, [r9, #4]
 	str r0, [sp, #0x94]
-	ldr r0, [sb, #8]
+	ldr r0, [r9, #8]
 	str r0, [sp, #0x98]
 	ldr r0, [r1, #0x2c]
 	cmp r0, #5
@@ -51313,7 +51313,7 @@ _0214adf4:
 	add r1, sp, #4
 	mov r2, #1
 	bl func_01ffa9fc
-	ldr r2, [sb, #4]
+	ldr r2, [r9, #4]
 	ldr r1, [sp, #0x7c]
 	ldr r0, [r10, #0xfc]
 	add r1, r2, r1
@@ -51336,7 +51336,7 @@ _0214af2c:
 	str r2, [sp]
 	bl func_01ffa9fc
 	add sp, sp, #0xb4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0214a874
 _0214af58: .word data_027e10a4
@@ -51672,16 +51672,16 @@ _0214b3f4:
 	.global func_ov15_0214b408
 	arm_func_start func_ov15_0214b408
 func_ov15_0214b408: ; 0x0214b408
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x78
-	mov sb, r0
+	mov r9, r0
 	ldr r0, _0214b5f4 ; =0x0000019a
-	ldr r1, [sb, #0xc0]
+	ldr r1, [r9, #0xc0]
 	str r0, [sp, #0x6c]
 	str r0, [sp, #0x70]
 	str r0, [sp, #0x74]
 	cmp r1, #0
-	ldrneb r0, [sb, #0x1c9]
+	ldrneb r0, [r9, #0x1c9]
 	cmpne r0, #0
 	beq _0214b590
 	ldr r4, [r1, #4]
@@ -51694,17 +51694,17 @@ func_ov15_0214b408: ; 0x0214b408
 	str r3, [sp, #0x64]
 	ldr r3, [r4, #0xe8]
 	str r3, [sp, #0x68]
-	ldr r3, [sb, #0x110]
+	ldr r3, [r9, #0x110]
 	str r3, [sp, #0x54]
-	ldr r3, [sb, #0x114]
+	ldr r3, [r9, #0x114]
 	str r3, [sp, #0x58]
-	ldr r3, [sb, #0x118]
+	ldr r3, [r9, #0x118]
 	str r3, [sp, #0x5c]
 	bl func_01ff9bf8
 	add r0, sp, #0x54
 	mov r1, r0
 	bl func_01ff9d4c
-	ldr r1, [sb, #0x190]
+	ldr r1, [r9, #0x190]
 	add r0, sp, #0x54
 	bl func_01fffbec
 	mov r1, #0
@@ -51712,11 +51712,11 @@ func_ov15_0214b408: ; 0x0214b408
 	str r1, [sp, #0x48]
 	str r0, [sp, #0x4c]
 	str r1, [sp, #0x50]
-	ldr r0, [sb, #0x10c]
-	ldr r1, [sb, #0x108]
+	ldr r0, [r9, #0x10c]
+	ldr r1, [r9, #0x108]
 	bl func_01ffa0f4
-	ldr r0, [sb, #0x104]
-	ldr r1, [sb, #0x108]
+	ldr r0, [r9, #0x104]
+	ldr r1, [r9, #0x108]
 	bl func_01ffa0f4
 	mov r7, #0
 	mov r10, #0x180
@@ -51753,7 +51753,7 @@ _0214b4e0:
 	ldrsh r2, [r2, #2]
 	mov r0, r11
 	blx func_01ff8214
-	ldr r0, [sb, #0xb4]
+	ldr r0, [r9, #0xb4]
 	add r7, r7, #1
 	add r0, r0, r8
 	add lr, sp, #0x18
@@ -51767,21 +51767,21 @@ _0214b4e0:
 	cmp r7, #5
 	str r0, [ip]
 	blt _0214b4e0
-	ldr r0, [sb, #0xb4]
+	ldr r0, [r9, #0xb4]
 	mov r1, #1
 	strb r1, [r0, #0x130]
 	b _0214b59c
 _0214b590:
-	ldr r0, [sb, #0xb4]
+	ldr r0, [r9, #0xb4]
 	mov r1, #0
 	strb r1, [r0, #0x130]
 _0214b59c:
-	ldr r1, [sb, #0xc0]
-	ldr r0, [sb, #0xb4]
+	ldr r1, [r9, #0xc0]
+	ldr r0, [r9, #0xb4]
 	ldr r1, [r1, #4]
 	add r1, r1, #0x5c
 	bl func_ov00_020b3ee8
-	ldr r0, [sb, #0xb4]
+	ldr r0, [r9, #0xb4]
 	add r3, sp, #0xc
 	add r0, r0, #0x124
 	ldmia r0, {r0, r1, r2}
@@ -51797,7 +51797,7 @@ _0214b59c:
 	str r2, [sp, #8]
 	bl func_ov15_0214b600
 	add sp, sp, #0x78
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0214b408
 _0214b5f4: .word 0x0000019a
@@ -55247,7 +55247,7 @@ func_ov15_0214e118: ; 0x0214e118
 	.global func_ov15_0214e138
 	arm_func_start func_ov15_0214e138
 func_ov15_0214e138: ; 0x0214e138
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0xbc
 	mov r10, r0
 	ldr r2, [r10, #0x1a0]
@@ -55259,7 +55259,7 @@ func_ov15_0214e138: ; 0x0214e138
 	ldr r0, [r10, #0x58]
 	add sp, sp, #0xbc
 	str r0, [r10, #0x4c]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0214e16c:
 	add r0, r10, #0x100
 	ldrh r1, [r0, #0x68]
@@ -55349,7 +55349,7 @@ _0214e16c:
 	add r1, sp, #0x80
 	mov r0, r10
 	bl func_ov15_0214eabc
-	mov sb, r0
+	mov r9, r0
 	add r1, sp, #0x74
 	mov r0, r10
 	bl func_ov15_0214eabc
@@ -55363,7 +55363,7 @@ _0214e16c:
 	bl func_ov15_0214eabc
 	mov r6, r0
 	mov r0, #0
-	add r1, sb, r5
+	add r1, r9, r5
 	add r1, r6, r1
 	add r2, r8, r1
 	mov r1, r2, asr #0x1f
@@ -55377,10 +55377,10 @@ _0214e16c:
 	str r0, [sp, #0x50]
 	str r0, [sp, #0x58]
 	str r3, [sp, #0x54]
-	cmp sb, r5
+	cmp r9, r5
 	ble _0214e368
 	ldr r2, [sp, #0xb4]
-	sub r3, sb, r5
+	sub r3, r9, r5
 	smull r7, r2, r3, r2
 	adds r3, r7, r1
 	adc r1, r2, r0
@@ -55390,7 +55390,7 @@ _0214e16c:
 	b _0214e38c
 _0214e368:
 	ldr r2, [sp, #0xb4]
-	sub r3, r5, sb
+	sub r3, r5, r9
 	smull r7, r2, r3, r2
 	adds r3, r7, r1
 	adc r1, r2, r0
@@ -55673,22 +55673,22 @@ _0214e738:
 	str r4, [sp, #8]
 	ldr r0, [r0]
 	bl func_ov05_021082e4
-	cmp sb, r5
-	movgt r2, sb
+	cmp r9, r5
+	movgt r2, r9
 	movle r2, r5
 	cmp r8, r6
 	movgt r3, r8
 	movle r3, r6
 	cmp r8, r6
 	movge r8, r6
-	cmp sb, r5
-	movge sb, r5
-	cmp sb, r8
-	movge sb, r8
+	cmp r9, r5
+	movge r9, r5
+	cmp r9, r8
+	movge r9, r8
 	cmp r2, r3
 	movgt r0, r2
 	movle r0, r3
-	add r0, sb, r0
+	add r0, r9, r0
 	cmp r2, #0x800
 	movlt r5, r2
 	add r0, r0, r0, lsr #31
@@ -55859,7 +55859,7 @@ _0214ea14:
 	add r0, r4, r0
 	add sp, sp, #0xbc
 	str r0, [r10, #0x164]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0214ea84:
 	umull r2, r1, r4, r3
 	mla r1, r4, r0, r1
@@ -55870,7 +55870,7 @@ _0214ea84:
 	sub r0, r4, r0
 	str r0, [r10, #0x164]
 	add sp, sp, #0xbc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0214e138
 _0214eaac: .word data_02050f54
@@ -56213,7 +56213,7 @@ func_ov15_0214eedc: ; 0x0214eedc
 	.global func_ov15_0214ef04
 	arm_func_start func_ov15_0214ef04
 func_ov15_0214ef04: ; 0x0214ef04
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #0x48
 	ldr r1, _0214f10c ; =data_027e0f74
 	mov r7, r0
@@ -56223,7 +56223,7 @@ func_ov15_0214ef04: ; 0x0214ef04
 	cmp r0, #0
 	addne sp, sp, #0x48
 	movne r0, #0
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	ldr r0, _0214f110 ; =data_027e0ff0
 	ldrh r1, [r7, #0x20]
 	ldr r0, [r0]
@@ -56240,7 +56240,7 @@ func_ov15_0214ef04: ; 0x0214ef04
 	ble _0214f058
 	mov r6, r4
 	add r10, sp, #0x30
-	add sb, sp, #0x3c
+	add r9, sp, #0x3c
 	mov r8, #0x24
 _0214ef78:
 	add r0, r4, #1
@@ -56284,7 +56284,7 @@ _0214efcc:
 	str r1, [sp, #0x38]
 _0214f010:
 	mov r0, r10
-	mov r1, sb
+	mov r1, r9
 	mov r2, r10
 	bl func_01ff9bf8
 	ldr r0, [sp, #0x30]
@@ -56348,7 +56348,7 @@ _0214f0d0:
 	strb r2, [r7, #0x20c]
 	str r2, [r7, #0x1a0]
 	add sp, sp, #0x48
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0214ef04
 _0214f10c: .word data_027e0f74
@@ -56802,15 +56802,15 @@ func_ov15_0214f754: ; 0x0214f754
 	.global func_ov15_0214f768
 	arm_func_start func_ov15_0214f768
 func_ov15_0214f768: ; 0x0214f768
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x4c
 	ldr r1, _0214f9c8 ; =data_027e0f94
-	mov sb, r0
+	mov r9, r0
 	add r7, sp, #0x40
 	ldmia r1, {r0, r1, r2}
 	stmia r7, {r0, r1, r2}
-	ldr r0, [sb, #0x158]
-	ldrb r1, [sb, #0x1ac]
+	ldr r0, [r9, #0x158]
+	ldrb r1, [r9, #0x1ac]
 	ldr r2, [r0]
 	mvn r0, #0
 	str r0, [sp, #4]
@@ -56826,7 +56826,7 @@ func_ov15_0214f768: ; 0x0214f768
 	mov r10, r8
 	add r4, sp, #0x28
 _0214f7c4:
-	ldr r1, [sb, #0x158]
+	ldr r1, [r9, #0x158]
 	mov r0, r7
 	ldr r2, [r1, #4]
 	add r1, sp, #0x34
@@ -56856,7 +56856,7 @@ _0214f81c:
 	mov r7, r8
 	add r11, sp, #0x28
 _0214f834:
-	ldr r1, [sb, #0x158]
+	ldr r1, [r9, #0x158]
 	add r0, sp, #0x40
 	ldr r2, [r1, #4]
 	add r1, sp, #0x34
@@ -56874,7 +56874,7 @@ _0214f834:
 	ldr r1, [sp, #0x30]
 	bl func_01ffa0f4
 	mov r1, r0, lsl #0x10
-	add r0, sb, r8, lsl #1
+	add r0, r9, r8, lsl #1
 	add r0, r0, #0x100
 	ldrsh r2, [r0, #0x64]
 	mov r0, r11
@@ -56894,7 +56894,7 @@ _0214f834:
 	mov r3, lr, lsr #0xc
 	orrs r3, r3, r2, lsl #20
 	bmi _0214f91c
-	add r2, sb, r8, lsl #2
+	add r2, r9, r8, lsl #2
 	ldr r2, [r2, #0x178]
 	cmp r3, r2
 	bge _0214f91c
@@ -56930,7 +56930,7 @@ _0214f92c:
 	mvn r0, #0
 	strb r0, [sp, #0xc]
 	strb r0, [sp, #0xd]
-	ldrh r2, [sb, #0x20]
+	ldrh r2, [r9, #0x20]
 	ldr r0, _0214f9d0 ; =data_027e0ff0
 	add r1, sp, #0xc
 	strb r2, [sp, #0xc]
@@ -56946,21 +56946,21 @@ _0214f92c:
 	beq _0214f9bc
 	mov r0, #0
 	str r0, [sp]
-	strb r0, [sb, #0x1ac]
+	strb r0, [r9, #0x1ac]
 	b _0214f9bc
 _0214f99c:
-	ldrb r1, [sb, #0x1ac]
+	ldrb r1, [r9, #0x1ac]
 	mov r0, #0
 	str r0, [sp]
 	cmp r1, #0
 	ldreq r0, [sp]
-	streqb r0, [sb, #0x1a5]
+	streqb r0, [r9, #0x1a5]
 	mov r0, #1
-	strb r0, [sb, #0x1ac]
+	strb r0, [r9, #0x1ac]
 _0214f9bc:
 	ldr r0, [sp]
 	add sp, sp, #0x4c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0214f768
 _0214f9c8: .word data_027e0f94
@@ -56970,7 +56970,7 @@ _0214f9d0: .word data_027e0ff0
 	.global func_ov15_0214f9d4
 	arm_func_start func_ov15_0214f9d4
 func_ov15_0214f9d4: ; 0x0214f9d4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x60
 	ldr r1, _0214fbdc ; =data_027e0f74
 	str r0, [sp]
@@ -56979,7 +56979,7 @@ func_ov15_0214f9d4: ; 0x0214f9d4
 	bl func_ov00_02097760
 	cmp r0, #0
 	addeq sp, sp, #0x60
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, [sp]
 	add r0, r0, #0x100
 	str r0, [sp, #8]
@@ -56987,7 +56987,7 @@ func_ov15_0214f9d4: ; 0x0214f9d4
 	ldrsb r0, [r0, #0xa4]
 	cmp r1, r0
 	addeq sp, sp, #0x60
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, _0214fbe4 ; =data_027e10a4
 	ldr r1, _0214fbe8 ; =data_027e0f94
 	ldr r3, [r0]
@@ -57006,7 +57006,7 @@ func_ov15_0214f9d4: ; 0x0214f9d4
 	str r0, [sp, #4]
 	cmp r0, #0
 	addle sp, sp, #0x60
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, [sp]
 	mov r10, r8
 	add r0, r0, #0xa5
@@ -57016,8 +57016,8 @@ func_ov15_0214f9d4: ; 0x0214f9d4
 _0214fa80:
 	ldr r0, [r7, #4]
 	add r2, r0, r10
-	ldrsb sb, [r2, #0x10]
-	cmp sb, #0
+	ldrsb r9, [r2, #0x10]
+	cmp r9, #0
 	blt _0214fbb8
 	ldr r0, [r2, #4]
 	add r3, r8, #1
@@ -57078,7 +57078,7 @@ _0214fa80:
 	bpl _0214fbb8
 	ldr r0, [sp, #8]
 	ldrsb r0, [r0, #0xa5]
-	cmp r0, sb
+	cmp r0, r9
 	bne _0214fb98
 	ldrsb r0, [r4]
 	add r0, r0, #1
@@ -57086,13 +57086,13 @@ _0214fa80:
 	b _0214fbb8
 _0214fb98:
 	cmp r0, #1
-	cmpeq sb, #0
+	cmpeq r9, #0
 	beq _0214fbb8
 	ldr r0, [sp]
 	mov r1, #0
 	strb r1, [r0, #0x1a5]
 	add sp, sp, #0x60
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0214fbb8:
 	add r0, r8, #1
 	mov r1, r0, lsl #0x18
@@ -57102,7 +57102,7 @@ _0214fbb8:
 	mov r8, r1, asr #0x18
 	bgt _0214fa80
 	add sp, sp, #0x60
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0214f9d4
 _0214fbdc: .word data_027e0f74
@@ -57113,36 +57113,36 @@ _0214fbe8: .word data_027e0f94
 	.global func_ov15_0214fbec
 	arm_func_start func_ov15_0214fbec
 func_ov15_0214fbec: ; 0x0214fbec
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x50
-	mov sb, r0
-	ldr r0, [sb, #0x130]
+	mov r9, r0
+	ldr r0, [r9, #0x130]
 	cmp r0, #4
 	bne _0214fcb8
 	ldr r0, _0214fe98 ; =data_027e0f64
-	add r1, sb, #0x210
+	add r1, r9, #0x210
 	ldr r0, [r0]
 	ldr r0, [r0, #4]
 	bl func_ov00_02087d34
 	mov r0, #0x2800
-	str r0, [sb, #0x228]
+	str r0, [r9, #0x228]
 	mov r0, #0x3000
-	str r0, [sb, #0x220]
+	str r0, [r9, #0x220]
 	ldr r1, _0214fe9c ; =0x00001770
 	ldr r0, _0214fea0 ; =data_027e0fac
-	str r1, [sb, #0x21c]
+	str r1, [r9, #0x21c]
 	ldrsh r0, [r0]
 	mov r2, #0
-	mov r1, sb
+	mov r1, r9
 	add r0, r0, #0xff
 	add r0, r0, #0xff00
 	mov r0, r0, lsl #0x10
 	mov r0, r0, asr #0x10
-	str r0, [sb, #0x224]
-	str r2, [sb, #0x22c]
-	str r2, [sb, #0x230]
+	str r0, [r9, #0x224]
+	str r2, [r9, #0x22c]
+	str r2, [r9, #0x230]
 	add r0, sp, #0x44
-	str r2, [sb, #0x234]
+	str r2, [r9, #0x234]
 	bl func_ov15_0214fea4
 	ldr r2, [sp, #0x44]
 	ldr r1, [sp, #0x48]
@@ -57157,38 +57157,38 @@ func_ov15_0214fbec: ; 0x0214fbec
 	ldr r0, _0214fe98 ; =data_027e0f64
 	add r1, sp, #0x38
 	ldr r0, [r0]
-	add r3, sb, #0x210
+	add r3, r9, #0x210
 	ldr r0, [r0, #4]
 	mov r2, #2
 	bl func_ov00_02089318
 	add sp, sp, #0x50
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _0214fcb8:
-	ldr r0, [sb, #0x138]
+	ldr r0, [r9, #0x138]
 	cmp r0, #0x78
 	bgt _0214fe3c
-	ldr r2, [sb, #0x220]
+	ldr r2, [r9, #0x220]
 	rsb r3, r0, #0x78
-	ldr r1, [sb, #0x21c]
-	ldr r0, [sb, #0x224]
+	ldr r1, [r9, #0x21c]
+	ldr r0, [r9, #0x224]
 	mov r4, r2, lsl #0x10
 	mov r7, r3, lsl #0xc
-	ldr r2, [sb, #0x290]
+	ldr r2, [r9, #0x290]
 	cmp r7, #0x1000
 	mov r5, r1, lsl #0x10
 	mov r6, r0, lsl #0x10
-	strle r2, [sb, #0x228]
+	strle r2, [r9, #0x228]
 	ble _0214fd10
-	ldr r0, [sb, #0x228]
+	ldr r0, [r9, #0x228]
 	mov r1, r7
 	sub r0, r2, r0
 	bl Divide
-	ldr r1, [sb, #0x228]
+	ldr r1, [r9, #0x228]
 	add r0, r1, r0
-	str r0, [sb, #0x228]
+	str r0, [r9, #0x228]
 _0214fd10:
-	ldr r0, [sb, #0x288]
+	ldr r0, [r9, #0x288]
 	cmp r7, #0x1000
 	mov r0, r0, lsl #0x10
 	mov r8, r0, asr #0x10
@@ -57204,7 +57204,7 @@ _0214fd10:
 	mov r0, r0, lsl #0x10
 	mov r8, r0, asr #0x10
 _0214fd4c:
-	ldr r0, [sb, #0x284]
+	ldr r0, [r9, #0x284]
 	cmp r7, #0x1000
 	mov r0, r0, lsl #0x10
 	mov r4, r0, asr #0x10
@@ -57220,7 +57220,7 @@ _0214fd4c:
 	mov r0, r0, lsl #0x10
 	mov r4, r0, asr #0x10
 _0214fd88:
-	ldr r0, [sb, #0x28c]
+	ldr r0, [r9, #0x28c]
 	cmp r7, #0x1000
 	mov r0, r0, lsl #0x10
 	mov r2, r0, asr #0x10
@@ -57237,14 +57237,14 @@ _0214fd88:
 	mov r2, r0, asr #0x10
 _0214fdc4:
 	mov r0, #0
-	str r0, [sb, #0x22c]
-	str r0, [sb, #0x230]
-	str r0, [sb, #0x234]
-	str r8, [sb, #0x220]
-	str r4, [sb, #0x21c]
+	str r0, [r9, #0x22c]
+	str r0, [r9, #0x230]
+	str r0, [r9, #0x234]
+	str r8, [r9, #0x220]
+	str r4, [r9, #0x21c]
 	add r0, sp, #0x2c
-	mov r1, sb
-	str r2, [sb, #0x224]
+	mov r1, r9
+	str r2, [r9, #0x224]
 	bl func_ov15_0214fea4
 	ldr r2, [sp, #0x2c]
 	ldr r1, [sp, #0x30]
@@ -57259,16 +57259,16 @@ _0214fdc4:
 	ldr r0, _0214fe98 ; =data_027e0f64
 	add r1, sp, #0x20
 	ldr r0, [r0]
-	add r3, sb, #0x210
+	add r3, r9, #0x210
 	ldr r0, [r0, #4]
 	mov r2, #2
 	bl func_ov00_02089318
 	add sp, sp, #0x50
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _0214fe3c:
 	add r0, sp, #0x14
-	mov r1, sb
+	mov r1, r9
 	bl func_ov15_0214fea4
 	ldr r2, [sp, #0x14]
 	ldr r1, [sp, #0x18]
@@ -57283,13 +57283,13 @@ _0214fe3c:
 	ldr r0, _0214fe98 ; =data_027e0f64
 	add r1, sp, #8
 	ldr r0, [r0]
-	add r3, sb, #0x210
+	add r3, r9, #0x210
 	ldr r0, [r0, #4]
 	mov r2, #2
 	bl func_ov00_02089318
 	mov r0, #1
 	add sp, sp, #0x50
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0214fbec
 _0214fe98: .word data_027e0f64
@@ -57548,7 +57548,7 @@ _021501a8: .word data_027e0f6c
 	.global func_ov15_021501ac
 	arm_func_start func_ov15_021501ac
 func_ov15_021501ac: ; 0x021501ac
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x8c
 	ldr r1, _02150848 ; =data_027e0dbc
 	add r6, sp, #0x7c
@@ -57686,7 +57686,7 @@ _0215036c:
 	cmp r0, #0
 	addne sp, sp, #0x8c
 	movne r0, #0
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r1, sp, #8
 	mov r0, r10
 	bl func_ov15_02151208
@@ -57715,8 +57715,8 @@ _02150408:
 	ldrb r1, [sp, #8]
 	add r0, sp, #0x54
 	add r0, r0, r6, lsl #2
-	ldrsb sb, [r1, r0]
-	cmp sb, #3
+	ldrsb r9, [r1, r0]
+	cmp r9, #3
 	bne _02150460
 	ldr r1, _02150864 ; =data_ov15_0218bef4
 	ldr r0, _02150850 ; =data_027e0fe4
@@ -57725,7 +57725,7 @@ _02150408:
 	add sp, sp, #0x8c
 	strb r2, [r1, #0x28]
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02150460:
 	ldr r0, _02150868 ; =data_027e0f94
 	add r3, sp, #0x48
@@ -57758,18 +57758,18 @@ _02150460:
 	bl func_ov00_0208e7a4
 	cmp r0, #0
 	beq _021504fc
-	cmp sb, #0
-	rsblt r0, sb, #0
+	cmp r9, #0
+	rsblt r0, r9, #0
 	movlt r0, r0, lsl #0x18
-	movlt sb, r0, asr #0x18
-	rsb r0, sb, #0
+	movlt r9, r0, asr #0x18
+	rsb r0, r9, #0
 	mov r0, r0, lsl #0x18
-	mov sb, r0, asr #0x18
+	mov r9, r0, asr #0x18
 	b _02150560
 _021504fc:
-	cmp sb, #1
+	cmp r9, #1
 	beq _02150510
-	cmp sb, #2
+	cmp r9, #2
 	beq _0215053c
 	b _02150560
 _02150510:
@@ -57798,7 +57798,7 @@ _0215053c:
 _02150560:
 	mov r0, r4, lsl #0x18
 	mov r7, r0, asr #0x18
-	rsb r0, sb, #0
+	rsb r0, r9, #0
 	str r0, [sp, #4]
 	mov r0, r0, lsl #0x18
 	mov r11, r0, asr #0x18
@@ -57810,8 +57810,8 @@ _02150578:
 	strb r5, [sp, #0xa]
 	bl func_ov00_020c47cc
 	mov r4, r0
-	cmp sb, #0
-	movge r1, sb
+	cmp r9, #0
+	movge r1, r9
 	ldrsb r0, [r4, #0x10]
 	movlt r1, r11
 	cmp r0, r1
@@ -57824,7 +57824,7 @@ _02150578:
 	bl func_01ff9ec0
 	cmp r0, #0x32000
 	bge _021505d4
-	cmp sb, #0
+	cmp r9, #0
 	bge _021505e0
 _021505d4:
 	mov r1, #0x3c
@@ -57874,11 +57874,11 @@ _02150674:
 	mla r2, r1, r0, r5
 	mov r0, #0xa4
 	mul r1, r2, r0
-	cmp sb, #0
+	cmp r9, #0
 	ldrlt r0, [sp, #4]
 	movlt r0, r0, lsl #0x18
-	movlt sb, r0, asr #0x18
-	cmp sb, #2
+	movlt r9, r0, asr #0x18
+	cmp r9, #2
 	bne _021506c4
 	cmp r6, #1
 	cmpne r6, #3
@@ -57912,7 +57912,7 @@ _021506e0:
 	add sp, sp, #0x8c
 	strb r2, [r1, #0x28]
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02150714:
 	ldr r0, [r10, #0x48]
 	str r0, [r5, #0x1c]
@@ -57994,7 +57994,7 @@ _021507b0:
 	strb r0, [r10, #0x2a8]
 	mov r0, #1
 	add sp, sp, #0x8c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_021501ac
 _02150848: .word data_027e0dbc
@@ -59231,7 +59231,7 @@ _021518f0: .word data_027e0764
 	.global func_ov15_021518f4
 	arm_func_start func_ov15_021518f4
 func_ov15_021518f4: ; 0x021518f4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x28
 	mov r10, r0
 	mov r0, #0
@@ -59251,8 +59251,8 @@ _02151908:
 	add r11, sp, #0x10
 _02151938:
 	add r0, r10, r7, lsl #2
-	ldr sb, [r0, #0x160]
-	cmp sb, #0
+	ldr r9, [r0, #0x160]
+	cmp r9, #0
 	beq _02151a20
 	ldr r1, [r8, #0x48]
 	mov r0, r6
@@ -59263,11 +59263,11 @@ _02151938:
 	ldr r3, [r8, #0x50]
 	mov r2, r5
 	str r3, [sp, #0x24]
-	ldr r3, [sb, #0x48]
+	ldr r3, [r9, #0x48]
 	str r3, [sp, #0x10]
-	ldr r3, [sb, #0x4c]
+	ldr r3, [r9, #0x4c]
 	str r3, [sp, #0x14]
-	ldr r3, [sb, #0x50]
+	ldr r3, [r9, #0x50]
 	str r3, [sp, #0x18]
 	bl func_01ff9bf8
 	mov r0, r5
@@ -59303,11 +59303,11 @@ _02151938:
 	ldr r0, [sp, #0x24]
 	str r0, [r8, #0x50]
 	ldr r0, [sp, #0x10]
-	str r0, [sb, #0x48]
+	str r0, [r9, #0x48]
 	ldr r0, [sp, #0x14]
-	str r0, [sb, #0x4c]
+	str r0, [r9, #0x4c]
 	ldr r0, [sp, #0x18]
-	str r0, [sb, #0x50]
+	str r0, [r9, #0x50]
 _02151a20:
 	add r7, r7, #1
 	cmp r7, #5
@@ -59319,7 +59319,7 @@ _02151a2c:
 	cmp r0, #4
 	blt _02151908
 	add sp, sp, #0x28
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	arm_func_end func_ov15_021518f4
 
 	.global func_ov15_02151a48
@@ -59918,7 +59918,7 @@ func_ov15_0215214c: ; 0x0215214c
 	.global func_ov15_02152184
 	arm_func_start func_ov15_02152184
 func_ov15_02152184: ; 0x02152184
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x7c
 	mov r7, r0
 	ldrb r0, [r7, #0x406]
@@ -59931,7 +59931,7 @@ func_ov15_02152184: ; 0x02152184
 	mov r6, #0
 	add r5, sp, #0x68
 	ldr ip, _0215234c ; =_ZTV11FilterActor
-	ldr sb, _02152350 ; =0x4653524c
+	ldr r9, _02152350 ; =0x4653524c
 	add r4, sp, #0xc
 	mov r3, #5
 	ldr r0, [r0]
@@ -59939,7 +59939,7 @@ func_ov15_02152184: ; 0x02152184
 	add r2, sp, #0
 	str r6, [sp, #8]
 	str ip, [sp, #0x34]
-	str sb, [sp, #0x38]
+	str r9, [sp, #0x38]
 	str r8, [sp, #0x3c]
 	str r8, [sp, #0x40]
 	str r6, [sp, #0x44]
@@ -59986,7 +59986,7 @@ _02152278:
 	ldreqb r0, [r7, #0x444]
 	cmpeq r0, #1
 	addne sp, sp, #0x7c
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	mov r0, r7
 	mov r1, #6
 	bl func_ov15_02136b34
@@ -59995,7 +59995,7 @@ _02152278:
 	mov r2, r1
 	bl func_ov15_02152548
 	add r0, r7, #8
-	ldr sb, _02152348 ; =data_027e0fe4
+	ldr r9, _02152348 ; =data_027e0fe4
 	add r6, r0, #0x400
 	mov r5, #0
 	mvn r8, #0
@@ -60004,7 +60004,7 @@ _021522c0:
 	ldr r0, [r0, #0x408]
 	cmp r0, r8
 	beq _02152330
-	ldr r0, [sb]
+	ldr r0, [r9]
 	mov r1, r6
 	bl _ZN12ActorManager8GetActorEP8ActorRef
 	movs r4, r0
@@ -60027,14 +60027,14 @@ _021522c0:
 	orr r0, r3, r2, lsl r0
 	strh r0, [r1, #0x32]
 	add sp, sp, #0x7c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _02152330:
 	add r5, r5, #1
 	cmp r5, #5
 	add r6, r6, #8
 	blt _021522c0
 	add sp, sp, #0x7c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02152184
 _02152348: .word data_027e0fe4
@@ -60564,7 +60564,7 @@ _02152a40:
 	.global func_ov15_02152a48
 	arm_func_start func_ov15_02152a48
 func_ov15_02152a48: ; 0x02152a48
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x1ac
 	ldr r1, _02153464 ; =data_027e0fe4
 	mov r5, r0
@@ -60678,7 +60678,7 @@ _02152b98:
 	add r3, r6, #1
 	mov r3, r3, lsl #0x1
 	ldrsh r6, [r11, r3]
-	umull r10, sb, r8, r0
+	umull r10, r9, r8, r0
 	umull ip, r7, r6, r0
 	mov r2, r2, lsl #0x10
 	mov r2, r2, lsr #0x10
@@ -60688,18 +60688,18 @@ _02152b98:
 	mov r2, r2, lsl #0x1
 	ldrsh lr, [r11, r2]
 	adds r10, r10, #0x800
-	mla sb, r8, r1, sb
+	mla r9, r8, r1, r9
 	mla r7, r6, r1, r7
 	mov r1, r6, asr #0x1f
 	mov r3, r3, lsl #0x1
 	str ip, [sp, #8]
 	ldrsh ip, [r11, r3]
 	mov r11, r8, asr #0x1f
-	mla sb, r11, r0, sb
+	mla r9, r11, r0, r9
 	rsb r2, r0, #0x800
 	mla r7, r1, r0, r7
 	mov r10, r10, lsr #0xc
-	adc r8, sb, #0
+	adc r8, r9, #0
 	orr r10, r10, r8, lsl #20
 	sub r8, r10, #0x2000
 	str r8, [r5, #0x4b8]
@@ -60708,7 +60708,7 @@ _02152b98:
 	ldr r0, [sp, #8]
 	mov r11, #0
 	adds r1, r0, #0x800
-	umull sb, r8, lr, r2
+	umull r9, r8, lr, r2
 	adc r0, r7, #0
 	mov r1, r1, lsr #0xc
 	orr r1, r1, r0, lsl #20
@@ -60718,7 +60718,7 @@ _02152b98:
 	mla r8, lr, r11, r8
 	mov r7, lr, asr #0x1f
 	mla r8, r7, r2, r8
-	adds r7, sb, #0x800
+	adds r7, r9, #0x800
 	mov r3, r2
 	add r6, r0, #0xcd
 	adc r2, r8, #0
@@ -61235,7 +61235,7 @@ _02153454:
 	mov r0, r5
 	bl func_ov15_021548c4
 	add sp, sp, #0x1ac
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02152a48
 _02153464: .word data_027e0fe4
@@ -61667,7 +61667,7 @@ _02153a5c: .word data_ov15_0218f6c8
 	.global func_ov15_02153a60
 	arm_func_start func_ov15_02153a60
 func_ov15_02153a60: ; 0x02153a60
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0xc0
 	ldr r1, _02153f58 ; =data_027e0fe4
 	mov r5, r0
@@ -61676,7 +61676,7 @@ func_ov15_02153a60: ; 0x02153a60
 	bl _ZN12ActorManager8GetActorEP8ActorRef
 	movs r4, r0
 	addeq sp, sp, #0xc0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	mov r0, r5
 	bl func_ov15_0214325c
 	ldrb r0, [r5, #0x436]
@@ -61710,7 +61710,7 @@ _02153ae4:
 	cmp r1, r0
 	add sp, sp, #0xc0
 	strle r0, [r5, #0x280]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02153b04:
 	ldr r0, _02153f5c ; =data_027e1060
 	bl func_ov15_0217705c
@@ -61906,14 +61906,14 @@ _02153d74:
 	mov r11, #0x3000
 	ldr lr, _02153f88 ; =data_ov15_021863a8
 	ldr r0, [r4, #0x41c]
-	umull r10, sb, r8, r11
+	umull r10, r9, r8, r11
 	ldr r2, [lr, r0, lsl #2]
 	mov r0, #0
-	mla sb, r8, r0, sb
+	mla r9, r8, r0, r9
 	mov r7, r8, asr #0x1f
-	mla sb, r7, r11, sb
+	mla r9, r7, r11, r9
 	adds r7, r10, #0x800
-	adc r0, sb, #0
+	adc r0, r9, #0
 	mov r7, r7, lsr #0xc
 	orr r7, r7, r0, lsl #20
 	ldr r6, [sp, #0x64]
@@ -61995,7 +61995,7 @@ _02153d74:
 	ldrsh r1, [r1, #0x4c]
 	bl func_ov15_0216ea14
 	add sp, sp, #0xc0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02153a60
 _02153f58: .word data_027e0fe4
@@ -62865,7 +62865,7 @@ _02154b98:
 	.global func_ov15_02154ba4
 	arm_func_start func_ov15_02154ba4
 func_ov15_02154ba4: ; 0x02154ba4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x34
 	mov r4, r0
 	ldr r0, [r4, #0x3e8]
@@ -62983,9 +62983,9 @@ _02154d24:
 	bl func_01ffa0f4
 	add r1, r4, #0x400
 	mov r0, r0, lsl #0x10
-	ldrsh sb, [r1, #4]
+	ldrsh r9, [r1, #4]
 	mov r8, r0, asr #0x10
-	rsb r0, sb, r0, asr #16
+	rsb r0, r9, r0, asr #16
 	mov r0, r0, lsl #0x10
 	movs r0, r0, asr #0x10
 	rsbmi r0, r0, #0
@@ -62997,21 +62997,21 @@ _02154d24:
 	mov r0, r0, asr #0x14
 	mov r0, r0, lsl #0x1
 	add r1, r0, #1
-	cmp sb, #0
+	cmp r9, #0
 	cmplt r8, #0
 	ldr r0, _02155214 ; =data_02050f54
 	mov r1, r1, lsl #0x1
 	ldrsh r7, [r0, r1]
-	cmplt r8, sb
+	cmplt r8, r9
 	blt _02154dd4
-	cmp sb, #0
+	cmp r9, #0
 	cmpgt r8, #0
-	cmpgt r8, sb
+	cmpgt r8, r9
 	ble _02154e24
 _02154dd4:
-	cmp sb, #0
-	movge r0, sb
-	rsblt r0, sb, #0
+	cmp r9, #0
+	movge r0, r9
+	rsblt r0, r9, #0
 	movlt r0, r0, lsl #0x10
 	movlt r0, r0, asr #0x10
 	mov r1, r0, asr #0x4
@@ -63020,9 +63020,9 @@ _02154dd4:
 	ldrsh r0, [r0, r1]
 	cmp r7, r0
 	bge _02154e24
-	cmp sb, #0
-	movge r0, sb
-	rsblt r0, sb, #0
+	cmp r9, #0
+	movge r0, r9
+	rsblt r0, r9, #0
 	movlt r0, r0, lsl #0x10
 	movlt r0, r0, asr #0x10
 	mov r1, r0, asr #0x4
@@ -63041,7 +63041,7 @@ _02154e24:
 	str r2, [r4, #0x3d0]
 	add r0, r4, #0x400
 	strh r8, [r0, #2]
-	strh sb, [r0, #4]
+	strh r9, [r0, #4]
 	ldr r1, [r4, #0x3cc]
 	mov r0, #0
 	cmp r1, #0x100
@@ -63159,7 +63159,7 @@ _02154ff8:
 	ldreqb r5, [r4, #0x292]
 	cmpeq r5, #0
 	addne sp, sp, #0x34
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	subs r0, r1, r0
 	rsbmi r0, r0, #0
 	cmp r0, #4
@@ -63277,7 +63277,7 @@ _021551c0:
 	ldr r0, [r4, #0x3e8]
 	cmp r0, #0
 	addne sp, sp, #0x34
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	mov r0, #5
 	str r0, [r4, #0x3e8]
 	mov r2, #0
@@ -63291,7 +63291,7 @@ _021551dc:
 	blt _021551dc
 	strb r7, [r4, #0x441]
 	add sp, sp, #0x34
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02154ba4
 _02155204: .word data_027e0fe4
@@ -65147,7 +65147,7 @@ _02156b00: .word 0x00000285
 	.global func_ov15_02156b04
 	arm_func_start func_ov15_02156b04
 func_ov15_02156b04: ; 0x02156b04
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x38
 	mov r6, r0
 	add r0, r6, #0x200
@@ -65156,7 +65156,7 @@ func_ov15_02156b04: ; 0x02156b04
 	movne r0, #0
 	addne sp, sp, #0x38
 	strne r0, [r6, #0x2e0]
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r1, [r6, #0x2e4]
 	add r0, r6, #0x2e0
 	mov r2, #0xcd
@@ -65177,20 +65177,20 @@ func_ov15_02156b04: ; 0x02156b04
 	ldr r4, [r6, #0x2e0]
 	add r0, r6, #0x2bc
 	mov r3, r3, asr #0x4
-	mov sb, r3, lsl #0x1
-	add r3, sb, #1
-	mov sb, sb, lsl #0x1
-	ldrsh sb, [r8, sb]
+	mov r9, r3, lsl #0x1
+	add r3, r9, #1
+	mov r9, r9, lsl #0x1
+	ldrsh r9, [r8, r9]
 	mov r3, r3, lsl #0x1
 	ldrsh r8, [r8, r3]
-	smull r3, r10, sb, r4
+	smull r3, r10, r9, r4
 	adds r3, r3, #0x800
-	smull sb, r4, r8, r4
+	smull r9, r4, r8, r4
 	adc r10, r10, #0
 	mov r3, r3, lsr #0xc
 	orr r3, r3, r10, lsl #20
 	add r7, r7, r3
-	adds r8, sb, #0x800
+	adds r8, r9, #0x800
 	adc r3, r4, #0
 	mov r4, r8, lsr #0xc
 	orr r4, r4, r3, lsl #20
@@ -65351,11 +65351,11 @@ _02156d4c:
 	ldrsh r5, [r1, r5]
 	ldrsh r7, [r1, r7]
 	ldrsh r1, [r1, r2]
-	mov sb, r10, asr #0x1f
+	mov r9, r10, asr #0x1f
 	mov r8, r5, asr #0x1f
 	mov r2, r7, asr #0x1f
-	mov r11, sb, lsl #0xd
-	mov sb, r8, lsl #0xd
+	mov r11, r9, lsl #0xd
+	mov r9, r8, lsl #0xd
 	mov r8, r2, lsl #0xd
 	mov r2, r1, asr #0x1f
 	mov r2, r2, lsl #0xd
@@ -65366,15 +65366,15 @@ _02156d4c:
 	orr r11, r11, r10, lsl #20
 	add r4, r4, r11
 	adds r10, r0, r5, lsl #13
-	orr sb, sb, r5, lsr #19
-	adc r5, sb, #0
-	mov sb, r10, lsr #0xc
-	orr sb, sb, r5, lsl #20
-	add r5, r3, sb
-	adds sb, r0, r7, lsl #13
+	orr r9, r9, r5, lsr #19
+	adc r5, r9, #0
+	mov r9, r10, lsr #0xc
+	orr r9, r9, r5, lsl #20
+	add r5, r3, r9
+	adds r9, r0, r7, lsl #13
 	orr r8, r8, r7, lsr #19
 	adc r3, r8, #0
-	mov r7, sb, lsr #0xc
+	mov r7, r9, lsr #0xc
 	orr r7, r7, r3, lsl #20
 	adds r3, r0, r1, lsl #13
 	orr r2, r2, r1, lsr #19
@@ -65406,7 +65406,7 @@ _02156ed4:
 	ldr r2, [sp, #0x24]
 	ldrsh r3, [sp, #4]
 	str r2, [sp]
-	ldr sb, [sp, #0x20]
+	ldr r9, [sp, #0x20]
 	sub r2, r3, #0x4000
 	mov r2, r2, lsl #0x10
 	add r3, r3, #0x4000
@@ -65448,14 +65448,14 @@ _02156ed4:
 	adc r0, r0, #0
 	mov r8, r8, lsr #0xc
 	orr r8, r8, r0, lsl #20
-	add r0, sb, r8
+	add r0, r9, r8
 	adds r8, r1, lr, lsl #12
 	orr r7, r7, lr, lsr #20
-	ldr sb, [sp, #0x28]
+	ldr r9, [sp, #0x28]
 	adc r7, r7, #0
 	mov r8, r8, lsr #0xc
 	orr r8, r8, r7, lsl #20
-	add r7, sb, r8
+	add r7, r9, r8
 	adds r8, r1, r10, lsl #14
 	orr r4, r4, r10, lsr #18
 	adc r4, r4, #0
@@ -65500,7 +65500,7 @@ _02157038:
 	ldr r0, [sp, #0x10]
 	str r0, [r6, #0x5c]
 	add sp, sp, #0x38
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02156b04
 _02157078: .word data_02050f54
@@ -65511,7 +65511,7 @@ _02157084: .word data_027e0f94
 	.global func_ov15_02157088
 	arm_func_start func_ov15_02157088
 func_ov15_02157088: ; 0x02157088
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x18
 	mov r10, r0
 	add r0, r10, #0x200
@@ -65545,17 +65545,17 @@ func_ov15_02157088: ; 0x02157088
 	add r0, r2, r1
 	add sp, sp, #0x18
 	str r0, [r10, #0x2d0]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02157114:
 	cmp r8, #0
 	addeq sp, sp, #0x18
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	bl func_ov15_0213ce4c
 	mov r1, #0xc
 	ldr r2, [r0, #4]
-	smulbb sb, r7, r1
-	ldr r0, [r2, sb]
-	add r2, r2, sb
+	smulbb r9, r7, r1
+	ldr r0, [r2, r9]
+	add r2, r2, r9
 	str r0, [sp, #0xc]
 	ldr r1, [r2, #4]
 	add r0, sp, #0xc
@@ -65606,7 +65606,7 @@ _021571ec:
 	sub r1, r7, #1
 	mov r1, r1, lsl #0x10
 	sub r8, r8, r0
-	sub sb, sb, #0xc
+	sub r9, r9, #0xc
 	movs r7, r1, asr #0x10
 	bmi _02157264
 	ldr r0, [sp, #0xc]
@@ -65618,8 +65618,8 @@ _021571ec:
 	bl func_ov15_0213ce4c
 	ldr r2, [r0, #4]
 	mov r0, r11
-	ldr r1, [r2, sb]
-	add r3, r2, sb
+	ldr r1, [r2, r9]
+	add r3, r2, r9
 	str r1, [sp, #0xc]
 	ldr r2, [r3, #4]
 	add r1, r10, #0x2c8
@@ -65637,7 +65637,7 @@ _02157264:
 	add r0, r10, #0x200
 	strh r7, [r0, #0xec]
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02157088
 _02157274: .word data_02050f54
@@ -65645,7 +65645,7 @@ _02157274: .word data_02050f54
 	.global func_ov15_02157278
 	arm_func_start func_ov15_02157278
 func_ov15_02157278: ; 0x02157278
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x24
 	ldr r2, [r1]
 	mov r10, r0
@@ -65666,7 +65666,7 @@ func_ov15_02157278: ; 0x02157278
 	str r1, [r10, #0x2cc]
 	ldr r0, [r0, #8]
 	str r0, [r10, #0x2d0]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _021572d0:
 	bne _02157308
 	bl func_ov15_0213ce4c
@@ -65681,14 +65681,14 @@ _021572d0:
 	str r0, [r10, #0x2cc]
 	ldr r0, [r1, #8]
 	str r0, [r10, #0x2d0]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02157308:
 	add r0, r10, #0x2bc
 	mov r3, #0xc
 	add r6, sp, #0xc
 	ldmia r0, {r0, r1, r2}
 	stmia r6, {r0, r1, r2}
-	smulbb sb, r7, r3
+	smulbb r9, r7, r3
 	mov r8, #0x800
 	add r11, sp, #0
 	add r5, sp, #0x18
@@ -65697,8 +65697,8 @@ _02157330:
 	bl func_ov15_0213ce4c
 	ldr r2, [r0, #4]
 	mov r0, r11
-	ldr r1, [r2, sb]
-	add r3, r2, sb
+	ldr r1, [r2, r9]
+	add r3, r2, r9
 	str r1, [sp]
 	ldr r2, [r3, #4]
 	mov r1, r6
@@ -65721,7 +65721,7 @@ _02157330:
 	str r3, [sp, #0x10]
 	str r2, [sp, #0x14]
 	sub r8, r8, r0
-	sub sb, sb, #0xc
+	sub r9, r9, #0xc
 	movs r7, r1, asr #0x10
 	bpl _02157330
 	ldr r0, [sp, #0x18]
@@ -65776,7 +65776,7 @@ _0215744c:
 	str r1, [r10, #0x2d0]
 	strh r7, [r0, #0xec]
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02157278
 _02157474: .word data_027e0f94
@@ -66134,7 +66134,7 @@ func_ov15_02157844: ; 0x02157844
 	.global func_ov15_021578e0
 	arm_func_start func_ov15_021578e0
 func_ov15_021578e0: ; 0x021578e0
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x5c
 	mov r4, r0
 	mov r11, r1
@@ -66177,9 +66177,9 @@ func_ov15_021578e0: ; 0x021578e0
 	bge _02157b1c
 	ldr r3, [r4, #0x1e8]
 	ldr r10, [r4, #0x1ec]
-	ldr sb, [r4, #0x1e4]
+	ldr r9, [r4, #0x1e4]
 	ldr r5, _02157c2c ; =data_02050f54
-	str sb, [sp, #0x44]
+	str r9, [sp, #0x44]
 	str r3, [sp, #0x48]
 	str r10, [sp, #0x4c]
 	ldrh r2, [r4, #0x78]
@@ -66199,7 +66199,7 @@ func_ov15_021578e0: ; 0x021578e0
 	mov r6, r7, lsr #0xc
 	orr r6, r6, r2, lsl #20
 	adds r7, lr, #0x800
-	add r2, sb, r6
+	add r2, r9, r6
 	adc r6, ip, #0
 	mov r7, r7, lsr #0xc
 	orr r7, r7, r6, lsl #20
@@ -66213,7 +66213,7 @@ func_ov15_021578e0: ; 0x021578e0
 	mov r1, r1, lsl #0x2
 	ldrsh r1, [r5, r1]
 	mov r7, #0
-	smull r1, sb, r0, r1
+	smull r1, r9, r0, r1
 	ldr r0, _02157c28 ; =data_027e0f94
 	adds r5, r1, #0x800
 	ldmia r0, {r0, r1, r2}
@@ -66222,7 +66222,7 @@ func_ov15_021578e0: ; 0x021578e0
 	ldr r2, [sp, #0x3c]
 	str r0, [sp, #8]
 	str r2, [sp, #0xc]
-	adc r1, sb, #0
+	adc r1, r9, #0
 	mov r0, r5, lsr #0xc
 	orr r0, r0, r1, lsl #20
 	add r0, r3, r0
@@ -66237,9 +66237,9 @@ func_ov15_021578e0: ; 0x021578e0
 	ldr r7, _02157c34 ; =0x000004cd
 	sub r5, r1, r0
 	add r0, r4, #0x48
-	add sb, sp, #0x2c
+	add r9, sp, #0x2c
 	ldmia r0, {r0, r1, r2}
-	stmia sb, {r0, r1, r2}
+	stmia r9, {r0, r1, r2}
 	ldr r8, [sp, #0x44]
 	sub r6, r7, #0x800
 	str r8, [r4, #0x48]
@@ -66345,7 +66345,7 @@ _02157c08:
 	add r2, r4, #0x1d8
 	bl func_ov00_0207a1c8
 	add sp, sp, #0x5c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_021578e0
 _02157c20: .word data_ov15_0218c1d8
@@ -66542,13 +66542,13 @@ _02157e64: .word data_027e0d0c
 	.global func_ov15_02157e68
 	arm_func_start func_ov15_02157e68
 func_ov15_02157e68: ; 0x02157e68
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x5c
 	mov r10, r0
 	bl _ZN5Actor18func_ov00_020c313cEj
 	cmp r0, #0
 	addeq sp, sp, #0x5c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldrb r0, [r10, #0x176]
 	cmp r0, #0
 	bne _021580c4
@@ -66569,14 +66569,14 @@ func_ov15_02157e68: ; 0x02157e68
 	ldrne r0, [r10, #0x170]
 	addne r0, r0, #1
 	strne r0, [r10, #0x170]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02157ed8:
 	ldr r0, _021583a4 ; =data_027e10a4
 	ldr r0, [r0]
 	bl func_ov15_0213a54c
 	cmp r0, #0
 	addne sp, sp, #0x5c
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, _021583a8 ; =data_027e0e60
 	ldrh r1, [r10, #0x20]
 	ldr r0, [r0]
@@ -66584,7 +66584,7 @@ _02157ed8:
 	bl func_ov00_020836dc
 	cmp r0, #0
 	addeq sp, sp, #0x5c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r0, r10, #0x100
 	ldrh r1, [r0, #0x74]
 	sub r1, r1, #1
@@ -66592,7 +66592,7 @@ _02157ed8:
 	ldrh r1, [r0, #0x74]
 	cmp r1, #0
 	addne sp, sp, #0x5c
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	mov r1, #0x1e
 	ldr r2, _021583ac ; =data_027e0764
 	strh r1, [r0, #0x74]
@@ -66609,13 +66609,13 @@ _02157ed8:
 	mov r7, #0x64
 	str r6, [r2]
 	mov r8, #0
-	umull sb, r11, r5, r7
+	umull r9, r11, r5, r7
 	mla r11, r5, r8, r11
 	mla r11, r8, r7, r11
 	cmp r11, #0xa
 	addge sp, sp, #0x5c
 	str r5, [r2, #4]
-	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmgeia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	umull r8, r7, r1, r6
 	mla r7, r1, r5, r7
 	ldrh r5, [r10, #0x22]
@@ -66625,10 +66625,10 @@ _02157ed8:
 	mov r0, r4, lsr #0x10
 	mov r0, r0, lsl #0x10
 	str r1, [r2]
-	and sb, r5, #0xff
+	and r9, r5, #0xff
 	mov r3, r0, lsr #0x10
 	str r4, [r2, #4]
-	mov r1, sb
+	mov r1, r9
 	mov r0, #0x10000
 	mov r4, r3, lsl #0x10
 	bl func_02002c14
@@ -66666,9 +66666,9 @@ _02157ed8:
 	and r0, r0, #0xff
 	mov r6, #0
 	strh r0, [sp, #0x18]
-	cmp sb, #0
+	cmp r9, #0
 	addle sp, sp, #0x5c
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	mov r7, r6
 	add r8, r10, #0x158
 	mvn r11, #0
@@ -66691,15 +66691,15 @@ _0215806c:
 	add r8, r8, #8
 	addne r0, r0, #1
 	strneb r0, [r10, #0x176]
-	cmp r6, sb
+	cmp r6, r9
 	blt _0215806c
 	add sp, sp, #0x5c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _021580c4:
 	mov r6, #0
 	mov r7, r6
 	mov r8, r6
-	add sb, r10, #0x158
+	add r9, r10, #0x158
 	add r5, sp, #4
 	mov r11, r6
 	mvn r4, #0
@@ -66711,7 +66711,7 @@ _021580e0:
 	cmp r0, r4
 	beq _02158134
 	ldr r0, _021583bc ; =data_027e0fe4
-	mov r1, sb
+	mov r1, r9
 	ldr r0, [r0]
 	bl _ZN12ActorManager8GetActorEP8ActorRef
 	cmp r0, #0
@@ -66728,7 +66728,7 @@ _021580e0:
 _02158134:
 	add r8, r8, #1
 	cmp r8, #3
-	add sb, sb, #8
+	add r9, r9, #8
 	blt _021580e0
 	cmp r7, #1
 	beq _02158394
@@ -66802,7 +66802,7 @@ _0215821c:
 	b _02158394
 _0215824c:
 	ldr r4, _021583c4 ; =0xffffaaab
-	add sb, r10, #0x158
+	add r9, r10, #0x158
 	mov r8, #0
 	add r6, sp, #4
 	mvn r5, #0
@@ -66875,7 +66875,7 @@ _02158340:
 	cmp r0, r1, lsr #16
 	bge _02158384
 	ldr r0, _021583bc ; =data_027e0fe4
-	mov r1, sb
+	mov r1, r9
 	ldr r0, [r0]
 	bl _ZN12ActorManager8GetActorEP8ActorRef
 	cmp r0, #0
@@ -66887,13 +66887,13 @@ _02158340:
 _02158384:
 	add r8, r8, #1
 	cmp r8, #3
-	add sb, sb, #8
+	add r9, r9, #8
 	blt _02158260
 _02158394:
 	mov r0, r10
 	bl func_ov15_0215846c
 	add sp, sp, #0x5c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02157e68
 _021583a4: .word data_027e10a4
@@ -66964,11 +66964,11 @@ _02158468: .word data_027e0fe4
 	.global func_ov15_0215846c
 	arm_func_start func_ov15_0215846c
 func_ov15_0215846c: ; 0x0215846c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	mov r5, r0
 	ldrb r0, [r5, #0x179]
 	cmp r0, #0
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	ldrh r0, [r5, #0x24]
 	mov r4, #0
 	ands r1, r0, #0xff
@@ -66981,7 +66981,7 @@ func_ov15_0215846c: ; 0x0215846c
 	beq _021584f8
 	ldr r6, _02158570 ; =data_027e0fe4
 	add r10, r5, #0x158
-	mov sb, r4
+	mov r9, r4
 	mov r7, r4
 	mov r8, #1
 _021584bc:
@@ -66995,26 +66995,26 @@ _021584bc:
 	movne r4, r8
 	moveq r4, r7
 _021584e0:
-	add sb, sb, #1
-	cmp sb, #3
+	add r9, r9, #1
+	cmp r9, #3
 	add r10, r10, #8
 	blt _021584bc
 	strb r4, [r5, #0x179]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _021584f8:
 	ldrh r0, [r5, #0x26]
 	ands r1, r0, #0xff
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	ldr r0, _0215856c ; =data_027e0e60
 	mov r2, #0
 	ldr r0, [r0]
 	bl func_ov00_020836dc
 	cmp r0, #0
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
-	mov sb, #0
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
+	mov r9, #0
 	ldr r6, _02158570 ; =data_027e0fe4
 	add r10, r5, #0x158
-	mov r7, sb
+	mov r7, r9
 	mov r8, #1
 _02158530:
 	ldr r0, [r6]
@@ -67027,12 +67027,12 @@ _02158530:
 	movne r4, r8
 	moveq r4, r7
 _02158554:
-	add sb, sb, #1
-	cmp sb, #3
+	add r9, r9, #1
+	cmp r9, #3
 	add r10, r10, #8
 	blt _02158530
 	strb r4, [r5, #0x179]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0215846c
 _0215856c: .word data_027e0e60
@@ -67307,7 +67307,7 @@ _021588e0: .word data_ov15_0218650c
 	.global func_ov15_021588e4
 	arm_func_start func_ov15_021588e4
 func_ov15_021588e4: ; 0x021588e4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #0x24
 	mov r4, r1
 	mov r5, r0
@@ -67344,15 +67344,15 @@ _02158938:
 	str r3, [r5, #0x68]
 	ldr r6, [r2]
 	ldmib r2, {r3, r7}
-	umull sb, r8, r7, r6
+	umull r9, r8, r7, r6
 	mla r8, r7, r3, r8
 	ldr r3, [r2, #0xc]
 	ldr r10, [r2, #0x10]
 	mla r8, r3, r6, r8
 	ldr r7, [r2, #0x14]
-	adds sb, r10, sb
+	adds r9, r10, r9
 	adc r6, r7, r8
-	str sb, [r2]
+	str r9, [r2]
 	mov r3, r6, asr #0x1f
 	str r6, [r2, #4]
 	tst r3, #1
@@ -67390,16 +67390,16 @@ _021589f8:
 	mov r0, r0, asr #0x4
 	mov r0, r0, lsl #0x1
 	mov r3, r0, lsl #0x1
-	ldrsh sb, [r1, r3]
+	ldrsh r9, [r1, r3]
 	add r0, r0, #1
 	mov r0, r0, lsl #0x1
 	mov r3, #0x7000
 	ldrsh r6, [r1, r0]
-	umull r0, r10, sb, r3
+	umull r0, r10, r9, r3
 	adds r1, r0, r2
 	umull r8, r7, r6, r3
-	mla r10, sb, ip, r10
-	mov r0, sb, asr #0x1f
+	mla r10, r9, ip, r10
+	mov r0, r9, asr #0x1f
 	mla r10, r0, r3, r10
 	adc r0, r10, #0
 	adds r8, r8, r2
@@ -67562,7 +67562,7 @@ _02158c9c:
 	str r0, [r5, #0x138]
 	str r4, [r5, #0x130]
 	add sp, sp, #0x24
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov15_021588e4
 _02158cb0: .word data_027e0d0c
@@ -67581,7 +67581,7 @@ _02158cdc: .word 0x000003bd
 	.global func_ov15_02158ce0
 	arm_func_start func_ov15_02158ce0
 func_ov15_02158ce0: ; 0x02158ce0
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x4c
 	mov r4, r0
 	ldr r1, [r4, #0x130]
@@ -67608,7 +67608,7 @@ _02158d24:
 	str r1, [r4, #0x64]
 	ldr r0, [r0, #8]
 	str r0, [r4, #0x68]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _02158d48:
 	add r0, sp, #0x10
 	bl func_ov15_0215cef8
@@ -67629,13 +67629,13 @@ _02158d48:
 	ldrsh r7, [r2, r0]
 	mov r6, #0x29
 	mov r0, r4
-	umull sb, r8, r7, r3
+	umull r9, r8, r7, r3
 	mla r8, r7, ip, r8
 	mov r7, r7, asr #0x1f
 	mla r8, r7, r3, r8
-	adds sb, sb, #0x800
+	adds r9, r9, #0x800
 	adc r3, r8, #0
-	mov r7, sb, lsr #0xc
+	mov r7, r9, lsr #0xc
 	orr r7, r7, r3, lsl #20
 	add r1, r1, r7
 	str r1, [r4, #0x60]
@@ -67660,7 +67660,7 @@ _02158d48:
 	mov r0, r4
 	bl func_ov15_02159db8
 	add sp, sp, #0x4c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _02158e14:
 	ldr r0, _02159278 ; =data_027e0f94
 	add r3, sp, #0x40
@@ -67735,10 +67735,10 @@ _02158e14:
 	ldrsh r7, [r2, r0]
 	ldr r1, [r4, #0x60]
 	mov r6, #0x29
-	umull sb, r8, r7, r3
+	umull r9, r8, r7, r3
 	mla r8, r7, ip, r8
 	mov lr, r7, asr #0x1f
-	adds r7, sb, #0x800
+	adds r7, r9, #0x800
 	mla r8, lr, r3, r8
 	adc r3, r8, #0
 	mov r7, r7, lsr #0xc
@@ -67767,7 +67767,7 @@ _02158e14:
 	mov r0, r4
 	bl func_ov15_02159db8
 	add sp, sp, #0x4c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _02158fbc:
 	bl func_ov15_02159db8
 _02158fc0:
@@ -67835,7 +67835,7 @@ _02158fc0:
 	add sp, sp, #0x4c
 	sub r0, r1, r0
 	str r0, [r4, #0x68]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _021590c4:
 	ldrh r1, [r4, #0x78]
 	ldr r5, _02159274 ; =data_02050f54
@@ -67900,13 +67900,13 @@ _02159184:
 	strgt r0, [r4, #0x64]
 	add sp, sp, #0x4c
 	strle r0, [r4, #0x64]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _021591bc:
 	mov r0, #0
 	str r0, [r4, #0x64]
 	add sp, sp, #0x4c
 	str r5, [r4, #0x4c]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _021591d0:
 	sub r1, r5, #0x800
 	cmp r0, r1
@@ -67915,7 +67915,7 @@ _021591d0:
 	str r0, [r4, #0x64]
 	add sp, sp, #0x4c
 	str r1, [r4, #0x4c]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _021591f0:
 	sub r1, r0, r1
 	mvn r0, #0x9c
@@ -67923,7 +67923,7 @@ _021591f0:
 	strgt r0, [r4, #0x64]
 	add sp, sp, #0x4c
 	strle r1, [r4, #0x64]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _0215920c:
 	mov r0, r4
 	mov r1, #1
@@ -67931,11 +67931,11 @@ _0215920c:
 	mov r0, r4
 	bl func_ov15_02159b70
 	add sp, sp, #0x4c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _02159228:
 	bl _ZN5Actor12ApplyGravityEv
 	add sp, sp, #0x4c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _02159234:
 	mov r1, #0
 	mvn r5, #0x80000000
@@ -67952,7 +67952,7 @@ _02159234:
 	bl func_0202b418
 _02159268:
 	add sp, sp, #0x4c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02158ce0
 _02159270: .word data_027e0d0c
@@ -68827,7 +68827,7 @@ _02159e38: .word 0xfffff4cd
 	.global func_ov15_02159e3c
 	arm_func_start func_ov15_02159e3c
 func_ov15_02159e3c: ; 0x02159e3c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #0x3c
 	str r0, [sp]
 	ldrb r0, [r0, #0xa4]
@@ -68881,7 +68881,7 @@ _02159ea0:
 	mov r5, r5, lsr #0xc
 	smull r3, r8, r6, r2
 	adc r2, r7, #0
-	adds sb, r3, #0x800
+	adds r9, r3, #0x800
 	ldr r6, [sp, #0xc]
 	mov r3, r10, lsr #0xc
 	orr r3, r3, r2, lsl #20
@@ -68892,15 +68892,15 @@ _02159ea0:
 	smull r7, r6, r0, r6
 	adc r8, r8, #0
 	adds r7, r7, #0x800
-	mov sb, sb, lsr #0xc
+	mov r9, r9, lsr #0xc
 	adc r0, r6, #0
 	mov r6, r7, lsr #0xc
 	mov r3, r3, asr #0x1f
 	str r3, [sp, #8]
 	ldr r3, [sp, #0xc]
-	orr sb, sb, r8, lsl #20
+	orr r9, r9, r8, lsl #20
 	orr r6, r6, r0, lsl #20
-	add r0, sb, r6
+	add r0, r9, r6
 	str r0, [sp, #0x38]
 	ldr r0, [sp]
 	mov r3, r3, asr #0x1f
@@ -68931,69 +68931,69 @@ _02159ea0:
 	add r6, r0, #0x184
 	add r8, r0, #0x1b4
 _02159fd0:
-	ldrsh sb, [r5]
+	ldrsh r9, [r5]
 	ldr r0, [sp]
 	ldr r10, [sp, #0x10]
-	rsb r2, sb, #0
+	rsb r2, r9, #0
 	mov ip, r2, asr #0x1f
 	str ip, [sp, #0x1c]
 	ldr ip, [sp, #0xc]
 	ldrb r0, [r0, #0x2f3]
-	umull lr, ip, sb, ip
-	mla ip, sb, r10, ip
-	mov r3, sb, asr #0x1f
-	ldr sb, [sp, #0xc]
+	umull lr, ip, r9, ip
+	mla ip, r9, r10, ip
+	mov r3, r9, asr #0x1f
+	ldr r9, [sp, #0xc]
 	ldrsh r1, [r5, #4]
-	mla ip, r3, sb, ip
-	adds sb, lr, #0x800
+	mla ip, r3, r9, ip
+	adds r9, lr, #0x800
 	adc r3, ip, #0
-	mov lr, sb, lsr #0xc
+	mov lr, r9, lsr #0xc
 	orr lr, lr, r3, lsl #20
 	ldr r3, [sp, #4]
 	str r0, [sp, #0x20]
 	umull r10, r3, r1, r3
-	adds sb, r10, #0x800
-	mov ip, sb, lsr #0xc
-	ldr sb, [sp, #8]
+	adds r9, r10, #0x800
+	mov ip, r9, lsr #0xc
+	ldr r9, [sp, #8]
 	mov r0, r1, asr #0x1f
-	mla r3, r1, sb, r3
-	ldr sb, [sp, #4]
+	mla r3, r1, r9, r3
+	ldr r9, [sp, #4]
 	ldrsh r4, [r5, #2]
-	mla r3, r0, sb, r3
+	mla r3, r0, r9, r3
 	adc r3, r3, #0
 	orr ip, ip, r3, lsl #20
 	add r3, lr, ip
 	mov r3, r3, lsl #0x10
 	mov r3, r3, asr #0x10
 	str r3, [sp, #0x14]
-	mov r3, sb
-	ldr sb, [sp, #8]
+	mov r3, r9
+	ldr r9, [sp, #8]
 	umull ip, r3, r2, r3
-	mla r3, r2, sb, r3
-	ldr sb, [sp, #0x1c]
+	mla r3, r2, r9, r3
+	ldr r9, [sp, #0x1c]
 	ldr r2, [sp, #4]
-	mla r3, sb, r2, r3
-	adds sb, ip, #0x800
+	mla r3, r9, r2, r3
+	adds r9, ip, #0x800
 	adc r3, r3, #0
-	mov r2, sb, lsr #0xc
+	mov r2, r9, lsr #0xc
 	orr r2, r2, r3, lsl #20
 	ldr r3, [sp, #0xc]
-	umull r10, sb, r1, r3
+	umull r10, r9, r1, r3
 	ldr r3, [sp, #0x10]
-	mla sb, r1, r3, sb
+	mla r9, r1, r3, r9
 	ldr r1, [sp, #0xc]
-	mla sb, r0, r1, sb
+	mla r9, r0, r1, r9
 	mov r0, #0x800
 	adds r3, r10, r0
 	mov r0, #0
-	adc r1, sb, r0
+	adc r1, r9, r0
 	ldr r0, [sp, #0x20]
 	cmp r0, #1
 	mov r0, r3, lsr #0xc
 	orr r0, r0, r1, lsl #20
 	add r0, r2, r0
 	mov r0, r0, lsl #0x10
-	mov sb, r0, asr #0x10
+	mov r9, r0, asr #0x10
 	add r2, sp, #0x30
 	bne _0215a10c
 	ldr r0, _0215a1b4 ; =data_027e0e58
@@ -69006,7 +69006,7 @@ _02159fd0:
 	ldr r0, [sp, #0x14]
 	strh r0, [r1, #0x50]
 	strh r4, [r1, #0x52]
-	strh sb, [r1, #0x54]
+	strh r9, [r1, #0x54]
 _0215a100:
 	mov r0, r8
 	bl func_ov00_020b7e6c
@@ -69022,7 +69022,7 @@ _0215a10c:
 	ldr r0, [sp, #0x14]
 	strh r0, [r1, #0x50]
 	strh r4, [r1, #0x52]
-	strh sb, [r1, #0x54]
+	strh r9, [r1, #0x54]
 _0215a138:
 	mov r0, r6
 	bl func_ov00_020b7e6c
@@ -69037,7 +69037,7 @@ _0215a140:
 	cmp r0, #4
 	blt _02159fd0
 	add sp, sp, #0x3c
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 _0215a16c:
 	ldr r0, [sp]
 	mov r6, #0
@@ -69054,7 +69054,7 @@ _0215a17c:
 	add r5, r5, #0xc
 	blt _0215a17c
 	add sp, sp, #0x3c
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02159e3c
 _0215a1a8: .word data_02050f54
@@ -69306,7 +69306,7 @@ func_ov15_0215a440: ; 0x0215a440
 	.global func_ov15_0215a478
 	arm_func_start func_ov15_0215a478
 func_ov15_0215a478: ; 0x0215a478
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x30
 	ldr r1, _0215a748 ; =data_027e0f74
 	mov r10, r0
@@ -69319,7 +69319,7 @@ func_ov15_0215a478: ; 0x0215a478
 	cmp r0, #0
 	addne sp, sp, #0x30
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	mvn r0, #0
 	str r0, [r10, #0x98]
 	str r0, [r10, #0x88]
@@ -69364,7 +69364,7 @@ _0215a500:
 	cmp r0, #0
 	addlt sp, sp, #0x30
 	movlt r0, #0
-	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmltia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, _0215a75c ; =data_027e0e60
 	ldrh r1, [r10, #0x20]
 	ldr r0, [r0]
@@ -69392,13 +69392,13 @@ _0215a500:
 	str r8, [r10, #0x1ec]
 	cmp r7, #0
 	ble _0215a6b0
-	mov sb, r8
+	mov r9, r8
 	add r5, r10, #0x1f0
 	mov r11, #0xc
 	mov r4, #0x24
 _0215a5d8:
 	ldr r0, [r6, #4]
-	add r2, r0, sb
+	add r2, r0, r9
 	ldrsb r0, [r2, #0x10]
 	cmp r0, #0
 	beq _0215a5f8
@@ -69423,7 +69423,7 @@ _0215a5f8:
 	ldr r2, [sp, #0x14]
 	str r2, [ip, #8]
 	ldr ip, [r6, #4]
-	add r2, ip, sb
+	add r2, ip, r9
 	ldrsb r3, [r2, #0x11]
 	mla r2, r3, r4, ip
 	ldr r3, [r2, #4]
@@ -69451,7 +69451,7 @@ _0215a698:
 	add r0, r8, #1
 	mov r0, r0, lsl #0x18
 	cmp r7, r0, asr #24
-	add sb, sb, #0x24
+	add r9, r9, #0x24
 	mov r8, r0, asr #0x18
 	bgt _0215a5d8
 _0215a6b0:
@@ -69492,7 +69492,7 @@ _0215a6b0:
 	strb r1, [r10, #0x239]
 	strb r1, [r10, #0x23a]
 	add sp, sp, #0x30
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0215a478
 _0215a748: .word data_027e0f74
@@ -69661,7 +69661,7 @@ func_ov15_0215a95c: ; 0x0215a95c
 	.global func_ov15_0215a970
 	arm_func_start func_ov15_0215a970
 func_ov15_0215a970: ; 0x0215a970
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x40
 	ldr r1, _0215b264 ; =data_027e0f94
 	add r3, sp, #0x34
@@ -69680,7 +69680,7 @@ func_ov15_0215a970: ; 0x0215a970
 	mov r0, r4
 	bl func_ov15_0215b790
 	add sp, sp, #0x40
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0215a9c0:
 	ldr r0, _0215b26c ; =data_027e0e60
 	mov r6, #0
@@ -69755,7 +69755,7 @@ _0215aa5c:
 	cmp r0, #0
 	addne sp, sp, #0x40
 	strneb r3, [r4, #0x238]
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r1, sp, #0x10
 	add r2, sp, #0xc
 	mov r0, r4
@@ -69844,8 +69844,8 @@ _0215ac10:
 	mov r8, #0
 	umull r2, r1, r10, r0
 	mla r1, r10, r8, r1
-	mov sb, r10, asr #0x1f
-	mla r1, sb, r0, r1
+	mov r9, r10, asr #0x1f
+	mla r1, r9, r0, r1
 	adds r2, r2, #0x800
 	adc r0, r1, #0
 	mov r1, r2, lsr #0xc
@@ -69865,7 +69865,7 @@ _0215ac50:
 	mov r2, ip, asr #0x1f
 	mla lr, r10, r2, lr
 	adds r5, r5, #0x800
-	mla lr, sb, ip, lr
+	mla lr, r9, ip, lr
 	adc r2, lr, r11
 	mov r5, r5, lsr #0xc
 	orr r5, r5, r2, lsl #20
@@ -69879,7 +69879,7 @@ _0215ac50:
 	umull r3, r2, r10, r0
 	mov r1, #0
 	mla r2, r10, r1, r2
-	mla r2, sb, r0, r2
+	mla r2, r9, r0, r2
 	adds r3, r3, #0x800
 	mov r0, r3, lsr #0xc
 	adc r1, r2, #0
@@ -69888,14 +69888,14 @@ _0215ac50:
 	cmp r11, #0x1000
 	movge r11, #0x1000
 	mov ip, #0
-	ldr sb, _0215b284 ; =data_ov15_021865dc
+	ldr r9, _0215b284 ; =data_ov15_021865dc
 	ldr r3, _0215b288 ; =data_ov15_021865fc
 	str r0, [sp, #4]
 	mov r10, r11, asr #0x1f
 	add r1, sp, #0x14
 	mov lr, ip
 _0215ace4:
-	ldr r8, [sb, ip, lsl #2]
+	ldr r8, [r9, ip, lsl #2]
 	ldr r2, [r3, ip, lsl #2]
 	add r0, ip, #1
 	sub r5, r2, r8
@@ -70016,8 +70016,8 @@ _0215ae94:
 	mov r10, #0
 	umull r2, r1, r5, r0
 	mla r1, r5, r10, r1
-	mov sb, r5, asr #0x1f
-	mla r1, sb, r0, r1
+	mov r9, r5, asr #0x1f
+	mla r1, r9, r0, r1
 	adds r2, r2, #0x800
 	adc r0, r1, #0
 	mov r1, r2, lsr #0xc
@@ -70037,7 +70037,7 @@ _0215aed4:
 	adds r6, ip, #0x800
 	mov ip, r2, asr #0x1f
 	mla r3, r5, ip, r3
-	mla r3, sb, r2, r3
+	mla r3, r9, r2, r3
 	mov r6, r6, lsr #0xc
 	adc r2, r3, lr
 	orr r6, r6, r2, lsl #20
@@ -70051,7 +70051,7 @@ _0215aed4:
 	umull r3, r2, r5, r0
 	mov r1, #0
 	mla r2, r5, r1, r2
-	mla r2, sb, r0, r2
+	mla r2, r9, r0, r2
 	adds r3, r3, #0x800
 	mov r0, r3, lsr #0xc
 	adc r1, r2, #0
@@ -70060,14 +70060,14 @@ _0215aed4:
 	cmp r11, #0x1000
 	movge r11, #0x1000
 	mov ip, #0
-	ldr sb, _0215b284 ; =data_ov15_021865dc
+	ldr r9, _0215b284 ; =data_ov15_021865dc
 	ldr r3, _0215b288 ; =data_ov15_021865fc
 	str r0, [sp, #4]
 	mov r10, r11, asr #0x1f
 	add r1, sp, #0x14
 	mov lr, ip
 _0215af68:
-	ldr r8, [sb, ip, lsl #2]
+	ldr r8, [r9, ip, lsl #2]
 	ldr r2, [r3, ip, lsl #2]
 	add r0, ip, #1
 	sub r5, r2, r8
@@ -70105,16 +70105,16 @@ _0215afb4:
 	tst r0, #1
 	movne r10, #1
 	moveq r10, #0
-	mov sb, #0
+	mov r9, #0
 	add r5, r4, #0x1c8
 _0215b004:
 	ldr r2, _0215b280 ; =data_ov15_021865e8
 	add r1, sp, #0x20
-	ldr r3, [r2, sb, lsl #2]
+	ldr r3, [r2, r9, lsl #2]
 	ldr r2, _0215b27c ; =data_ov15_021865c8
-	ldr r1, [r1, sb, lsl #2]
-	ldr r2, [r2, sb, lsl #2]
-	add r0, r5, sb, lsl #2
+	ldr r1, [r1, r9, lsl #2]
+	ldr r2, [r2, r9, lsl #2]
+	add r0, r5, r9, lsl #2
 	sub ip, r3, r2
 	umull r3, r2, ip, r8
 	mla r2, ip, r7, r2
@@ -70126,12 +70126,12 @@ _0215b004:
 	orr r2, r2, r3, lsl #20
 	bl Approach_thunk
 	tst r10, r0
-	add r0, sb, #1
+	add r0, r9, #1
 	mov r0, r0, lsl #0x10
 	movne r10, #1
-	mov sb, r0, lsr #0x10
+	mov r9, r0, lsr #0x10
 	moveq r10, #0
-	cmp sb, #5
+	cmp r9, #5
 	blo _0215b004
 	mov r0, #0x9000
 	mov r1, #0
@@ -70149,16 +70149,16 @@ _0215b004:
 	movne r10, #1
 	moveq r10, #0
 	mov r7, r8, asr #0x1f
-	mov sb, #0
+	mov r9, #0
 	add r5, r4, #0x1e0
 _0215b0b0:
 	ldr r2, _0215b288 ; =data_ov15_021865fc
 	add r1, sp, #0x14
-	ldr r3, [r2, sb, lsl #2]
+	ldr r3, [r2, r9, lsl #2]
 	ldr r2, _0215b284 ; =data_ov15_021865dc
-	ldr r1, [r1, sb, lsl #2]
-	ldr r2, [r2, sb, lsl #2]
-	add r0, r5, sb, lsl #2
+	ldr r1, [r1, r9, lsl #2]
+	ldr r2, [r2, r9, lsl #2]
+	add r0, r5, r9, lsl #2
 	sub ip, r3, r2
 	umull r3, r2, ip, r8
 	mla r2, ip, r7, r2
@@ -70170,12 +70170,12 @@ _0215b0b0:
 	orr r2, r2, r3, lsl #20
 	bl Approach_thunk
 	tst r10, r0
-	add r0, sb, #1
+	add r0, r9, #1
 	mov r0, r0, lsl #0x10
 	movne r10, #1
-	mov sb, r0, lsr #0x10
+	mov r9, r0, lsr #0x10
 	moveq r10, #0
-	cmp sb, #3
+	cmp r9, #3
 	blo _0215b0b0
 	ldr r0, [r4, #0x1dc]
 	cmp r0, #0
@@ -70264,7 +70264,7 @@ _0215b248:
 	add r0, r4, #0x228
 	bl Approach_thunk
 	add sp, sp, #0x40
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0215a970
 _0215b264: .word data_027e0f94
@@ -70285,7 +70285,7 @@ _0215b298: .word 0x0005000e
 	.global func_ov15_0215b29c
 	arm_func_start func_ov15_0215b29c
 func_ov15_0215b29c: ; 0x0215b29c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x10
 	ldr r5, _0215b354 ; =data_027e0f94
 	add r4, sp, #4
@@ -70296,7 +70296,7 @@ func_ov15_0215b29c: ; 0x0215b29c
 	ldmia r5, {r0, r1, r2}
 	stmia r4, {r0, r1, r2}
 	ldr r0, [r10, #0x1ec]
-	mov sb, r3
+	mov r9, r3
 	mov r7, r6
 	cmp r0, #0
 	mvn r5, #0x80000000
@@ -70320,19 +70320,19 @@ _0215b30c:
 	strne r5, [r11]
 	cmp r0, #0
 	strne r6, [r0]
-	cmp sb, #0
+	cmp r9, #0
 	addeq sp, sp, #0x10
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	mov r0, #0xc
 	mla r1, r6, r0, r10
 	ldr r0, [r1, #0x1f0]
-	str r0, [sb]
+	str r0, [r9]
 	ldr r0, [r1, #0x1f4]
-	str r0, [sb, #4]
+	str r0, [r9, #4]
 	ldr r0, [r1, #0x1f8]
-	str r0, [sb, #8]
+	str r0, [r9, #8]
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0215b29c
 _0215b354: .word data_027e0f94
@@ -70340,7 +70340,7 @@ _0215b354: .word data_027e0f94
 	.global func_ov15_0215b358
 	arm_func_start func_ov15_0215b358
 func_ov15_0215b358: ; 0x0215b358
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	str r0, [sp]
 	ldr r0, _0215b620 ; =data_ov00_020ee0a0
 	mov r1, #0xa0
@@ -70356,13 +70356,13 @@ func_ov15_0215b358: ; 0x0215b358
 	sub r8, r0, r6
 	mov r7, r8, asr #0x1f
 	mov r10, #0
-	mov sb, #0x800
+	mov r9, #0x800
 _0215b39c:
 	mov r1, r5, lsl #0x9
 	mov r0, r1, asr #0x1f
 	umull r3, r2, r8, r1
 	mla r2, r8, r0, r2
-	adds r3, r3, sb
+	adds r3, r3, r9
 	mla r2, r7, r1, r2
 	adc r0, r2, r10
 	mov r1, r3, lsr #0xc
@@ -70392,14 +70392,14 @@ _0215b39c:
 	sub r6, r0, r7
 	mov r5, r6, asr #0x1f
 	mov r10, #0
-	mov sb, #0x800
+	mov r9, #0x800
 _0215b428:
 	sub r0, r8, #8
 	mov r1, r0, lsl #0x9
 	mov r0, r1, asr #0x1f
 	umull r3, r2, r6, r1
 	mla r2, r6, r0, r2
-	adds r3, r3, sb
+	adds r3, r3, r9
 	mla r2, r5, r1, r2
 	adc r0, r2, r10
 	mov r1, r3, lsr #0xc
@@ -70429,14 +70429,14 @@ _0215b428:
 	sub r6, r0, r7
 	mov r5, r6, asr #0x1f
 	mov r10, #0
-	mov sb, #0x800
+	mov r9, #0x800
 _0215b4b8:
 	sub r0, r8, #0x10
 	mov r1, r0, lsl #0x9
 	mov r0, r1, asr #0x1f
 	umull r3, r2, r6, r1
 	mla r2, r6, r0, r2
-	adds r3, r3, sb
+	adds r3, r3, r9
 	mla r2, r5, r1, r2
 	adc r0, r2, r10
 	mov r1, r3, lsr #0xc
@@ -70454,16 +70454,16 @@ _0215b4b8:
 	blo _0215b4b8
 	ldr r1, _0215b624 ; =data_ov15_021865c8
 	ldr r0, _0215b620 ; =data_ov00_020ee0a0
-	ldr sb, [r1, #0xc]
+	ldr r9, [r1, #0xc]
 	mov r1, #0x18
-	mov r2, sb, asr #0xc
+	mov r2, r9, asr #0xc
 	and r2, r2, #0xff
 	bl func_ov00_0209cd40
 	ldr r0, _0215b624 ; =data_ov15_021865c8
 	ldr r11, _0215b620 ; =data_ov00_020ee0a0
 	ldr r0, [r0, #0x10]
 	ldr r4, _0215b628 ; =0x00000249
-	sub r8, r0, sb
+	sub r8, r0, r9
 	mov r10, #0x19
 	mov r7, r8, asr #0x1f
 	mov r6, #0
@@ -70479,7 +70479,7 @@ _0215b54c:
 	adc r0, r2, r6
 	mov r1, r3, lsr #0xc
 	orr r1, r1, r0, lsl #20
-	add r0, sb, r1
+	add r0, r9, r1
 	mov r1, r0, asr #0xc
 	mov r0, r11
 	and r2, r1, #0xff
@@ -70521,7 +70521,7 @@ _0215b54c:
 	mov r1, #0
 	ldr r0, [r0]
 	bl func_ov00_020823a4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0215b358
 _0215b620: .word data_ov00_020ee0a0
@@ -70652,7 +70652,7 @@ _0215b78c: .word data_027e10a8
 	.global func_ov15_0215b790
 	arm_func_start func_ov15_0215b790
 func_ov15_0215b790: ; 0x0215b790
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x14
 	ldr r1, _0215b840 ; =data_027e10a8
 	mov r2, #1
@@ -70669,19 +70669,19 @@ func_ov15_0215b790: ; 0x0215b790
 	str r0, [sp, #0x10]
 	strb r2, [r10, #0x23a]
 	add r4, r10, #0x3a
-	add sb, r10, #0x1c8
+	add r9, r10, #0x1c8
 	mov r11, r8
 	mov r5, r2
 	add r7, sp, #0
 	mov r6, #0x2000
 _0215b7e8:
 	ldr r1, [r7, r8, lsl #2]
-	mov r0, sb
+	mov r0, r9
 	mov r2, r6
 	bl Approach_thunk
 	ldrb r1, [r4, #0x200]
 	add r8, r8, #1
-	add sb, sb, #4
+	add r9, r9, #4
 	tst r1, r0
 	movne r0, r5
 	moveq r0, r11
@@ -70696,7 +70696,7 @@ _0215b7e8:
 	mov r0, r10
 	bl func_ov15_0215b84c
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0215b790
 _0215b840: .word data_027e10a8
@@ -70706,7 +70706,7 @@ _0215b848: .word data_027e0f94
 	.global func_ov15_0215b84c
 	arm_func_start func_ov15_0215b84c
 func_ov15_0215b84c: ; 0x0215b84c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	ldr r1, _0215bac0 ; =data_027e0e60
 	mov r4, r0
 	ldr r0, [r1]
@@ -70820,7 +70820,7 @@ _0215b990:
 	ldr r5, _0215bac4 ; =data_ov00_020ee0a0
 	ldr r7, _0215bac8 ; =0x00000249
 	mov r6, #0x19
-	mov sb, #0
+	mov r9, #0
 	mov r8, #0x800
 _0215ba10:
 	sub r0, r6, #0x18
@@ -70831,7 +70831,7 @@ _0215ba10:
 	sub r3, r3, r1
 	smull ip, r2, r3, r2
 	adds r3, ip, r8
-	adc r2, r2, sb
+	adc r2, r2, r9
 	mov r3, r3, lsr #0xc
 	orr r3, r3, r2, lsl #20
 	add r1, r1, r3
@@ -70866,7 +70866,7 @@ _0215ba10:
 	ldr r0, _0215bac4 ; =data_ov00_020ee0a0
 	mov r1, r1, lsr #0x10
 	bl func_ov00_0209cdbc
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0215b84c
 _0215bac0: .word data_027e0e60
@@ -71164,7 +71164,7 @@ _0215be48: .word data_027e103c
 	.global func_ov15_0215be4c
 	arm_func_start func_ov15_0215be4c
 func_ov15_0215be4c: ; 0x0215be4c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x1b4
 	mov r4, r0
 	mov r2, #1
@@ -71187,7 +71187,7 @@ _0215be90:
 	bl _ZN5Actor18func_ov00_020c198cEv
 	cmp r0, #0
 	addeq sp, sp, #0x1b4
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	add r0, sp, #0x104
 	bl func_ov00_0209a4f4
 	mov r2, #0
@@ -71221,12 +71221,12 @@ _0215be90:
 	str r1, [r4, #0x130]
 	bl func_ov00_0209a508
 	add sp, sp, #0x1b4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _0215bf2c:
 	bl func_ov15_0215cf38
 	cmp r0, #0
 	addne sp, sp, #0x1b4
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	ldr r0, _0215c338 ; =data_027e0c68
 	ldr r2, _0215c33c ; =0x0005004a
 	add r1, r4, #0x158
@@ -71239,7 +71239,7 @@ _0215bf2c:
 	mov r0, #2
 	add sp, sp, #0x1b4
 	str r0, [r4, #0x130]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _0215bf70:
 	add r0, r4, #0x158
 	ldr r1, [r0]
@@ -71251,7 +71251,7 @@ _0215bf70:
 	and r0, r1, r0
 	cmp r0, #0x1000000
 	addne sp, sp, #0x1b4
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	mov r3, #0
 	sub r2, r3, #2
 	mov r5, #0x47
@@ -71278,13 +71278,13 @@ _0215bf70:
 	ldrb ip, [sp, #0x4f]
 	ldrb r3, [sp, #0x50]
 	ldrb r2, [sp, #0x51]
-	ldr sb, [sp, #0x3c]
+	ldr r9, [sp, #0x3c]
 	ldr r8, [sp, #0x40]
 	ldr r7, [sp, #0x44]
 	ldr r6, [sp, #0x48]
 	ldr r0, [r0]
 	add r1, sp, #0
-	str sb, [sp]
+	str r9, [sp]
 	str r8, [sp, #4]
 	str r7, [sp, #8]
 	str r6, [sp, #0xc]
@@ -71303,7 +71303,7 @@ _0215c058:
 	mov r0, #3
 	add sp, sp, #0x1b4
 	str r0, [r4, #0x130]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _0215c068:
 	ldr r0, _0215c334 ; =data_027e10a4
 	ldr r0, [r0]
@@ -71326,7 +71326,7 @@ _0215c068:
 	mov r0, r4
 	bl _ZN5Actor10SetUnk_11cEc
 	add sp, sp, #0x1b4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _0215c0c0:
 	mov r0, #0x10000
 	ldr r1, [r4, #0x170]
@@ -71334,7 +71334,7 @@ _0215c0c0:
 	and r0, r1, r0
 	cmp r0, #0x1000000
 	addeq sp, sp, #0x1b4
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	add r0, r4, #0x158
 	ldr r1, [r0]
 	ldr r1, [r1, #0x10]
@@ -71345,7 +71345,7 @@ _0215c0c0:
 	and r0, r1, r0
 	cmp r0, #0x1000000
 	addne sp, sp, #0x1b4
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	mov r1, #0
 	ldr r0, _0215c338 ; =data_027e0c68
 	strb r1, [r4, #0x1b9]
@@ -71364,7 +71364,7 @@ _0215c0c0:
 	mov r2, #0
 	bl func_ov00_020cfae8
 	add sp, sp, #0x1b4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _0215c154:
 	ldr r0, _0215c354 ; =data_027e0f94
 	add r3, sp, #0x30
@@ -71424,18 +71424,18 @@ _0215c154:
 	add r0, sp, #0x54
 	bl func_ov00_0209a508
 	add sp, sp, #0x1b4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _0215c240:
 	ldrb r0, [r4, #0x1bc]
 	cmp r0, #0
 	addne sp, sp, #0x1b4
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	ldr r1, _0215c348 ; =data_027e0e2c
 	mvn r0, #0
 	ldr r1, [r1, #4]
 	cmp r1, r0
 	addne sp, sp, #0x1b4
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	ldrb r1, [r4, #0x1b9]
 	cmp r1, #0
 	bne _0215c29c
@@ -71448,13 +71448,13 @@ _0215c240:
 	mov r0, r4
 	bl _ZN5Actor10SetUnk_11cEc
 	add sp, sp, #0x1b4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _0215c29c:
 	ldr r1, [r4, #0x170]
 	and r0, r1, r0, lsl #16
 	cmp r0, #0x1000000
 	addeq sp, sp, #0x1b4
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	add r0, r4, #0x158
 	ldr r1, [r0]
 	ldr r1, [r1, #0x10]
@@ -71465,7 +71465,7 @@ _0215c29c:
 	and r0, r1, r0
 	cmp r0, #0x1000000
 	addne sp, sp, #0x1b4
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	mov r1, #0
 	mov r0, r4
 	strb r1, [r4, #0x1b9]
@@ -71487,7 +71487,7 @@ _0215c31c:
 	str r0, [r4, #0x1b4]
 _0215c324:
 	add sp, sp, #0x1b4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0215be4c
 _0215c32c: .word data_027e0f64
@@ -71752,7 +71752,7 @@ _0215c6c4:
 	.global func_ov15_0215c6d4
 	arm_func_start func_ov15_0215c6d4
 func_ov15_0215c6d4: ; 0x0215c6d4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x44
 	ldr r4, _0215c7d8 ; =data_027e0ff0
 	mov r7, #0
@@ -71760,7 +71760,7 @@ func_ov15_0215c6d4: ; 0x0215c6d4
 	str r0, [sp]
 	ldr r0, [r3, #4]
 	mov r10, r1
-	mov sb, r2
+	mov r9, r2
 	mov r8, r7
 	cmp r0, #0
 	ble _0215c7c0
@@ -71772,7 +71772,7 @@ _0215c710:
 	ldr r2, [r0, r8, lsl #3]
 	cmp r2, #0
 	beq _0215c7a8
-	ldrb r1, [sb]
+	ldrb r1, [r9]
 	ldrb r0, [r2, #4]
 	cmp r1, r0
 	bne _0215c7a8
@@ -71819,7 +71819,7 @@ _0215c7c0:
 	ldmia r0, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
 	add sp, sp, #0x44
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0215c6d4
 _0215c7d8: .word data_027e0ff0
@@ -71827,7 +71827,7 @@ _0215c7d8: .word data_027e0ff0
 	.global func_ov15_0215c7dc
 	arm_func_start func_ov15_0215c7dc
 func_ov15_0215c7dc: ; 0x0215c7dc
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x34
 	ldr r3, _0215c8b0 ; =data_027e0ff0
 	mov r7, #0
@@ -71842,13 +71842,13 @@ func_ov15_0215c7dc: ; 0x0215c7dc
 	add r8, r3, r2, lsl #3
 	cmp r6, #0
 	ble _0215c898
-	mov sb, r7
+	mov r9, r7
 	add r4, sp, #4
 	add r11, sp, #0x28
 _0215c824:
 	ldr r1, [r8, #4]
 	mov r0, r4
-	add r1, r1, sb
+	add r1, r1, r9
 	ldr r3, [r1, #0xc]
 	ldmib r1, {r2, ip}
 	str ip, [sp, #0x2c]
@@ -71874,7 +71874,7 @@ _0215c824:
 _0215c888:
 	add r5, r5, #1
 	cmp r5, r6
-	add sb, sb, #0x24
+	add r9, r9, #0x24
 	blt _0215c824
 _0215c898:
 	ldr r3, [sp]
@@ -71882,7 +71882,7 @@ _0215c898:
 	ldmia r0, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
 	add sp, sp, #0x34
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0215c7dc
 _0215c8b0: .word data_027e0ff0
@@ -71890,7 +71890,7 @@ _0215c8b0: .word data_027e0ff0
 	.global func_ov15_0215c8b4
 	arm_func_start func_ov15_0215c8b4
 func_ov15_0215c8b4: ; 0x0215c8b4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x60
 	ldr r3, _0215cb1c ; =data_027e0ff0
 	ldrb r1, [r1]
@@ -71913,7 +71913,7 @@ func_ov15_0215c8b4: ; 0x0215c8b4
 	str r0, [sp, #4]
 	str r1, [sp, #0x5c]
 	blt _0215cb10
-	mov sb, #0x24
+	mov r9, #0x24
 	add r11, sp, #0x30
 _0215c918:
 	cmp r6, r7
@@ -71927,7 +71927,7 @@ _0215c918:
 	str r1, [sp, #0x50]
 	b _0215c95c
 _0215c940:
-	add r0, r0, sb
+	add r0, r0, r9
 	ldr r2, [r0, #8]
 	ldr r1, [r0, #0xc]
 	ldr r0, [r0, #4]
@@ -72045,14 +72045,14 @@ _0215cae8:
 	ldr r0, [sp, #0x50]
 	str r0, [sp, #0x5c]
 _0215cb00:
-	add sb, sb, #0x24
+	add r9, r9, #0x24
 	add r6, r6, #1
 	cmp r6, r7
 	ble _0215c918
 _0215cb10:
 	mov r0, r5
 	add sp, sp, #0x60
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0215c8b4
 _0215cb1c: .word data_027e0ff0
@@ -72140,7 +72140,7 @@ _0215cc2c: .word data_027e0f94
 	.global func_ov15_0215cc30
 	arm_func_start func_ov15_0215cc30
 func_ov15_0215cc30: ; 0x0215cc30
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x24
 	ldr r6, _0215cee4 ; =data_027e0f94
 	add r4, sp, #0xc
@@ -72166,10 +72166,10 @@ func_ov15_0215cc30: ; 0x0215cc30
 	ldr r8, [r4]
 	ldr r6, _0215cee8 ; =0x00001333
 	ldr r1, _0215ceec ; =data_027e0fac
-	umull sb, r0, r8, r6
+	umull r9, r0, r8, r6
 	mov r7, #0
 	ldrh r10, [r1]
-	adds r1, sb, #0x800
+	adds r1, r9, #0x800
 	mla r0, r8, r7, r0
 	mov r7, r8, asr #0x1f
 	mla r0, r7, r6, r0
@@ -72203,18 +72203,18 @@ _0215cd18:
 	mov ip, #0
 	ldr r2, [r0]
 	ldmib r0, {r1, r6, lr}
-	umull sb, r3, r6, r2
+	umull r9, r3, r6, r2
 	mla r3, r6, r1, r3
 	ldr r8, [r0, #0x10]
 	mla r3, lr, r2, r3
 	ldr r7, [r0, #0x14]
-	adds r10, r8, sb
+	adds r10, r8, r9
 	str r10, [r0]
-	adc sb, r7, r3
-	str sb, [r0, #4]
+	adc r9, r7, r3
+	str r9, [r0, #4]
 	mov r1, ip, lsl #0x10
 	ldr r2, [r5]
-	orr r1, r1, sb, lsr #16
+	orr r1, r1, r9, lsr #16
 	sub r1, r1, #0x8000
 	mov r1, r1, lsl #0x10
 	add r3, r2, #1
@@ -72223,7 +72223,7 @@ _0215cd18:
 	movle r1, ip
 	ble _0215cda8
 	umull r2, r1, r6, r10
-	mla r1, r6, sb, r1
+	mla r1, r6, r9, r1
 	adds r2, r8, r2
 	mla r1, lr, r10, r1
 	adc r1, r7, r1
@@ -72315,7 +72315,7 @@ _0215ced0:
 	ldmia r0, {r0, r1, r2}
 	stmia r11, {r0, r1, r2}
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0215cc30
 _0215cee4: .word data_027e0f94
@@ -72452,7 +72452,7 @@ _0215d074: .word data_02050f54
 	.global func_ov15_0215d078
 	arm_func_start func_ov15_0215d078
 func_ov15_0215d078: ; 0x0215d078
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #0x6c
 	mov r5, #0
 	sub r4, r5, #2
@@ -72476,7 +72476,7 @@ func_ov15_0215d078: ; 0x0215d078
 	cmp r0, #0
 	addeq sp, sp, #0x6c
 	moveq r0, r5
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	cmp r4, #0
 	beq _0215d1cc
 	add r3, sp, #0x48
@@ -72518,7 +72518,7 @@ func_ov15_0215d078: ; 0x0215d078
 	ldrb lr, [sp, #0x68]
 	ldrb ip, [sp, #0x69]
 	ldr r10, [sp, #0x54]
-	ldr sb, [sp, #0x58]
+	ldr r9, [sp, #0x58]
 	ldr r8, [sp, #0x5c]
 	ldr r7, [sp, #0x60]
 	ldr r0, [r0]
@@ -72526,7 +72526,7 @@ func_ov15_0215d078: ; 0x0215d078
 	mov r2, r2, lsl #0xc
 	mov r3, r3, lsl #0xc
 	str r10, [sp, #0x24]
-	str sb, [sp, #0x28]
+	str r9, [sp, #0x28]
 	str r8, [sp, #0x2c]
 	str r7, [sp, #0x30]
 	strh r6, [sp, #0x34]
@@ -72536,7 +72536,7 @@ func_ov15_0215d078: ; 0x0215d078
 	strb ip, [sp, #0x39]
 	bl func_ov15_0214146c
 	add sp, sp, #0x6c
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 _0215d1cc:
 	ldr r0, _0215d234 ; =data_027e10a4
 	ldrsh r6, [sp, #0x64]
@@ -72545,13 +72545,13 @@ _0215d1cc:
 	ldrb r3, [sp, #0x68]
 	ldrb r2, [sp, #0x69]
 	ldr r10, [sp, #0x54]
-	ldr sb, [sp, #0x58]
+	ldr r9, [sp, #0x58]
 	ldr r8, [sp, #0x5c]
 	ldr r7, [sp, #0x60]
 	ldr r0, [r0]
 	add r1, sp, #0xc
 	str r10, [sp, #0xc]
-	str sb, [sp, #0x10]
+	str r9, [sp, #0x10]
 	str r8, [sp, #0x14]
 	str r7, [sp, #0x18]
 	strh r6, [sp, #0x1c]
@@ -72561,7 +72561,7 @@ _0215d1cc:
 	strb r2, [sp, #0x21]
 	bl func_ov15_021413f8
 	add sp, sp, #0x6c
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0215d078
 _0215d22c: .word data_027e0e60
@@ -74315,28 +74315,28 @@ _0215e884:
 	.global func_ov15_0215e890
 	arm_func_start func_ov15_0215e890
 func_ov15_0215e890: ; 0x0215e890
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0xd0
-	mov sb, r0
-	ldr r1, [sb, #0x3b8]
-	add r0, sb, #0x300
+	mov r9, r0
+	ldr r1, [r9, #0x3b8]
+	add r0, r9, #0x300
 	add r1, r1, #1
-	str r1, [sb, #0x3b8]
+	str r1, [r9, #0x3b8]
 	ldrsh r3, [r0, #0xe4]
 	ldr r2, _0215f7b8 ; =data_027e0e60
 	add r1, sp, #0x4c
 	add r3, r3, #1
 	strh r3, [r0, #0xe4]
-	ldr r3, [sb, #0x48]
+	ldr r3, [r9, #0x48]
 	ldr r0, [r2]
 	str r3, [sp, #0x4c]
-	ldr r3, [sb, #0x4c]
+	ldr r3, [r9, #0x4c]
 	mov r2, #0
 	str r3, [sp, #0x50]
-	ldr r3, [sb, #0x50]
+	ldr r3, [r9, #0x50]
 	str r3, [sp, #0x54]
 	bl func_ov00_02083ee0
-	ldr r1, [sb, #0x130]
+	ldr r1, [r9, #0x130]
 	mov r6, r0
 	cmp r1, #7
 	addls pc, pc, r1, lsl #2
@@ -74355,13 +74355,13 @@ _0215e918:
 	ldr r0, [r0]
 	bl func_ov00_020846a4
 	cmp r0, #6
-	ldr r0, [sb, #0x3b8]
+	ldr r0, [r9, #0x3b8]
 	subeq r0, r0, #1
-	streq r0, [sb, #0x3b8]
+	streq r0, [r9, #0x3b8]
 	beq _0215f70c
 	cmp r0, #0x12c
 	blt _0215f70c
-	mov r0, sb
+	mov r0, r9
 	bl func_ov15_0215fb6c
 	cmp r0, #0
 	beq _0215e9b0
@@ -74383,102 +74383,102 @@ _0215e918:
 	str r7, [r2]
 	mla r4, r1, r0, r4
 	str r5, [r2, #4]
-	ldrb r0, [sb, #0x3e8]
+	ldrb r0, [r9, #0x3e8]
 	cmp r4, r0
 	bge _0215e9b0
-	mov r0, sb
+	mov r0, r9
 	mov r1, #1
 	bl func_ov15_0215dff8
 _0215e9b0:
 	mov r0, #0
-	str r0, [sb, #0x3b8]
+	str r0, [r9, #0x3b8]
 	b _0215f70c
 _0215e9bc:
 	ldr r0, _0215f7c0 ; =data_027e0e58
-	add r1, sb, #0x1f8
+	add r1, r9, #0x1f8
 	ldr r0, [r0]
-	add r2, sb, #0x48
+	add r2, r9, #0x48
 	bl func_ov00_0207c474
 	ldr r0, _0215f7c4 ; =data_027e0f94
 	add r3, sp, #0xc4
 	ldmia r0, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
 	ldr r2, [sp, #0xc4]
-	ldr r1, [sb, #0x3ac]
-	mov r0, sb
+	ldr r1, [r9, #0x3ac]
+	mov r0, r9
 	add r1, r2, r1
-	str r1, [sb, #0x48]
+	str r1, [r9, #0x48]
 	ldr r2, [sp, #0xcc]
-	ldr r1, [sb, #0x3b4]
+	ldr r1, [r9, #0x3b4]
 	add r1, r2, r1
-	str r1, [sb, #0x50]
-	ldr r4, [sb, #0x64]
+	str r1, [r9, #0x50]
+	ldr r4, [r9, #0x64]
 	bl _ZN5Actor12ApplyGravityEv
 	cmp r4, #0
 	ble _0215ea34
-	ldr r0, [sb, #0x64]
+	ldr r0, [r9, #0x64]
 	cmp r0, #0
 	bgt _0215ea34
 	ldr r0, _0215f7c8 ; =data_027e0ffc
 	ldr r1, _0215f7cc ; =0x00000286
-	add r2, sb, #0x48
+	add r2, r9, #0x48
 	mov r3, #0
 	bl func_ov00_020ceacc
 _0215ea34:
-	add r0, sb, #0x48
-	add r1, sb, #0x60
+	add r0, r9, #0x48
+	add r1, r9, #0x60
 	mov r2, r0
 	bl func_01ff9bc4
-	ldr r0, [sb, #0x6c]
-	ldr r1, [sb, #0x64]
+	ldr r0, [r9, #0x6c]
+	ldr r1, [r9, #0x64]
 	rsb r0, r0, r0, lsl #4
 	cmp r1, r0
 	bge _0215ea8c
 	ldr r2, _0215f7d0 ; =0x00000889
-	add r0, sb, #0x3c8
+	add r0, r9, #0x3c8
 	mov r1, #0x10000
 	bl Approach_thunk
 	ldr r2, _0215f7d4 ; =0x00000444
-	add r0, sb, #0x3c4
+	add r0, r9, #0x3c4
 	mov r1, #0x14000
 	bl Approach_thunk
-	add r0, sb, #0x300
+	add r0, r9, #0x300
 	ldrsh r1, [r0, #0xdc]
 	ldr r2, _0215f7d4 ; =0x00000444
-	add r0, sb, #0x78
+	add r0, r9, #0x78
 	bl func_0202b154
 _0215ea8c:
-	ldr r0, [sb, #0x64]
+	ldr r0, [r9, #0x64]
 	cmp r0, #0
 	bge _0215eb2c
-	add r0, sb, #0x300
-	ldrsh r1, [sb, #0x78]
+	add r0, r9, #0x300
+	ldrsh r1, [r9, #0x78]
 	ldrsh r0, [r0, #0xdc]
 	cmp r1, r0
 	bne _0215eab8
-	add r0, sb, #0x204
+	add r0, r9, #0x204
 	mov r1, #0x3800
 	bl func_ov15_0215dc38
 _0215eab8:
 	mov r0, #0x1000
-	ldr r1, [sb, #0x4c]
+	ldr r1, [r9, #0x4c]
 	rsb r0, r0, #0
 	cmp r1, r0
 	bge _0215eadc
-	mov r0, sb
+	mov r0, r9
 	mov r1, #2
 	bl func_ov15_0215dff8
 	b _0215ebac
 _0215eadc:
-	ldrb r0, [sb, #0x3ec]
+	ldrb r0, [r9, #0x3ec]
 	cmp r0, #1
 	bne _0215ebac
 	cmp r1, r6
 	bge _0215ebac
-	ldr r3, [sb, #0x50]
-	ldr r2, [sb, #0x48]
+	ldr r3, [r9, #0x50]
+	ldr r2, [r9, #0x48]
 	add r1, sp, #0xb8
-	mov r0, sb
+	mov r0, r9
 	str r2, [sp, #0xb8]
 	str r6, [sp, #0xbc]
 	str r3, [sp, #0xc0]
@@ -74487,32 +74487,32 @@ _0215eadc:
 	ldr r0, _0215f7c8 ; =data_027e0ffc
 	ldr r1, _0215f7d8 ; =0x00000289
 	add r2, sp, #0xb8
-	strb r3, [sb, #0x3ec]
+	strb r3, [r9, #0x3ec]
 	bl func_ov00_020ceacc
 	b _0215ebac
 _0215eb2c:
-	add r0, sb, #0x204
+	add r0, r9, #0x204
 	mvn r1, #1
 	bl func_ov15_0215dc24
 	cmp r0, #0xb000
 	blt _0215eb58
-	ldr r2, [sb, #0x214]
+	ldr r2, [r9, #0x214]
 	mov r3, #0xb000
-	add r0, sb, #0x204
+	add r0, r9, #0x204
 	mov r1, #0
 	str r3, [r2, #0x14]
 	bl func_ov15_0215dc38
 _0215eb58:
-	ldrb r0, [sb, #0x3ec]
+	ldrb r0, [r9, #0x3ec]
 	cmp r0, #0
 	bne _0215ebac
-	ldr r0, [sb, #0x4c]
+	ldr r0, [r9, #0x4c]
 	cmp r0, r6
 	blt _0215ebac
-	ldr r3, [sb, #0x50]
-	ldr r2, [sb, #0x48]
+	ldr r3, [r9, #0x50]
+	ldr r2, [r9, #0x48]
 	add r1, sp, #0xac
-	mov r0, sb
+	mov r0, r9
 	str r2, [sp, #0xac]
 	str r6, [sp, #0xb0]
 	str r3, [sp, #0xb4]
@@ -74522,28 +74522,28 @@ _0215eb58:
 	add r2, sp, #0xac
 	mov r1, #0x288
 	mov r3, #0
-	strb r4, [sb, #0x3ec]
+	strb r4, [r9, #0x3ec]
 	bl func_ov00_020ceacc
 _0215ebac:
-	add r0, sb, #0x300
+	add r0, r9, #0x300
 	mov r1, #0
 	strh r1, [r0, #0xe4]
 	b _0215f70c
 _0215ebbc:
 	ldr r0, _0215f7c0 ; =data_027e0e58
-	add r1, sb, #0x1f8
+	add r1, r9, #0x1f8
 	ldr r0, [r0]
-	add r2, sb, #0x48
+	add r2, r9, #0x48
 	bl func_ov00_0207c474
 	mov r0, #0x1000
-	ldr r1, [sb, #0x4c]
+	ldr r1, [r9, #0x4c]
 	rsb r0, r0, #0
 	cmp r1, r0
 	bgt _0215ecbc
-	ldr r0, [sb, #0x6c]
+	ldr r0, [r9, #0x6c]
 	cmp r0, #0
 	bne _0215ecbc
-	mov r0, sb
+	mov r0, r9
 	bl func_ov15_0215fb6c
 	cmp r0, #0
 	beq _0215ec14
@@ -74553,16 +74553,16 @@ _0215ebbc:
 	cmp r0, #6
 	bne _0215ec24
 _0215ec14:
-	mov r0, sb
+	mov r0, r9
 	mov r1, #3
 	bl func_ov15_0215dff8
 	b _0215f70c
 _0215ec24:
-	add r0, sb, #0x300
+	add r0, r9, #0x300
 	ldrsh r0, [r0, #0xe4]
 	cmp r0, #0x258
 	blt _0215ec44
-	mov r0, sb
+	mov r0, r9
 	mov r1, #3
 	bl func_ov15_0215dff8
 	b _0215f70c
@@ -74587,26 +74587,26 @@ _0215ec44:
 	str r5, [r2, #4]
 	cmp r4, #5
 	bge _0215f70c
-	mov r0, sb
+	mov r0, r9
 	bl func_ov15_0215f81c
 	ldr r1, _0215f7dc ; =0x00000666
 	mov r0, #0
-	str r1, [sb, #0x88]
-	str r0, [sb, #0x3c8]
-	add r0, sb, #0x300
+	str r1, [r9, #0x88]
+	str r0, [r9, #0x3c8]
+	add r0, r9, #0x300
 	mov r1, #0x5b0
 	strh r1, [r0, #0xda]
 	b _0215f70c
 _0215ecbc:
-	mov r0, sb
+	mov r0, r9
 	bl func_ov15_0215f8b0
 	mov r0, #0x1000
-	ldr r1, [sb, #0x4c]
+	ldr r1, [r9, #0x4c]
 	rsb r0, r0, #0
 	cmp r1, r0
 	ble _0215f70c
-	ldr r1, [sb, #0x68]
-	ldr r0, [sb, #0x60]
+	ldr r1, [r9, #0x68]
+	ldr r0, [r9, #0x60]
 	mov r4, r1, lsl #0x6
 	mov r1, r0, lsl #0x6
 	smull r0, r2, r1, r1
@@ -74624,73 +74624,73 @@ _0215ecbc:
 	mov r2, r0, asr #0x6
 	str r2, [sp, #0xc]
 	add r1, sp, #0xc
-	mov r0, sb
-	add r2, sb, #0x64
+	mov r0, r9
+	add r2, r9, #0x64
 	bl func_ov15_0215fa30
-	ldr r2, [sb, #0x64]
+	ldr r2, [r9, #0x64]
 	cmp r2, #0
 	ble _0215ed88
-	ldr r0, [sb, #0x3c8]
+	ldr r0, [r9, #0x3c8]
 	cmp r0, #0x14000
 	bge _0215ed64
 	ldr r2, _0215f7e0 ; =0x00000266
 	mvn r4, #0x80000000
-	add r0, sb, #0x3c8
+	add r0, r9, #0x3c8
 	mov r1, #0x14000
 	mov r3, #0x16c
 	str r4, [sp]
 	bl func_0202b418
 _0215ed64:
-	add r0, sb, #0x204
+	add r0, r9, #0x204
 	mvn r1, #1
 	bl func_ov15_0215dc24
 	cmp r0, #0xb000
 	bne _0215edd8
-	add r0, sb, #0x204
+	add r0, r9, #0x204
 	mov r1, #0
 	bl func_ov15_0215dc38
 	b _0215edd8
 _0215ed88:
 	ldr r0, _0215f7e4 ; =data_ov15_0218c8b0
-	ldr r1, [sb, #0x4c]
+	ldr r1, [r9, #0x4c]
 	ldr r0, [r0, #0x10]
 	cmp r1, r0
 	bgt _0215edd8
 	cmp r2, #0
 	bge _0215edd8
-	add r0, sb, #0x204
+	add r0, r9, #0x204
 	mov r1, #0x4000
 	bl func_ov15_0215dc38
-	add r0, sb, #0xda
+	add r0, r9, #0xda
 	ldr r1, _0215f7e8 ; =0x000009f5
 	add r0, r0, #0x300
 	mov r2, #0x200
 	bl func_0202b154
-	add r0, sb, #0x300
+	add r0, r9, #0x300
 	ldrsh r2, [r0, #0xda]
-	add r0, sb, #0x3c8
+	add r0, r9, #0x3c8
 	mov r1, #0x1c000
 	bl Approach_thunk
 _0215edd8:
-	ldr r0, [sb, #0x3c8]
+	ldr r0, [r9, #0x3c8]
 	cmp r0, #0x14000
 	blt _0215f70c
 	cmp r0, #0x1c000
 	bge _0215f70c
 	add r0, r0, #0xdd
 	add r0, r0, #0x400
-	str r0, [sb, #0x3c8]
+	str r0, [r9, #0x3c8]
 	cmp r0, #0x1c000
 	movge r0, #0x1c000
-	strge r0, [sb, #0x3c8]
+	strge r0, [r9, #0x3c8]
 	b _0215f70c
 _0215ee08:
 	ldr r0, _0215f7c0 ; =data_027e0e58
-	add r1, sb, #0x1f8
+	add r1, r9, #0x1f8
 	ldr r0, [r0]
-	add r2, sb, #0x48
+	add r2, r9, #0x48
 	bl func_ov00_0207c474
-	ldr r0, [sb, #0x6c]
+	ldr r0, [r9, #0x6c]
 	cmp r0, #0
 	bne _0215eea0
 	ldr r2, _0215f7bc ; =data_027e0764
@@ -74714,20 +74714,20 @@ _0215ee08:
 	cmp r4, #0x14
 	bge _0215eef4
 	mov r0, #0x21
-	str r0, [sb, #0x6c]
+	str r0, [r9, #0x6c]
 	rsb r1, r0, #0x1ec
 	ldr r0, _0215f7dc ; =0x00000666
-	str r1, [sb, #0x64]
-	str r0, [sb, #0x88]
-	ldrb r0, [sb, #0x3e9]
+	str r1, [r9, #0x64]
+	str r0, [r9, #0x88]
+	ldrb r0, [r9, #0x3e9]
 	add r0, r0, #1
-	strb r0, [sb, #0x3e9]
+	strb r0, [r9, #0x3e9]
 	b _0215eef4
 _0215eea0:
-	mov r0, sb
+	mov r0, r9
 	bl func_ov15_0215f8b0
-	ldr r2, [sb, #0x68]
-	ldr r4, [sb, #0x60]
+	ldr r2, [r9, #0x68]
+	ldr r4, [r9, #0x60]
 	smull r1, r0, r2, r2
 	smull r3, r2, r4, r4
 	adds r3, r3, #0x800
@@ -74742,88 +74742,88 @@ _0215eea0:
 	bl func_01ff9958
 	str r0, [sp, #8]
 	add r1, sp, #8
-	mov r0, sb
-	add r2, sb, #0x64
+	mov r0, r9
+	add r2, r9, #0x64
 	bl func_ov15_0215fa30
 _0215eef4:
 	ldr r0, _0215f7c4 ; =data_027e0f94
 	add r3, sp, #0xa0
 	ldmia r0, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
-	ldr r0, [sb, #0x4c]
+	ldr r0, [r9, #0x4c]
 	str r0, [sp, #0xa4]
-	ldr r0, [sb, #0x6c]
+	ldr r0, [r9, #0x6c]
 	cmp r0, #0
 	bne _0215f70c
 	mov r1, r3
-	add r0, sb, #0x48
+	add r0, r9, #0x48
 	bl func_ov00_020ce2f0
 	cmp r0, #0xa000
 	ble _0215f70c
-	ldrb r0, [sb, #0x3e9]
+	ldrb r0, [r9, #0x3e9]
 	cmp r0, #3
 	blo _0215f70c
-	mov r0, sb
+	mov r0, r9
 	mov r1, #0
 	bl func_ov15_0215dff8
 	b _0215f70c
 _0215ef48:
-	ldrh r0, [sb, #0x24]
+	ldrh r0, [r9, #0x24]
 	cmp r0, #2
 	bhi _0215ef6c
-	ldrh r0, [sb, #0x22]
+	ldrh r0, [r9, #0x22]
 	cmp r0, #0
 	bne _0215ef6c
 	ldr r0, _0215f7ec ; =data_027e0dbc
 	mov r1, #0
 	blx func_ov03_020f3d74
 _0215ef6c:
-	mov r0, sb
+	mov r0, r9
 	mov r1, #7
 	bl func_ov15_02123828
 	b _0215f70c
 _0215ef7c:
 	ldr r0, _0215f7c0 ; =data_027e0e58
-	add r1, sb, #0x1f8
+	add r1, r9, #0x1f8
 	ldr r0, [r0]
-	add r2, sb, #0x48
+	add r2, r9, #0x48
 	bl func_ov00_0207c474
-	ldr r0, [sb, #0x6c]
+	ldr r0, [r9, #0x6c]
 	cmp r0, #0
 	beq _0215f130
 	ldr r2, _0215f7d0 ; =0x00000889
-	add r0, sb, #0x3c8
+	add r0, r9, #0x3c8
 	mov r1, #0x10000
 	bl Approach_thunk
 	ldr r2, _0215f7d0 ; =0x00000889
-	add r0, sb, #0x3c4
+	add r0, r9, #0x3c4
 	mov r1, #0x14000
 	bl Approach_thunk
-	add r0, sb, #0x48
-	add r1, sb, #0x60
+	add r0, r9, #0x48
+	add r1, r9, #0x60
 	mov r2, r0
 	bl func_01ff9bc4
-	ldr r1, [sb, #0x48]
+	ldr r1, [r9, #0x48]
 	ldr r0, _0215f7b8 ; =data_027e0e60
 	str r1, [sp, #0x40]
-	ldr r1, [sb, #0x4c]
+	ldr r1, [r9, #0x4c]
 	ldr r0, [r0]
 	str r1, [sp, #0x44]
-	ldr r2, [sb, #0x50]
+	ldr r2, [r9, #0x50]
 	add r1, sp, #0x40
 	str r2, [sp, #0x48]
 	mov r2, #0
 	bl func_ov00_02083ee0
-	ldrb r1, [sb, #0x3ec]
+	ldrb r1, [r9, #0x3ec]
 	cmp r1, #1
 	bne _0215f048
-	ldr r1, [sb, #0x4c]
+	ldr r1, [r9, #0x4c]
 	cmp r1, r0
 	bge _0215f048
 	mov r3, #0
-	strb r3, [sb, #0x3ec]
-	ldr r5, [sb, #0x50]
-	ldr r4, [sb, #0x48]
+	strb r3, [r9, #0x3ec]
+	ldr r5, [r9, #0x50]
+	ldr r4, [r9, #0x48]
 	ldr r1, _0215f7d8 ; =0x00000289
 	str r0, [sp, #0x98]
 	ldr r0, _0215f7c8 ; =data_027e0ffc
@@ -74832,69 +74832,69 @@ _0215ef7c:
 	str r5, [sp, #0x9c]
 	bl func_ov00_020ceacc
 	add r1, sp, #0x94
-	mov r0, sb
+	mov r0, r9
 	bl func_ov15_0215fca0
 _0215f048:
 	mov r0, #0x1000
-	ldr r1, [sb, #0x4c]
+	ldr r1, [r9, #0x4c]
 	rsb r0, r0, #0
 	cmp r1, r0
-	ldrlt r0, [sb, #0x64]
+	ldrlt r0, [r9, #0x64]
 	cmplt r0, #0
 	bge _0215f478
 	ldr r1, _0215f7f0 ; =data_027e0d0c
 	mov r0, #0
-	str r0, [sb, #0x6c]
+	str r0, [r9, #0x6c]
 	ldr r0, [r1]
 	ldr r2, _0215f7f4 ; =data_ov15_0218664c
-	str r0, [sb, #0x60]
+	str r0, [r9, #0x60]
 	ldr r3, [r1, #4]
-	add r0, sb, #0x204
-	str r3, [sb, #0x64]
+	add r0, r9, #0x204
+	str r3, [r9, #0x64]
 	ldr r3, [r1, #8]
 	mov r1, #0xa3
-	str r3, [sb, #0x68]
+	str r3, [r9, #0x68]
 	bl func_ov00_020c5c98
-	add r0, sb, #0x204
+	add r0, r9, #0x204
 	bl func_ov15_0215d918
-	ldrsb r2, [sb, #0x2c]
+	ldrsb r2, [r9, #0x2c]
 	add r1, sp, #4
-	add r0, sb, #0x204
+	add r0, r9, #0x204
 	mov r2, r2, lsl #0xc
 	str r2, [sp, #4]
 	bl func_ov15_0215d9e0
 	mov r1, #0
-	str r1, [sb, #0x3c8]
-	mov r0, sb
-	str r1, [sb, #0x3c4]
+	str r1, [r9, #0x3c8]
+	mov r0, r9
+	str r1, [r9, #0x3c4]
 	bl _ZN5Actor14GetAngleToLinkEv
-	strh r0, [sb, #0x78]
-	add r0, sb, #0x204
+	strh r0, [r9, #0x78]
+	add r0, r9, #0x204
 	mov r1, #1
 	bl func_ov15_0215db90
 	mov r2, #0
-	str r2, [sb, #0x138]
+	str r2, [r9, #0x138]
 	mov r0, #1
-	strb r0, [sb, #0x3ea]
-	ldr r1, [sb, #0x48]
+	strb r0, [r9, #0x3ea]
+	ldr r1, [r9, #0x48]
 	ldr r0, _0215f7b8 ; =data_027e0e60
 	str r1, [sp, #0x34]
-	ldr r3, [sb, #0x4c]
+	ldr r3, [r9, #0x4c]
 	ldr r0, [r0]
 	str r3, [sp, #0x38]
-	ldr r3, [sb, #0x50]
+	ldr r3, [r9, #0x50]
 	add r1, sp, #0x34
 	str r3, [sp, #0x3c]
 	bl func_ov00_02083ee0
 	ldr r1, _0215f7f8 ; =0xfffffccd
-	ldr r2, [sb, #0x4c]
+	ldr r2, [r9, #0x4c]
 	add r0, r0, r1
 	add r1, r2, r0
-	str r1, [sb, #0x3cc]
-	str r0, [sb, #0x4c]
+	str r1, [r9, #0x3cc]
+	str r0, [r9, #0x4c]
 	b _0215f478
 _0215f130:
-	ldrb r0, [sb, #0x3ea]
+	ldrb r0, [r9, #0x3ea]
 	cmp r0, #5
 	addls pc, pc, r0, lsl #2
 	b _0215f478
@@ -74906,24 +74906,24 @@ _0215f140: ; jump table
 	b _0215f35c ; case 4
 	b _0215f40c ; case 5
 _0215f158:
-	mov r0, sb
+	mov r0, r9
 	bl _ZN5Actor16XzDistanceToLinkEv
 	ldr r1, _0215f7c4 ; =data_027e0f94
-	ldr r2, [sb, #0x4c]
+	ldr r2, [r9, #0x4c]
 	ldr r1, [r1, #4]
 	add r1, r1, #0x1800
 	sub r1, r1, r2
 	bl func_01ffa0f4
 	rsb r1, r0, #0x4000
-	add r0, sb, #0x200
+	add r0, r9, #0x200
 	strh r1, [r0, #0x82]
-	ldr r1, [sb, #0x48]
+	ldr r1, [r9, #0x48]
 	ldr r0, _0215f7b8 ; =data_027e0e60
 	str r1, [sp, #0x28]
-	ldr r1, [sb, #0x4c]
+	ldr r1, [r9, #0x4c]
 	ldr r0, [r0]
 	str r1, [sp, #0x2c]
-	ldr r3, [sb, #0x50]
+	ldr r3, [r9, #0x50]
 	add r1, sp, #0x28
 	mov r2, #0
 	str r3, [sp, #0x30]
@@ -74932,31 +74932,31 @@ _0215f158:
 	ldr r0, _0215f7f8 ; =0xfffffccd
 	ldr r2, _0215f7e0 ; =0x00000266
 	add r1, r4, r0
-	str r1, [sb, #0x4c]
-	add r0, sb, #0x3cc
+	str r1, [r9, #0x4c]
+	add r0, r9, #0x3cc
 	mov r1, #0
 	bl Approach_thunk
 	cmp r0, #0
 	beq _0215f1f4
 	mov r1, #5
 	mov r3, #3
-	add r0, sb, #0x204
+	add r0, r9, #0x204
 	rsb r2, r1, #0x338
-	strb r3, [sb, #0x3ea]
+	strb r3, [r9, #0x3ea]
 	bl func_ov15_0215da64
 	b _0215f478
 _0215f1f4:
-	ldrb r0, [sb, #0x3ec]
+	ldrb r0, [r9, #0x3ec]
 	cmp r0, #0
 	bne _0215f478
-	ldr r1, [sb, #0x3cc]
+	ldr r1, [r9, #0x3cc]
 	ldr r0, _0215f7fc ; =0xfffff99a
 	cmp r1, r0
 	blt _0215f478
 	mov r0, #1
-	strb r0, [sb, #0x3ec]
-	ldr r7, [sb, #0x50]
-	ldr r5, [sb, #0x48]
+	strb r0, [r9, #0x3ec]
+	ldr r7, [r9, #0x50]
+	ldr r5, [r9, #0x48]
 	ldr r0, _0215f7c8 ; =data_027e0ffc
 	add r2, sp, #0x88
 	mov r1, #0x288
@@ -74966,23 +74966,23 @@ _0215f1f4:
 	str r7, [sp, #0x90]
 	bl func_ov00_020ceacc
 	add r1, sp, #0x88
-	mov r0, sb
+	mov r0, r9
 	bl func_ov15_0215fca0
 	b _0215f478
 _0215f250:
-	ldr r1, [sb, #0x48]
+	ldr r1, [r9, #0x48]
 	ldr r0, _0215f7b8 ; =data_027e0e60
 	str r1, [sp, #0x1c]
-	ldr r1, [sb, #0x4c]
+	ldr r1, [r9, #0x4c]
 	ldr r0, [r0]
 	str r1, [sp, #0x20]
-	ldr r2, [sb, #0x50]
+	ldr r2, [r9, #0x50]
 	add r1, sp, #0x1c
 	str r2, [sp, #0x24]
 	mov r2, #0
-	ldr r4, [sb, #0x50]
+	ldr r4, [r9, #0x50]
 	bl func_ov00_02083ee0
-	ldr r1, [sb, #0x48]
+	ldr r1, [r9, #0x48]
 	mov r3, #0
 	str r0, [sp, #0x80]
 	str r1, [sp, #0x7c]
@@ -74990,31 +74990,31 @@ _0215f250:
 	str r3, [sp]
 	ldr r2, _0215f800 ; =0x00000548
 	add r1, sp, #0x7c
-	add r0, sb, #0x188
+	add r0, r9, #0x188
 	mov r3, #0xa
 	bl func_ov00_020c7734
 	ldr r2, [sp, #0x80]
 	ldr r1, _0215f7f8 ; =0xfffffccd
-	mov r0, sb
+	mov r0, r9
 	add r1, r2, r1
-	str r1, [sb, #0x4c]
+	str r1, [r9, #0x4c]
 	bl _ZN5Actor16XzDistanceToLinkEv
 	ldr r1, _0215f7c4 ; =data_027e0f94
-	ldr r2, [sb, #0x4c]
+	ldr r2, [r9, #0x4c]
 	ldr r1, [r1, #4]
 	add r1, r1, #0x1800
 	sub r1, r1, r2
 	bl func_01ffa0f4
 	rsb r2, r0, #0x4000
-	add r0, sb, #0x200
+	add r0, r9, #0x200
 	mov r1, #0x10000
 	strh r2, [r0, #0x82]
-	ldr r0, [sb, #0x1a8]
+	ldr r0, [r9, #0x1a8]
 	rsb r1, r1, #0
 	and r0, r0, r1
 	cmp r0, #0x1000000
 	bne _0215f478
-	ldr r0, [sb, #0x218]
+	ldr r0, [r9, #0x218]
 	cmp r0, #6
 	addls pc, pc, r0, lsl #2
 	b _0215f340
@@ -75028,27 +75028,27 @@ _0215f310: ; jump table
 	b _0215f350 ; case 6
 _0215f32c:
 	ldr r2, _0215f804 ; =0x00000333
-	add r0, sb, #0x204
+	add r0, r9, #0x204
 	mov r1, #6
 	bl func_ov15_0215da64
 	b _0215f350
 _0215f340:
 	ldr r2, _0215f804 ; =0x00000333
-	add r0, sb, #0x204
+	add r0, r9, #0x204
 	mov r1, #8
 	bl func_ov15_0215da64
 _0215f350:
 	mov r0, #4
-	strb r0, [sb, #0x3ea]
+	strb r0, [r9, #0x3ea]
 	b _0215f478
 _0215f35c:
-	ldr r1, [sb, #0x48]
+	ldr r1, [r9, #0x48]
 	ldr r0, _0215f7b8 ; =data_027e0e60
 	str r1, [sp, #0x10]
-	ldr r1, [sb, #0x4c]
+	ldr r1, [r9, #0x4c]
 	ldr r0, [r0]
 	str r1, [sp, #0x14]
-	ldr r3, [sb, #0x50]
+	ldr r3, [r9, #0x50]
 	add r1, sp, #0x10
 	mov r2, #0
 	str r3, [sp, #0x18]
@@ -75056,25 +75056,25 @@ _0215f35c:
 	mov r1, #0x2000
 	mov r4, r0
 	ldr r2, _0215f808 ; =0x0000019a
-	add r0, sb, #0x4c
+	add r0, r9, #0x4c
 	rsb r1, r1, #0
 	bl Approach_thunk
 	cmp r0, #0
 	movne r0, #5
-	strneb r0, [sb, #0x3ea]
+	strneb r0, [r9, #0x3ea]
 	bne _0215f478
-	ldrb r0, [sb, #0x3ec]
+	ldrb r0, [r9, #0x3ec]
 	cmp r0, #1
 	bne _0215f478
 	ldr r0, _0215f7fc ; =0xfffff99a
-	ldr r1, [sb, #0x4c]
+	ldr r1, [r9, #0x4c]
 	add r0, r4, r0
 	cmp r1, r0
 	bge _0215f478
 	mov r3, #0
-	strb r3, [sb, #0x3ec]
-	ldr r7, [sb, #0x50]
-	ldr r5, [sb, #0x48]
+	strb r3, [r9, #0x3ec]
+	ldr r7, [r9, #0x50]
+	ldr r5, [r9, #0x48]
 	ldr r0, _0215f7c8 ; =data_027e0ffc
 	ldr r1, _0215f7d8 ; =0x00000289
 	add r2, sp, #0x70
@@ -75083,11 +75083,11 @@ _0215f35c:
 	str r7, [sp, #0x78]
 	bl func_ov00_020ceacc
 	add r1, sp, #0x70
-	mov r0, sb
+	mov r0, r9
 	bl func_ov15_0215fca0
 	b _0215f478
 _0215f40c:
-	ldr r0, [sb, #0x3c0]
+	ldr r0, [r9, #0x3c0]
 	mov r7, #0
 	cmp r0, #0
 	ble _0215f464
@@ -75105,23 +75105,23 @@ _0215f430:
 	str r5, [r4, r7, lsl #3]
 	add r0, r4, r7, lsl #3
 	str r5, [r0, #4]
-	ldr r0, [sb, #0x3c0]
+	ldr r0, [r9, #0x3c0]
 	add r7, r7, #1
 	cmp r7, r0
 	add r8, r8, #8
 	blt _0215f430
 _0215f464:
 	mov r2, #0
-	mov r0, sb
+	mov r0, r9
 	mov r1, #6
-	str r2, [sb, #0x3c0]
+	str r2, [r9, #0x3c0]
 	bl func_ov15_0215dff8
 _0215f478:
-	add r0, sb, #0x204
+	add r0, r9, #0x204
 	bl func_ov15_0215dc0c
 	cmp r0, #0
 	beq _0215f70c
-	ldr r0, [sb, #0x218]
+	ldr r0, [r9, #0x218]
 	cmp r0, #8
 	addls pc, pc, r0, lsl #2
 	b _0215f70c
@@ -75137,48 +75137,48 @@ _0215f498: ; jump table
 	b _0215f4f8 ; case 8
 _0215f4bc:
 	mov r1, #3
-	add r0, sb, #0x204
+	add r0, r9, #0x204
 	add r2, r1, #0x330
 	bl func_ov15_0215da64
 	b _0215f70c
 _0215f4d0:
 	mov r1, #1
-	add r0, sb, #0x204
+	add r0, r9, #0x204
 	rsb r2, r1, #0x334
 	bl func_ov15_0215da64
 	b _0215f70c
 _0215f4e4:
 	ldr r2, _0215f804 ; =0x00000333
-	add r0, sb, #0x204
+	add r0, r9, #0x204
 	mov r1, #4
 	bl func_ov15_0215da64
 	b _0215f70c
 _0215f4f8:
 	ldr r2, _0215f804 ; =0x00000333
-	add r0, sb, #0x204
+	add r0, r9, #0x204
 	mov r1, #2
 	bl func_ov15_0215da64
 	b _0215f70c
 _0215f50c:
-	ldr r0, [sb, #0x184]
+	ldr r0, [r9, #0x184]
 	add r3, sp, #0x64
 	add r0, r0, #0x48
 	ldmia r0, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
-	ldr r0, [sb, #0x4c]
+	ldr r0, [r9, #0x4c]
 	add r1, r0, #0xcd
-	str r1, [sb, #0x4c]
+	str r1, [r9, #0x4c]
 	ldr r4, [sp, #0x68]
 	add r0, r4, #0xa000
 	cmp r1, r0
-	strgt r0, [sb, #0x4c]
-	ldr r2, [sb, #0x4c]
+	strgt r0, [r9, #0x4c]
+	ldr r2, [r9, #0x4c]
 	ldr r3, _0215f814 ; =0x0000099a
 	sub r5, r2, r4
 	mov r1, #0
 	umull r7, r0, r5, r3
 	mla r0, r5, r1, r0
-	add r4, sb, #0x300
+	add r4, r9, #0x300
 	ldrh r8, [r4, #0xe6]
 	mov r5, r5, asr #0x1f
 	mla r0, r5, r3, r0
@@ -75203,14 +75203,14 @@ _0215f50c:
 	ldr r3, [sp, #0x64]
 	orr r7, r7, r5, lsl #20
 	add r3, r3, r7
-	str r3, [sb, #0x48]
-	str r2, [sb, #0x4c]
+	str r3, [r9, #0x48]
+	str r2, [r9, #0x4c]
 	adc r0, r0, #0
 	mov r1, r1, lsr #0xc
 	ldr r2, [sp, #0x6c]
 	orr r1, r1, r0, lsl #20
 	add r0, r2, r1
-	str r0, [sb, #0x50]
+	str r0, [r9, #0x50]
 	ldrsh r1, [r4, #0xe6]
 	mov r8, #0x800
 	sub r0, r8, #0xe2
@@ -75237,10 +75237,10 @@ _0215f50c:
 	mov r2, r0
 	add r0, r7, #0x31c
 	add r0, r0, #0x400
-	ldr r4, [sb, #0x3c4]
+	ldr r4, [r9, #0x3c4]
 	mov r0, r0, lsl #0x10
 	add r0, r4, r0, asr #16
-	str r0, [sb, #0x3c4]
+	str r0, [r9, #0x3c4]
 	ldr r4, [r3]
 	ldmib r3, {r0, r7}
 	umull r10, r8, r7, r4
@@ -75258,10 +75258,10 @@ _0215f50c:
 	mla r4, r0, r1, r4
 	add r0, r4, #0x31c
 	add r0, r0, #0x400
-	ldrsh r5, [sb, #0x78]
+	ldrsh r5, [r9, #0x78]
 	mov r0, r0, lsl #0x10
 	add r0, r5, r0, asr #16
-	strh r0, [sb, #0x78]
+	strh r0, [r9, #0x78]
 	ldr r1, [r3]
 	ldmib r3, {r0, r5}
 	umull r8, r7, r5, r1
@@ -75279,24 +75279,24 @@ _0215f50c:
 	mla r1, r0, r2, r1
 	add r0, r1, #0x31c
 	add r0, r0, #0x400
-	ldr r3, [sb, #0x3c8]
+	ldr r3, [r9, #0x3c8]
 	mov r0, r0, lsl #0x10
 	add r0, r3, r0, asr #16
-	str r0, [sb, #0x3c8]
+	str r0, [r9, #0x3c8]
 	ldr r0, _0215f7c0 ; =data_027e0e58
-	add r1, sb, #0x1f8
+	add r1, r9, #0x1f8
 	ldr r0, [r0]
-	add r2, sb, #0x48
+	add r2, r9, #0x48
 	bl func_ov00_0207c474
 _0215f70c:
-	add r0, sb, #0x204
+	add r0, r9, #0x204
 	bl func_ov00_020c5e20
-	ldrb r0, [sb, #0xa4]
+	ldrb r0, [r9, #0xa4]
 	cmp r0, #0
-	ldreqb r0, [sb, #0xa5]
+	ldreqb r0, [r9, #0xa5]
 	cmpeq r0, #0
 	beq _0215f7a8
-	add r0, sb, #0x48
+	add r0, r9, #0x48
 	add r3, sp, #0x58
 	ldmia r0, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
@@ -75304,21 +75304,21 @@ _0215f70c:
 	mov r2, r3
 	ldr r0, [r0]
 	str r6, [sp, #0x5c]
-	add r1, sb, #0x1ec
+	add r1, r9, #0x1ec
 	bl func_ov00_0207c474
-	ldr r1, [sb, #0x4c]
+	ldr r1, [r9, #0x4c]
 	ldr r0, [sp, #0x5c]
 	mov r2, #0
 	cmp r1, r0
 	bgt _0215f770
-	ldr r0, [sb, #0x130]
+	ldr r0, [r9, #0x130]
 	cmp r0, #2
 	moveq r2, #1
 _0215f770:
-	ldr r3, [sb, #0x1ec]
+	ldr r3, [r9, #0x1ec]
 	cmp r3, #0
 	addeq sp, sp, #0xd0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	cmp r2, #0
 	moveq r0, #1
 	ldr r1, [r3, #0x24]
@@ -75328,12 +75328,12 @@ _0215f770:
 	orr r0, r1, r0, lsr #30
 	add sp, sp, #0xd0
 	str r0, [r3, #0x24]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0215f7a8:
-	add r0, sb, #0x1ec
+	add r0, r9, #0x1ec
 	bl func_ov00_020b7e6c
 	add sp, sp, #0xd0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0215e890
 _0215f7b8: .word data_027e0e60
@@ -77722,7 +77722,7 @@ _021617a4: .word data_02063e4c
 	.global func_ov15_021617a8
 	arm_func_start func_ov15_021617a8
 func_ov15_021617a8: ; 0x021617a8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0xc
 	ldrh r4, [r0, #0x78]
 	mvn r3, #0
@@ -77740,7 +77740,7 @@ func_ov15_021617a8: ; 0x021617a8
 	sub r2, r2, #0xc00
 	mla r6, r4, r3, r6
 	adds r7, r5, #0x800
-	umull sb, lr, ip, r2
+	umull r9, lr, ip, r2
 	mla lr, ip, r3, lr
 	mov r4, r4, asr #0x1f
 	mla r6, r4, r8, r6
@@ -77749,7 +77749,7 @@ func_ov15_021617a8: ; 0x021617a8
 	adc r6, r6, #0
 	mov r7, r7, lsr #0xc
 	mla lr, r3, r2, lr
-	adds r4, sb, #0x800
+	adds r4, r9, #0x800
 	adc r2, lr, #0
 	mov r3, r4, lsr #0xc
 	ldr r4, [r0, #0x50]
@@ -77770,11 +77770,11 @@ func_ov15_021617a8: ; 0x021617a8
 	beq _0216186c
 	bl func_0202b864
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _0216186c:
 	bl func_0202b894
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov15_021617a8
 _02161878: .word data_02050f54
@@ -78102,7 +78102,7 @@ _02161c84: .word data_027e0e2c
 	.global func_ov15_02161c88
 	arm_func_start func_ov15_02161c88
 func_ov15_02161c88: ; 0x02161c88
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x6c
 	ldr r1, _02162424 ; =data_027e0f74
 	mov r10, r0
@@ -78120,7 +78120,7 @@ func_ov15_02161c88: ; 0x02161c88
 _02161cc4:
 	add sp, sp, #0x6c
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02161cd0:
 	mov r1, #2
 	ldr r0, _02162428 ; =data_027e0fec
@@ -78270,7 +78270,7 @@ _02161f00:
 	ldr r1, [r1]
 	mov r0, #0
 	strb r5, [r1, #0x38]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02161f18:
 	ldr r0, _02162424 ; =data_027e0f74
 	mov r1, #0x62
@@ -78300,7 +78300,7 @@ _02161f2c:
 	add sp, sp, #0x6c
 	strb r2, [r1, #0x38]
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02161f88:
 	ldrb r0, [r10, #0x2a]
 	cmp r0, #0
@@ -78320,7 +78320,7 @@ _02161f88:
 	bl func_ov15_02162688
 	add sp, sp, #0x6c
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02161fd4:
 	ldr r0, _02162438 ; =data_027e0fe4
 	add r3, sp, #0x60
@@ -78345,7 +78345,7 @@ _02161fd4:
 	ldr r2, [r1]
 	and r1, r4, #0xff
 	ldr r1, [r2, r1, lsl #3]
-	ldr sb, _02162444 ; =data_ov15_021867c4
+	ldr r9, _02162444 ; =data_ov15_021867c4
 	ldrb r8, [r1, #1]
 	add r3, sp, #0x50
 	mov r6, #0
@@ -78353,9 +78353,9 @@ _02161fd4:
 	strb r0, [sp, #5]
 	mov r2, #8
 _0216204c:
-	ldrb r1, [sb]
-	ldrb r0, [sb, #1]
-	add sb, sb, #2
+	ldrb r1, [r9]
+	ldrb r0, [r9, #1]
+	add r9, r9, #2
 	strb r1, [r3]
 	strb r0, [r3, #1]
 	add r3, r3, #2
@@ -78363,8 +78363,8 @@ _0216204c:
 	bne _0216204c
 	add r0, sp, #0x50
 	add r0, r0, r7, lsl #2
-	ldrsb sb, [r5, r0]
-	cmp sb, #3
+	ldrsb r9, [r5, r0]
+	cmp r9, #3
 	bne _021620bc
 	ldr r1, _0216243c ; =data_ov15_0218cc00
 	ldr r0, _02162438 ; =data_027e0fe4
@@ -78381,7 +78381,7 @@ _0216204c:
 _021620b0:
 	add sp, sp, #0x6c
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _021620bc:
 	ldr r0, _0216244c ; =data_027e0f94
 	add r3, sp, #0x44
@@ -78414,18 +78414,18 @@ _021620bc:
 	bl func_ov00_0208e7a4
 	cmp r0, #0
 	beq _02162158
-	cmp sb, #0
-	rsblt r0, sb, #0
+	cmp r9, #0
+	rsblt r0, r9, #0
 	movlt r0, r0, lsl #0x18
-	movlt sb, r0, asr #0x18
-	rsb r0, sb, #0
+	movlt r9, r0, asr #0x18
+	rsb r0, r9, #0
 	mov r0, r0, lsl #0x18
-	mov sb, r0, asr #0x18
+	mov r9, r0, asr #0x18
 	b _021621b4
 _02162158:
-	cmp sb, #1
+	cmp r9, #1
 	beq _0216216c
-	cmp sb, #2
+	cmp r9, #2
 	beq _02162194
 	b _021621b4
 _0216216c:
@@ -78450,7 +78450,7 @@ _02162194:
 	sub r0, r0, #0xc000
 	str r0, [sp, #0x4c]
 _021621b4:
-	rsb r0, sb, #0
+	rsb r0, r9, #0
 	str r0, [sp]
 	mov r0, r0, lsl #0x18
 	mov r11, r0, asr #0x18
@@ -78462,8 +78462,8 @@ _021621c4:
 	strb r6, [sp, #5]
 	bl func_ov00_020c47cc
 	mov r5, r0
-	cmp sb, #0
-	movge r1, sb
+	cmp r9, #0
+	movge r1, r9
 	ldrsb r0, [r5, #0x10]
 	movlt r1, r11
 	cmp r0, r1
@@ -78476,7 +78476,7 @@ _021621c4:
 	bl func_01ff9ec0
 	cmp r0, #0x32000
 	bge _02162220
-	cmp sb, #0
+	cmp r9, #0
 	bge _0216222c
 _02162220:
 	mov r1, #0x3c
@@ -78526,11 +78526,11 @@ _021622c0:
 	mla r2, r1, r0, r5
 	mov r0, #0x148
 	mul r1, r2, r0
-	cmp sb, #0
+	cmp r9, #0
 	ldrlt r0, [sp]
 	movlt r0, r0, lsl #0x18
-	movlt sb, r0, asr #0x18
-	cmp sb, #2
+	movlt r9, r0, asr #0x18
+	cmp r9, #2
 	bne _02162310
 	cmp r7, #1
 	cmpne r7, #3
@@ -78572,7 +78572,7 @@ _0216232c:
 _02162370:
 	add sp, sp, #0x6c
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0216237c:
 	ldr r0, [r10, #0x48]
 	str r0, [r4, #0x2c]
@@ -78618,7 +78618,7 @@ _021623c4:
 	mov r0, #1
 	strh r1, [r10, #0x78]
 	add sp, sp, #0x6c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02161c88
 _02162424: .word data_027e0f74
@@ -78795,7 +78795,7 @@ _02162684: .word data_ov15_021867d4
 	.global func_ov15_02162688
 	arm_func_start func_ov15_02162688
 func_ov15_02162688: ; 0x02162688
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x394
 	mov r4, r1
 	mov r5, r0
@@ -78975,10 +78975,10 @@ _02162904:
 	umull r8, r7, r6, r3
 	mla r7, r6, r0, r7
 	ldr r0, [r2, #0xc]
-	ldr sb, [r2, #0x10]
+	ldr r9, [r2, #0x10]
 	mla r7, r0, r3, r7
 	ldr r6, [r2, #0x14]
-	adds r8, sb, r8
+	adds r8, r9, r8
 	adc r7, r6, r7
 	mov r0, #0x1f
 	umull r3, r6, r7, r0
@@ -79072,7 +79072,7 @@ _021629c0:
 	ldr r11, [sp, #0x2c4]
 	str r10, [sp, #0x34c]
 	ldr r10, [sp, #0x2c8]
-	ldrb sb, [sp, #0x2dc]
+	ldrb r9, [sp, #0x2dc]
 	ldrb r8, [sp, #0x2dd]
 	ldrb r7, [sp, #0x2de]
 	ldrb r6, [sp, #0x2df]
@@ -79092,7 +79092,7 @@ _021629c0:
 	str r11, [sp, #0x368]
 	strb r0, [sp, #0x2f8]
 	str r10, [sp, #0x36c]
-	strb sb, [sp, #0x370]
+	strb r9, [sp, #0x370]
 	strb r8, [sp, #0x371]
 	strb r7, [sp, #0x372]
 	strb r6, [sp, #0x373]
@@ -79121,14 +79121,14 @@ _02162b58:
 	add r0, sp, #0x1cc
 	bl func_ov00_0209a4f4
 	ldr r1, _02162e0c ; =data_027e0f94
-	mvn sb, #0
+	mvn r9, #0
 	ldr r3, [r1]
 	ldr r2, [r1, #4]
 	mov r8, #0x32
 	mov r7, #2
 	mov r6, #3
 	ldr r0, _02162df4 ; =data_027e0f64
-	str sb, [sp, #0x1d0]
+	str r9, [sp, #0x1d0]
 	strb r8, [sp, #0x1d5]
 	strb r7, [sp, #0x1d6]
 	strb r6, [sp, #0x1d7]
@@ -79141,7 +79141,7 @@ _02162b58:
 	add r1, sp, #0x164
 	bl func_ov00_02087d34
 	ldr r0, [sp, #0x164]
-	mov sb, #5
+	mov r9, #5
 	str r0, [r5, #0x298]
 	ldr r0, [sp, #0x168]
 	mov r10, #1
@@ -79207,10 +79207,10 @@ _02162b58:
 	ldr r2, [sp, #0x178]
 	ldr r1, [sp, #0x17c]
 	ldr r0, [sp, #0x180]
-	str sb, [sp, #0x168]
+	str r9, [sp, #0x168]
 	strb r10, [sp, #0x1e0]
 	str r8, [sp, #0x1f8]
-	str sb, [sp, #0x1fc]
+	str r9, [sp, #0x1fc]
 	str r7, [sp, #0x200]
 	str r6, [sp, #0x204]
 	str r3, [sp, #0x208]
@@ -79222,7 +79222,7 @@ _02162b58:
 	str r0, [sp, #0x220]
 	ldr r0, [sp, #0x1a0]
 	ldr r1, [sp, #0x188]
-	ldr sb, [sp, #0x190]
+	ldr r9, [sp, #0x190]
 	ldr r8, [sp, #0x194]
 	str r7, [sp, #0x218]
 	ldr r7, [sp, #0x198]
@@ -79230,8 +79230,8 @@ _02162b58:
 	ldr r0, [sp, #0x1b4]
 	str r1, [sp, #0x21c]
 	ldr r1, [sp, #0x19c]
-	str sb, [sp, #0x224]
-	ldr sb, [sp, #0x1a4]
+	str r9, [sp, #0x224]
+	ldr r9, [sp, #0x1a4]
 	str r8, [sp, #0x228]
 	ldr r8, [sp, #0x1a8]
 	str r7, [sp, #0x22c]
@@ -79245,8 +79245,8 @@ _02162b58:
 	ldr r0, _02162de0 ; =data_027e0f74
 	str r1, [sp, #0x230]
 	ldr r1, [sp, #0x1b0]
-	str sb, [sp, #0x238]
-	ldr sb, [sp, #0x1b8]
+	str r9, [sp, #0x238]
+	ldr r9, [sp, #0x1b8]
 	str r8, [sp, #0x23c]
 	ldr r8, [sp, #0x1bc]
 	str r7, [sp, #0x240]
@@ -79255,7 +79255,7 @@ _02162b58:
 	str r1, [sp, #0x244]
 	ldr r0, [r0]
 	add r1, sp, #0x1cc
-	str sb, [sp, #0x24c]
+	str r9, [sp, #0x24c]
 	str r8, [sp, #0x250]
 	str r7, [sp, #0x254]
 	strb r6, [sp, #0x258]
@@ -79279,7 +79279,7 @@ _02162dc4:
 	str r4, [r5, #0x130]
 	strb r0, [r5, #0x255]
 	add sp, sp, #0x394
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02162688
 _02162ddc: .word 0x0000ffff
@@ -79300,7 +79300,7 @@ _02162e10: .word 0x00050046
 	.global func_ov15_02162e14
 	arm_func_start func_ov15_02162e14
 func_ov15_02162e14: ; 0x02162e14
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0xe8
 	mov r4, r0
 	ldr r0, [r4, #0x238]
@@ -79853,10 +79853,10 @@ _0216346c:
 	ldr r5, [r0, #0xc]
 	ldr ip, [r0, #0x10]
 	mla r7, r5, r3, r7
-	ldr sb, [r0, #0x14]
+	ldr r9, [r0, #0x14]
 	adds r3, ip, r8
 	mov r1, r1, lsl #0x4
-	adc r2, sb, r7
+	adc r2, r9, r7
 	str r3, [r0]
 	orr r1, r1, r2, lsr #28
 	str r2, [r0, #4]
@@ -80013,13 +80013,13 @@ _02163854:
 	ldrb ip, [sp, #0x6f]
 	ldrb r3, [sp, #0x70]
 	ldrb r2, [sp, #0x71]
-	ldr sb, [sp, #0x5c]
+	ldr r9, [sp, #0x5c]
 	ldr r8, [sp, #0x60]
 	ldr r7, [sp, #0x64]
 	ldr r6, [sp, #0x68]
 	ldr r0, [r0]
 	add r1, sp, #0x38
-	str sb, [sp, #0x38]
+	str r9, [sp, #0x38]
 	str r8, [sp, #0x3c]
 	str r7, [sp, #0x40]
 	str r6, [sp, #0x44]
@@ -80237,7 +80237,7 @@ _02163bf4:
 	str r2, [r4, #0x1a0]
 	bl func_ov15_0214e138
 	add sp, sp, #0xe8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02162e14
 _02163c2c: .word data_027e0f74
@@ -80948,9 +80948,9 @@ _02164638: .word data_ov00_020eec68
 	.global func_ov15_0216463c
 	arm_func_start func_ov15_0216463c
 func_ov15_0216463c: ; 0x0216463c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x74
-	mov sb, r0
+	mov r9, r0
 	mov r8, r1
 	mov r7, r2
 	bl func_ov00_0209a4f4
@@ -80977,8 +80977,8 @@ _02164698:
 	mov r1, #2
 	ldmia r0, {r4, r5, r6}
 	mov r0, #7
-	strb r1, [sb, #0xa]
-	strb r0, [sb, #0xb]
+	strb r1, [r9, #0xa]
+	strb r0, [r9, #0xb]
 	ldr r0, [sp, #0xc]
 	str r0, [r8, #0x298]
 	ldr r0, [sp, #0x10]
@@ -81050,9 +81050,9 @@ _0216479c:
 	mov r3, #0x7f
 	bl func_ov00_020d70a4
 	mov r0, #3
-	strb r0, [sb, #0xa]
+	strb r0, [r9, #0xa]
 	mov r0, #6
-	strb r0, [sb, #0xb]
+	strb r0, [r9, #0xb]
 	mov r0, #5
 	str r0, [sp, #0x10]
 	mov r0, r8
@@ -81090,10 +81090,10 @@ _02164854:
 	ldr r5, [r8, #0x4c]
 	ldr r6, [r8, #0x50]
 	mov r0, #4
-	strb r0, [sb, #0xa]
+	strb r0, [r9, #0xa]
 	mov r1, #7
 	mov r0, r8
-	strb r1, [sb, #0xb]
+	strb r1, [r9, #0xb]
 	mov r1, #5
 	str r1, [sp, #0x10]
 	bl _ZN5Actor14DistanceToLinkEv
@@ -81128,18 +81128,18 @@ _021648d4:
 	ldr r5, [r8, #0x4c]
 	ldr r6, [r8, #0x50]
 	mov r0, #0
-	strb r0, [sb, #0xa]
+	strb r0, [r9, #0xa]
 	mov r0, #7
-	strb r0, [sb, #0xb]
+	strb r0, [r9, #0xb]
 	b _02164ab8
 _02164908:
 	ldr r4, [r8, #0x48]
 	ldr r5, [r8, #0x4c]
 	ldr r6, [r8, #0x50]
 	mov r0, #2
-	strb r0, [sb, #0xa]
+	strb r0, [r9, #0xa]
 	mov r1, #7
-	strb r1, [sb, #0xb]
+	strb r1, [r9, #0xb]
 	mov r2, #5
 	mov r1, #0x2000
 	mov r0, r8
@@ -81175,8 +81175,8 @@ _0216499c:
 	mov r2, #0x1800
 	ldmia r0, {r4, r5, r6}
 	mov r0, #2
-	strb r0, [sb, #0xa]
-	strb r0, [sb, #0xb]
+	strb r0, [r9, #0xa]
+	strb r0, [r9, #0xb]
 	mov r0, #5
 	str r0, [sp, #0x10]
 	ldr r0, [r8, #0x298]
@@ -81244,76 +81244,76 @@ _0216499c:
 	str r0, [sp, #0x18]
 _02164ab8:
 	mvn r0, #0
-	str r0, [sb, #4]
+	str r0, [r9, #4]
 	mov r0, #0x32
-	strb r0, [sb, #9]
-	str r4, [sb, #0x20]
-	str r5, [sb, #0x24]
-	str r6, [sb, #0x28]
+	strb r0, [r9, #9]
+	str r4, [r9, #0x20]
+	str r5, [r9, #0x24]
+	str r6, [r9, #0x28]
 	mov r0, #1
-	strb r0, [sb, #0x14]
+	strb r0, [r9, #0x14]
 	ldr r1, [sp, #0xc]
 	mov r0, #0x5c
-	str r1, [sb, #0x2c]
+	str r1, [r9, #0x2c]
 	ldr r1, [sp, #0x10]
-	str r1, [sb, #0x30]
+	str r1, [r9, #0x30]
 	ldr r1, [sp, #0x14]
-	str r1, [sb, #0x34]
+	str r1, [r9, #0x34]
 	ldr r1, [sp, #0x18]
-	str r1, [sb, #0x38]
+	str r1, [r9, #0x38]
 	ldr r1, [sp, #0x1c]
-	str r1, [sb, #0x3c]
+	str r1, [r9, #0x3c]
 	ldr r1, [sp, #0x20]
-	str r1, [sb, #0x40]
+	str r1, [r9, #0x40]
 	ldr r1, [sp, #0x24]
-	str r1, [sb, #0x44]
+	str r1, [r9, #0x44]
 	ldr r1, [sp, #0x28]
-	str r1, [sb, #0x48]
+	str r1, [r9, #0x48]
 	ldr r1, [sp, #0x2c]
-	str r1, [sb, #0x4c]
+	str r1, [r9, #0x4c]
 	ldr r1, [sp, #0x30]
-	str r1, [sb, #0x50]
+	str r1, [r9, #0x50]
 	ldr r1, [sp, #0x34]
-	str r1, [sb, #0x54]
+	str r1, [r9, #0x54]
 	ldr r1, [sp, #0x38]
-	str r1, [sb, #0x58]
+	str r1, [r9, #0x58]
 	ldr r1, [sp, #0x3c]
-	str r1, [sb, #0x5c]
+	str r1, [r9, #0x5c]
 	ldr r1, [sp, #0x40]
-	str r1, [sb, #0x60]
+	str r1, [r9, #0x60]
 	ldr r1, [sp, #0x44]
-	str r1, [sb, #0x64]
+	str r1, [r9, #0x64]
 	ldr r1, [sp, #0x48]
-	str r1, [sb, #0x68]
+	str r1, [r9, #0x68]
 	ldr r1, [sp, #0x4c]
-	str r1, [sb, #0x6c]
+	str r1, [r9, #0x6c]
 	ldr r1, [sp, #0x50]
-	str r1, [sb, #0x70]
+	str r1, [r9, #0x70]
 	ldr r1, [sp, #0x54]
-	str r1, [sb, #0x74]
+	str r1, [r9, #0x74]
 	ldr r1, [sp, #0x58]
-	str r1, [sb, #0x78]
+	str r1, [r9, #0x78]
 	ldr r1, [sp, #0x5c]
-	str r1, [sb, #0x7c]
+	str r1, [r9, #0x7c]
 	ldr r1, [sp, #0x60]
-	str r1, [sb, #0x80]
+	str r1, [r9, #0x80]
 	ldr r1, [sp, #0x64]
-	str r1, [sb, #0x84]
+	str r1, [r9, #0x84]
 	ldr r1, [sp, #0x68]
-	str r1, [sb, #0x88]
+	str r1, [r9, #0x88]
 	ldrb r1, [sp, #0x6c]
-	strb r1, [sb, #0x8c]
+	strb r1, [r9, #0x8c]
 	ldrb r1, [sp, #0x6d]
-	strb r1, [sb, #0x8d]
+	strb r1, [r9, #0x8d]
 	ldrb r1, [sp, #0x6e]
-	strb r1, [sb, #0x8e]
+	strb r1, [r9, #0x8e]
 	ldrb r1, [sp, #0x6f]
-	strb r1, [sb, #0x8f]
+	strb r1, [r9, #0x8f]
 	ldrb r1, [sp, #0x70]
-	strb r1, [sb, #0x90]
-	str r0, [sb, #0x94]
+	strb r1, [r9, #0x90]
+	str r0, [r9, #0x94]
 	add sp, sp, #0x74
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0216463c
 _02164bd4: .word data_027e0f64
@@ -83224,7 +83224,7 @@ _02166580: .word 0xfffffe66
 	.global func_ov15_02166584
 	arm_func_start func_ov15_02166584
 func_ov15_02166584: ; 0x02166584
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x20
 	mov r4, r0
 	add r0, r4, #0x48
@@ -83266,26 +83266,26 @@ func_ov15_02166584: ; 0x02166584
 	add r2, sp, #0x14
 	mov r3, #0
 	bl func_ov00_020ceacc
-	mov sb, #0
+	mov r9, #0
 	ldr r7, _0216668c ; =data_ov15_021867fc
 	ldr r4, _0216667c ; =data_027e0e58
-	mov r8, sb
+	mov r8, r9
 	add r6, sp, #0x14
 	mov r5, #2
 _02166644:
 	str r8, [sp]
-	mov r0, sb, lsl #0x1
+	mov r0, r9, lsl #0x1
 	str r8, [sp, #4]
 	ldrsh r1, [r7, r0]
 	ldr r0, [r4]
 	mov r2, r6
 	mov r3, r5
 	bl func_ov00_0207c1b0
-	add sb, sb, #1
-	cmp sb, #4
+	add r9, r9, #1
+	cmp r9, #4
 	blt _02166644
 	add sp, sp, #0x20
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02166584
 _02166678: .word data_027e0e60
@@ -85035,7 +85035,7 @@ _02167d2c: .word data_027e0f94
 	.global func_ov15_02167d30
 	arm_func_start func_ov15_02167d30
 func_ov15_02167d30: ; 0x02167d30
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	mov r6, r1
 	mov r7, r0
 	cmp r6, #6
@@ -85082,11 +85082,11 @@ _02167d74:
 	add r1, r1, #0x66
 	add r5, r3, #0x400
 	mov r4, r0
-	add sb, r1, #0x600
+	add r9, r1, #0x600
 	sub r0, r5, r2
 	bl func_01ff9958
 	mov r8, r0
-	sub r0, r5, sb
+	sub r0, r5, r9
 	bl func_01ff9958
 	add r1, r8, r0
 	mov r0, r8
@@ -85159,7 +85159,7 @@ _02167ef0:
 	mov r0, #0
 	str r0, [r7, #0x138]
 	str r6, [r7, #0x130]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02167d30
 _02167f00: .word data_027e0fac
@@ -86785,7 +86785,7 @@ _021694f0: .word data_027e0f6c
 	.global func_ov15_021694f4
 	arm_func_start func_ov15_021694f4
 func_ov15_021694f4: ; 0x021694f4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x20
 	mov r10, r0
 	str r1, [sp, #4]
@@ -86824,7 +86824,7 @@ _02169544:
 	mov r7, #0
 	ldr r4, _02169674 ; =data_027e0ffc
 	ldr r5, _02169678 ; =data_ov15_02186918
-	mov sb, r7
+	mov r9, r7
 	add r11, sp, #0x14
 _02169594:
 	add r0, r10, r7
@@ -86832,7 +86832,7 @@ _02169594:
 	tst r6, #1
 	beq _02169638
 	ldr r0, [r10, #0x48]
-	ldr r3, [r5, sb, lsl #2]
+	ldr r3, [r5, r9, lsl #2]
 	str r0, [sp, #8]
 	ldr r1, [r10, #0x4c]
 	ldr r0, _0216967c ; =data_027e0e60
@@ -86846,7 +86846,7 @@ _02169594:
 	add r8, r8, r3
 	bl func_ov00_02083ee0
 	ldr r2, [r10, #0x48]
-	ldr r1, [r5, sb, lsl #2]
+	ldr r1, [r5, r9, lsl #2]
 	str r0, [sp, #0x18]
 	add r0, r2, r1
 	str r0, [sp, #0x14]
@@ -86870,7 +86870,7 @@ _02169620:
 	add r3, r7, r3
 	bl func_ov00_020cec60
 _02169638:
-	add sb, sb, #2
+	add r9, r9, #2
 	add r7, r7, #1
 	cmp r7, #0x10
 	blt _02169594
@@ -86883,7 +86883,7 @@ _02169650:
 	add r2, r10, #0x48
 	bl func_ov00_0207a1c8
 	add sp, sp, #0x20
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_021694f4
 _02169668: .word data_ov15_021868f0
@@ -86973,7 +86973,7 @@ _02169778: .word data_027e0194
 	.global func_ov15_0216977c
 	arm_func_start func_ov15_0216977c
 func_ov15_0216977c: ; 0x0216977c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x44
 	ldrh r1, [r1]
 	mov r10, r0
@@ -86981,7 +86981,7 @@ func_ov15_0216977c: ; 0x0216977c
 	bne _021697a0
 	tst r1, #8
 	addeq sp, sp, #0x44
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _021697a0:
 	add r1, sp, #0x14
 	str r1, [sp]
@@ -86996,7 +86996,7 @@ _021697a0:
 	bl func_ov00_02079470
 	cmp r0, #0
 	addeq sp, sp, #0x44
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r0, sp, #0x24
 	bl func_01ffbe34
 	ldr r0, _02169928 ; =data_027e0d3c
@@ -87021,12 +87021,12 @@ _021697a0:
 	ldr r8, _02169930 ; =data_ov15_021869b8
 	ldr r4, _02169934 ; =data_ov15_02186998
 	ldr r11, _02169928 ; =data_027e0d3c
-	mov sb, #0
+	mov r9, #0
 	add r7, sp, #0x14
 	add r6, sp, #0x10
 	add r5, sp, #0x24
 _02169848:
-	add r0, r10, sb
+	add r0, r10, r9
 	ldrb r0, [r0, #0x23c]
 	cmp r0, #4
 	bhs _021698c0
@@ -87050,22 +87050,22 @@ _02169848:
 	mov r3, r2
 	bl func_ov00_02079470
 	str r5, [sp]
-	mov r3, sb, lsl #0x1
+	mov r3, r9, lsl #0x1
 	ldrh r3, [r4, r3]
 	ldr r0, _0216992c ; =data_02063e4c
 	ldr r1, [sp, #0x14]
 	ldr r2, [sp, #0x10]
 	bl func_020313c8
 _021698c0:
-	add sb, sb, #1
-	cmp sb, #0x10
+	add r9, r9, #1
+	cmp r9, #0x10
 	add r8, r8, #8
 	blt _02169848
 	add sp, sp, #0x44
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _021698d8:
 	addne sp, sp, #0x44
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r0, r10, #0x100
 	ldrh r0, [r0, #0xb4]
 	cmp r0, #1
@@ -87076,14 +87076,14 @@ _021698d8:
 	movne r0, #0
 	cmp r0, #0
 	addne sp, sp, #0x44
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r1, [sp, #0x14]
 	ldr r2, [sp, #0x10]
 	add r3, sp, #0x24
 	add r0, r10, #0x158
 	bl func_02034a1c
 	add sp, sp, #0x44
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0216977c
 _02169928: .word data_027e0d3c
@@ -87094,7 +87094,7 @@ _02169934: .word data_ov15_02186998
 	.global func_ov15_02169938
 	arm_func_start func_ov15_02169938
 func_ov15_02169938: ; 0x02169938
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0xc
 	mov r5, r1
 	ldr r2, [r5, #0x14]
@@ -87102,13 +87102,13 @@ func_ov15_02169938: ; 0x02169938
 	cmp r2, #0
 	addeq sp, sp, #0xc
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	ldr r1, [r2, #4]
 	ldr r0, _02169aac ; =0x434e424c
 	cmp r1, r0
 	addne sp, sp, #0xc
 	movne r0, #0
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	add r0, r2, #0x48
 	add r3, sp, #0
 	ldmia r0, {r0, r1, r2}
@@ -87130,22 +87130,22 @@ func_ov15_02169938: ; 0x02169938
 	ldr r0, [r0, #0x24c]
 	ldr r8, [r2, #0x88]
 	add r0, r1, r0
-	add sb, r0, #0xd800
+	add r9, r0, #0xd800
 	ldr r0, [sp, #4]
-	add r1, sb, r8
+	add r1, r9, r8
 	cmp r1, r0
 	ldrb r7, [r5, r6]
 	addlt sp, sp, #0xc
 	movlt r0, #0
-	ldmltia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmltia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	add r1, sp, #0
 	mov r0, r4
 	bl _ZN5Actor12XzDistanceToEP5Vec3p
 	ldr r2, [sp, #4]
 	ldr r1, _02169ab0 ; =0x0000159f
-	sub r2, r2, sb
+	sub r2, r2, r9
 	add r2, r2, #0xd800
-	mov sb, r0
+	mov r9, r0
 	cmp r2, r1
 	movlt r0, #0xf800
 	blt _02169a54
@@ -87167,15 +87167,15 @@ func_ov15_02169938: ; 0x02169938
 	add r0, r1, #0x9000
 _02169a54:
 	add r0, r0, r8
-	cmp sb, r0
+	cmp r9, r0
 	bgt _02169a6c
 	rsb r0, r8, #0x9000
-	cmp sb, r0
+	cmp r9, r0
 	bge _02169a78
 _02169a6c:
 	add sp, sp, #0xc
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _02169a78:
 	ldr r0, [r4, #0x130]
 	cmp r0, #2
@@ -87190,7 +87190,7 @@ _02169a78:
 _02169aa0:
 	mov r0, #1
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02169938
 _02169aac: .word 0x434e424c
@@ -87654,7 +87654,7 @@ _0216a0fc: .word data_027e0f74
 	.global func_ov15_0216a100
 	arm_func_start func_ov15_0216a100
 func_ov15_0216a100: ; 0x0216a100
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x3c
 	ldr r1, _0216a384 ; =data_027e0f90
 	mov r4, r0
@@ -87662,7 +87662,7 @@ func_ov15_0216a100: ; 0x0216a100
 	ldrsh r0, [r0, #0xa]
 	cmp r0, #0
 	addle sp, sp, #0x3c
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	ldrb r0, [r4, #0x2de]
 	tst r0, #1
 	bne _0216a2f8
@@ -87672,7 +87672,7 @@ func_ov15_0216a100: ; 0x0216a100
 	subne r1, r1, #1
 	strneh r1, [r0, #0xdc]
 	addne sp, sp, #0x3c
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	add r0, sp, #4
 	bl func_ov00_020c1500
 	mvn r1, #0
@@ -87690,10 +87690,10 @@ func_ov15_0216a100: ; 0x0216a100
 	ldr r2, [r5, #4]
 	str r0, [sp, #0x30]
 	ldr r0, [r4, #0x4c]
-	mov sb, #0
+	mov r9, #0
 	str r0, [sp, #0x34]
 	ldr r0, [r4, #0x50]
-	mov r6, sb, lsl #0x1
+	mov r6, r9, lsl #0x1
 	str r0, [sp, #0x38]
 	ldr r1, [r5, #8]
 	ldr r0, [r5, #0xc]
@@ -87708,7 +87708,7 @@ func_ov15_0216a100: ; 0x0216a100
 	add r6, r6, #3
 	and r8, r6, #0xff
 	str lr, [r5]
-	mov r6, sb
+	mov r6, r9
 	str ip, [r5, #4]
 	strh r8, [sp, #4]
 	cmp r8, #4
@@ -87724,9 +87724,9 @@ func_ov15_0216a100: ; 0x0216a100
 	cmp r8, #0
 	moveq r6, ip
 	umullne r0, r6, ip, r8
-	mlane r6, ip, sb, r6
+	mlane r6, ip, r9, r6
 	str lr, [r5]
-	mlane r6, sb, r8, r6
+	mlane r6, r9, r8, r6
 	str ip, [r5, #4]
 _0216a228:
 	and r0, r6, #0xff
@@ -87738,18 +87738,18 @@ _0216a234:
 _0216a23c:
 	ldr r6, _0216a388 ; =data_027e0764
 	ldr r5, _0216a38c ; =0x00005555
-	ldr sb, [r6, #8]
+	ldr r9, [r6, #8]
 	ldr r1, [r6, #0xc]
-	umull r2, r3, sb, lr
-	mla r3, sb, ip, r3
+	umull r2, r3, r9, lr
+	mla r3, r9, ip, r3
 	mla r3, r1, lr, r3
 	ldr r0, [r6, #0x10]
 	mov lr, #0
 	adds ip, r0, r2
 	ldr r2, [r6, #0x14]
-	umull r8, r7, sb, ip
+	umull r8, r7, r9, ip
 	adc r3, r2, r3
-	mla r7, sb, r3, r7
+	mla r7, r9, r3, r7
 	mla r7, r1, ip, r7
 	adds r0, r0, r8
 	adc r8, r2, r7
@@ -87782,7 +87782,7 @@ _0216a23c:
 	add sp, sp, #0x3c
 	orr r0, r0, #1
 	strb r0, [r4, #0x2de]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _0216a2f8:
 	ldr r0, _0216a398 ; =data_027e0fe4
 	add r1, r4, #0x28c
@@ -87790,7 +87790,7 @@ _0216a2f8:
 	bl _ZN12ActorManager8GetActorEP8ActorRef
 	cmp r0, #0
 	addne sp, sp, #0x3c
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	ldrb r0, [r4, #0x2de]
 	ldr r2, _0216a388 ; =data_027e0764
 	mov r1, #0
@@ -87818,7 +87818,7 @@ _0216a2f8:
 	add r0, r4, #0x200
 	strh r1, [r0, #0xdc]
 	add sp, sp, #0x3c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0216a100
 _0216a384: .word data_027e0f90
@@ -87831,7 +87831,7 @@ _0216a398: .word data_027e0fe4
 	.global func_ov15_0216a39c
 	arm_func_start func_ov15_0216a39c
 func_ov15_0216a39c: ; 0x0216a39c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0xc
 	mov ip, #0xf000
 	rsb ip, ip, #0
@@ -87853,13 +87853,13 @@ _0216a3d4:
 	bne _0216a458
 	ldr r5, [r3]
 	ldmib r3, {r4, r7}
-	umull sb, r8, r7, r5
+	umull r9, r8, r7, r5
 	mla r8, r7, r4, r8
 	ldr r6, [r3, #0xc]
 	ldr lr, [r3, #0x10]
 	mla r8, r6, r5, r8
 	ldr r10, [r3, #0x14]
-	adds r4, lr, sb
+	adds r4, lr, r9
 	adc r5, r10, r8
 	stmia r3, {r4, r5}
 	mov r4, #0x1ec
@@ -87884,13 +87884,13 @@ _0216a458:
 	bne _0216a4d4
 	ldr r5, [r3]
 	ldmib r3, {r4, r7}
-	umull sb, r8, r7, r5
+	umull r9, r8, r7, r5
 	mla r8, r7, r4, r8
 	ldr r6, [r3, #0xc]
 	ldr lr, [r3, #0x10]
 	mla r8, r6, r5, r8
 	ldr r10, [r3, #0x14]
-	adds r4, lr, sb
+	adds r4, lr, r9
 	adc r5, r10, r8
 	stmia r3, {r4, r5}
 	mov r4, #0x1ec
@@ -87921,9 +87921,9 @@ _0216a4d4:
 	ldr r5, [r3, #0xc]
 	ldr r10, [r3, #0x10]
 	mla r7, r5, r4, r7
-	ldr sb, [r3, #0x14]
+	ldr r9, [r3, #0x14]
 	adds r4, r10, r8
-	adc r5, sb, r7
+	adc r5, r9, r7
 	stmia r3, {r4, r5}
 	mov r4, #0x1ec
 	umull r4, r6, r5, r4
@@ -87944,7 +87944,7 @@ _0216a540:
 	cmp r2, #0x10
 	blt _0216a3d4
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0216a39c
 _0216a554: .word data_027e0764
@@ -87976,7 +87976,7 @@ func_ov15_0216a574: ; 0x0216a574
 	.global func_ov15_0216a590
 	arm_func_start func_ov15_0216a590
 func_ov15_0216a590: ; 0x0216a590
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #8
 	mov r0, #1
 	ldr r1, _0216a734 ; =data_027e0f74
@@ -87990,7 +87990,7 @@ func_ov15_0216a590: ; 0x0216a590
 	mov r6, r11
 	mov r7, r11
 	mov r8, r11
-	mov sb, r11
+	mov r9, r11
 	mov r10, r11
 	bl func_ov00_02097738
 	cmp r0, #0
@@ -88016,9 +88016,9 @@ _0216a614:
 	ldr r0, [r0]
 	ldr r0, [r0, #0x2c]
 	cmp r0, #1
-	movne sb, #0
+	movne r9, #0
 _0216a630:
-	cmp sb, #0
+	cmp r9, #0
 	bne _0216a64c
 	ldr r0, _0216a744 ; =data_027e10a4
 	ldr r0, [r0]
@@ -88090,7 +88090,7 @@ _0216a704:
 _0216a728:
 	ldr r0, [sp, #4]
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0216a590
 _0216a734: .word data_027e0f74
@@ -89229,15 +89229,15 @@ _0216b588: .word 0x000011c7
 	.global func_ov15_0216b58c
 	arm_func_start func_ov15_0216b58c
 func_ov15_0216b58c: ; 0x0216b58c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x80
-	mov sb, r0
-	ldr r4, [sb, #0x88]
+	mov r9, r0
+	ldr r4, [r9, #0x88]
 	mov r5, r1
 	cmp r4, #0
 	mov r0, #0
 	blt _0216b5e8
-	add r0, sb, #0x48
+	add r0, r9, #0x48
 	add r3, sp, #0x74
 	ldmia r0, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
@@ -89257,14 +89257,14 @@ _0216b5e8:
 	cmp r0, #0
 	addeq sp, sp, #0x80
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
-	ldr r0, [sb, #0x48]
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
+	ldr r0, [r9, #0x48]
 	mov r2, #1
 	str r0, [sp, #0x3c]
-	ldr r1, [sb, #0x4c]
+	ldr r1, [r9, #0x4c]
 	ldr r0, _0216b9bc ; =data_027e0f64
 	str r1, [sp, #0x40]
-	ldr r3, [sb, #0x50]
+	ldr r3, [r9, #0x50]
 	add r1, sp, #0x3c
 	str r3, [sp, #0x44]
 	str r2, [sp]
@@ -89293,41 +89293,41 @@ _0216b668: ; jump table
 	b _0216b6b0 ; case 2
 	b _0216b6c0 ; case 3
 _0216b678:
-	ldr r0, [sb, #0x88]
+	ldr r0, [r9, #0x88]
 	add r0, r5, r0
 	str r0, [sp, #0x48]
-	ldr r0, [sb, #0x88]
+	ldr r0, [r9, #0x88]
 	add r0, r5, r0, lsl #1
 	str r0, [sp, #0x4c]
 	b _0216b6cc
 _0216b694:
-	ldr r0, [sb, #0x88]
+	ldr r0, [r9, #0x88]
 	sub r0, r5, r0
 	str r0, [sp, #0x48]
-	ldr r0, [sb, #0x88]
+	ldr r0, [r9, #0x88]
 	add r0, r5, r0, lsl #1
 	str r0, [sp, #0x4c]
 	b _0216b6cc
 _0216b6b0:
-	ldr r0, [sb, #0x88]
+	ldr r0, [r9, #0x88]
 	add r0, r5, r0
 	str r0, [sp, #0x48]
 	b _0216b6cc
 _0216b6c0:
-	ldr r0, [sb, #0x88]
+	ldr r0, [r9, #0x88]
 	sub r0, r5, r0
 	str r0, [sp, #0x48]
 _0216b6cc:
-	ldrsh r1, [sb, #0x78]
+	ldrsh r1, [r9, #0x78]
 	mov r0, r4
 	bl func_ov00_020a61ac
-	ldr r1, [sb, #0x48]
+	ldr r1, [r9, #0x48]
 	mov r0, r4
 	str r1, [sp, #0x30]
-	ldr r2, [sb, #0x4c]
+	ldr r2, [r9, #0x4c]
 	add r1, sp, #0x30
 	str r2, [sp, #0x34]
-	ldr r3, [sb, #0x50]
+	ldr r3, [r9, #0x50]
 	mov r2, r4
 	str r3, [sp, #0x38]
 	bl func_01ff9bc4
@@ -89341,7 +89341,7 @@ _0216b6cc:
 	cmp r0, #0
 	addeq sp, sp, #0x80
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r6, r6, #1
 	cmp r6, #4
 	add r7, r7, #4
@@ -89360,7 +89360,7 @@ _0216b6cc:
 	bne _0216b778
 	add sp, sp, #0x80
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0216b778:
 	ldr r1, [sp, #0x64]
 	ldr r0, [sp, #0x68]
@@ -89397,7 +89397,7 @@ _0216b7e0:
 	ldr r1, [sp, #0x5c]
 	ldr r0, [sp, #0x60]
 	ldr r5, [sp, #0x64]
-	ldr sb, [sp, #0x68]
+	ldr r9, [sp, #0x68]
 	sub r6, r4, #8
 	sub r10, r3, r5
 	ldr r4, [sp, #0x6c]
@@ -89405,16 +89405,16 @@ _0216b7e0:
 	sub r5, r11, r6
 	sub r2, r2, #8
 	sub r6, r11, r2
-	sub sb, r3, sb
+	sub r9, r3, r9
 	sub r8, r3, r4
 	add r1, r1, #8
 	sub r4, r11, r1
 	sub r7, r3, r7
 	add r0, r0, #8
 	sub r3, r11, r0
-	smull r1, r0, sb, r6
+	smull r1, r0, r9, r6
 	smull r11, r2, r10, r5
-	smull lr, ip, sb, r4
+	smull lr, ip, r9, r4
 	str r0, [sp, #4]
 	str ip, [sp, #0x24]
 	subs r11, r11, r1
@@ -89438,21 +89438,21 @@ _0216b7e0:
 	str r5, [sp, #0x1c]
 	smull r4, r5, r8, r3
 	str r5, [sp, #0x2c]
-	smull r6, r5, sb, r3
+	smull r6, r5, r9, r3
 	str r8, [sp, #0x6c]
-	str sb, [sp, #0x68]
+	str r9, [sp, #0x68]
 	ldr r3, [sp, #0x24]
 	str r7, [sp, #0x70]
 	subs r8, lr, r1
 	sbc r7, r3, r0
 	ldr r3, [sp, #0x28]
-	mov sb, ip
+	mov r9, ip
 	str r10, [sp, #0x64]
-	subs r10, r3, sb
-	ldr sb, [sp, #8]
+	subs r10, r3, r9
+	ldr r9, [sp, #8]
 	ldr r3, [sp, #0x10]
 	str ip, [sp, #0xc]
-	sbc sb, sb, r3
+	sbc r9, r9, r3
 	ldr r3, [sp, #0x14]
 	subs ip, r3, r4
 	ldr r4, [sp, #0x18]
@@ -89473,7 +89473,7 @@ _0216b7e0:
 	sbcs lr, r7, r5
 	blt _0216b92c
 	subs lr, r10, r5
-	sbcs lr, sb, r5
+	sbcs lr, r9, r5
 	bge _0216b9a4
 _0216b92c:
 	mov r5, #0
@@ -89484,7 +89484,7 @@ _0216b92c:
 	sbcs r2, r5, r7
 	blt _0216b954
 	subs r2, r5, r10
-	sbcs r2, r5, sb
+	sbcs r2, r5, r9
 	bge _0216b9a4
 _0216b954:
 	subs r2, ip, #0
@@ -89511,11 +89511,11 @@ _0216b97c:
 _0216b9a4:
 	add sp, sp, #0x80
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0216b9b0:
 	mov r0, #0
 	add sp, sp, #0x80
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0216b58c
 _0216b9bc: .word data_027e0f64
@@ -90497,7 +90497,7 @@ _0216c6b4: .word data_027e0e60
 	.global func_ov15_0216c6b8
 	arm_func_start func_ov15_0216c6b8
 func_ov15_0216c6b8: ; 0x0216c6b8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #0xc
 	mov r4, r0
 	ldr r0, [r4, #0x4d0]
@@ -90537,14 +90537,14 @@ func_ov15_0216c6b8: ; 0x0216c6b8
 	ldrsh r8, [ip, r0]
 	mov r6, #0
 	ldr lr, [sp]
-	umull r10, sb, r8, r5
-	mla sb, r8, r6, sb
+	umull r10, r9, r8, r5
+	mla r9, r8, r6, r9
 	mov r7, r8, asr #0x1f
 	adds r8, r10, #0x800
-	mla sb, r7, r5, sb
+	mla r9, r7, r5, r9
 	ldr r0, _0216c7fc ; =data_027e0e58
 	mov r2, r3
-	adc r7, sb, #0
+	adc r7, r9, #0
 	mov r8, r8, lsr #0xc
 	orr r8, r8, r7, lsl #20
 	add r7, lr, r8
@@ -90573,7 +90573,7 @@ _0216c7d8:
 	mov r0, r4
 	bl func_ov15_0216ced8
 	add sp, sp, #0xc
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0216c6b8
 _0216c7e8: .word data_027e0764
@@ -92821,19 +92821,19 @@ _0216e698: .word 0x000001df
 	.global func_ov15_0216e69c
 	arm_func_start func_ov15_0216e69c
 func_ov15_0216e69c: ; 0x0216e69c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x50
 	mov r4, r1
 	mvn ip, #0
 	ldr r1, [r4, #8]
-	sub sb, ip, #0xcc
-	umull r5, r7, r1, sb
+	sub r9, ip, #0xcc
+	umull r5, r7, r1, r9
 	str r3, [sp, #0x10]
 	adds r3, r5, #0x800
 	mov r5, r0
 	mla r7, r1, ip, r7
 	mov r0, r1, asr #0x1f
-	mla r7, r0, sb, r7
+	mla r7, r0, r9, r7
 	ldmia r4, {r6, r8}
 	adc r0, r7, #0
 	mov r3, r3, lsr #0xc
@@ -92841,15 +92841,15 @@ func_ov15_0216e69c: ; 0x0216e69c
 	str r3, [sp, #0x4c]
 	ldr r3, _0216e96c ; =0x0000152d
 	mov r7, r8, asr #0x1f
-	umull r10, sb, r8, r3
+	umull r10, r9, r8, r3
 	mov r3, #0
-	mla sb, r8, r3, sb
+	mla r9, r8, r3, r9
 	ldr r3, _0216e96c ; =0x0000152d
 	mov r11, r2
-	mla sb, r7, r3, sb
+	mla r9, r7, r3, r9
 	adds r7, r10, #0x800
 	add r0, sp, #0x44
-	adc r3, sb, #0
+	adc r3, r9, #0
 	mov r7, r7, lsr #0xc
 	orr r7, r7, r3, lsl #20
 	ldr r3, _0216e970 ; =0xfffffa1d
@@ -92996,7 +92996,7 @@ _0216e930:
 	add r2, r5, #0x64
 	cmp r3, r2
 	addeq sp, sp, #0x50
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0216e944:
 	ldr r1, [r3]
 	add r3, r3, #4
@@ -93007,7 +93007,7 @@ _0216e944:
 	cmp r3, r2
 	bne _0216e944
 	add sp, sp, #0x50
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0216e69c
 _0216e96c: .word 0x0000152d
@@ -93093,7 +93093,7 @@ func_ov15_0216ea14: ; 0x0216ea14
 	.global func_ov15_0216ea30
 	arm_func_start func_ov15_0216ea30
 func_ov15_0216ea30: ; 0x0216ea30
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #0x94
 	mov r8, r0
 	ldr r1, [r8, #0x11c]
@@ -93110,7 +93110,7 @@ func_ov15_0216ea30: ; 0x0216ea30
 	str r1, [sp]
 	bl func_01ff80d4
 	add r10, sp, #0x4c
-	add sb, sp, #0
+	add r9, sp, #0
 	b _0216eaa8
 _0216ea7c:
 	mov r0, r8
@@ -93125,7 +93125,7 @@ _0216ea7c:
 	add r1, r1, #0x28
 	bl func_01ff8690
 _0216eaa8:
-	mov r0, sb
+	mov r0, r9
 	mov r2, r7
 	add r1, r5, r4
 	bl func_0201b2f8
@@ -93176,7 +93176,7 @@ _0216eb64:
 	ldr r0, [r8, #0x11c]
 	tst r0, #2
 	addeq sp, sp, #0x94
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	ldr r1, [r8, #0x118]
 	mov r0, r8
 	bl func_ov00_020a9624
@@ -93198,7 +93198,7 @@ _0216eb64:
 	mov r2, r0
 	bl func_01ff8690
 	add sp, sp, #0x94
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0216ea30
 _0216ebcc: .word data_02050f54
@@ -93477,7 +93477,7 @@ func_ov15_0216ef0c: ; 0x0216ef0c
 	.global func_ov15_0216ef4c
 	arm_func_start func_ov15_0216ef4c
 func_ov15_0216ef4c: ; 0x0216ef4c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	mov r4, r0
 	add r1, r4, #0x200
 	mov r2, #0
@@ -93498,9 +93498,9 @@ func_ov15_0216ef4c: ; 0x0216ef4c
 	ldr r5, [r2, #0xc]
 	ldr r10, [r2, #0x10]
 	mla r7, r5, lr, r7
-	ldr sb, [r2, #0x14]
+	ldr r9, [r2, #0x14]
 	adds r6, r10, r8
-	adc r5, sb, r7
+	adc r5, r9, r7
 	str r6, [r2]
 	str r5, [r2, #4]
 	mov r2, r5, lsr #0x10
@@ -93516,7 +93516,7 @@ func_ov15_0216ef4c: ; 0x0216ef4c
 	ldr r2, [r2, r4, lsl #2]
 	bl func_ov00_0207c1f8
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0216ef4c
 _0216efec: .word data_027e0764
@@ -94579,7 +94579,7 @@ _0216fdfc: .word data_027e0764
 	.global func_ov15_0216fe00
 	arm_func_start func_ov15_0216fe00
 func_ov15_0216fe00: ; 0x0216fe00
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x338
 	mov r4, r1
 	mov r5, r0
@@ -94701,14 +94701,14 @@ _0216fe54:
 	ldrb r3, [sp, #0x283]
 	ldrb r2, [sp, #0x284]
 	ldr r1, [sp, #0x26c]
-	ldr sb, [sp, #0x274]
+	ldr r9, [sp, #0x274]
 	ldr r8, [sp, #0x278]
 	ldr r7, [sp, #0x27c]
 	str r1, [sp, #0x300]
 	mov r11, #0x5c
 	ldr r0, [r0]
 	add r1, sp, #0x288
-	str sb, [sp, #0x308]
+	str r9, [sp, #0x308]
 	str r8, [sp, #0x30c]
 	str r7, [sp, #0x310]
 	strb r6, [sp, #0x314]
@@ -94794,24 +94794,24 @@ _021700a4:
 	mov r0, r0, lsl #0x10
 	mov r0, r0, lsr #0x10
 	mov r0, r0, asr #0x4
-	mov sb, r0, lsl #0x1
-	mov r0, sb, lsl #0x1
-	add sb, sb, #1
-	mov r10, sb, lsl #0x1
+	mov r9, r0, lsl #0x1
+	mov r0, r9, lsl #0x1
+	add r9, r9, #1
+	mov r10, r9, lsl #0x1
 	ldrsh r8, [r7, r8]
-	mov sb, #0x4800
+	mov r9, #0x4800
 	ldrsh r6, [r7, r6]
-	smulbb r8, r8, sb
+	smulbb r8, r8, r9
 	add r8, r8, #0x800
-	smulbb r6, r6, sb
+	smulbb r6, r6, r9
 	add r6, r6, #0x800
 	ldrsh r2, [r7, r2]
 	mov r8, r8, asr #0xc
 	ldrsh r1, [r7, r1]
-	mul sb, r2, r8
+	mul r9, r2, r8
 	mul r8, r1, r8
 	ldr r2, [r5, #0x48]
-	add r1, sb, #0x800
+	add r1, r9, #0x800
 	add r1, r2, r1, asr #12
 	str r1, [r5, #0x48]
 	ldrsh r1, [r7, r0]
@@ -94842,14 +94842,14 @@ _021700a4:
 	ldrsh r8, [r7, r2]
 	add r2, r3, #1
 	mov r2, r2, lsl #0x1
-	umull r10, sb, r8, r0
+	umull r10, r9, r8, r0
 	ldrsh r2, [r7, r2]
-	mla sb, r8, r1, sb
+	mla r9, r8, r1, r9
 	umull r6, r3, r2, r0
 	mov r7, r8, asr #0x1f
 	adds r8, r10, #0x800
-	mla sb, r7, r0, sb
-	adc r7, sb, #0
+	mla r9, r7, r0, r9
+	adc r7, r9, #0
 	mov r8, r8, lsr #0xc
 	adds r6, r6, #0x800
 	mla r3, r2, r1, r3
@@ -94901,7 +94901,7 @@ _0217029c:
 	ldr r0, _02170630 ; =data_027e0f94
 	mvn r7, #0
 	mov r10, #0x32
-	mov sb, #0
+	mov r9, #0
 	mov r8, #3
 	mov r3, #1
 	add r6, sp, #0x4c
@@ -94914,7 +94914,7 @@ _0217029c:
 	ldr r2, [sp, #0x54]
 	ldr r0, [r0]
 	strb r10, [sp, #0x179]
-	strb sb, [sp, #0x17a]
+	strb r9, [sp, #0x17a]
 	strb r8, [sp, #0x17b]
 	add r1, sp, #0x170
 	str r7, [sp, #0x190]
@@ -94925,11 +94925,11 @@ _0217029c:
 	str r0, [r5, #0x53c]
 	add r6, sp, #0x38
 	add r1, sp, #0x48
-	mov r0, sb
+	mov r0, r9
 	mov r2, #4
 	bl func_020078f4
 	add r1, r6, #0x10
-	mov r0, sb
+	mov r0, r9
 	mov r2, #4
 	bl func_020078f4
 	ldr r0, [sp, #0x48]
@@ -94964,7 +94964,7 @@ _021703c8:
 	mov r1, #4
 	bl func_ov15_0216fe00
 	add sp, sp, #0x338
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _021703e8:
 	ldr r0, _0217063c ; =data_027e10a4
 	mov r6, #0
@@ -95057,7 +95057,7 @@ _021703e8:
 	str r0, [sp, #0xf8]
 	str r1, [sp, #0xfc]
 	ldr r0, [sp, #0xa8]
-	ldr sb, [sp, #0xa0]
+	ldr r9, [sp, #0xa0]
 	str r0, [sp, #0x13c]
 	ldr r0, _02170638 ; =data_027e0f74
 	ldrb r8, [sp, #0xb8]
@@ -95068,15 +95068,15 @@ _021703e8:
 	ldr r1, [sp, #0xa4]
 	ldr r11, [sp, #0xac]
 	ldr r10, [sp, #0xb0]
-	str sb, [sp, #0x134]
-	ldr sb, [sp, #0xb4]
+	str r9, [sp, #0x134]
+	ldr r9, [sp, #0xb4]
 	str r1, [sp, #0x138]
 	mov lr, #0x5c
 	ldr r0, [r0]
 	add r1, sp, #0xc0
 	str r11, [sp, #0x140]
 	str r10, [sp, #0x144]
-	str sb, [sp, #0x148]
+	str r9, [sp, #0x148]
 	strb r8, [sp, #0x14c]
 	strb r7, [sp, #0x14d]
 	strb r6, [sp, #0x14e]
@@ -95109,7 +95109,7 @@ _0217060c:
 	str r4, [r5, #0x130]
 	strb r0, [r5, #0x56c]
 	add sp, sp, #0x338
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0216fe00
 _02170624: .word 0x0000ffff
@@ -95401,7 +95401,7 @@ _02170a00: .word 0x4852434e
 	.global func_ov15_02170a04
 	arm_func_start func_ov15_02170a04
 func_ov15_02170a04: ; 0x02170a04
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x294
 	mov r4, r0
 	ldrb r1, [r4, #0x56c]
@@ -95430,11 +95430,11 @@ _02170a5c:
 	bl func_ov15_021733b0
 	cmp r0, #0
 	addeq sp, sp, #0x294
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, [r4, #0x138]
 	cmp r0, #0x5a
 	addlt sp, sp, #0x294
-	ldmltia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmltia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r1, r4, #0x9c
 	ldr r0, _02170fe4 ; =data_027e0c68
 	ldr r2, _02170fe8 ; =0x00050027
@@ -95442,7 +95442,7 @@ _02170a5c:
 	bl func_02036ce4
 	cmp r0, #0
 	addeq sp, sp, #0x294
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	mov r0, r4
 	mov r1, #1
 	bl _ZN5Actor10SetUnk_11cEc
@@ -95452,7 +95452,7 @@ _02170a5c:
 	ldr r0, [r0]
 	bl func_ov15_021413d4
 	add sp, sp, #0x294
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02170ac8:
 	ldr r0, _02170fec ; =data_027e0f64
 	add r1, sp, #0x22c
@@ -95485,7 +95485,7 @@ _02170ac8:
 	and r0, r1, r0
 	cmp r0, #0x1000000
 	addeq sp, sp, #0x294
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r0, r4, #0x9c
 	add r0, r0, #0x400
 	ldr r1, [r0]
@@ -95497,7 +95497,7 @@ _02170ac8:
 	and r0, r1, r0
 	cmp r0, #0x1000000
 	addne sp, sp, #0x294
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r0, sp, #0x17c
 	bl func_ov00_0209a4f4
 	mvn r5, #0
@@ -95526,7 +95526,7 @@ _02170ac8:
 	mov r1, #0
 	umull r5, r3, r2, r0
 	adds r6, r6, #0x800
-	mov sb, r6, lsr #0xc
+	mov r9, r6, lsr #0xc
 	mla r8, r7, r1, r8
 	mla r3, r2, r1, r3
 	mov r1, r2, asr #0x1f
@@ -95544,8 +95544,8 @@ _02170ac8:
 	sub r0, r0, #0x900
 	add r1, r2, r1
 	ldr r10, [sp, #0x2c]
-	orr sb, sb, r6, lsl #20
-	add r6, r10, sb
+	orr r9, r9, r6, lsl #20
+	add r6, r10, r9
 	str r0, [sp, #0x30]
 	str r0, [sp, #0x1a0]
 	ldr r0, _02170fec ; =data_027e0f64
@@ -95594,7 +95594,7 @@ _02170ac8:
 	ldr r1, [sp, #0x144]
 	str r0, [sp, #0x1dc]
 	ldr r0, [sp, #0x160]
-	ldr sb, [sp, #0x14c]
+	ldr r9, [sp, #0x14c]
 	ldr r8, [sp, #0x150]
 	ldr r7, [sp, #0x154]
 	ldr r6, [sp, #0x158]
@@ -95607,8 +95607,8 @@ _02170ac8:
 	ldr r0, _02170ff8 ; =data_027e0f74
 	str r1, [sp, #0x1d8]
 	ldr r1, [sp, #0x15c]
-	str sb, [sp, #0x1e0]
-	ldr sb, [sp, #0x164]
+	str r9, [sp, #0x1e0]
+	ldr r9, [sp, #0x164]
 	str r8, [sp, #0x1e4]
 	ldr r8, [sp, #0x168]
 	str r7, [sp, #0x1e8]
@@ -95619,7 +95619,7 @@ _02170ac8:
 	str r1, [sp, #0x1f0]
 	ldr r0, [r0]
 	add r1, sp, #0x17c
-	str sb, [sp, #0x1f8]
+	str r9, [sp, #0x1f8]
 	str r8, [sp, #0x1fc]
 	str r7, [sp, #0x200]
 	str r6, [sp, #0x204]
@@ -95662,7 +95662,7 @@ _02170db8:
 	strb r1, [r4, #0x575]
 	bl func_ov00_0209a508
 	add sp, sp, #0x294
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02170e08:
 	ldr r0, _02170fec ; =data_027e0f64
 	ldr r0, [r0]
@@ -95670,13 +95670,13 @@ _02170e08:
 	bl func_ov00_02089a2c
 	cmp r0, #0
 	addne sp, sp, #0x294
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	mov r0, #3
 	strb r0, [r4, #0x56c]
 	mov r0, #0
 	add sp, sp, #0x294
 	str r0, [r4, #0x138]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02170e3c:
 	add r0, r4, #0x4c
 	mov r1, #0x2000
@@ -95706,7 +95706,7 @@ _02170e3c:
 	ldr r0, [r4, #0x138]
 	cmp r0, #0x3c
 	addlt sp, sp, #0x294
-	ldmltia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmltia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r1, r4, #0x9c
 	ldr r0, _02170fe4 ; =data_027e0c68
 	ldr r2, _02171004 ; =0x00050028
@@ -95714,14 +95714,14 @@ _02170e3c:
 	bl func_02036ce4
 	cmp r0, #0
 	addeq sp, sp, #0x294
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	mov r0, r4
 	mov r1, #1
 	bl _ZN5Actor10SetUnk_11cEc
 	mov r0, #4
 	add sp, sp, #0x294
 	strb r0, [r4, #0x56c]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02170eec:
 	add r0, r4, #0x4c
 	mov r1, #0x2000
@@ -95754,7 +95754,7 @@ _02170eec:
 	and r0, r1, r0
 	cmp r0, #0x1000000
 	addeq sp, sp, #0x294
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r0, r4, #0x9c
 	add r0, r0, #0x400
 	ldr r1, [r0]
@@ -95766,7 +95766,7 @@ _02170eec:
 	and r0, r1, r0
 	cmp r0, #0x1000000
 	addne sp, sp, #0x294
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, _02170ff8 ; =data_027e0f74
 	ldr r1, [r4, #0x540]
 	ldr r0, [r0]
@@ -95785,7 +95785,7 @@ _02170fc4:
 	bl func_ov15_0216fe00
 _02170fd8:
 	add sp, sp, #0x294
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02170a04
 _02170fe0: .word data_027e10a4
@@ -95802,7 +95802,7 @@ _02171004: .word 0x00050028
 	.global func_ov15_02171008
 	arm_func_start func_ov15_02171008
 func_ov15_02171008: ; 0x02171008
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0xc
 	mov r4, r0
 	add r0, r4, #0x500
@@ -95915,21 +95915,21 @@ _02171114:
 	mov r8, #0
 	ldr r6, [r7]
 	ldmib r7, {r0, r2}
-	umull r5, sb, r2, r6
+	umull r5, r9, r2, r6
 	ldr ip, [r7, #0x10]
-	mla sb, r2, r0, sb
+	mla r9, r2, r0, r9
 	ldr r1, [r7, #0xc]
 	ldr r3, [r7, #0x14]
-	mla sb, r1, r6, sb
+	mla r9, r1, r6, r9
 	adds r5, ip, r5
-	adc lr, r3, sb
+	adc lr, r3, r9
 	mov r6, #0x64000
-	umull r0, sb, lr, r6
-	mla sb, lr, r8, sb
+	umull r0, r9, lr, r6
+	mla r9, lr, r8, r9
 	mov r0, r8
-	mla sb, r0, r6, sb
+	mla r9, r0, r6, r9
 	stmia r7, {r5, lr}
-	cmp sb, #0x28000
+	cmp r9, #0x28000
 	bge _0217121c
 	mov r0, #2
 	strb r0, [r4, #0x56e]
@@ -95941,16 +95941,16 @@ _02171114:
 	str r0, [r4, #0x554]
 	b _0217125c
 _0217121c:
-	umull sb, r6, r2, r5
+	umull r9, r6, r2, r5
 	mla r6, r2, lr, r6
-	adds sb, ip, sb
+	adds r9, ip, r9
 	mla r6, r1, r5, r6
 	adc r5, r3, r6
 	mov r1, #3
 	umull r2, r3, r5, r1
 	mla r3, r5, r8, r3
 	mla r3, r0, r1, r3
-	str sb, [r7]
+	str r9, [r7]
 	str r5, [r7, #4]
 	add r0, r3, #4
 	strb r0, [r4, #0x56f]
@@ -95961,7 +95961,7 @@ _0217125c:
 	mov r0, r4
 	bl func_ov15_02172d90
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02171008
 _0217126c: .word 0x0000b7dc
@@ -97081,7 +97081,7 @@ func_ov15_02172238: ; 0x02172238
 	.global func_ov15_02172260
 	arm_func_start func_ov15_02172260
 func_ov15_02172260: ; 0x02172260
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x40
 	mov r4, r0
 	str r1, [sp]
@@ -97097,21 +97097,21 @@ func_ov15_02172260: ; 0x02172260
 	cmp r1, r0
 	addge sp, sp, #0x40
 	movge r0, #0
-	ldmgeia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmgeia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r10, [r4, #0x48]
 	mov r1, #0x800
 	str r10, [sp, #0x28]
 	ldr r0, [r4, #0x4c]
 	sub ip, r1, #0x2800
 	str r0, [sp, #0x2c]
-	ldr sb, [r4, #0x50]
+	ldr r9, [r4, #0x50]
 	ldr r11, _021724c4 ; =0x00001266
 	str r0, [sp, #0x38]
-	str sb, [sp, #0x30]
+	str r9, [sp, #0x30]
 	mov r0, #0
 	sub r0, r0, #1
 	str r10, [sp, #0x34]
-	str sb, [sp, #0x3c]
+	str r9, [sp, #0x3c]
 	ldrh r2, [r4, #0x78]
 	str r0, [sp, #0xc]
 	mov lr, ip
@@ -97145,7 +97145,7 @@ func_ov15_02172260: ; 0x02172260
 	adc r3, r7, #0
 	mov r5, r5, lsr #0xc
 	orr r5, r5, r3, lsl #20
-	add r3, sb, r5
+	add r3, r9, r5
 	str r3, [sp, #0x3c]
 	ldrh r3, [r4, #0x78]
 	mov r0, #0
@@ -97180,7 +97180,7 @@ func_ov15_02172260: ; 0x02172260
 	adc r3, r6, #0
 	mov r5, r5, lsr #0xc
 	orr r5, r5, r3, lsl #20
-	add r3, sb, r5
+	add r3, r9, r5
 	add r0, sp, #0x28
 	add r2, sp, #0x1c
 	str r3, [sp, #0x30]
@@ -97230,11 +97230,11 @@ func_ov15_02172260: ; 0x02172260
 	cmp r1, r0
 	addlt sp, sp, #0x40
 	movlt r0, #1
-	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmltia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _021724b8:
 	mov r0, #0
 	add sp, sp, #0x40
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02172260
 _021724c4: .word 0x00001266
@@ -97314,17 +97314,17 @@ _021725c8: .word data_027e0f94
 	.global func_ov15_021725cc
 	arm_func_start func_ov15_021725cc
 func_ov15_021725cc: ; 0x021725cc
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #8
 	mov r5, r0
 	ldr r0, [r5, #0x578]
 	cmp r0, #0
 	addeq sp, sp, #8
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	ldr r0, [r5, #0x554]
 	cmp r0, #0
 	addne sp, sp, #8
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	mov r0, #1
 	strb r0, [sp]
 	ldr r1, [r5, #0x550]
@@ -97354,7 +97354,7 @@ func_ov15_021725cc: ; 0x021725cc
 	cmp r6, #0x2a
 	bne _021726b0
 	add sp, sp, #8
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _02172670:
 	ands r6, r4, #0xfc0
 	beq _021726b0
@@ -97371,7 +97371,7 @@ _02172670:
 	bl func_ov15_021728ac
 	cmp r6, #0xa80
 	addeq sp, sp, #8
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _021726b0:
 	ldrb lr, [sp]
 	cmp lr, #0
@@ -97386,16 +97386,16 @@ _021726b0:
 _021726d8:
 	cmp lr, #0
 	addne sp, sp, #8
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	ldrh r1, [sp, #2]
 	ldr r0, _02172848 ; =0x000037dc
 	cmp r1, r0
 	addlo sp, sp, #8
-	ldmloia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmloia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	ldr r0, _0217284c ; =0x00005208
 	cmp r1, r0
 	addhi sp, sp, #8
-	ldmhiia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmhiia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _02172708:
 	ldrb r0, [r5, #0x56f]
 	cmp r0, #0
@@ -97412,7 +97412,7 @@ _02172728:
 	subne r1, r1, #1
 	strneh r1, [r0, #0x62]
 	addne sp, sp, #8
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	mov r0, #3
 	mov r1, #0
 	ldr r8, _02172850 ; =data_027e0764
@@ -97420,21 +97420,21 @@ _02172728:
 	mov r6, r0
 _02172758:
 	ldr r10, [r8, #8]
-	ldmia r8, {sb, ip}
-	umull r3, r2, r10, sb
+	ldmia r8, {r9, ip}
+	umull r3, r2, r10, r9
 	mla r2, r10, ip, r2
 	ldr r10, [r8, #0xc]
 	ldr ip, [r8, #0x10]
-	mla r2, r10, sb, r2
-	ldr sb, [r8, #0x14]
+	mla r2, r10, r9, r2
+	ldr r9, [r8, #0x14]
 	adds r3, ip, r3
-	adc sb, sb, r2
-	umull ip, r2, sb, r6
-	mla r2, sb, r7, r2
+	adc r9, r9, r2
+	umull ip, r2, r9, r6
+	mla r2, r9, r7, r2
 	mla r2, r1, r6, r2
 	cmp lr, #1
 	addeq r2, r2, #3
-	stmia r8, {r3, sb}
+	stmia r8, {r3, r9}
 	mov r3, r2, lsl #0x1
 	and r3, r4, r0, lsl r3
 	cmp r3, #2
@@ -97478,7 +97478,7 @@ _02172830:
 	mov r1, #0x1e
 	strh r1, [r0, #0x66]
 	add sp, sp, #8
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov15_021725cc
 _02172844: .word 0x00002af8
@@ -97858,7 +97858,7 @@ _02172d8c: .word data_027e0e58
 	.global func_ov15_02172d90
 	arm_func_start func_ov15_02172d90
 func_ov15_02172d90: ; 0x02172d90
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x1c
 	mov r4, r0
 	ldr r1, [r4, #0x48]
@@ -97894,15 +97894,15 @@ func_ov15_02172d90: ; 0x02172d90
 	mov r0, r0, lsl #0x1
 	ldr r2, _02172ef4 ; =0x0000119a
 	ldrsh r5, [r1, r0]
-	umull r0, sb, r8, r2
+	umull r0, r9, r8, r2
 	umull r7, r6, r5, r2
 	adds r1, r0, #0x800
-	mla sb, r8, r3, sb
+	mla r9, r8, r3, r9
 	mov r0, r8, asr #0x1f
 	mla r6, r5, r3, r6
-	mla sb, r0, r2, sb
+	mla r9, r0, r2, r9
 	mov r8, r1, lsr #0xc
-	adc r0, sb, #0
+	adc r0, r9, #0
 	mov r1, r5, asr #0x1f
 	orr r8, r8, r0, lsl #20
 	ldr r3, [sp, #0x10]
@@ -97936,7 +97936,7 @@ func_ov15_02172d90: ; 0x02172d90
 	add r2, r4, #0x48
 	bl func_ov00_020cec60
 	add sp, sp, #0x1c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _02172ecc:
 	add r0, r4, #0x5c
 	add r0, r0, #0x400
@@ -97945,7 +97945,7 @@ _02172ecc:
 	add r0, r0, #0x400
 	bl func_ov00_020b7e6c
 	add sp, sp, #0x1c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02172d90
 _02172eec: .word data_027e0e60
@@ -98168,7 +98168,7 @@ _02173178: .word func_ov15_0216fe00
 	.global func_ov15_0217317c
 	arm_func_start func_ov15_0217317c
 func_ov15_0217317c: ; 0x0217317c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0xac
 	ldr r3, _021733a0 ; =data_027e0f64
 	mov r5, r1
@@ -98183,7 +98183,7 @@ func_ov15_0217317c: ; 0x0217317c
 	ldmia r7, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
 	add r0, r6, #0x11c
-	add sb, r0, #0x400
+	add r9, r0, #0x400
 	add r3, sp, #0x2c
 	ldmia r7, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
@@ -98204,7 +98204,7 @@ func_ov15_0217317c: ; 0x0217317c
 	ldr r3, _021733a8 ; =data_027e0e60
 	mov r0, r0, lsl #0x10
 	mov r7, r0, lsr #0x10
-	ldmia sb, {r0, r1, r2}
+	ldmia r9, {r0, r1, r2}
 	stmia r8, {r0, r1, r2}
 	ldr r2, [sp, #0x20]
 	ldr r1, [sp, #0x24]
@@ -98250,8 +98250,8 @@ _02173264:
 	mov r8, r2, lsl #0x1
 	add r2, r2, #1
 	adc lr, r3, #0
-	smull sb, r0, r1, r0
-	adds r1, sb, #0x800
+	smull r9, r0, r1, r0
+	adds r1, r9, #0x800
 	mov r7, r7, lsr #0xc
 	mov r2, r2, lsl #0x1
 	ldrsh r3, [ip, r8]
@@ -98306,7 +98306,7 @@ _02173350:
 	mov r2, #2
 	bl func_ov00_02089318
 	add sp, sp, #0xac
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0217317c
 _021733a0: .word data_027e0f64
@@ -98995,7 +98995,7 @@ func_ov15_02173c84: ; 0x02173c84
 	.global func_ov15_02173cb4
 	arm_func_start func_ov15_02173cb4
 func_ov15_02173cb4: ; 0x02173cb4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x78
 	mov r4, r0
 	add r0, r4, #0x48
@@ -99043,7 +99043,7 @@ func_ov15_02173cb4: ; 0x02173cb4
 	bl _ZN12ActorManager8GetActorEP8ActorRef
 	movs r4, r0
 	addeq sp, sp, #0x78
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, _02173fdc ; =data_027e0ffc
 	ldr r1, _02173fe0 ; =0x000002eb
 	add r2, sp, #0x6c
@@ -99059,25 +99059,25 @@ func_ov15_02173cb4: ; 0x02173cb4
 	ldr lr, _02173fec ; =data_02050f54
 	ldr r6, [r0, #8]
 	ldr r10, [r0]
-	ldr sb, [r0, #4]
+	ldr r9, [r0, #4]
 	umull ip, r11, r6, r10
-	mla r11, r6, sb, r11
+	mla r11, r6, r9, r11
 	ldr r5, [r0, #0xc]
 	ldr r8, [r0, #0x10]
 	mla r11, r5, r10, r11
 	ldr r7, [r0, #0x14]
 	mov r0, #0
 	adds r10, r8, ip
-	adc sb, r7, r11
+	adc r9, r7, r11
 	mov r3, r0, lsl #0x10
-	orr r3, r3, sb, lsr #16
+	orr r3, r3, r9, lsr #16
 	sub r3, r3, #0x8000
 	ldr r11, _02173fe8 ; =data_027e0764
 	mov r3, r3, lsl #0x10
 	mov r3, r3, lsr #0x10
 	str r10, [r11]
 	mov r3, r3, asr #0x4
-	str sb, [r11, #4]
+	str r9, [r11, #4]
 	mov r11, r3, lsl #0x1
 	mov r3, r11, lsl #0x1
 	add r11, r11, #1
@@ -99085,7 +99085,7 @@ func_ov15_02173cb4: ; 0x02173cb4
 	ldrsh r3, [lr, r3]
 	ldrsh r11, [lr, r11]
 	umull lr, ip, r6, r10
-	mla ip, r6, sb, ip
+	mla ip, r6, r9, ip
 	mla ip, r5, r10, ip
 	adds r8, r8, lr
 	ldr r5, _02173fe8 ; =data_027e0764
@@ -99151,7 +99151,7 @@ func_ov15_02173cb4: ; 0x02173cb4
 	ldr r2, _02173fec ; =data_02050f54
 	mov r1, r1, lsl #0x1
 	mov r0, r0, lsl #0x1
-	ldrsh sb, [r2, r0]
+	ldrsh r9, [r2, r0]
 	ldrsh r1, [r2, r1]
 	mov r3, #0xf6
 	mov r2, #0
@@ -99166,10 +99166,10 @@ func_ov15_02173cb4: ; 0x02173cb4
 	add r6, r7, #0
 	ldr r7, [sp, #0x38]
 	ldr r0, [sp, #0x70]
-	mov r8, sb, asr #0x1f
+	mov r8, r9, asr #0x1f
 	sub r0, r7, r0
-	umull r10, r7, sb, r3
-	mla r7, sb, r2, r7
+	umull r10, r7, r9, r3
+	mla r7, r9, r2, r7
 	mla r7, r8, r3, r7
 	adds r3, r10, #0x800
 	adc r2, r7, #0
@@ -99192,7 +99192,7 @@ func_ov15_02173cb4: ; 0x02173cb4
 	str r0, [r4, #0x64]
 	str r7, [r4, #0x68]
 	add sp, sp, #0x78
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02173cb4
 _02173fcc: .word data_027e0e58
@@ -101692,7 +101692,7 @@ _02176114: .word func_ov15_02176300
 	.global func_ov15_02176118
 	arm_func_start func_ov15_02176118
 func_ov15_02176118: ; 0x02176118
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	bl func_ov15_0213ce4c
 	bl func_ov15_0213d1ec
 	ldr r4, _021762cc ; =0x04000488
@@ -101748,7 +101748,7 @@ _02176138:
 	add r0, r7, #0x80
 	bl func_ov05_0210e288
 	ldr r1, _021762dc ; =data_02050f54
-	mov sb, r0
+	mov r9, r0
 	add r1, r1, r8, lsl #1
 	ldrsh r1, [r1, #2]
 	mov r1, r1, lsl #0x6
@@ -101759,14 +101759,14 @@ _02176138:
 	bl func_ov05_0210e2a4
 	mov r0, r0, lsl #0x10
 	mov r0, r0, lsr #0x10
-	mov r2, sb, lsl #0x10
+	mov r2, r9, lsl #0x10
 	mov r1, #0x400
 	mov r0, r0, lsl #0x10
 	str r1, [r4]
 	orr r0, r0, r2, lsr #16
-	rsb sb, r8, #0x80
+	rsb r9, r8, #0x80
 	str r0, [r4, #0xc]
-	add r0, sb, r10, asr #12
+	add r0, r9, r10, asr #12
 	bl func_ov05_0210e288
 	mov r10, r0
 	rsb r7, r7, #0xc0
@@ -101780,7 +101780,7 @@ _02176138:
 	str r1, [r4]
 	orr r0, r0, r2, lsr #16
 	str r0, [r4, #0xc]
-	mov r0, sb
+	mov r0, r9
 	bl func_ov05_0210e288
 	mov r8, r0
 	mov r0, r7
@@ -101801,7 +101801,7 @@ _02176138:
 	cmp r6, #4
 	mov r5, r0, lsr #0x10
 	blt _02176138
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02176118
 _021762cc: .word 0x04000488
@@ -102655,13 +102655,13 @@ _02176e30:
 	.global func_ov15_02176ed8
 	arm_func_start func_ov15_02176ed8
 func_ov15_02176ed8: ; 0x02176ed8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	ldr r2, _02177050 ; =data_027e0618
 	mov r10, r0
 	ldrb r0, [r2, #0x101]
 	mov r4, r1
 	cmp r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, _02177054 ; =data_027e0c54
 	bl func_020360a8
 	mov r1, r0
@@ -102670,20 +102670,20 @@ func_ov15_02176ed8: ; 0x02176ed8
 	cmp r0, #0
 	ldrne r8, [r10, #0x318]
 	cmpne r8, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, _02177058 ; =data_027e0c38
-	mov sb, #0
+	mov r9, #0
 	ldr r0, [r0, #0x10]
 	add r5, r10, #0x17c
 	cmp r0, #1
 	addeq r8, r8, #0x28
 	add r4, r10, #0x300
-	mov r6, sb
+	mov r6, r9
 	mov r11, #0x62
-	mov r7, sb
+	mov r7, r9
 _02176f40:
 	ldrsh r0, [r4, #0x28]
-	cmp r0, sb
+	cmp r0, r9
 	ble _02176f60
 	mov r3, r7
 	add r0, r5, #0x400
@@ -102697,8 +102697,8 @@ _02176f60:
 	ldmia r8, {r2, r3}
 	bl func_02034984
 _02176f74:
-	add sb, sb, #1
-	cmp sb, #5
+	add r9, r9, #1
+	cmp r9, #5
 	add r8, r8, #8
 	blt _02176f40
 	ldr r4, [r10, #0x318]
@@ -102741,17 +102741,17 @@ _02176f74:
 	bl func_02034984
 	ldrb r0, [r10, #0x351]
 	cmp r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, [r10, #0x324]
 	cmp r0, #1
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r0, r10, #0x204
 	ldr r1, [r4, #0x70]
 	ldr r2, [r4, #0x74]
 	add r0, r0, #0x400
 	mov r3, #0
 	bl func_02034a1c
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02176ed8
 _02177050: .word data_027e0618
@@ -102791,7 +102791,7 @@ _02177088: .word func_ov09_0211372c
 	.global func_ov15_0217708c
 	arm_func_start func_ov15_0217708c
 func_ov15_0217708c: ; 0x0217708c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	mov r0, #1
 	str r0, [sp]
 	ldr r11, [sp]
@@ -102802,7 +102802,7 @@ func_ov15_0217708c: ; 0x0217708c
 	mov r6, r11
 	mov r7, r11
 	mov r8, r11
-	mov sb, r11
+	mov r9, r11
 	mov r10, r11
 	bl func_ov00_02097738
 	cmp r0, #0
@@ -102828,9 +102828,9 @@ _02177104:
 	ldr r0, [r0]
 	ldr r0, [r0, #0x2c]
 	cmp r0, #1
-	movne sb, #0
+	movne r9, #0
 _02177120:
-	cmp sb, #0
+	cmp r9, #0
 	bne _0217713c
 	ldr r0, _0217720c ; =data_027e10a4
 	ldr r0, [r0]
@@ -102891,7 +102891,7 @@ _021771d4:
 	strne r0, [sp]
 _021771f4:
 	ldr r0, [sp]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0217708c
 _021771fc: .word data_027e0f74
@@ -103487,7 +103487,7 @@ _02177960: .word data_027e10b0
 	.global func_ov15_02177964
 	arm_func_start func_ov15_02177964
 func_ov15_02177964: ; 0x02177964
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x7c
 	ldr r1, _02177ef4 ; =data_027e10b0
 	mov r4, r0
@@ -103542,12 +103542,12 @@ func_ov15_02177964: ; 0x02177964
 	ldr r3, [r4, #0x4c]
 	sub ip, r5, #0x11
 	str r3, [r4, #0x1cc]
-	ldr sb, [r4, #0x50]
+	ldr r9, [r4, #0x50]
 	mov r3, #2
-	str sb, [r4, #0x1d0]
-	ldrsh sb, [r4, #0x78]
+	str r9, [r4, #0x1d0]
+	ldrsh r9, [r4, #0x78]
 	ldr r11, _02177f00 ; =0x0000a332
-	strh sb, [r1, #0xd4]
+	strh r9, [r1, #0xd4]
 	str r8, [r4, #0x44c]
 	str r7, [r4, #0x198]
 	str r6, [r4, #0x19c]
@@ -103585,39 +103585,39 @@ func_ov15_02177964: ; 0x02177964
 	mov r7, #0xf
 	strh r6, [r1, #0x6a]
 	strh r8, [r1, #0x6e]
-	ldrsh sb, [r1, #0x6e]
+	ldrsh r9, [r1, #0x6e]
 	mov r6, #0x3d
 	ldr lr, _02177f08 ; =data_027e0d38
-	strh sb, [r1, #0x6c]
+	strh r9, [r1, #0x6c]
 	str r8, [r4, #0x164]
 	str r8, [r4, #0x160]
-	ldr sb, [r4, #0x4c]
+	ldr r9, [r4, #0x4c]
 	str r8, [sp, #0xc]
-	str sb, [r4, #0x1a0]
-	ldr sb, [r4, #8]
-	str sb, [r4, #0x334]
-	ldr sb, [r4, #0xc]
-	str sb, [r4, #0x338]
+	str r9, [r4, #0x1a0]
+	ldr r9, [r4, #8]
+	str r9, [r4, #0x334]
+	ldr r9, [r4, #0xc]
+	str r9, [r4, #0x338]
 	strb r8, [r4, #0x368]
 	str r5, [r4, #0x3a0]
 	str r3, [r4, #0x3a4]
 	str r5, [r4, #0x3ac]
 	str r3, [r4, #0x3b0]
 	ldr r11, [r2]
-	ldmib r2, {sb, ip}
+	ldmib r2, {r9, ip}
 	umull r5, r3, ip, r11
-	mla r3, ip, sb, r3
-	ldr sb, [r2, #0xc]
+	mla r3, ip, r9, r3
+	ldr r9, [r2, #0xc]
 	ldr ip, [r2, #0x10]
-	mla r3, sb, r11, r3
-	ldr sb, [r2, #0x14]
+	mla r3, r9, r11, r3
+	ldr r9, [r2, #0x14]
 	adds r5, ip, r5
-	adc r11, sb, r3
-	umull r3, sb, r11, r6
-	mla sb, r11, r8, sb
-	mla sb, r10, r6, sb
+	adc r11, r9, r3
+	umull r3, r9, r11, r6
+	mla r9, r11, r8, r9
+	mla r9, r10, r6, r9
 	stmia r2, {r5, r11}
-	add r2, sb, #0x3c
+	add r2, r9, #0x3c
 	strh r2, [r0, #0x64]
 	strh r7, [r1, #0x20]
 	ldr r0, [lr]
@@ -103663,7 +103663,7 @@ _02177bd4:
 _02177c14:
 	add sp, sp, #0x7c
 	mov r0, r8
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02177c20:
 	ldr r3, [r4, #0x4c]
 	ldr r2, [r4, #0x50]
@@ -103707,9 +103707,9 @@ _02177c84:
 	orr r1, r1, #0x4000
 	bic r1, r1, #0x1f
 	orr r3, r1, #7
-	add sb, sp, #0x70
+	add r9, sp, #0x70
 	ldmia r0, {r0, r1, r2}
-	stmia sb, {r0, r1, r2}
+	stmia r9, {r0, r1, r2}
 	ldr r2, [sp, #0x78]
 	ldr r1, [sp, #0x70]
 	add r2, r2, #0x3000
@@ -103738,7 +103738,7 @@ _02177c84:
 	cmp r0, #5
 	addeq sp, sp, #0x7c
 	moveq r0, #1
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r0, sp, #0x44
 	bl func_ov00_020c1500
 	mvn r1, #0
@@ -103770,7 +103770,7 @@ _02177c84:
 	cmp r1, r0
 	addeq sp, sp, #0x7c
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, _02177f20 ; =data_027e0fe4
 	add r1, sp, #4
 	ldr r0, [r0]
@@ -103791,7 +103791,7 @@ _02177c84:
 	cmp r1, r0
 	addeq sp, sp, #0x7c
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, _02177f20 ; =data_027e0fe4
 	add r1, sp, #4
 	ldr r0, [r0]
@@ -103812,7 +103812,7 @@ _02177c84:
 	cmp r1, r0
 	addeq sp, sp, #0x7c
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, _02177f20 ; =data_027e0fe4
 	add r1, sp, #4
 	ldr r0, [r0]
@@ -103835,7 +103835,7 @@ _02177c84:
 	cmp r1, r0
 	addeq sp, sp, #0x7c
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, _02177f20 ; =data_027e0fe4
 	add r1, sp, #4
 	ldr r0, [r0]
@@ -103847,7 +103847,7 @@ _02177c84:
 	str r0, [r4, #0x3bc]
 	mov r0, #1
 	add sp, sp, #0x7c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02177964
 _02177ef4: .word data_027e10b0
@@ -103892,7 +103892,7 @@ _02177f58: .word 0x434e424c
 	.global func_ov15_02177f5c
 	arm_func_start func_ov15_02177f5c
 func_ov15_02177f5c: ; 0x02177f5c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x28
 	mov r6, r1
 	mov r7, r0
@@ -103943,14 +103943,14 @@ _02177fa0:
 	ble _0217804c
 	ldr r8, _0217812c ; =data_027e0fe4
 	mov r5, r4
-	mov sb, r4
+	mov r9, r4
 _02178020:
 	ldr r1, [sp, #4]
 	ldr r0, [r8]
 	add r1, r1, r5
 	bl _ZN12ActorManager8GetActorEP8ActorRef
 	cmp r0, #0
-	strneb sb, [r0, #0x118]
+	strneb r9, [r0, #0x118]
 	ldr r0, [sp, #0xc]
 	add r4, r4, #1
 	cmp r4, r0
@@ -104015,7 +104015,7 @@ _02178114:
 	str r0, [r7, #0x138]
 	str r6, [r7, #0x130]
 	add sp, sp, #0x28
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02177f5c
 _02178128: .word data_027e10a4
@@ -104742,7 +104742,7 @@ _02178b78: .word data_ov15_0218ddc8
 	.global func_ov15_02178b7c
 	arm_func_start func_ov15_02178b7c
 func_ov15_02178b7c: ; 0x02178b7c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x30
 	mov r4, r0
 	bl func_ov15_0217aa30
@@ -104779,13 +104779,13 @@ func_ov15_02178b7c: ; 0x02178b7c
 	ldrb ip, [sp, #0x2b]
 	ldrb r3, [sp, #0x2c]
 	ldrb r2, [sp, #0x2d]
-	ldr sb, [sp, #0x18]
+	ldr r9, [sp, #0x18]
 	ldr r8, [sp, #0x1c]
 	ldr r7, [sp, #0x20]
 	ldr r6, [sp, #0x24]
 	ldr r0, [r0]
 	add r1, sp, #0
-	str sb, [sp]
+	str r9, [sp]
 	str r8, [sp, #4]
 	str r7, [sp, #8]
 	str r6, [sp, #0xc]
@@ -104801,7 +104801,7 @@ _02178c58:
 	mov r0, r4
 	bl func_ov15_0217a734
 	add sp, sp, #0x30
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02178b7c
 _02178c68: .word data_027e0e60
@@ -105054,7 +105054,7 @@ _02178ff4: .word 0xffffe99a
 	.global func_ov15_02178ff8
 	arm_func_start func_ov15_02178ff8
 func_ov15_02178ff8: ; 0x02178ff8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0xa0
 	ldrh r1, [r1]
 	mov r10, r0
@@ -105063,7 +105063,7 @@ func_ov15_02178ff8: ; 0x02178ff8
 	bne _02179020
 	tst r1, #8
 	addeq sp, sp, #0xa0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02179020:
 	cmp r4, #0x69
 	beq _021790c8
@@ -105080,7 +105080,7 @@ _02179020:
 	bl func_ov00_02079470
 	cmp r0, #0
 	addeq sp, sp, #0xa0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r0, sp, #0x80
 	bl func_01ffbe34
 	mov r0, #1
@@ -105108,7 +105108,7 @@ _021790a4:
 	mov r3, r4
 	bl func_020313c8
 	add sp, sp, #0xa0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _021790c8:
 	add r0, sp, #0x60
 	bl func_01ffbe34
@@ -105119,7 +105119,7 @@ _021790c8:
 	add r0, sp, #0x50
 	ldr r7, _02179338 ; =data_ov15_02186e60
 	ldr r6, _0217933c ; =data_ov15_02186e9c
-	mov sb, #0
+	mov r9, #0
 	str r0, [sp, #0x60]
 	add r4, r10, #0x400
 	add r11, sp, #0x44
@@ -105129,7 +105129,7 @@ _02179104:
 	ldrh r0, [r4, #0x6a]
 	tst r0, r8, lsl sb
 	bne _0217916c
-	ldr r2, [r7, sb, lsl #2]
+	ldr r2, [r7, r9, lsl #2]
 	mov r0, r11
 	add r1, r6, r2, lsl #3
 	ldr r2, [r6, r2, lsl #3]
@@ -105153,8 +105153,8 @@ _02179104:
 	mov r3, #0x6a
 	bl func_020313c8
 _0217916c:
-	add sb, sb, #1
-	cmp sb, #0xf
+	add r9, r9, #1
+	cmp r9, #0xf
 	blt _02179104
 	ldr r0, _02179340 ; =data_027e0d0c
 	add r4, sp, #0x38
@@ -105186,22 +105186,22 @@ _0217916c:
 	mov r1, r4
 	mov r0, #0x7000
 	mov r4, r5, asr #0x4
-	mov sb, r4, lsl #0x1
-	mov r4, sb, lsl #0x1
+	mov r9, r4, lsl #0x1
+	mov r4, r9, lsl #0x1
 	ldrsh r5, [r3, r4]
-	add r4, sb, #1
-	umull r11, sb, r8, r0
+	add r4, r9, #1
+	umull r11, r9, r8, r0
 	mov r4, r4, lsl #0x1
 	ldrsh r4, [r3, r4]
-	mla sb, r8, r2, sb
+	mla r9, r8, r2, r9
 	mov r7, r8, asr #0x1f
-	mla sb, r7, r0, sb
+	mla r9, r7, r0, r9
 	adds r7, r11, #0x800
-	adc r0, sb, #0
-	mov sb, r7, lsr #0xc
-	orr sb, sb, r0, lsl #20
-	smull r8, r7, r5, sb
-	smull r5, r0, r4, sb
+	adc r0, r9, #0
+	mov r9, r7, lsr #0xc
+	orr r9, r9, r0, lsl #20
+	smull r8, r7, r5, r9
+	smull r5, r0, r4, r9
 	adds r8, r8, #0x800
 	adc r4, r7, #0
 	mov r7, r8, lsr #0xc
@@ -105264,7 +105264,7 @@ _0217916c:
 	str r5, [sp]
 	bl func_020313c8
 	add sp, sp, #0xa0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02178ff8
 _0217932c: .word data_027e0d3c
@@ -105279,7 +105279,7 @@ _02179348: .word data_02051f54
 	.global func_ov15_0217934c
 	arm_func_start func_ov15_0217934c
 func_ov15_0217934c: ; 0x0217934c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0xc8
 	mov r5, r1
 	ldr r3, [r5, #0x14]
@@ -105289,7 +105289,7 @@ func_ov15_0217934c: ; 0x0217934c
 	cmp r2, r1
 	addne sp, sp, #0xc8
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r0, r3, #0x48
 	add r8, sp, #0xbc
 	ldmia r0, {r0, r1, r2}
@@ -105311,11 +105311,11 @@ func_ov15_0217934c: ; 0x0217934c
 	cmp r1, r0
 	addge sp, sp, #0xc8
 	movge r0, #0
-	ldmgeia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmgeia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r0, r4, #0x48
-	add sb, sp, #0xa0
+	add r9, sp, #0xa0
 	ldmia r0, {r0, r1, r2}
-	stmia sb, {r0, r1, r2}
+	stmia r9, {r0, r1, r2}
 	ldrh r0, [r4, #0x78]
 	ldr r1, [sp, #0xa4]
 	ldr r2, _021796a8 ; =data_02050f54
@@ -105338,15 +105338,15 @@ func_ov15_0217934c: ; 0x0217934c
 	mov r7, r0, lsr #0xc
 	mov r0, r8
 	str r10, [sp, #0xa4]
-	mov r1, sb
-	ldr sb, [r4, #0x448]
+	mov r1, r9
+	ldr r9, [r4, #0x448]
 	ldr r2, _021796ac ; =0xffffeccd
-	sub sb, r10, sb
-	str sb, [sp, #0xa4]
-	mov sb, r5, asr #0x1f
+	sub r9, r10, r9
+	str r9, [sp, #0xa4]
+	mov r9, r5, asr #0x1f
 	ldr r5, _021796ac ; =0xffffeccd
 	mov r3, r3, asr #0x1f
-	mla r6, sb, r5, r6
+	mla r6, r9, r5, r6
 	adc r5, r6, #0
 	mla ip, r3, r2, ip
 	adds r3, lr, #0x800
@@ -105392,7 +105392,7 @@ func_ov15_0217934c: ; 0x0217934c
 	str r0, [sp, #0x98]
 	ldr r0, [sp, #0x78]
 	add r8, sp, #0x4c
-	add sb, r4, #0x3d0
+	add r9, r4, #0x3d0
 	str r1, [sp, #0x94]
 	str r0, [sp, #0x9c]
 	mov r7, r8
@@ -105400,7 +105400,7 @@ func_ov15_0217934c: ; 0x0217934c
 	stmia r8!, {r0, r1, r2, r3}
 	ldmia sb!, {r0, r1, r2, r3}
 	stmia r8!, {r0, r1, r2, r3}
-	ldmia sb, {r0, r1, r2, r3}
+	ldmia r9, {r0, r1, r2, r3}
 	stmia r8, {r0, r1, r2, r3}
 	ldr r6, _021796b0 ; =data_ov15_0218ddc4
 	mov r0, r7
@@ -105418,7 +105418,7 @@ func_ov15_0217934c: ; 0x0217934c
 	ldr r1, [sp, #0x70]
 	str r0, [sp, #0x8c]
 	ldr r0, [sp, #0x78]
-	add sb, r4, #0x3d0
+	add r9, r4, #0x3d0
 	mov r8, r7
 	str r1, [sp, #0x88]
 	str r0, [sp, #0x90]
@@ -105426,7 +105426,7 @@ func_ov15_0217934c: ; 0x0217934c
 	stmia r8!, {r0, r1, r2, r3}
 	ldmia sb!, {r0, r1, r2, r3}
 	stmia r8!, {r0, r1, r2, r3}
-	ldmia sb, {r0, r1, r2, r3}
+	ldmia r9, {r0, r1, r2, r3}
 	stmia r8, {r0, r1, r2, r3}
 	ldr r1, [r6, #0x34]
 	add r2, r5, #0x5b00
@@ -105486,14 +105486,14 @@ func_ov15_0217934c: ; 0x0217934c
 	cmpge r0, #0
 	addlt sp, sp, #0xc8
 	movlt r0, #0
-	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmltia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0217968c:
 	add r0, r4, #0x1d8
 	mov r1, #1
 	bl func_ov00_020c5d74
 	mov r0, #1
 	add sp, sp, #0xc8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0217934c
 _021796a4: .word 0x434e424c
@@ -105581,7 +105581,7 @@ _021797cc: .word data_027e0f94
 	.global func_ov15_021797d0
 	arm_func_start func_ov15_021797d0
 func_ov15_021797d0: ; 0x021797d0
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0xc
 	mov r7, r0
 	add r1, r7, #0x400
@@ -105590,7 +105590,7 @@ func_ov15_021797d0: ; 0x021797d0
 	subne r0, r0, #1
 	strneh r0, [r1, #0x64]
 	addne sp, sp, #0xc
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r2, _02179ac0 ; =data_027e0764
 	mov r5, #0
 	ldr r3, [r2]
@@ -105632,23 +105632,23 @@ _0217987c:
 	ldrb r11, [sp]
 	cmp r11, #0
 	addeq sp, sp, #0xc
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldrh r2, [sp, #8]
 	ldr r3, _02179ac0 ; =data_027e0764
 	mov ip, #1
 	mov lr, #0
 _021798ac:
-	ldr sb, [r3]
+	ldr r9, [r3]
 	ldmib r3, {r8, r10}
-	umull r1, r0, r10, sb
+	umull r1, r0, r10, r9
 	mla r0, r10, r8, r0
 	ldr r8, [r3, #0xc]
 	ldr r10, [r3, #0x10]
-	mla r0, r8, sb, r0
-	ldr sb, [r3, #0x14]
+	mla r0, r8, r9, r0
+	ldr r9, [r3, #0x14]
 	adds r1, r10, r1
 	mov r8, lr, lsl #0x2
-	adc r0, sb, r0
+	adc r0, r9, r0
 	orr r8, r8, r0, lsr #30
 	mov r8, r8, lsl #0x10
 	str r1, [r3]
@@ -105657,9 +105657,9 @@ _021798ac:
 	tst r2, ip, lsl r8
 	bne _021798ac
 	mov r3, #0x1e000
-	sub sb, r3, #0x1f000
+	sub r9, r3, #0x1f000
 	strh r8, [sp, #6]
-	cmp r4, sb
+	cmp r4, r9
 	blt _02179910
 	cmp r4, #0x1000
 	ble _02179914
@@ -105710,10 +105710,10 @@ _02179988:
 	mov r5, #1
 	mov r7, r3
 _021799bc:
-	ldr sb, [r4, #8]
+	ldr r9, [r4, #8]
 	ldr r3, [r4, #0xc]
-	umull r11, r10, sb, r1
-	mla r10, sb, r0, r10
+	umull r11, r10, r9, r1
+	mla r10, r9, r0, r10
 	mla r10, r3, r1, r10
 	ldr r1, [r4, #0x10]
 	ldr r0, [r4, #0x14]
@@ -105743,12 +105743,12 @@ _02179a20:
 	ldr r4, _02179ac0 ; =data_027e0764
 	ldr r7, [r4, #8]
 	ldr r5, [r4, #0xc]
-	umull sb, r8, r7, r1
+	umull r9, r8, r7, r1
 	mla r8, r7, r0, r8
 	mla r8, r5, r1, r8
 	ldr r7, [r4, #0x10]
 	ldr r0, [r4, #0x14]
-	adds r1, r7, sb
+	adds r1, r7, r9
 	adc r5, r0, r8
 	stmia r4, {r1, r5}
 	cmp r2, #0
@@ -105768,7 +105768,7 @@ _02179a78:
 	strneh r0, [sp, #4]
 	bne _02179aa8
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02179aa0:
 	mov r0, #0
 	strh r0, [sp, #4]
@@ -105778,7 +105778,7 @@ _02179aa8:
 	mov r0, r6
 	bl func_ov15_0217bbb0
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_021797d0
 _02179ac0: .word data_027e0764
@@ -106744,7 +106744,7 @@ _0217a84c: .word data_027e0e58
 	.global func_ov15_0217a850
 	arm_func_start func_ov15_0217a850
 func_ov15_0217a850: ; 0x0217a850
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x130
 	mov r4, r0
 	add r0, sp, #0x80
@@ -106834,7 +106834,7 @@ func_ov15_0217a850: ; 0x0217a850
 	ldrb r2, [sp, #0x7c]
 	ldr r0, [sp, #0x60]
 	ldr r10, [sp, #0x64]
-	ldr sb, [sp, #0x68]
+	ldr r9, [sp, #0x68]
 	ldr r8, [sp, #0x6c]
 	ldr r7, [sp, #0x70]
 	ldr r6, [sp, #0x74]
@@ -106844,7 +106844,7 @@ func_ov15_0217a850: ; 0x0217a850
 	ldr r0, [r1]
 	add r1, sp, #0x80
 	str r10, [sp, #0xf8]
-	str sb, [sp, #0xfc]
+	str r9, [sp, #0xfc]
 	str r8, [sp, #0x100]
 	str r7, [sp, #0x104]
 	str r6, [sp, #0x108]
@@ -106859,7 +106859,7 @@ func_ov15_0217a850: ; 0x0217a850
 	add r0, sp, #0x80
 	bl func_ov00_0209a508
 	add sp, sp, #0x130
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0217a850
 _0217aa20: .word data_027e0e60
@@ -107936,7 +107936,7 @@ func_ov15_0217b848: ; 0x0217b848
 	.global func_ov15_0217b84c
 	arm_func_start func_ov15_0217b84c
 func_ov15_0217b84c: ; 0x0217b84c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x12c
 	mov r4, r0
 	ldrh r5, [r4, #0x20]
@@ -107948,7 +107948,7 @@ func_ov15_0217b84c: ; 0x0217b84c
 	bne _0217b8c4
 	mul r0, r8, r1
 	ldrb r2, [r4, #0x2e4]
-	ldr sb, _0217ba9c ; =data_ov15_0218e010
+	ldr r9, _0217ba9c ; =data_ov15_0218e010
 	ldr r10, _0217baa0 ; =data_ov15_0218e00c
 	mov r7, r8, lsl #0x1
 	ldr r5, _0217baa4 ; =data_ov15_02186fa8
@@ -107958,13 +107958,13 @@ func_ov15_0217b84c: ; 0x0217b84c
 	ldr r3, _0217baac ; =data_ov15_02186fae
 	ldrh r5, [r5, r7]
 	cmp r2, #0
-	ldr sb, [sb, r0]
+	ldr r9, [r9, r0]
 	ldrh r6, [r4, #0x78]
 	ldrh r7, [r3, r7]
 	beq _0217b91c
 	sub r0, r1, #0xd
-	mul r0, sb, r0
-	mov sb, r0
+	mul r0, r9, r0
+	mov r9, r0
 	b _0217b91c
 _0217b8c4:
 	mov r0, #0x30
@@ -107972,22 +107972,22 @@ _0217b8c4:
 	mul r3, r8, r1
 	ldr r2, _0217bab0 ; =data_ov15_0218df7c
 	ldr ip, _0217bab4 ; =data_ov15_0218df80
-	ldr sb, _0217bab8 ; =data_ov15_02186f60
+	ldr r9, _0217bab8 ; =data_ov15_02186f60
 	ldr r7, _0217babc ; =data_ov15_02186f78
 	ldr r6, _0217bac0 ; =data_ov15_02186f90
 	ldr r10, _0217bac4 ; =data_ov15_0218df84
 	add r2, r2, r0
 	add r1, ip, r0
 	add r0, r10, r0
-	add r10, sb, r5, lsl #3
-	add sb, r7, r5, lsl #3
+	add r10, r9, r5, lsl #3
+	add r9, r7, r5, lsl #3
 	mov r8, r8, lsl #0x1
 	add r7, r6, r5, lsl #3
 	ldrh r5, [r8, r10]
-	ldrh r6, [r8, sb]
+	ldrh r6, [r8, r9]
 	ldrh r7, [r8, r7]
 	ldr r8, [r3, r2]
-	ldr sb, [r3, r1]
+	ldr r9, [r3, r1]
 	ldr r10, [r3, r0]
 _0217b91c:
 	ldr lr, [sp, #4]
@@ -108001,7 +108001,7 @@ _0217b91c:
 	stmia ip, {r0, r1, r2, r3}
 	ldr r0, [sp, #8]
 	mov r2, r8
-	mov r3, sb
+	mov r3, r9
 	mov r1, r0
 	str r10, [sp]
 	bl func_01ff8988
@@ -108082,12 +108082,12 @@ _0217ba78:
 	ldr r0, [r4, #0x284]
 	cmp r0, #0
 	addeq sp, sp, #0x12c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r1, [sp, #4]
 	mov r2, r11
 	bl func_ov15_0217b84c
 	add sp, sp, #0x12c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0217b84c
 _0217ba9c: .word data_ov15_0218e010
@@ -109249,7 +109249,7 @@ _0217ca00: .word 0x000001b1
 	.global func_ov15_0217ca04
 	arm_func_start func_ov15_0217ca04
 func_ov15_0217ca04: ; 0x0217ca04
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #0x5c
 	mov r4, r0
 	ldr r0, [r4, #0x6c]
@@ -109287,13 +109287,13 @@ func_ov15_0217ca04: ; 0x0217ca04
 	mov r0, r0, lsl #0x10
 	mov r1, r0, lsr #0x10
 	mov r0, r1, asr #0x4
-	mov sb, r0, lsl #0x1
+	mov r9, r0, lsl #0x1
 	add r0, r1, #0x8000
-	mov r1, sb, lsl #0x1
+	mov r1, r9, lsl #0x1
 	ldrsh r7, [r8, r1]
-	add r1, sb, #1
+	add r1, r9, #1
 	mov r1, r1, lsl #0x1
-	ldrsh sb, [r8, r1]
+	ldrsh r9, [r8, r1]
 	smull r3, r1, r7, r3
 	adds r3, r3, #0x800
 	mov r0, r0, lsl #0x10
@@ -109306,21 +109306,21 @@ func_ov15_0217ca04: ; 0x0217ca04
 	str r1, [sp, #0x50]
 	ldr r8, [r4, #0x2e0]
 	ldr r0, [sp, #0x58]
-	smull r10, r8, sb, r8
-	adds sb, r10, #0x800
+	smull r10, r8, r9, r8
+	adds r9, r10, #0x800
 	adc r8, r8, #0
-	mov sb, sb, lsr #0xc
-	orr sb, sb, r8, lsl #20
-	add r0, r0, sb
+	mov r9, r9, lsr #0xc
+	orr r9, r9, r8, lsl #20
+	add r0, r0, r9
 	str r0, [sp, #0x58]
 	ldr r8, [r4, #0x48]
 	ldr r3, _0217ceb0 ; =0x000004cd
 	sub r1, r1, r8
 	str r1, [r4, #0x60]
-	ldr sb, [sp, #0x58]
+	ldr r9, [sp, #0x58]
 	ldr r8, [r4, #0x50]
 	mov r7, #0
-	sub r8, sb, r8
+	sub r8, r9, r8
 	str r8, [r4, #0x68]
 	strh r5, [r2, #0xe6]
 	add r0, sp, #0x44
@@ -109349,7 +109349,7 @@ func_ov15_0217ca04: ; 0x0217ca04
 	str r2, [sp, #0x40]
 	bl func_ov00_020a61ac
 	ldr r10, _0217cec0 ; =data_027e0e58
-	mov sb, r4
+	mov r9, r4
 	add r8, r4, #0x2a0
 	add r5, sp, #0x44
 _0217cba0:
@@ -109357,7 +109357,7 @@ _0217cba0:
 	mov r1, r8
 	mov r2, r5
 	bl func_ov00_0207c474
-	ldr r3, [sb, #0x2a0]
+	ldr r3, [r9, #0x2a0]
 	cmp r3, #0
 	beq _0217cbd4
 	ldr r2, [sp, #0x3c]
@@ -109370,7 +109370,7 @@ _0217cbd4:
 	add r7, r7, #1
 	cmp r7, #2
 	add r8, r8, #0xc
-	add sb, sb, #0xc
+	add r9, r9, #0xc
 	blt _0217cba0
 	ldr r5, _0217cec4 ; =0x00000733
 	ldr r3, _0217ceb8 ; =0x00000d71
@@ -109381,13 +109381,13 @@ _0217cbd4:
 	str r3, [sp, #0x3c]
 	str r2, [sp, #0x40]
 	bl func_ov00_020a61ac
-	ldr sb, _0217cec0 ; =data_027e0e58
+	ldr r9, _0217cec0 ; =data_027e0e58
 	add r6, r4, #0x2b8
 	add r7, r4, #0x18
 	mov r8, #2
 	add r5, sp, #0x44
 _0217cc20:
-	ldr r0, [sb]
+	ldr r0, [r9]
 	mov r1, r6
 	mov r2, r5
 	bl func_ov00_0207c474
@@ -109409,13 +109409,13 @@ _0217cc54:
 	mov r0, r4
 	bl func_ov15_0217cedc
 	add sp, sp, #0x5c
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 _0217cc78:
 	ldr r2, [r4, #0x4c]
 	ldr r0, [r1]
 	cmp r2, r0
 	addge sp, sp, #0x5c
-	ldmgeia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmgeia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	add r0, r4, #0x48
 	add r3, sp, #0x2c
 	ldmia r0, {r0, r1, r2}
@@ -109550,7 +109550,7 @@ _0217ce00:
 	bl func_01ff9958
 	str r0, [r4, #0x2dc]
 	add sp, sp, #0x5c
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0217ca04
 _0217cea0: .word 0x0000019a
@@ -109572,17 +109572,17 @@ _0217ced8: .word data_027e0d0c
 	.global func_ov15_0217cedc
 	arm_func_start func_ov15_0217cedc
 func_ov15_0217cedc: ; 0x0217cedc
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x20
 	mov r10, r0
 	ldr r1, [r10, #0x2e0]
 	cmp r1, #0
 	addge sp, sp, #0x20
-	ldmgeia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmgeia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	bl _ZN5Actor16XzDistanceToLinkEv
 	cmp r0, #0x6000
 	addlt sp, sp, #0x20
-	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmltia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r0, r10, #0x48
 	add r3, sp, #0x14
 	ldmia r0, {r0, r1, r2}
@@ -109625,7 +109625,7 @@ func_ov15_0217cedc: ; 0x0217cedc
 	mov r8, #0
 	ldr r6, _0217d01c ; =data_ov15_02187048
 	ldr r4, _0217d00c ; =data_027e0e58
-	add sb, r10, #0x2a0
+	add r9, r10, #0x2a0
 	mov r7, r8
 	add r5, sp, #0x14
 	mov r11, #2
@@ -109638,16 +109638,16 @@ _0217cfc0:
 	mov r2, r5
 	mov r3, r11
 	bl func_ov00_0207c1b0
-	mov r0, sb
+	mov r0, r9
 	bl func_ov00_020b7e6c
 	add r8, r8, #1
 	cmp r8, #4
-	add sb, sb, #0xc
+	add r9, r9, #0xc
 	blt _0217cfc0
 	mov r0, #0
 	strb r0, [r10, #0x118]
 	add sp, sp, #0x20
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0217cedc
 _0217d008: .word data_027e0e60
@@ -109912,7 +109912,7 @@ _0217d3b8: .word 0x53485254
 	.global func_ov15_0217d3bc
 	arm_func_start func_ov15_0217d3bc
 func_ov15_0217d3bc: ; 0x0217d3bc
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x34
 	ldr r1, [sp, #0x58]
 	ldr r6, [sp, #0x5c]
@@ -109925,21 +109925,21 @@ func_ov15_0217d3bc: ; 0x0217d3bc
 	mov r5, #0
 _0217d3e8:
 	mov ip, #0
-	umull r10, sb, r4, r11
-	mla sb, r4, ip, sb
+	umull r10, r9, r4, r11
+	mla r9, r4, ip, r9
 	mov lr, r4, asr #0x1f
 	adds r10, r10, #0x800
-	mla sb, lr, r11, sb
+	mla r9, lr, r11, r9
 	mov r10, r10, lsr #0xc
-	adc sb, sb, #0
-	orr r10, r10, sb, lsl #20
+	adc r9, r9, #0
+	orr r10, r10, r9, lsl #20
 	ldr r2, _0217d53c ; =data_ov15_0218e198
 	ldr r3, _0217d540 ; =data_ov15_0218e19c
 	str r10, [sp, #0xc]
-	mov sb, ip
+	mov r9, ip
 	add r0, sp, #0x1c
 	add r1, sp, #0xc
-	str sb, [sp]
+	str r9, [sp]
 	bl func_ov15_0215cc30
 	ldr r1, [sp, #0x1c]
 	ldr r0, [sp, #0x20]
@@ -109962,7 +109962,7 @@ _0217d3e8:
 	mov r4, r0
 	blt _0217d3e8
 	ldr r0, _0217d538 ; =0x0000010a
-	mov r4, sb
+	mov r4, r9
 	umull r3, r2, r6, r0
 	mla r2, r6, r4, r2
 	mov r1, r6, asr #0x1f
@@ -109992,7 +109992,7 @@ _0217d3e8:
 	ldmia r1, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
 	add sp, sp, #0x34
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0217d4fc:
 	sub r1, r4, #0x1000
 	cmp r0, r1
@@ -110009,7 +110009,7 @@ _0217d50c:
 	ldmia r2, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
 	add sp, sp, #0x34
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0217d3bc
 _0217d538: .word 0x0000010a
@@ -110389,7 +110389,7 @@ func_ov15_0217d980: ; 0x0217d980
 	.global func_ov15_0217d994
 	arm_func_start func_ov15_0217d994
 func_ov15_0217d994: ; 0x0217d994
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #0x10
 	ldr r2, _0217db3c ; =data_027e10a4
 	mov r7, r0
@@ -110403,8 +110403,8 @@ func_ov15_0217d994: ; 0x0217d994
 	str r1, [sp, #4]
 	ldr r1, [r3, #0x308]
 	str r1, [sp, #8]
-	ldr sb, [r3, #0x30c]
-	str sb, [sp, #0xc]
+	ldr r9, [r3, #0x30c]
+	str r9, [sp, #0xc]
 	ldr r5, [r7, #0x158]
 	ldr r10, [r0, r5, lsl #2]
 	ldr r4, [r10]
@@ -110413,20 +110413,20 @@ func_ov15_0217d994: ; 0x0217d994
 	bl func_02042f68
 	ldr r2, [sp, #4]
 	ldr r3, [r7, #0x4c]
-	sub r1, r2, sb
+	sub r1, r2, r9
 	sub r1, r1, r3
-	add r2, r2, sb
+	add r2, r2, r9
 	rsb ip, r4, r1, asr #8
 	cmp ip, r0
 	sub r2, r2, r3
 	addge sp, sp, #0x10
 	rsb r1, r4, r2, asr #8
 	movge r0, #0
-	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmgeia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	cmp r1, #0
 	addle sp, sp, #0x10
 	movle r0, #0
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	cmp r1, r0
 	movgt r1, r0
 	cmp ip, #0
@@ -110447,11 +110447,11 @@ _0217da68:
 	ldr r4, [r7, #0x48]
 	ldr r8, [r8]
 	add r3, r4, r2, lsl #8
-	sub lr, r8, sb
+	sub lr, r8, r9
 	cmp lr, r3
 	addgt sp, sp, #0x10
 	movgt r0, #0
-	ldmgtia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmgtia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	cmp r5, #2
 	bne _0217dab8
 	cmp ip, r1
@@ -110467,11 +110467,11 @@ _0217daa0:
 	ble _0217daa0
 _0217dab8:
 	sub r1, r4, r2, lsl #8
-	add r0, r8, sb
+	add r0, r8, r9
 	cmp r0, r1
 	addlt sp, sp, #0x10
 	movlt r0, #0
-	ldmltia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmltia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	ldr r0, [r7, #0x168]
 	cmp r0, #0
 	beq _0217daf8
@@ -110479,7 +110479,7 @@ _0217dab8:
 	beq _0217db24
 	cmp r0, #2
 	subeq r0, r1, #0x600
-	subeq r0, r0, sb
+	subeq r0, r0, r9
 	streq r0, [r6]
 	b _0217db30
 _0217daf8:
@@ -110487,22 +110487,22 @@ _0217daf8:
 	cmp r8, r0, asr #1
 	ble _0217db14
 	add r0, r3, #0x600
-	add r0, sb, r0
+	add r0, r9, r0
 	str r0, [r6]
 	b _0217db30
 _0217db14:
 	sub r0, r1, #0x600
-	sub r0, r0, sb
+	sub r0, r0, r9
 	str r0, [r6]
 	b _0217db30
 _0217db24:
 	add r0, r3, #0x600
-	add r0, sb, r0
+	add r0, r9, r0
 	str r0, [r6]
 _0217db30:
 	mov r0, #1
 	add sp, sp, #0x10
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0217d994
 _0217db3c: .word data_027e10a4
@@ -110803,10 +110803,10 @@ _0217def8: .word func_ov15_0217e1c8
 	.global func_ov15_0217defc
 	arm_func_start func_ov15_0217defc
 func_ov15_0217defc: ; 0x0217defc
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x24
 	mov r10, r0
-	mov sb, r1
+	mov r9, r1
 	ldr r0, _0217dffc ; =data_027e0cbc
 	mov r1, #2
 	bl func_0203d7e0
@@ -110814,7 +110814,7 @@ func_ov15_0217defc: ; 0x0217defc
 	ldrnesb r0, [r10, #0x14]
 	cmpne r0, #0
 	addeq sp, sp, #0x24
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r0, sp, #4
 	bl func_01ffbe34
 	mov r0, r10
@@ -110824,7 +110824,7 @@ func_ov15_0217defc: ; 0x0217defc
 	mov r1, #0
 	strneb r0, [sp, #0xe]
 	add r4, sp, #4
-	mov r2, sb
+	mov r2, r9
 	mov r3, r1
 	mov r0, #5
 	str r4, [sp]
@@ -110832,7 +110832,7 @@ func_ov15_0217defc: ; 0x0217defc
 	mov r0, r4
 	mov r1, #0
 	str r0, [sp]
-	mov r2, sb
+	mov r2, r9
 	mov r3, r1
 	mov r0, #0x11
 	bl func_0203493c
@@ -110840,7 +110840,7 @@ func_ov15_0217defc: ; 0x0217defc
 	mov r7, #0
 	cmp r0, #0
 	addle sp, sp, #0x24
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	mov r11, r4
 	ldr r4, _0217e000 ; =gItemManager
 	mov r8, r7
@@ -110857,7 +110857,7 @@ _0217dfa8:
 _0217dfc4:
 	str r10, [sp]
 	ldr r0, [r10, #0x20]
-	mov r1, sb
+	mov r1, r9
 	mov r2, r5
 	mov r3, r11
 	add r0, r0, r8
@@ -110869,7 +110869,7 @@ _0217dfe0:
 	cmp r7, r0
 	blt _0217dfa8
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0217defc
 _0217dffc: .word data_027e0cbc
@@ -111137,7 +111137,7 @@ func_ov15_0217e354: ; 0x0217e354
 	.global func_ov15_0217e368
 	arm_func_start func_ov15_0217e368
 func_ov15_0217e368: ; 0x0217e368
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	ldr r0, _0217e4a4 ; =data_027e0f74
 	mov r4, #1
 	ldr r0, [r0]
@@ -111145,7 +111145,7 @@ func_ov15_0217e368: ; 0x0217e368
 	mov r6, r4
 	mov r7, r4
 	mov r8, r4
-	mov sb, r4
+	mov r9, r4
 	mov r10, r4
 	bl func_ov00_02097738
 	cmp r0, #0
@@ -111171,9 +111171,9 @@ _0217e3d4:
 	ldr r0, [r0]
 	ldr r0, [r0, #0x2c]
 	cmp r0, #1
-	movne sb, #0
+	movne r9, #0
 _0217e3f0:
-	cmp sb, #0
+	cmp r9, #0
 	bne _0217e40c
 	ldr r0, _0217e4b4 ; =data_027e10a4
 	ldr r0, [r0]
@@ -111222,7 +111222,7 @@ _0217e498:
 	mov r4, #0
 _0217e49c:
 	mov r0, r4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0217e368
 _0217e4a4: .word data_027e0f74
@@ -111702,7 +111702,7 @@ _0217eb08: .word data_027e104c
 	.global func_ov15_0217eb0c
 	arm_func_start func_ov15_0217eb0c
 func_ov15_0217eb0c: ; 0x0217eb0c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x14
 	mov r4, r0
 	str r1, [r4, #0xc]
@@ -111800,12 +111800,12 @@ _0217ec5c:
 	ldr r10, _0217ee20 ; =data_ov15_0218e6d8
 	ldr r11, _0217ee1c ; =data_027e104c
 	mov r8, #6
-	mov sb, r7
+	mov r9, r7
 	mov r6, #3
 	add r5, sp, #0x10
 _0217ec88:
 	mov r0, r4
-	mov r1, sb
+	mov r1, r9
 	bl func_ov15_0217f47c
 	cmp r0, #0
 	beq _0217ece0
@@ -111819,16 +111819,16 @@ _0217ec88:
 	cmp r0, #0
 	beq _0217ece0
 	cmp r8, #6
-	moveq r8, sb
+	moveq r8, r9
 	ldreq r7, [sp, #0x10]
 	beq _0217ece0
 	ldr r0, [sp, #0x10]
 	cmp r0, r7
 	movgt r7, r0
-	movgt r8, sb
+	movgt r8, r9
 _0217ece0:
-	add sb, sb, #1
-	cmp sb, #6
+	add r9, r9, #1
+	cmp r9, #6
 	add r10, r10, #0x28
 	blt _0217ec88
 	str r8, [r4, #0x1c]
@@ -111910,7 +111910,7 @@ _0217ede8:
 _0217ee04:
 	mov r0, #1
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0217eb0c
 _0217ee10: .word data_ov15_0218e688
@@ -111944,7 +111944,7 @@ _0217ee60: .word func_ov15_0217ee64
 	.global func_ov15_0217ee64
 	arm_func_start func_ov15_0217ee64
 func_ov15_0217ee64: ; 0x0217ee64
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x14c
 	ldr r3, _0217f3a0 ; =0x0000ffff
 	ldr r2, _0217f3a4 ; =0x040004c0
@@ -112140,11 +112140,11 @@ _0217f164:
 	ldr r0, [sp, #4]
 	mov r8, #0
 	ldr r0, [r0, #0x14]
-	add sb, r0, #0x20
+	add r9, r0, #0x20
 _0217f174:
 	mov r0, r5
 	mov r1, r4
-	str sb, [sp, #0x7c]
+	str r9, [sp, #0x7c]
 	str r10, [sp, #0x80]
 	str r7, [sp, #0x84]
 	str r7, [sp, #0x88]
@@ -112154,7 +112154,7 @@ _0217f174:
 	bl func_ov05_0210e2c4
 	add r8, r8, #1
 	cmp r8, #6
-	add sb, sb, #0x20
+	add r9, r9, #0x20
 	blt _0217f174
 	ldr r0, [sp, #8]
 	add r10, r10, #0x20
@@ -112166,7 +112166,7 @@ _0217f174:
 	mov r10, #0
 	ldr r1, [r0, #0x18]
 	ldr r0, [r0, #0x14]
-	add sb, r1, #0x80
+	add r9, r1, #0x80
 	add r8, r0, #0x20
 	mov r7, #0x20
 	mov r6, #0x10
@@ -112179,7 +112179,7 @@ _0217f1f0:
 	mov r1, r11
 	mov r3, r2
 	str r8, [sp, #0x6c]
-	str sb, [sp, #0x70]
+	str r9, [sp, #0x70]
 	str r7, [sp, #0x74]
 	str r6, [sp, #0x78]
 	str r5, [sp]
@@ -112281,7 +112281,7 @@ _0217f1f0:
 	str r4, [sp]
 	bl func_ov05_0210e2c4
 	add sp, sp, #0x14c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_0217ee64
 _0217f3a0: .word 0x0000ffff
@@ -113201,7 +113201,7 @@ _0217fe8c: .word data_027e10a4
 	.global func_ov15_0217fe90
 	arm_func_start func_ov15_0217fe90
 func_ov15_0217fe90: ; 0x0217fe90
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x50
 	mov r4, r0
 	mov r10, #0
@@ -113210,7 +113210,7 @@ func_ov15_0217fe90: ; 0x0217fe90
 	ldr r0, _02180330 ; =data_027e0d0c
 	str r1, [r4, #0x54]
 	ldr r1, [r4, #0x4c]
-	mov sb, #0x6000
+	mov r9, #0x6000
 	str r1, [r4, #0x58]
 	ldr r1, [r4, #0x50]
 	mov r7, #0x7000
@@ -113234,7 +113234,7 @@ func_ov15_0217fe90: ; 0x0217fe90
 	ldr r0, [r0, #8]
 	mov r3, #0xb0
 	str r0, [r4, #0x84]
-	str sb, [r4, #0x88]
+	str r9, [r4, #0x88]
 	ldr r0, [r4, #0x7c]
 	mov r2, #0xb1
 	str r0, [r4, #0x8c]
@@ -113247,7 +113247,7 @@ func_ov15_0217fe90: ; 0x0217fe90
 	add r0, r4, #0x158
 	str r8, [r4, #0x98]
 	str r10, [r4, #0xa8]
-	str sb, [r4, #0xac]
+	str r9, [r4, #0xac]
 	str r10, [r4, #0xb0]
 	str r7, [r4, #0xb4]
 	strh r6, [r1, #0x20]
@@ -113288,7 +113288,7 @@ func_ov15_0217fe90: ; 0x0217fe90
 	bl func_ov15_021803ac
 	add sp, sp, #0x50
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0217fff0:
 	cmp r0, #8
 	bne _02180038
@@ -113302,14 +113302,14 @@ _0217fff0:
 _02180014:
 	add sp, sp, #0x50
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02180020:
 	mov r0, r4
 	mov r1, #0xa
 	bl func_ov15_021803ac
 	add sp, sp, #0x50
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02180038:
 	cmp r0, #9
 	bne _02180058
@@ -113318,7 +113318,7 @@ _02180038:
 	bl func_ov15_021803ac
 	add sp, sp, #0x50
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02180058:
 	ldrh r0, [r4, #0x24]
 	cmp r0, #0
@@ -113337,7 +113337,7 @@ _02180078:
 	beq _021800fc
 	add sp, sp, #0x50
 	mov r0, r10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0218009c:
 	ldr r0, _02180334 ; =data_027e0f74
 	mov r1, #0x33
@@ -113347,7 +113347,7 @@ _0218009c:
 	beq _021800fc
 	add sp, sp, #0x50
 	mov r0, r10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _021800c0:
 	ldr r0, _02180334 ; =data_027e0f74
 	mov r1, #0x33
@@ -113356,14 +113356,14 @@ _021800c0:
 	cmp r0, #0
 	addeq sp, sp, #0x50
 	moveq r0, r10
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	mov r0, r4
 	mov r1, r10
 	bl _ZN5Actor18func_Ov00_020c1bfcEi
 	cmp r0, #0
 	addne sp, sp, #0x50
 	movne r0, r10
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _021800fc:
 	ldr r0, [r4, #8]
 	mov r1, #0
@@ -113522,7 +113522,7 @@ _0218031c:
 _02180324:
 	mov r0, #1
 	add sp, sp, #0x50
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 _02180330: .word data_027e0d0c
 _02180334: .word data_027e0f74
@@ -113565,7 +113565,7 @@ _021803a8: .word 0x53424f53
 	.global func_ov15_021803ac
 	arm_func_start func_ov15_021803ac
 func_ov15_021803ac: ; 0x021803ac
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x31c
 	mov r5, r0
 	mov r4, r1
@@ -113612,7 +113612,7 @@ _02180424:
 	bl func_ov15_02141344
 	cmp r0, #0
 	addeq sp, sp, #0x31c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r0, r5, #0x300
 	mov r1, #0
 	strh r1, [r0, #0x9a]
@@ -113696,14 +113696,14 @@ _02180424:
 	str r1, [r5, #0x32c]
 	bl func_ov00_0209a4f4
 	ldr r1, _02180ad4 ; =data_027e0f94
-	mvn sb, #0
+	mvn r9, #0
 	ldr r3, [r1]
 	ldr r2, [r1, #4]
 	mov r8, #0x32
 	mov r7, #0
 	mov r6, #2
 	ldr r0, _02180adc ; =data_027e0f74
-	str sb, [sp, #0x208]
+	str r9, [sp, #0x208]
 	strb r8, [sp, #0x20d]
 	strb r7, [sp, #0x20e]
 	strb r6, [sp, #0x20f]
@@ -113754,7 +113754,7 @@ _0218064c:
 	bl func_ov15_02141344
 	cmp r0, #0
 	addeq sp, sp, #0x31c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	mov r2, #0
 	str r2, [r5, #0x37c]
 	strb r2, [r5, #0x39e]
@@ -113803,14 +113803,14 @@ _021806b8:
 	str r1, [r5, #0x50]
 	bl func_ov00_0209a4f4
 	ldr r1, _02180ad4 ; =data_027e0f94
-	mvn sb, #0
+	mvn r9, #0
 	ldr r3, [r1]
 	ldr r2, [r1, #4]
 	mov r8, #0x32
 	mov r7, #2
 	mov r6, #3
 	ldr r0, _02180ad8 ; =data_027e0f64
-	str sb, [sp, #0x158]
+	str r9, [sp, #0x158]
 	strb r8, [sp, #0x15d]
 	strb r7, [sp, #0x15e]
 	strb r6, [sp, #0x15f]
@@ -113893,14 +113893,14 @@ _021806b8:
 	ldr r0, [r1, #0x268]
 	str r0, [r5, #0x32c]
 	ldr r0, [sp, #0xfc]
-	ldr sb, [sp, #0xec]
+	ldr r9, [sp, #0xec]
 	ldr r8, [sp, #0xf0]
 	ldr r7, [sp, #0xf4]
 	str r0, [sp, #0x190]
 	ldr r0, [sp, #0x110]
 	ldr r1, [sp, #0xf8]
-	str sb, [sp, #0x180]
-	ldr sb, [sp, #0x100]
+	str r9, [sp, #0x180]
+	ldr r9, [sp, #0x100]
 	str r8, [sp, #0x184]
 	ldr r8, [sp, #0x104]
 	str r7, [sp, #0x188]
@@ -113909,8 +113909,8 @@ _021806b8:
 	ldr r0, [sp, #0x124]
 	str r1, [sp, #0x18c]
 	ldr r1, [sp, #0x10c]
-	str sb, [sp, #0x194]
-	ldr sb, [sp, #0x114]
+	str r9, [sp, #0x194]
+	ldr r9, [sp, #0x114]
 	str r8, [sp, #0x198]
 	ldr r8, [sp, #0x118]
 	str r7, [sp, #0x19c]
@@ -113919,8 +113919,8 @@ _021806b8:
 	ldr r0, [sp, #0x138]
 	str r1, [sp, #0x1a0]
 	ldr r1, [sp, #0x120]
-	str sb, [sp, #0x1a8]
-	ldr sb, [sp, #0x128]
+	str r9, [sp, #0x1a8]
+	ldr r9, [sp, #0x128]
 	str r8, [sp, #0x1ac]
 	ldr r8, [sp, #0x12c]
 	str r7, [sp, #0x1b0]
@@ -113934,10 +113934,10 @@ _021806b8:
 	ldr r0, _02180adc ; =data_027e0f74
 	str r1, [sp, #0x1b4]
 	ldr r1, [sp, #0x134]
-	str sb, [sp, #0x1bc]
+	str r9, [sp, #0x1bc]
 	ldr r10, [sp, #0x13c]
 	str r8, [sp, #0x1c0]
-	ldr sb, [sp, #0x140]
+	ldr r9, [sp, #0x140]
 	str r7, [sp, #0x1c4]
 	ldr r8, [sp, #0x144]
 	ldr r7, [sp, #0x148]
@@ -113945,7 +113945,7 @@ _021806b8:
 	ldr r0, [r0]
 	add r1, sp, #0x154
 	str r10, [sp, #0x1d0]
-	str sb, [sp, #0x1d4]
+	str r9, [sp, #0x1d4]
 	str r8, [sp, #0x1d8]
 	str r7, [sp, #0x1dc]
 	strb r6, [sp, #0x1e0]
@@ -114004,14 +114004,14 @@ _02180a3c:
 	strh r2, [r1, #0x98]
 	bl func_ov00_0209a4f4
 	ldr r1, _02180ad4 ; =data_027e0f94
-	mvn sb, #0
+	mvn r9, #0
 	ldr r3, [r1]
 	ldr r2, [r1, #4]
 	mov r8, #0x32
 	mov r7, #0
 	mov r6, #2
 	ldr r0, _02180adc ; =data_027e0f74
-	str sb, [sp, #0x40]
+	str r9, [sp, #0x40]
 	strb r8, [sp, #0x45]
 	strb r7, [sp, #0x46]
 	strb r6, [sp, #0x47]
@@ -114032,7 +114032,7 @@ _02180ab8:
 	str r0, [r5, #0x138]
 	str r4, [r5, #0x130]
 	add sp, sp, #0x31c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_021803ac
 _02180acc: .word data_027e0d0c
@@ -114305,7 +114305,7 @@ _02180e40: .word 0x00000133
 	.global func_ov15_02180e44
 	arm_func_start func_ov15_02180e44
 func_ov15_02180e44: ; 0x02180e44
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x114
 	mov r4, r0
 	ldr r1, [r4, #0x390]
@@ -114372,21 +114372,21 @@ _02180f1c:
 	ldrsh r3, [r2, r3]
 	mov r0, r0, lsl #0x1
 	ldrsh r2, [r2, r0]
-	smull sb, r8, r3, r1
+	smull r9, r8, r3, r1
 	mov r0, #0
-	adds sb, sb, #0x800
+	adds r9, r9, #0x800
 	smull r3, r1, r2, r1
 	adc r8, r8, r0
 	adds r2, r3, #0x800
-	mov sb, sb, lsr #0xc
-	orr sb, sb, r8, lsl #20
+	mov r9, r9, lsr #0xc
+	orr r9, r9, r8, lsl #20
 	mov r3, r2, lsr #0xc
 	adc r1, r1, r0
 	orr r3, r3, r1, lsl #20
 	add r8, sp, #0x2c
 	add r1, sp, #0x3c
 	mov r2, #4
-	str sb, [sp, #0x40]
+	str r9, [sp, #0x40]
 	str r0, [sp, #0x44]
 	str r3, [sp, #0x48]
 	bl func_020078f4
@@ -114440,14 +114440,14 @@ _02181038:
 	ldr r5, [sp, #0x58]
 	ldr r3, [sp, #0x5c]
 	ldr r2, [sp, #0x60]
-	mvn sb, #0
+	mvn r9, #0
 	mov r8, #0x32
 	mov lr, #0
 	mov ip, #1
 	mov r7, #4
 	ldr r0, [r0]
 	add r1, sp, #0x64
-	str sb, [sp, #0x68]
+	str r9, [sp, #0x68]
 	strb r8, [sp, #0x6d]
 	strb lr, [sp, #0x6e]
 	strb ip, [sp, #0x6f]
@@ -114540,7 +114540,7 @@ _0218117c:
 	ldr r0, [r0]
 	bl func_ov15_0214138c
 	add sp, sp, #0x114
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _021811d8:
 	bne _021812e4
 	mov r0, #0
@@ -114608,17 +114608,17 @@ _021811d8:
 	cmp r0, #4
 	moveq r0, #0
 	streq r0, [r4, #0x37c]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _021812e4:
 	mov r0, r4
 	bl func_ov15_02182810
 	cmp r0, #0
 	addeq sp, sp, #0x114
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	ldr r0, [r4, #0x390]
 	cmp r0, #0x5a
 	addlt sp, sp, #0x114
-	ldmltia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmltia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	ldr r0, _02181388 ; =data_027e10a4
 	mov r1, #0
 	ldr r0, [r0]
@@ -114630,7 +114630,7 @@ _021812e4:
 	mov r1, #6
 	bl func_ov15_021803ac
 	add sp, sp, #0x114
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _02181338:
 	ldr r0, _0218137c ; =data_027e0f74
 	ldr r1, [r4, #0x38c]
@@ -114641,7 +114641,7 @@ _02181338:
 	str r1, [r4, #0x38c]
 	bl func_ov15_02182b48
 	add sp, sp, #0x114
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02180e44
 _02181360: .word data_027e0f94
@@ -114858,13 +114858,13 @@ _02181614: .word data_027e0f94
 	.global func_ov15_02181618
 	arm_func_start func_ov15_02181618
 func_ov15_02181618: ; 0x02181618
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x118
 	mov r4, r0
 	bl _ZN5Actor18func_ov00_020c198cEv
 	cmp r0, #0
 	addeq sp, sp, #0x118
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r0, sp, #0x68
 	bl func_ov00_0209a4f4
 	ldr r1, _021818c0 ; =data_027e0f94
@@ -114971,7 +114971,7 @@ func_ov15_02181618: ; 0x02181618
 	ldr r0, [sp, #0x48]
 	ldr r1, [sp, #0x28]
 	ldr r10, [sp, #0x30]
-	ldr sb, [sp, #0x34]
+	ldr r9, [sp, #0x34]
 	str r8, [sp, #0xb0]
 	ldr r8, [sp, #0x38]
 	str r7, [sp, #0xb4]
@@ -114989,8 +114989,8 @@ func_ov15_02181618: ; 0x02181618
 	ldr r1, [sp, #0x44]
 	str r10, [sp, #0xc4]
 	ldr r10, [sp, #0x4c]
-	str sb, [sp, #0xc8]
-	ldr sb, [sp, #0x50]
+	str r9, [sp, #0xc8]
+	ldr r9, [sp, #0x50]
 	str r8, [sp, #0xcc]
 	ldr r8, [sp, #0x54]
 	str r7, [sp, #0xd0]
@@ -115002,7 +115002,7 @@ func_ov15_02181618: ; 0x02181618
 	ldr r0, [r0]
 	add r1, sp, #0x68
 	str r10, [sp, #0xe0]
-	str sb, [sp, #0xe4]
+	str r9, [sp, #0xe4]
 	str r8, [sp, #0xe8]
 	str r7, [sp, #0xec]
 	str r6, [sp, #0xf0]
@@ -115028,7 +115028,7 @@ _021818b0:
 	add r0, sp, #0x68
 	bl func_ov00_0209a508
 	add sp, sp, #0x118
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02181618
 _021818c0: .word data_027e0f94
@@ -115620,7 +115620,7 @@ _0218210c: .word 0x4647474e
 	.global func_ov15_02182110
 	arm_func_start func_ov15_02182110
 func_ov15_02182110: ; 0x02182110
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x150
 	mov r4, r0
 	ldrb r1, [r4, #0x39e]
@@ -115746,7 +115746,7 @@ _02182140:
 	str r1, [sp, #0xe0]
 	str r0, [sp, #0xe4]
 	ldr r0, [sp, #0x68]
-	ldr sb, [sp, #0x54]
+	ldr r9, [sp, #0x54]
 	ldr r8, [sp, #0x58]
 	ldr r7, [sp, #0x5c]
 	ldr r2, [sp, #0x60]
@@ -115754,8 +115754,8 @@ _02182140:
 	ldr r0, [sp, #0x84]
 	ldr r1, [sp, #0x64]
 	ldr r10, [sp, #0x6c]
-	str sb, [sp, #0xe8]
-	ldr sb, [sp, #0x70]
+	str r9, [sp, #0xe8]
+	ldr r9, [sp, #0x70]
 	str r8, [sp, #0xec]
 	ldr r8, [sp, #0x74]
 	str r7, [sp, #0xf0]
@@ -115773,8 +115773,8 @@ _02182140:
 	ldr r1, [sp, #0x80]
 	str r10, [sp, #0x100]
 	ldr r10, [sp, #0x88]
-	str sb, [sp, #0x104]
-	ldr sb, [sp, #0x8c]
+	str r9, [sp, #0x104]
+	ldr r9, [sp, #0x8c]
 	str r8, [sp, #0x108]
 	ldr r8, [sp, #0x90]
 	str r7, [sp, #0x10c]
@@ -115786,7 +115786,7 @@ _02182140:
 	ldr r0, [r0]
 	add r1, sp, #0xa0
 	str r10, [sp, #0x11c]
-	str sb, [sp, #0x120]
+	str r9, [sp, #0x120]
 	str r8, [sp, #0x124]
 	str r7, [sp, #0x128]
 	strb r6, [sp, #0x12c]
@@ -115903,13 +115903,13 @@ _02182548:
 	and r0, r1, r0
 	cmp r0, #0x1000000
 	addeq sp, sp, #0x150
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r0, r4, #0x3a4
 	ldr r1, [r0]
 	ldr r1, [r1, #0x10]
 	blx r1
 	add sp, sp, #0x150
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02182110
 _0218257c: .word data_027e0e60
@@ -116711,7 +116711,7 @@ func_ov15_02182fa8: ; 0x02182fa8
 	.global func_ov15_02182fc0
 	arm_func_start func_ov15_02182fc0
 func_ov15_02182fc0: ; 0x02182fc0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0xb0
 	mov r6, r0
 	ldr r0, [r6, #0x138]
@@ -116799,8 +116799,8 @@ _021830c0:
 	mov r8, r2, lsl #0x1
 	add r2, r2, #1
 	adc lr, r3, #0
-	smull sb, r0, r1, r0
-	adds r1, sb, #0x800
+	smull r9, r0, r1, r0
+	adds r1, r9, #0x800
 	mov r7, r7, lsr #0xc
 	mov r2, r2, lsl #0x1
 	ldrsh r3, [ip, r8]
@@ -116873,7 +116873,7 @@ _021831d4:
 	mov r2, #2
 	bl func_ov00_02089318
 	add sp, sp, #0xb0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02182fc0
 _02183240: .word data_027e0f64
@@ -116884,7 +116884,7 @@ _0218324c: .word data_02050f54
 	.global func_ov15_02183250
 	arm_func_start func_ov15_02183250
 func_ov15_02183250: ; 0x02183250
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #0x30
 	mov r4, r0
 	add r0, r4, #0x300
@@ -116893,7 +116893,7 @@ func_ov15_02183250: ; 0x02183250
 	subne r1, r1, #1
 	strneh r1, [r0, #0x9c]
 	addne sp, sp, #0x30
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	add r0, sp, #4
 	bl func_ov00_020c1500
 	mvn r1, #0
@@ -116931,10 +116931,10 @@ func_ov15_02183250: ; 0x02183250
 	ldr r5, [r3, #0xc]
 	ldr r10, [r3, #0x10]
 	mla r7, r5, lr, r7
-	ldr sb, [r3, #0x14]
+	ldr r9, [r3, #0x14]
 	adds r6, r10, r8
 	mov r0, #0xb
-	adc r5, sb, r7
+	adc r5, r9, r7
 	str r6, [r3]
 	str r5, [r3, #4]
 	umull r3, ip, r5, r0
@@ -116944,7 +116944,7 @@ func_ov15_02183250: ; 0x02183250
 	add r0, ip, #0x1e
 	strh r0, [r2, #0x9c]
 	add sp, sp, #0x30
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02183250
 _02183344: .word data_027e0fe8
@@ -117355,34 +117355,34 @@ func_ov15_02183898: ; 0x02183898
 	.global func_ov15_021838b8
 	arm_func_start func_ov15_021838b8
 func_ov15_021838b8: ; 0x021838b8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	mov r10, r0
 	ldrb r0, [r10, #0x48]
 	cmp r0, #0
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, [r10, #0x14]
 	ldrb r0, [r0, #5]
 	cmp r0, #0
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldrsh r1, [r10]
 	ldrsh r0, [r10, #2]
 	cmp r1, r0
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, _02183990 ; =data_027e077c
 	ldr r0, [r0]
 	cmp r0, #0x3b
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
-	mov sb, #0
-	mov r6, sb
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
+	mov r9, #0
+	mov r6, r9
 	mov r8, r10
 	add r7, r10, #0x18
-	mov r11, sb
+	mov r11, r9
 	mov r4, #1
-	mov r5, sb
+	mov r5, r9
 _02183928:
 	mov r0, r7
 	ldr ip, [r0]
@@ -117393,7 +117393,7 @@ _02183928:
 	blx ip
 	tst r0, #8
 	beq _02183974
-	cmp sb, #0
+	cmp r9, #0
 	bne _02183968
 	ldrh r1, [r8, #0x22]
 	mov r0, r10
@@ -117401,18 +117401,18 @@ _02183928:
 	cmp r0, #0
 	beq _02183970
 _02183968:
-	mov sb, r4
+	mov r9, r4
 	b _02183974
 _02183970:
-	mov sb, r11
+	mov r9, r11
 _02183974:
 	add r6, r6, #1
 	cmp r6, #2
 	add r7, r7, #0x18
 	add r8, r8, #0x18
 	blt _02183928
-	mov r0, sb
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	mov r0, r9
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_021838b8
 _02183990: .word data_027e077c
@@ -117446,27 +117446,27 @@ _021839dc: .word data_027e077c
 	.global func_ov15_021839e0
 	arm_func_start func_ov15_021839e0
 func_ov15_021839e0: ; 0x021839e0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	ldr r1, _02183ae0 ; =data_027e0618
 	mov r5, r0
 	ldrb r0, [r1, #0x101]
 	cmp r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	ldr r0, [r5, #0x14]
 	ldrb r0, [r0, #5]
 	cmp r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	ldr r0, _02183ae4 ; =data_027e077c
 	ldr r1, _02183ae8 ; =data_02056be4
 	ldr r0, [r0]
 	ldrb r0, [r1, r0]
 	tst r0, #1
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	ldr r0, _02183aec ; =data_027e0cbc
 	mov r1, #0x14
 	bl func_0203d7e0
 	cmp r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	ldrsh r0, [r5]
 	ldrsh r2, [r5, #2]
 	mov r4, #0
@@ -117489,16 +117489,16 @@ _02183a74:
 	ldr r2, [r5, #0xc]
 	bl func_ov00_020d02bc
 	add r0, r0, #0x800
-	mov sb, r0, asr #0xc
+	mov r9, r0, asr #0xc
 	mov r6, #0
 	add r7, r5, #0x18
-	rsb r8, sb, #0
+	rsb r8, r9, #0
 	mov r5, r6
 _02183a9c:
 	cmp r6, #0
 	beq _02183ab0
 	cmp r6, #1
-	moveq r4, sb
+	moveq r4, r9
 	b _02183ab4
 _02183ab0:
 	mov r4, r8
@@ -117513,7 +117513,7 @@ _02183ab4:
 	cmp r6, #2
 	add r7, r7, #0x18
 	blt _02183a9c
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov15_021839e0
 _02183ae0: .word data_027e0618
@@ -118529,12 +118529,12 @@ _02184800:
 	.global func_ov15_02184838
 	arm_func_start func_ov15_02184838
 func_ov15_02184838: ; 0x02184838
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	ldr r1, [r0, #4]
 	ldr r2, [r0, #0x10]
 	cmp r1, #0
 	mov r1, #0
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	ldr r4, _021848cc ; =0x54534950
 	ldr lr, _021848d0 ; =0x444e5043
 	ldr ip, _021848d4 ; =0x474f4332
@@ -118542,7 +118542,7 @@ func_ov15_02184838: ; 0x02184838
 	mov r6, #1
 	mov r7, r1
 	mov r8, r1
-	mov sb, r1
+	mov r9, r1
 _02184870:
 	ldr r10, [r2]
 	cmp r10, #0
@@ -118551,7 +118551,7 @@ _02184870:
 	beq _021848b4
 	ldr r5, [r10, #4]
 	cmp r5, r4
-	streqb sb, [r10, #0x29e]
+	streqb r9, [r10, #0x29e]
 	beq _021848b4
 	cmp r5, lr
 	streqb r8, [r10, #0x39a]
@@ -118567,7 +118567,7 @@ _021848b4:
 	cmp r1, r5
 	add r2, r2, #4
 	blt _02184870
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02184838
 _021848cc: .word 0x54534950
@@ -118886,7 +118886,7 @@ _02184c0c: .word func_ov15_02184c10
 	.global func_ov15_02184c10
 	arm_func_start func_ov15_02184c10
 func_ov15_02184c10: ; 0x02184c10
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x5c
 	ldr r1, _02184eb8 ; =data_027e0f64
 	mov r2, #0x60
@@ -118903,17 +118903,17 @@ func_ov15_02184c10: ; 0x02184c10
 	str r2, [sp, #8]
 	cmp r5, r1
 	addlt sp, sp, #0x5c
-	ldmltia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmltia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	cmp r5, #0x110
 	addgt sp, sp, #0x5c
-	ldmgtia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmgtia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	mov r0, r1
 	cmp r4, r0
 	addlt sp, sp, #0x5c
-	ldmltia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmltia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	cmp r4, #0xd0
 	addgt sp, sp, #0x5c
-	ldmgtia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmgtia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	sub r1, r3, r5
 	mov r3, r1, lsl #0xc
 	sub r0, r2, r4
@@ -118929,7 +118929,7 @@ func_ov15_02184c10: ; 0x02184c10
 	bl func_01fffb4c
 	cmp r4, #0xa0000
 	addge sp, sp, #0x5c
-	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmgeia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	cmp r4, #0x50000
 	movle r7, #0x1000
 	ble _02184cec
@@ -118946,7 +118946,7 @@ _02184cec:
 	ldr r1, _02184ec0 ; =0xfffff4cd
 	cmp r0, r1
 	addle sp, sp, #0x5c
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	cmp r0, #0
 	bgt _02184d2c
 	rsb r0, r0, #0
@@ -118977,20 +118977,20 @@ _02184d64:
 	ldr r2, [r5, #4]
 	add r0, r8, r4, lsl #2
 	mov r1, r2, asr #0x1f
-	umull sb, r3, r7, r2
+	umull r9, r3, r7, r2
 	mla r3, r7, r1, r3
 	mla r3, r6, r2, r3
-	adds r2, sb, #0x800
+	adds r2, r9, #0x800
 	adc r1, r3, #0
 	mov r2, r2, lsr #0xc
 	orr r2, r2, r1, lsl #20
 	str r2, [r0, #0x34]
 	ldr r2, [r5]
 	mov r1, r2, asr #0x1f
-	umull sb, r3, r7, r2
+	umull r9, r3, r7, r2
 	mla r3, r7, r1, r3
 	mla r3, r6, r2, r3
-	adds r2, sb, #0x800
+	adds r2, r9, #0x800
 	adc r1, r3, #0
 	mov r2, r2, lsr #0xc
 	orr r2, r2, r1, lsl #20
@@ -118999,16 +118999,16 @@ _02184d64:
 	ldr r1, [r0]
 	ldr r1, [r1, #8]
 	blx r1
-	mov sb, r0
+	mov r9, r0
 	ldr r0, _02184ecc ; =data_ov00_020e9360
 	mov r1, #5
 	bl func_ov00_02079e68
 	mov r1, r0
-	mov r0, sb
+	mov r0, r9
 	bl func_020197bc
 	add r1, r8, r4, lsl #2
 	ldr r1, [r1, #0x34]
-	mov r0, sb
+	mov r0, r9
 	add r1, r1, #0x800
 	mov r1, r1, asr #0xc
 	bl func_020197fc
@@ -119028,7 +119028,7 @@ _02184d64:
 	orr r1, r1, r0, lsl #20
 	add r0, r1, r10, lsl #12
 	bl func_ov05_0210e19c
-	mov sb, r0
+	mov r9, r0
 	ldr r1, [r5, #8]
 	ldr r0, [sp, #0x38]
 	smull r3, r2, r1, r0
@@ -119043,13 +119043,13 @@ _02184d64:
 	str r0, [sp, #0x44]
 	mov r0, #0
 	str r0, [sp, #0x4c]
-	str sb, [sp, #0x48]
+	str r9, [sp, #0x48]
 	add r0, r8, r4, lsl #2
 	ldr r0, [r0, #4]
 	ldr r2, [sp]
-	ldr sb, [r0]
+	ldr r9, [r0]
 	add r1, sp, #0x50
-	ldr sb, [sb, #0x10]
+	ldr r9, [r9, #0x10]
 	add r3, sp, #0x44
 	blx sb
 	add r4, r4, #1
@@ -119058,7 +119058,7 @@ _02184d64:
 	blt _02184d64
 	bl func_01ffa8d4
 	add sp, sp, #0x5c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02184c10
 _02184eb8: .word data_027e0f64
@@ -119071,7 +119071,7 @@ _02184ecc: .word data_ov00_020e9360
 	.global func_ov15_02184ed0
 	arm_func_start func_ov15_02184ed0
 func_ov15_02184ed0: ; 0x02184ed0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	mov r4, r0
 	bl func_ov15_02185004
 	ldr r0, [r4]
@@ -119120,22 +119120,22 @@ _02184f78:
 	mov r0, r7
 	mov r2, r6
 	bl _ZN9SysObjectnwEmPjj
-	movs sb, r0
+	movs r9, r0
 	beq _02184fac
 	ldr r0, [r4]
 	mov r1, r8
 	bl func_ov00_020a5d10
 	mov r1, r0
-	mov r0, sb
+	mov r0, r9
 	blx func_ov00_020a9588
-	mov sb, r0
+	mov r9, r0
 _02184fac:
 	add r0, r4, r8, lsl #2
 	add r8, r8, #1
-	str sb, [r0, #4]
+	str r9, [r0, #4]
 	cmp r8, #6
 	blt _02184f78
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02184ed0
 _02184fc4: .word data_027e0ce0
@@ -119326,7 +119326,7 @@ _021851fc: .word data_ov00_020ee734
 	.global func_ov15_02185200
 	arm_func_start func_ov15_02185200
 func_ov15_02185200: ; 0x02185200
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0xc
 	mov r10, r0
 	ldrb r4, [r10, #0xc]
@@ -119369,7 +119369,7 @@ _02185284:
 	ldrlt r1, [r10, #4]
 	cmplt r1, #7
 	addge sp, sp, #0xc
-	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmgeia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	cmp r0, #0
 	bne _02185354
 	mov r0, r10
@@ -119393,11 +119393,11 @@ _02185284:
 _021852ec:
 	mov r6, #0
 	mov r8, r4
-	add sb, r11, r7
+	add r9, r11, r7
 _021852f8:
 	ldr r0, [r10, #4]
 	ldr r2, [r4, #0x14]
-	add r0, sb, r0, lsl #2
+	add r0, r9, r0, lsl #2
 	ldrb r1, [r6, r0]
 	mov r0, r8
 	bl func_ov15_02185940
@@ -119417,7 +119417,7 @@ _021852f8:
 	mov r0, #1
 	add sp, sp, #0xc
 	strb r0, [r10, #0xc]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02185354:
 	mov r11, #0
 	mov r6, r11
@@ -119438,12 +119438,12 @@ _02185364:
 	ldr r0, _0218541c ; =data_ov15_021872e4
 	mov r5, #0
 	mov r8, r4
-	add sb, r0, r7
+	add r9, r0, r7
 _021853a0:
 	mov r0, r8
 	ldr r1, [r10, #4]
 	ldr r2, [r4, #0x14]
-	add r1, sb, r1, lsl #2
+	add r1, r9, r1, lsl #2
 	ldrb r1, [r5, r1]
 	bl func_ov15_02185940
 	add r8, r8, #6
@@ -119462,16 +119462,16 @@ _021853c8:
 	ldr r0, [sp]
 	cmp r0, #0
 	addne sp, sp, #0xc
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, [sp, #4]
 	cmp r0, #1
 	addhi sp, sp, #0xc
-	ldmhiia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmhiia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, [r10, #0x24]
 	mov r1, #0xfa
 	bl func_0201f8ac
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02185200
 _0218541c: .word data_ov15_021872e4
@@ -127199,7 +127199,7 @@ _02188f7c: .word data_ov15_021903ec
 	.global func_ov15_02188f80
 	arm_func_start func_ov15_02188f80
 func_ov15_02188f80: ; 0x02188f80
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x90
 	ldr r6, _021891ec ; =data_ov15_0218e688
 	mov r0, #0
@@ -127292,16 +127292,16 @@ func_ov15_02188f80: ; 0x02188f80
 	mov r1, #0xe
 	mov r8, #3
 	mov r7, #0xf
-	ldrsh sb, [sp, #0x28]
+	ldrsh r9, [sp, #0x28]
 	ldr r5, _021891f0 ; =data_ov15_0218e788
 	str lr, [r6, #0xfc]
-	strh sb, [r5]
+	strh r9, [r5]
 	strb r3, [r6, #0x102]
 	strb r1, [r6, #0x103]
-	and sb, ip, #0xff
-	strb sb, [r6, #0x104]
-	and sb, r0, #0xff
-	strb sb, [r6, #0x105]
+	and r9, ip, #0xff
+	strb r9, [r6, #0x104]
+	and r9, r0, #0xff
+	strb r9, [r6, #0x105]
 	str r0, [r6, #0x118]
 	str r4, [r6, #0x11c]
 	str r0, [r6, #0x120]
@@ -127319,7 +127319,7 @@ func_ov15_02188f80: ; 0x02188f80
 	strb r3, [sp, #0x2a]
 	and r3, ip, #0xff
 	strb r3, [r6, #0x12c]
-	mov r3, sb
+	mov r3, r9
 	ldr r1, _021891f4 ; =func_ov15_0217f7d8
 	ldr r2, _021891f8 ; =data_ov15_0219040c
 	str r0, [sp, #0x30]
@@ -127353,7 +127353,7 @@ func_ov15_02188f80: ; 0x02188f80
 	mov r1, #0x10
 	str r1, [r0, #0x14c]
 	add sp, sp, #0x90
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov15_02188f80
 _021891ec: .word data_ov15_0218e688

--- a/asm/ov17.s
+++ b/asm/ov17.s
@@ -437,20 +437,20 @@ _0215b7d0: .word func_ov17_0215b7d4
 	.global func_ov17_0215b7d4
 	arm_func_start func_ov17_0215b7d4
 func_ov17_0215b7d4: ; 0x0215b7d4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x1c
 	mov r10, r0
 	ldr r0, [r10, #0x188]
 	cmp r0, #0
 	addeq sp, sp, #0x1c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldrh r0, [r10, #0x28]
-	ldrh sb, [r10, #0x2a]
+	ldrh r9, [r10, #0x2a]
 	cmp r0, #0x40
 	str r0, [sp]
-	cmpls sb, #0x30
+	cmpls r9, #0x30
 	addhi sp, sp, #0x1c
-	ldmhiia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmhiia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	mov r0, #0
 	str r0, [sp, #4]
 	strb r0, [sp, #8]
@@ -458,9 +458,9 @@ func_ov17_0215b7d4: ; 0x0215b7d4
 	ldr r0, [sp]
 	cmp r0, #0
 	addle sp, sp, #0x1c
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0215b82c:
-	cmp sb, #0
+	cmp r9, #0
 	mov r8, #0
 	ble _0215b974
 	ldr r0, [sp, #4]
@@ -541,7 +541,7 @@ _0215b850:
 	ldr r3, [r3, #0xa8]
 	blx r3
 	add r8, r8, #1
-	cmp r8, sb
+	cmp r8, r9
 	blt _0215b850
 _0215b974:
 	ldr r0, [sp, #4]
@@ -551,7 +551,7 @@ _0215b974:
 	cmp r1, r0
 	blt _0215b82c
 	add sp, sp, #0x1c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	arm_func_end func_ov17_0215b7d4
 
 	.global func_ov17_0215b994
@@ -764,7 +764,7 @@ func_ov17_0215bbbc: ; 0x0215bbbc
 	.global func_ov17_0215bbd4
 	arm_func_start func_ov17_0215bbd4
 func_ov17_0215bbd4: ; 0x0215bbd4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x1c
 	mov r6, r2
 	mov r7, r1
@@ -781,11 +781,11 @@ func_ov17_0215bbd4: ; 0x0215bbd4
 	ldr r2, [r2, #0x60]
 	blx r2
 	ldr r1, _0215bd28 ; =data_027e0e60
-	mov sb, r0
+	mov r9, r0
 	ldr r0, [r1]
 	ldrb r1, [r6]
 	bl func_ov00_02083c24
-	str sb, [sp, #0x14]
+	str r9, [sp, #0x14]
 	str r4, [sp, #0x18]
 	str r0, [sp, #0x10]
 	mov r0, r8
@@ -851,11 +851,11 @@ _0215bca4:
 _0215bd10:
 	add sp, sp, #0x1c
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _0215bd1c:
 	mov r0, #1
 	add sp, sp, #0x1c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov17_0215bbd4
 _0215bd28: .word data_027e0e60
@@ -3499,7 +3499,7 @@ _0215dfec: .word func_01ff9bc4
 	.global func_ov17_0215dff0
 	arm_func_start func_ov17_0215dff0
 func_ov17_0215dff0: ; 0x0215dff0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #8
 	ldr r2, _0215e1b4 ; =data_027e0e60
 	mov r11, r1
@@ -3515,12 +3515,12 @@ func_ov17_0215dff0: ; 0x0215dff0
 _0215e024:
 	ldrb r1, [sp, #6]
 	sub r0, r7, #1
-	mov sb, #0
+	mov r9, #0
 	add r0, r1, r0
 	and r8, r0, #0xff
 _0215e038:
 	ldrb r2, [sp, #7]
-	sub r1, sb, #1
+	sub r1, r9, #1
 	ldr r0, [r4]
 	add r2, r2, r1
 	mov r1, r6
@@ -3536,8 +3536,8 @@ _0215e038:
 	streq r5, [r10, #0x1ec]
 	beq _0215e090
 _0215e078:
-	add sb, sb, #1
-	cmp sb, #3
+	add r9, r9, #1
+	cmp r9, #3
 	blt _0215e038
 	add r7, r7, #1
 	cmp r7, #3
@@ -3547,7 +3547,7 @@ _0215e090:
 	cmp r0, #0
 	addeq sp, sp, #8
 	mov r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	strb r0, [r10, #0x11b]
 	ldr r1, [r11]
 	mov r2, #0x14
@@ -3615,7 +3615,7 @@ _0215e090:
 	bl func_ov00_0207c1f8
 	mov r0, #1
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov17_0215dff0
 _0215e1b4: .word data_027e0e60
@@ -3743,7 +3743,7 @@ _0215e334: .word func_ov00_020b7d74
 	.global func_ov17_0215e338
 	arm_func_start func_ov17_0215e338
 func_ov17_0215e338: ; 0x0215e338
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	ldr r2, _0215e460 ; =data_027e0e60
 	mov r11, r1
 	ldr r1, [r2]
@@ -3758,12 +3758,12 @@ func_ov17_0215e338: ; 0x0215e338
 _0215e368:
 	ldrb r1, [sp, #2]
 	sub r0, r7, #1
-	mov sb, #0
+	mov r9, #0
 	add r0, r1, r0
 	and r8, r0, #0xff
 _0215e37c:
 	ldrb r2, [sp, #3]
-	sub r1, sb, #1
+	sub r1, r9, #1
 	ldr r0, [r4]
 	add r2, r2, r1
 	mov r1, r6
@@ -3779,8 +3779,8 @@ _0215e37c:
 	streq r5, [r10, #0x250]
 	beq _0215e3e4
 _0215e3bc:
-	add sb, sb, #1
-	cmp sb, #3
+	add r9, r9, #1
+	cmp r9, #3
 	blt _0215e37c
 	add r7, r7, #1
 	cmp r7, #3
@@ -3788,7 +3788,7 @@ _0215e3bc:
 	ldr r0, [r10, #0x250]
 	cmp r0, #0
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0215e3e4:
 	mov r2, #0
 	str r2, [r10, #0x12c]
@@ -3820,7 +3820,7 @@ _0215e3e4:
 	str r2, [r10, #0x64]
 	bl func_ov17_0215e9ec
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov17_0215e338
 _0215e460: .word data_027e0e60
@@ -5644,7 +5644,7 @@ _0215fbd4: .word 0x0000ffff
 	.global func_ov17_0215fbd8
 	arm_func_start func_ov17_0215fbd8
 func_ov17_0215fbd8: ; 0x0215fbd8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	mov r7, r0
 	ldrsb r0, [r7, #0xdd]
 	strb r0, [r7, #0xdc]
@@ -5658,17 +5658,17 @@ func_ov17_0215fbd8: ; 0x0215fbd8
 	ldr r11, _0215fcd0 ; =data_027e0e60
 	mov r4, r7
 	add r5, r7, #4
-	mov sb, #0
+	mov r9, #0
 _0215fc14:
-	cmp sb, #6
-	cmpne sb, #7
-	cmpne sb, #8
+	cmp r9, #6
+	cmpne r9, #7
+	cmpne r9, #8
 	beq _0215fc78
 	mov r0, r7
-	mov r1, sb
+	mov r1, r9
 	bl func_ov17_02160274
 	mov r8, r0
-	cmp sb, r6
+	cmp r9, r6
 	bge _0215fcb4
 	ldr r10, [r11]
 	bl func_ov03_020f8068
@@ -5700,15 +5700,15 @@ _0215fc78:
 	bl func_ov17_0215fcd4
 	cmp r0, #0
 	movne r0, #1
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0215fcb4:
-	add sb, sb, #1
-	cmp sb, #9
+	add r9, r9, #1
+	cmp r9, #9
 	add r4, r4, #0x18
 	add r5, r5, #0x18
 	blt _0215fc14
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov17_0215fbd8
 _0215fcd0: .word data_027e0e60
@@ -5716,13 +5716,13 @@ _0215fcd0: .word data_027e0e60
 	.global func_ov17_0215fcd4
 	arm_func_start func_ov17_0215fcd4
 func_ov17_0215fcd4: ; 0x0215fcd4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	mov r11, r2
-	mov sb, r0
+	mov r9, r0
 	tst r11, #1
 	mov r10, r1
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	cmp r10, #0x34
 	cmpne r10, #0x35
 	cmpne r10, #0x36
@@ -5730,11 +5730,11 @@ func_ov17_0215fcd4: ; 0x0215fcd4
 	tst r11, #0x20
 	beq _0215fd1c
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0215fd10:
 	sub r1, r10, #0x37
 	bl func_ov17_02160274
-	strb r0, [sb, #0xdc]
+	strb r0, [r9, #0xdc]
 _0215fd1c:
 	ldr r4, _0215ff1c ; =0x0001869f
 	rsb r5, r4, #0
@@ -5780,15 +5780,15 @@ _0215fd8c: ; jump table
 _0215fdb0:
 	tst r11, #8
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
-	mov r0, sb
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
+	mov r0, r9
 	sub r1, r10, #0x37
 	bl func_ov17_02160274
-	strb r0, [sb, #0xdd]
-	mov r0, sb
+	strb r0, [r9, #0xdd]
+	mov r0, r9
 	sub r1, r10, #0x37
 	bl func_ov17_02160274
-	ldr r2, [sb]
+	ldr r2, [r9]
 	ldrsh r1, [r2, #0x30]
 	cmp r0, r1
 	beq _0215fe04
@@ -5804,13 +5804,13 @@ _0215fe04:
 	mov r1, #6
 	bl func_ov00_020d77e4
 	mov r0, #0
-	strh r0, [sb, #0xde]
+	strh r0, [r9, #0xde]
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0215fe20:
 	tst r11, #8
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, _0215ff2c ; =data_027e077c
 	mov r1, #9
 	bl func_0202e740
@@ -5818,19 +5818,19 @@ _0215fe20:
 	mov r1, #0x11
 	bl func_ov00_020d77e4
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0215fe4c:
-	ldrb r0, [sb, #0xe0]
+	ldrb r0, [r9, #0xe0]
 	cmp r0, #0
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	tst r11, #0x48
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
-	ldrsb r0, [sb, #0xe1]
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
+	ldrsb r0, [r9, #0xe1]
 	add r0, r0, #1
-	strb r0, [sb, #0xe1]
-	ldrsb r1, [sb, #0xe1]
+	strb r0, [r9, #0xe1]
+	ldrsb r1, [r9, #0xe1]
 	cmp r1, r5
 	movgt r1, r5
 	bgt _0215fe90
@@ -5838,26 +5838,26 @@ _0215fe4c:
 	cmp r1, r0
 	movlt r1, r0
 _0215fe90:
-	mov r0, sb
-	strb r1, [sb, #0xe1]
+	mov r0, r9
+	strb r1, [r9, #0xe1]
 	bl func_ov17_02160280
 	ldr r0, _0215ff28 ; =data_ov00_020eec9c
 	mov r1, #3
 	bl func_ov00_020d77e4
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0215feb0:
-	ldrb r0, [sb, #0xe0]
+	ldrb r0, [r9, #0xe0]
 	cmp r0, #0
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	tst r11, #0x48
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
-	ldrsb r0, [sb, #0xe1]
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
+	ldrsb r0, [r9, #0xe1]
 	sub r0, r0, #1
-	strb r0, [sb, #0xe1]
-	ldrsb r1, [sb, #0xe1]
+	strb r0, [r9, #0xe1]
+	ldrsb r1, [r9, #0xe1]
 	cmp r1, r5
 	movgt r1, r5
 	bgt _0215fef4
@@ -5865,17 +5865,17 @@ _0215feb0:
 	cmp r1, r0
 	movlt r1, r0
 _0215fef4:
-	mov r0, sb
-	strb r1, [sb, #0xe1]
+	mov r0, r9
+	strb r1, [r9, #0xe1]
 	bl func_ov17_02160280
 	ldr r0, _0215ff28 ; =data_ov00_020eec9c
 	mov r1, #3
 	bl func_ov00_020d77e4
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0215ff14:
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov17_0215fcd4
 _0215ff1c: .word 0x0001869f
@@ -5887,7 +5887,7 @@ _0215ff2c: .word data_027e077c
 	.global func_ov17_0215ff30
 	arm_func_start func_ov17_0215ff30
 func_ov17_0215ff30: ; 0x0215ff30
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x38
 	mov r10, r0
 	add r0, sp, #0x18
@@ -5915,13 +5915,13 @@ func_ov17_0215ff30: ; 0x0215ff30
 	str r10, [sp]
 	bl func_ov00_020d00c4
 	bl func_ov03_020f7fec
-	mov sb, r0
-	cmp sb, #6
-	movge sb, #6
+	mov r9, r0
+	cmp r9, #6
+	movge r9, #6
 	bl func_ov03_020f7fec
 	bl func_ov03_020f8008
 	str r0, [sp, #0x14]
-	cmp sb, #0
+	cmp r9, #0
 	mov r5, #0
 	ble _02160098
 	add r7, r10, #4
@@ -5977,13 +5977,13 @@ _0215ffcc:
 _02160088:
 	add r7, r7, #0x18
 	add r5, r5, #1
-	cmp r5, sb
+	cmp r5, r9
 	blt _0215ffcc
 _02160098:
 	ldrb r0, [r10, #0xe0]
 	cmp r0, #0
 	addeq sp, sp, #0x38
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	mov r2, #0
 	add r3, sp, #0x18
 	mov r1, r8
@@ -5997,7 +5997,7 @@ _02160098:
 	str r2, [sp]
 	bl func_ov00_020d00c4
 	add sp, sp, #0x38
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov17_0215ff30
 _021600e0: .word data_027e0618
@@ -6016,9 +6016,9 @@ func_ov17_021600f0: ; 0x021600f0
 	.global func_ov17_021600fc
 	arm_func_start func_ov17_021600fc
 func_ov17_021600fc: ; 0x021600fc
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x28
-	mov sb, r0
+	mov r9, r0
 	add r0, sp, #8
 	mov r8, r1
 	mov r7, r2
@@ -6043,15 +6043,15 @@ _02160148: ; jump table
 	b _02160160 ; case 4
 	b _02160160 ; case 5
 _02160160:
-	mov r0, sb
+	mov r0, r9
 	bl func_ov17_02160274
-	ldrsb r1, [sb, #0xdc]
+	ldrsb r1, [r9, #0xdc]
 	cmp r1, r0
 	bne _021601c0
-	mov r0, sb
+	mov r0, r9
 	sub r1, r5, #0x37
 	bl func_ov17_02160274
-	ldrsb r1, [sb, #0xdd]
+	ldrsb r1, [r9, #0xdd]
 	cmp r1, r0
 	beq _02160194
 	tst r4, #8
@@ -6067,11 +6067,11 @@ _02160194:
 	bl func_020349cc
 	add sp, sp, #0x28
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _021601c0:
 	mov r0, #0
 	add sp, sp, #0x28
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov17_021600fc
 _021601cc: .word data_027e0618
@@ -10091,7 +10091,7 @@ func_ov17_02163388: ; 0x02163388
 	.global func_ov17_02163390
 	arm_func_start func_ov17_02163390
 func_ov17_02163390: ; 0x02163390
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x34
 	ldr r2, [r0]
 	mov r7, r0
@@ -10099,7 +10099,7 @@ func_ov17_02163390: ; 0x02163390
 	blx r2
 	cmp r0, #0
 	addeq sp, sp, #0x34
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	ldrh r1, [r7, #0xc]
 	ldr r3, _021634d4 ; =data_02050f54
 	add r0, sp, #0x10
@@ -10123,11 +10123,11 @@ func_ov17_02163390: ; 0x02163390
 	ldr r0, [r7, #8]
 	cmp r0, #0
 	addeq sp, sp, #0x34
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	ldr r0, [r7, #0x6c]
 	cmp r0, #0x800
 	addle sp, sp, #0x34
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	add r0, r7, #0x18
 	add r3, sp, #4
 	ldmia r0, {r0, r1, r2}
@@ -10145,8 +10145,8 @@ func_ov17_02163390: ; 0x02163390
 	mov r4, r0
 	mov r5, #0
 	addle sp, sp, #0x34
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, pc}
-	add sb, sp, #0x10
+	ldmleia sp!, {r4, r5, r6, r7, r8, r9, pc}
+	add r9, sp, #0x10
 	add r8, sp, #4
 _02163474:
 	cmp r5, #0
@@ -10160,7 +10160,7 @@ _02163474:
 _02163494:
 	add r0, r7, #0x10c
 	ldr r3, [r0]
-	mov r1, sb
+	mov r1, r9
 	ldr r3, [r3, #0x14]
 	mov r2, r8
 	blx r3
@@ -10168,13 +10168,13 @@ _02163494:
 	cmp r5, r6
 	blt _02163474
 	add sp, sp, #0x34
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _021634c0:
 	ldr r3, [r3, #0x14]
 	add r2, r7, #0x18
 	blx r3
 	add sp, sp, #0x34
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov17_02163390
 _021634d4: .word data_02050f54
@@ -10922,10 +10922,10 @@ _02163e20: .word 0x00000b33
 	.global func_ov17_02163e24
 	arm_func_start func_ov17_02163e24
 func_ov17_02163e24: ; 0x02163e24
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	ldrb r0, [r0, #0x71]
 	cmp r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, _02163ecc ; =data_027e0e60
 	ldr r0, [r0]
 	bl func_ov00_0208335c
@@ -10934,16 +10934,16 @@ func_ov17_02163e24: ; 0x02163e24
 	ldr r0, [r1]
 	bl func_ov00_02083368
 	mov r8, r0
-	mov sb, #0
+	mov r9, #0
 	cmp r11, #0
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r4, _02163ecc ; =data_027e0e60
 	add r6, sp, #0
 _02163e68:
 	mov r10, #0
 	cmp r8, #0
 	ble _02163ebc
-	and r7, sb, #0xff
+	and r7, r9, #0xff
 _02163e78:
 	ldr r0, [r4]
 	mov r1, r6
@@ -10964,10 +10964,10 @@ _02163eb0:
 	cmp r10, r8
 	blt _02163e78
 _02163ebc:
-	add sb, sb, #1
-	cmp sb, r11
+	add r9, r9, #1
+	cmp r9, r11
 	blt _02163e68
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov17_02163e24
 _02163ecc: .word data_027e0e60
@@ -11260,13 +11260,13 @@ _02164280: .word data_027e0e60
 	.global func_ov17_02164284
 	arm_func_start func_ov17_02164284
 func_ov17_02164284: ; 0x02164284
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x10
 	mov r10, r0
 	ldrb r0, [r10, #0x71]
 	cmp r0, #0
 	addne sp, sp, #0x10
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldrb r0, [r10, #0x14]
 	ldr r1, _02164474 ; =data_027e0e60
 	str r0, [sp, #4]
@@ -11301,12 +11301,12 @@ _02164310:
 	mov r0, r8
 	cmp r0, r7
 	bge _0216438c
-	ldr sb, _02164474 ; =data_027e0e60
+	ldr r9, _02164474 ; =data_027e0e60
 	mov r4, #0
 	add r6, sp, #0xe
 _0216432c:
 	ldrb r2, [r10, #0x14]
-	ldr r0, [sb]
+	ldr r0, [r9]
 	mov r1, r6
 	strb r2, [sp, #0xe]
 	strb r8, [sp, #0xf]
@@ -11346,9 +11346,9 @@ _021643b4:
 	ldr r0, [sp, #4]
 	cmp r0, r1
 	beq _0216444c
-	ldr sb, [sp]
+	ldr r9, [sp]
 	mov r7, #0
-	mov r0, sb
+	mov r0, r9
 	cmp r0, r8
 	bge _02164438
 	ldr r0, [sp, #4]
@@ -11358,7 +11358,7 @@ _021643e0:
 	mov r1, r11
 	ldr r0, [r0]
 	strb r6, [sp, #0xc]
-	strb sb, [sp, #0xd]
+	strb r9, [sp, #0xd]
 	bl func_ov00_020840c4
 	mov r5, r0
 	cmp r5, r10
@@ -11374,8 +11374,8 @@ _021643e0:
 	mov r7, #1
 	strb r4, [r5, #0x71]
 _0216442c:
-	add sb, sb, #1
-	cmp sb, r8
+	add r9, r9, #1
+	cmp r9, r8
 	blt _021643e0
 _02164438:
 	cmp r7, #0
@@ -11394,7 +11394,7 @@ _02164464:
 	mov r0, #1
 	strb r0, [r10, #0x71]
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov17_02164284
 _02164474: .word data_027e0e60
@@ -12406,7 +12406,7 @@ _02165178: .word 0x00000dac
 	.global func_ov17_0216517c
 	arm_func_start func_ov17_0216517c
 func_ov17_0216517c: ; 0x0216517c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	mov r10, r0
 	ldr r0, [r10, #0x60]
 	cmp r0, #0
@@ -12418,12 +12418,12 @@ func_ov17_0216517c: ; 0x0216517c
 	cmp r0, #0
 	moveq r0, #1
 	movne r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _021651b0:
 	cmp r0, #1
 	moveq r0, #1
 	movne r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _021651c0:
 	ldr r0, _02165280 ; =data_027e0e60
 	ldr r0, [r0]
@@ -12441,14 +12441,14 @@ _021651c0:
 	ldr r4, _02165280 ; =data_027e0e60
 	add r6, sp, #0
 _021651fc:
-	mov sb, #0
+	mov r9, #0
 	cmp r7, #0
 	bls _02165268
 _02165208:
 	ldr r0, [r4]
 	mov r1, r6
 	strb r8, [sp]
-	strb sb, [sp, #1]
+	strb r9, [sp, #1]
 	bl func_ov00_020840c4
 	movs r5, r0
 	beq _02165258
@@ -12464,11 +12464,11 @@ _02165208:
 	ldr r0, [r5, #8]
 	cmp r1, r0
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02165258:
-	add r0, sb, #1
-	and sb, r0, #0xff
-	cmp sb, r7
+	add r0, r9, #1
+	and r9, r0, #0xff
+	cmp r9, r7
 	blo _02165208
 _02165268:
 	add r0, r8, #1
@@ -12477,7 +12477,7 @@ _02165268:
 	blo _021651fc
 _02165278:
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov17_0216517c
 _02165280: .word data_027e0e60
@@ -14062,7 +14062,7 @@ func_ov17_0216649c: ; 0x0216649c
 	.global func_ov17_021664c4
 	arm_func_start func_ov17_021664c4
 func_ov17_021664c4: ; 0x021664c4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #0x38
 	mov r4, r0
 	ldrh r2, [r4, #0x20]
@@ -14104,12 +14104,12 @@ func_ov17_021664c4: ; 0x021664c4
 	add ip, r4, #0x20c
 	bic r0, r0, #0xff
 	strh r0, [r4, #0x9c]
-	ldr sb, [r4, #0x4c]
+	ldr r9, [r4, #0x4c]
 	ldr r7, [r4, #0x48]
 	ldr r10, [r4, #0x50]
 	sub r8, r7, #0x1000
 	sub r1, r10, #0x1000
-	sub r0, sb, #0x800
+	sub r0, r9, #0x800
 	str r8, [sp, #0x2c]
 	add r8, r10, #0x1000
 	add r7, r7, #0x1000
@@ -14118,7 +14118,7 @@ func_ov17_021664c4: ; 0x021664c4
 	ldmia r2, {r0, r1, r2}
 	stmia r6, {r0, r1, r2}
 	str r7, [sp, #0x20]
-	str sb, [sp, #0x24]
+	str r9, [sp, #0x24]
 	str r8, [sp, #0x28]
 	ldmia r5, {r0, r1, r2}
 	stmia lr, {r0, r1, r2}
@@ -14146,7 +14146,7 @@ _021665f0:
 	mov r0, r4
 	bl func_ov14_02137970
 	add sp, sp, #0x38
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	arm_func_end func_ov17_021664c4
 
 	.global func_ov17_02166614
@@ -14362,46 +14362,46 @@ func_ov17_02166850: ; 0x02166850
 	.global func_ov17_02166878
 	arm_func_start func_ov17_02166878
 func_ov17_02166878: ; 0x02166878
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #0x54
-	mov sb, r0
-	ldr r1, [sb, #4]
+	mov r9, r0
+	ldr r1, [r9, #4]
 	ldr r0, _02166a54 ; =data_027e0e60
 	orr r1, r1, #0x810
-	str r1, [sb, #4]
+	str r1, [r9, #4]
 	ldr r5, [r0]
-	ldr r1, [sb, #0x18]
+	ldr r1, [r9, #0x18]
 	mov r0, r5
 	bl func_ov00_020839d4
 	mov r4, r0
-	ldr r1, [sb, #0x20]
+	ldr r1, [r9, #0x20]
 	mov r0, r5
 	bl func_ov00_020839f8
 	mov r2, r0
 	mov r0, r5
 	mov r1, r4
 	bl func_ov00_020840a0
-	str r0, [sb, #0x70]
-	ldrb r1, [sb, #0x7a]
-	ldr r2, [sb, #0x18]
-	mov r0, sb
+	str r0, [r9, #0x70]
+	ldrb r1, [r9, #0x7a]
+	ldr r2, [r9, #0x18]
+	mov r0, r9
 	sub r1, r1, #1
 	add r1, r2, r1, lsl #11
-	str r1, [sb, #0x18]
-	ldrb r1, [sb, #0x7a]
-	ldr r2, [sb, #0x20]
+	str r1, [r9, #0x18]
+	ldrb r1, [r9, #0x7a]
+	ldr r2, [r9, #0x20]
 	sub r1, r1, #1
 	add r1, r2, r1, lsl #11
-	str r1, [sb, #0x20]
+	str r1, [r9, #0x20]
 	bl func_ov00_0208c214
-	add r6, sb, #0x18
+	add r6, r9, #0x18
 	add r5, sp, #0x48
 	ldmia r6, {r0, r1, r2}
 	stmia r5, {r0, r1, r2}
 	add r4, sp, #0x3c
 	ldmia r6, {r0, r1, r2}
 	stmia r4, {r0, r1, r2}
-	ldrb r1, [sb, #0x7a]
+	ldrb r1, [r9, #0x7a]
 	mov r3, #0x2000
 	mov r0, r5
 	add r1, r1, #1
@@ -14412,7 +14412,7 @@ func_ov17_02166878: ; 0x02166878
 	str r1, [sp, #0x38]
 	add r1, sp, #0x30
 	bl func_01ff9bf8
-	ldrb r2, [sb, #0x7a]
+	ldrb r2, [r9, #0x7a]
 	mov r1, #0x2000
 	mov r0, r4
 	str r1, [sp, #0x28]
@@ -14433,20 +14433,20 @@ func_ov17_02166878: ; 0x02166878
 	add r3, sp, #0x18
 	ldmia r4, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
-	mov r0, sb
+	mov r0, r9
 	bl func_ov00_0208b9cc
 	mov r1, #0
 	mov r2, r0
 	str r1, [sp]
-	add r0, sb, #0x38
+	add r0, r9, #0x38
 	ldr r4, [r0]
 	ldr r3, [sp, #8]
 	ldr r4, [r4, #0x14]
 	mov r1, r5
 	blx r4
 	mov r0, #0
-	strb r0, [sb, #0x3c]
-	ldrb r7, [sb, #0x14]
+	strb r0, [r9, #0x3c]
+	ldrb r7, [r9, #0x14]
 	add r0, r7, #2
 	cmp r7, r0
 	bge _02166a38
@@ -14454,7 +14454,7 @@ func_ov17_02166878: ; 0x02166878
 	add r5, sp, #4
 	mov r4, #1
 _021669e4:
-	ldrb r8, [sb, #0x15]
+	ldrb r8, [r9, #0x15]
 	add r0, r8, #2
 	cmp r8, r0
 	bge _02166a24
@@ -14466,25 +14466,25 @@ _021669f8:
 	strb r6, [sp, #4]
 	strb r8, [sp, #5]
 	bl func_ov00_020826a0
-	ldrb r0, [sb, #0x15]
+	ldrb r0, [r9, #0x15]
 	add r8, r8, #1
 	add r0, r0, #2
 	cmp r8, r0
 	blt _021669f8
 _02166a24:
-	ldrb r0, [sb, #0x14]
+	ldrb r0, [r9, #0x14]
 	add r7, r7, #1
 	add r0, r0, #2
 	cmp r7, r0
 	blt _021669e4
 _02166a38:
 	ldr r0, _02166a54 ; =data_027e0e60
-	ldrh r2, [sb, #0x2a]
+	ldrh r2, [r9, #0x2a]
 	ldr r0, [r0]
-	add r1, sb, #0x64
+	add r1, r9, #0x64
 	bl func_ov00_020823c4
 	add sp, sp, #0x54
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov17_02166878
 _02166a54: .word data_027e0e60
@@ -15246,18 +15246,18 @@ _021674e4: .word data_02050f54
 	.global func_ov17_021674e8
 	arm_func_start func_ov17_021674e8
 func_ov17_021674e8: ; 0x021674e8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x14
 	mov r10, r0
 	ldrh r2, [r10, #0x28]
 	ldr r0, _021676a4 ; =data_027e0f6c
-	mov sb, r1
+	mov r9, r1
 	and r4, r2, #0xff
 	ldr r1, [r0]
 	add r0, sp, #4
 	mov r2, r4
 	bl func_ov00_02093a4c
-	cmp sb, #0
+	cmp r9, #0
 	add r2, sp, #4
 	beq _02167544
 	ldr r1, [sp, #4]
@@ -15286,7 +15286,7 @@ _02167560:
 	add r0, sp, #0
 	mov r2, r4
 	bl func_ov00_02093a4c
-	cmp sb, #0
+	cmp r9, #0
 	add r2, sp, #0
 	beq _021675ac
 	ldr r0, _021676a4 ; =data_027e0f6c
@@ -15334,7 +15334,7 @@ _021675cc:
 	mov r7, #0
 	cmp r1, #0
 	addle sp, sp, #0x14
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r4, _021676a8 ; =data_027e0e60
 	mov r11, #0x14
 _02167644:
@@ -15342,7 +15342,7 @@ _02167644:
 	cmp r1, #0
 	ble _02167690
 _02167650:
-	cmp sb, #0
+	cmp r9, #0
 	ldr r0, [r4]
 	beq _02167670
 	mov r3, r11
@@ -15365,7 +15365,7 @@ _02167690:
 	cmp r7, r1
 	blt _02167644
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov17_021674e8
 _021676a4: .word data_027e0f6c
@@ -16250,7 +16250,7 @@ func_ov17_0216823c: ; 0x0216823c
 	.global func_ov17_0216826c
 	arm_func_start func_ov17_0216826c
 func_ov17_0216826c: ; 0x0216826c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x54
 	mov r10, r0
 	ldr r1, [r10, #4]
@@ -16326,9 +16326,9 @@ func_ov17_0216826c: ; 0x0216826c
 	mov r5, #1
 	add r11, sp, #4
 _02168398:
-	ldrb sb, [r10, #0x15]
-	add r0, sb, #2
-	cmp sb, r0
+	ldrb r9, [r10, #0x15]
+	add r0, r9, #2
+	cmp r9, r0
 	bge _02168428
 	ldr r4, _0216845c ; =data_027e0e60
 	and r7, r8, #0xff
@@ -16337,11 +16337,11 @@ _021683b0:
 	mov r1, r6
 	mov r2, r5
 	strb r7, [sp, #6]
-	strb sb, [sp, #7]
+	strb r9, [sp, #7]
 	bl func_ov00_020826a0
 	ldr r0, [r4]
 	strb r7, [sp, #4]
-	strb sb, [sp, #5]
+	strb r9, [sp, #5]
 	mov r1, r11
 	mov r2, #1
 	bl func_ov00_02082680
@@ -16350,20 +16350,20 @@ _021683b0:
 	ldr r0, [r4]
 	bne _02168404
 	mov r1, r8
-	mov r2, sb
+	mov r2, r9
 	mov r3, #0x17
 	bl func_ov00_02084d24
 	b _02168414
 _02168404:
 	mov r1, r8
-	mov r2, sb
+	mov r2, r9
 	mov r3, #9
 	bl func_ov00_02084d24
 _02168414:
 	ldrb r0, [r10, #0x15]
-	add sb, sb, #1
+	add r9, r9, #1
 	add r0, r0, #2
-	cmp sb, r0
+	cmp r9, r0
 	blt _021683b0
 _02168428:
 	ldrb r0, [r10, #0x14]
@@ -16379,7 +16379,7 @@ _0216843c:
 	mov r2, r1
 	blx r3
 	add sp, sp, #0x54
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov17_0216826c
 _0216845c: .word data_027e0e60
@@ -16558,7 +16558,7 @@ func_ov17_02168658: ; 0x02168658
 	.global func_ov17_02168660
 	arm_func_start func_ov17_02168660
 func_ov17_02168660: ; 0x02168660
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0xc
 	str r0, [sp]
 	str r1, [r0]
@@ -16591,7 +16591,7 @@ func_ov17_02168660: ; 0x02168660
 	ldr r1, [sp, #8]
 	mov r5, r2, asr #0xa
 	ldr r2, [sp]
-	mov sb, r1, lsr #0x1
+	mov r9, r1, lsr #0x1
 	and r1, r10, #0x1f
 	add r1, r1, #0x1f
 	mov r0, #0x1f000
@@ -16618,7 +16618,7 @@ func_ov17_02168660: ; 0x02168660
 	mov r1, r10, lsl #0x1b
 	mul r0, r3, r0
 	add r0, r0, #0x800
-	cmp sb, #0
+	cmp r9, #0
 	mov r2, #0
 	mov lr, r0, asr #0xc
 	ble _021687d8
@@ -16651,7 +16651,7 @@ _02168760:
 	orr r3, r3, ip, lsl #5
 	orr r0, r3, r0, lsl #10
 	strh r0, [r8], #2
-	cmp r2, sb
+	cmp r2, r9
 	blt _02168760
 _021687d8:
 	ldr r0, [sp]
@@ -16659,13 +16659,13 @@ _021687d8:
 	ldr r0, [r0, #0x14]
 	bl func_0200e2a4
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	arm_func_end func_ov17_02168660
 
 	.global func_ov17_021687f0
 	arm_func_start func_ov17_021687f0
 func_ov17_021687f0: ; 0x021687f0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x18
 	mov r4, r0
 	ldr r1, [r4, #4]
@@ -16682,15 +16682,15 @@ func_ov17_021687f0: ; 0x021687f0
 	mov r8, #0
 	ble _021688a4
 _02168830:
-	ldrh sb, [r6], #2
+	ldrh r9, [r6], #2
 	ldrh r3, [r5], #2
 	ldr r2, [r4, #4]
-	and r0, sb, #0x3e0
+	and r0, r9, #0x3e0
 	mov r0, r0, asr #0x5
-	and r1, sb, #0x7c00
+	and r1, r9, #0x7c00
 	mov r1, r1, asr #0xa
-	and r11, sb, #0x1f
-	mul sb, r0, r2
+	and r11, r9, #0x1f
+	mul r9, r0, r2
 	and r10, r3, #0x3e0
 	and ip, r3, #0x7c00
 	mul r0, r1, r2
@@ -16701,8 +16701,8 @@ _02168830:
 	rsb r2, r2, #0x1000
 	mla r0, r1, r2, r0
 	mov r1, r10, asr #0x5
-	mla sb, r1, r2, sb
-	mov r1, sb, asr #0xc
+	mla r9, r1, r2, r9
+	mov r1, r9, asr #0xc
 	mla r2, ip, r2, r3
 	mov r1, r1, lsl #0x5
 	mov r3, r0, asr #0xc
@@ -16724,7 +16724,7 @@ _021688c4:
 	ldr r0, [r4, #0xc]
 	cmp r0, #0
 	addle sp, sp, #0x18
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, [r4]
 	str r0, [sp, #8]
 	ldrh r0, [r0, #0x1c]
@@ -16742,7 +16742,7 @@ _021688c4:
 	str r0, [sp, #0x10]
 	add r8, r1, r0
 	ldr r0, [sp, #0xc]
-	add sb, r1, r0
+	add r9, r1, r0
 	mov r0, r2, lsl #0x1
 	str r0, [sp, #0x14]
 	ldr r0, [sp, #4]
@@ -16775,16 +16775,16 @@ _02168940:
 	ldr r1, _02168a48 ; =0x00007fff
 	and r1, r2, r1
 	strh r1, [r8]
-	ldr r3, [sb]
+	ldr r3, [r9]
 	ldr r1, [sp, #0x14]
 	mov r2, #3
 	orr r1, r3, r2, lsl r1
-	str r1, [sb]
+	str r1, [r9]
 _021689ac:
 	ldr r1, [sp]
 	add r10, r10, #1
 	add r8, r8, #2
-	add sb, sb, #4
+	add r9, r9, #4
 	cmp r10, r1
 	blo _02168940
 _021689c4:
@@ -16821,7 +16821,7 @@ _02168a24:
 	cmp r0, #0x10
 	strge r1, [r4, #0x24]
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov17_021687f0
 _02168a48: .word 0x00007fff
@@ -19770,7 +19770,7 @@ func_ov17_0216af78: ; 0x0216af78
 	.global func_ov17_0216af8c
 	arm_func_start func_ov17_0216af8c
 func_ov17_0216af8c: ; 0x0216af8c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x30
 	ldr ip, _0216b024 ; =data_027e0ff0
 	mvn r6, #0
@@ -19783,7 +19783,7 @@ func_ov17_0216af8c: ; 0x0216af8c
 	ldr r0, [ip]
 	add r2, sp, #0x10
 	add r3, sp, #0
-	mov sb, r1
+	mov r9, r1
 	str r7, [sp, #0x10]
 	strb r5, [sp, #0x15]
 	strb lr, [sp, #0x16]
@@ -19797,17 +19797,17 @@ func_ov17_0216af8c: ; 0x0216af8c
 	cmp r0, #0
 	addeq sp, sp, #0x30
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	add r1, sp, #0
 	mov r0, r4
 	bl func_ov00_020c6940
 	mov r0, r4
-	mov r1, sb
+	mov r1, r9
 	mov r2, r8
 	bl func_ov00_020c69e8
 	mov r0, r5
 	add sp, sp, #0x30
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov17_0216af8c
 _0216b024: .word data_027e0ff0

--- a/asm/ov17.s
+++ b/asm/ov17.s
@@ -437,20 +437,20 @@ _0215b7d0: .word func_ov17_0215b7d4
 	.global func_ov17_0215b7d4
 	arm_func_start func_ov17_0215b7d4
 func_ov17_0215b7d4: ; 0x0215b7d4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x1c
-	mov sl, r0
-	ldr r0, [sl, #0x188]
+	mov r10, r0
+	ldr r0, [r10, #0x188]
 	cmp r0, #0
 	addeq sp, sp, #0x1c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
-	ldrh r0, [sl, #0x28]
-	ldrh sb, [sl, #0x2a]
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldrh r0, [r10, #0x28]
+	ldrh sb, [r10, #0x2a]
 	cmp r0, #0x40
 	str r0, [sp]
 	cmpls sb, #0x30
 	addhi sp, sp, #0x1c
-	ldmhiia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmhiia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	mov r0, #0
 	str r0, [sp, #4]
 	strb r0, [sp, #8]
@@ -458,7 +458,7 @@ func_ov17_0215b7d4: ; 0x0215b7d4
 	ldr r0, [sp]
 	cmp r0, #0
 	addle sp, sp, #0x1c
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0215b82c:
 	cmp sb, #0
 	mov r8, #0
@@ -471,71 +471,71 @@ _0215b82c:
 	add r11, sp, #0xe
 _0215b850:
 	mov r0, r6
-	mov r1, sl
+	mov r1, r10
 	mov r2, r5
 	mov r3, #0
 	strb r7, [sp, #8]
 	strb r8, [sp, #9]
 	bl func_ov00_0207f588
-	mov r0, sl
+	mov r0, r10
 	ldr r3, [r0]
 	mov r1, r5
 	ldr r3, [r3, #0x58]
 	mov r2, #0
 	blx r3
 	mov r2, r0
-	mov r0, sl
+	mov r0, r10
 	ldr r3, [r0]
 	mov r1, r6
 	ldr r3, [r3, #0xa8]
 	blx r3
 	mov r0, r4
-	mov r1, sl
+	mov r1, r10
 	mov r2, r5
 	mov r3, #1
 	bl func_ov00_0207f588
-	mov r0, sl
+	mov r0, r10
 	ldr r3, [r0]
 	mov r1, r5
 	ldr r3, [r3, #0x58]
 	mov r2, #1
 	blx r3
 	mov r2, r0
-	mov r0, sl
+	mov r0, r10
 	ldr r3, [r0]
 	mov r1, r4
 	ldr r3, [r3, #0xa8]
 	blx r3
 	mov r0, r11
-	mov r1, sl
+	mov r1, r10
 	mov r2, r5
 	mov r3, #2
 	bl func_ov00_0207f588
-	mov r0, sl
+	mov r0, r10
 	ldr r3, [r0]
 	mov r1, r5
 	ldr r3, [r3, #0x58]
 	mov r2, #2
 	blx r3
 	mov r2, r0
-	mov r0, sl
+	mov r0, r10
 	ldr r3, [r0]
 	mov r1, r11
 	ldr r3, [r3, #0xa8]
 	blx r3
 	add r0, sp, #0xa
-	mov r1, sl
+	mov r1, r10
 	mov r2, r5
 	mov r3, #3
 	bl func_ov00_0207f588
-	mov r0, sl
+	mov r0, r10
 	ldr r3, [r0]
 	mov r1, r5
 	ldr r3, [r3, #0x58]
 	mov r2, #3
 	blx r3
 	mov r2, r0
-	mov r0, sl
+	mov r0, r10
 	ldr r3, [r0]
 	add r1, sp, #0xa
 	ldr r3, [r3, #0xa8]
@@ -551,7 +551,7 @@ _0215b974:
 	cmp r1, r0
 	blt _0215b82c
 	add sp, sp, #0x1c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	arm_func_end func_ov17_0215b7d4
 
 	.global func_ov17_0215b994
@@ -3499,18 +3499,18 @@ _0215dfec: .word func_01ff9bc4
 	.global func_ov17_0215dff0
 	arm_func_start func_ov17_0215dff0
 func_ov17_0215dff0: ; 0x0215dff0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #8
 	ldr r2, _0215e1b4 ; =data_027e0e60
 	mov r11, r1
 	ldr r1, [r2]
-	mov sl, r0
+	mov r10, r0
 	add r0, sp, #6
 	mov r2, r11
 	bl func_ov00_02083a1c
 	mov r7, #0
 	ldr r4, _0215e1b4 ; =data_027e0e60
-	str r7, [sl, #0x1ec]
+	str r7, [r10, #0x1ec]
 	add r6, sp, #4
 _0215e024:
 	ldrb r1, [sp, #6]
@@ -3533,7 +3533,7 @@ _0215e038:
 	ldr r1, [r1, #0x1c]
 	blx r1
 	cmp r0, #0x21
-	streq r5, [sl, #0x1ec]
+	streq r5, [r10, #0x1ec]
 	beq _0215e090
 _0215e078:
 	add sb, sb, #1
@@ -3543,40 +3543,40 @@ _0215e078:
 	cmp r7, #3
 	blt _0215e024
 _0215e090:
-	ldr r0, [sl, #0x1ec]
+	ldr r0, [r10, #0x1ec]
 	cmp r0, #0
 	addeq sp, sp, #8
 	mov r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
-	strb r0, [sl, #0x11b]
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	strb r0, [r10, #0x11b]
 	ldr r1, [r11]
 	mov r2, #0x14
-	str r1, [sl, #0x1f0]
+	str r1, [r10, #0x1f0]
 	ldr r1, [r11, #4]
-	add r4, sl, #0x200
-	str r1, [sl, #0x1f4]
+	add r4, r10, #0x200
+	str r1, [r10, #0x1f4]
 	ldr r1, [r11, #8]
 	ldr r6, _0215e1b8 ; =data_ov17_0216bc64
-	str r1, [sl, #0x1f8]
-	ldr r1, [sl, #0x1f4]
+	str r1, [r10, #0x1f8]
+	ldr r1, [r10, #0x1f4]
 	mov r7, #2
 	add r1, r1, #0x7b
 	add r1, r1, #0x2400
-	str r1, [sl, #0x1f4]
-	ldr r1, [sl, #0x48]
+	str r1, [r10, #0x1f4]
+	ldr r1, [r10, #0x48]
 	ldr r5, _0215e1bc ; =data_027e0e58
-	str r1, [sl, #0x1fc]
-	ldr r3, [sl, #0x4c]
-	add r1, sl, #0x214
-	str r3, [sl, #0x200]
-	ldr r8, [sl, #0x50]
-	add r3, sl, #0x48
-	str r8, [sl, #0x204]
-	str r0, [sl, #0x60]
-	str r0, [sl, #0x64]
-	str r0, [sl, #0x68]
-	str r2, [sl, #0x224]
-	ldrsh r8, [sl, #0x78]
+	str r1, [r10, #0x1fc]
+	ldr r3, [r10, #0x4c]
+	add r1, r10, #0x214
+	str r3, [r10, #0x200]
+	ldr r8, [r10, #0x50]
+	add r3, r10, #0x48
+	str r8, [r10, #0x204]
+	str r0, [r10, #0x60]
+	str r0, [r10, #0x64]
+	str r0, [r10, #0x68]
+	str r2, [r10, #0x224]
+	ldrsh r8, [r10, #0x78]
 	mov r2, #0x47
 	add r8, r8, #0x4000
 	and r8, r8, #0x8000
@@ -3584,8 +3584,8 @@ _0215e090:
 	strh r0, [r4, #0x2e]
 	ldr r4, [r6, #0x28]
 	ldr r0, [r6, #0x2c]
-	str r4, [sl, #0x1e4]
-	str r0, [sl, #0x1e8]
+	str r4, [r10, #0x1e4]
+	str r0, [r10, #0x1e8]
 	str r7, [sp]
 	ldr r0, [r5]
 	bl func_ov00_0207c1f8
@@ -3593,29 +3593,29 @@ _0215e090:
 	str r1, [sp]
 	mov r0, r5
 	ldr r0, [r0]
-	add r1, sl, #0x218
-	add r3, sl, #0x48
+	add r1, r10, #0x218
+	add r3, r10, #0x48
 	mov r2, #0x47
 	bl func_ov00_0207c1f8
 	mov r1, r7
 	str r1, [sp]
 	mov r0, r5
 	ldr r0, [r0]
-	add r1, sl, #0x21c
-	add r3, sl, #0x48
+	add r1, r10, #0x21c
+	add r3, r10, #0x48
 	mov r2, #0x48
 	bl func_ov00_0207c1f8
 	mov r0, r7
 	str r0, [sp]
 	mov r0, r5
 	ldr r0, [r0]
-	add r1, sl, #0x220
-	add r3, sl, #0x48
+	add r1, r10, #0x220
+	add r3, r10, #0x48
 	mov r2, #0x48
 	bl func_ov00_0207c1f8
 	mov r0, #1
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov17_0215dff0
 _0215e1b4: .word data_027e0e60
@@ -3743,17 +3743,17 @@ _0215e334: .word func_ov00_020b7d74
 	.global func_ov17_0215e338
 	arm_func_start func_ov17_0215e338
 func_ov17_0215e338: ; 0x0215e338
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	ldr r2, _0215e460 ; =data_027e0e60
 	mov r11, r1
 	ldr r1, [r2]
-	mov sl, r0
+	mov r10, r0
 	add r0, sp, #2
 	mov r2, r11
 	bl func_ov00_02083a1c
 	mov r7, #0
 	ldr r4, _0215e460 ; =data_027e0e60
-	str r7, [sl, #0x250]
+	str r7, [r10, #0x250]
 	add r6, sp, #0
 _0215e368:
 	ldrb r1, [sp, #2]
@@ -3776,7 +3776,7 @@ _0215e37c:
 	ldr r1, [r1, #0x1c]
 	blx r1
 	cmp r0, #0x15
-	streq r5, [sl, #0x250]
+	streq r5, [r10, #0x250]
 	beq _0215e3e4
 _0215e3bc:
 	add sb, sb, #1
@@ -3785,42 +3785,42 @@ _0215e3bc:
 	add r7, r7, #1
 	cmp r7, #3
 	blt _0215e368
-	ldr r0, [sl, #0x250]
+	ldr r0, [r10, #0x250]
 	cmp r0, #0
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0215e3e4:
 	mov r2, #0
-	str r2, [sl, #0x12c]
+	str r2, [r10, #0x12c]
 	ldr r0, [r11]
 	mov r3, #0x1000
-	str r0, [sl, #0x158]
+	str r0, [r10, #0x158]
 	ldr r0, [r11, #4]
 	mov r1, #1
-	str r0, [sl, #0x15c]
+	str r0, [r10, #0x15c]
 	ldr r4, [r11, #8]
-	add r0, sl, #0x100
-	str r4, [sl, #0x160]
-	str r3, [sl, #0x15c]
-	strb r1, [sl, #0x184]
+	add r0, r10, #0x100
+	str r4, [r10, #0x160]
+	str r3, [r10, #0x15c]
+	strb r1, [r10, #0x184]
 	mov r1, #0x100
 	strh r1, [r0, #0x22]
 	mov r0, #0x1e
-	str r0, [sl, #0x138]
+	str r0, [r10, #0x138]
 	mov r0, #0x14
-	str r0, [sl, #0x254]
-	ldr r1, [sl, #0x48]
-	mov r0, sl
-	str r1, [sl, #0x238]
-	ldr r3, [sl, #0x4c]
+	str r0, [r10, #0x254]
+	ldr r1, [r10, #0x48]
+	mov r0, r10
+	str r1, [r10, #0x238]
+	ldr r3, [r10, #0x4c]
 	mov r1, #2
-	str r3, [sl, #0x23c]
-	ldr r3, [sl, #0x50]
-	str r3, [sl, #0x240]
-	str r2, [sl, #0x64]
+	str r3, [r10, #0x23c]
+	ldr r3, [r10, #0x50]
+	str r3, [r10, #0x240]
+	str r2, [r10, #0x64]
 	bl func_ov17_0215e9ec
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov17_0215e338
 _0215e460: .word data_027e0e60
@@ -5644,7 +5644,7 @@ _0215fbd4: .word 0x0000ffff
 	.global func_ov17_0215fbd8
 	arm_func_start func_ov17_0215fbd8
 func_ov17_0215fbd8: ; 0x0215fbd8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	mov r7, r0
 	ldrsb r0, [r7, #0xdd]
 	strb r0, [r7, #0xdc]
@@ -5670,37 +5670,37 @@ _0215fc14:
 	mov r8, r0
 	cmp sb, r6
 	bge _0215fcb4
-	ldr sl, [r11]
+	ldr r10, [r11]
 	bl func_ov03_020f8068
 	mov r1, r0
-	mov r0, sl
+	mov r0, r10
 	bl func_ov00_02083614
 	cmp r0, #0
 	beq _0215fcb4
-	ldr sl, [r11]
+	ldr r10, [r11]
 	mov r0, r8
 	bl func_ov03_020f8068
 	mov r1, r0
-	mov r0, sl
+	mov r0, r10
 	bl func_ov00_02083604
 	cmp r0, #0
 	beq _0215fcb4
 _0215fc78:
 	mov r0, r5
-	ldr sl, [r0]
+	ldr r10, [r0]
 	ldrh r8, [r4, #0xe]
 	mov r1, #0
-	ldr sl, [sl]
+	ldr r10, [r10]
 	mov r2, r1
 	mov r3, r1
-	blx sl
+	blx r10
 	mov r2, r0
 	mov r0, r7
 	mov r1, r8
 	bl func_ov17_0215fcd4
 	cmp r0, #0
 	movne r0, #1
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0215fcb4:
 	add sb, sb, #1
 	cmp sb, #9
@@ -5708,7 +5708,7 @@ _0215fcb4:
 	add r5, r5, #0x18
 	blt _0215fc14
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov17_0215fbd8
 _0215fcd0: .word data_027e0e60
@@ -5716,23 +5716,23 @@ _0215fcd0: .word data_027e0e60
 	.global func_ov17_0215fcd4
 	arm_func_start func_ov17_0215fcd4
 func_ov17_0215fcd4: ; 0x0215fcd4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	mov r11, r2
 	mov sb, r0
 	tst r11, #1
-	mov sl, r1
+	mov r10, r1
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
-	cmp sl, #0x34
-	cmpne sl, #0x35
-	cmpne sl, #0x36
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	cmp r10, #0x34
+	cmpne r10, #0x35
+	cmpne r10, #0x36
 	bne _0215fd10
 	tst r11, #0x20
 	beq _0215fd1c
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0215fd10:
-	sub r1, sl, #0x37
+	sub r1, r10, #0x37
 	bl func_ov17_02160274
 	strb r0, [sb, #0xdc]
 _0215fd1c:
@@ -5763,7 +5763,7 @@ _0215fd70:
 	cmp r7, r6
 	ble _0215fd3c
 _0215fd7c:
-	sub r0, sl, #0x34
+	sub r0, r10, #0x34
 	cmp r0, #8
 	addls pc, pc, r0, lsl #2
 	b _0215ff14
@@ -5780,13 +5780,13 @@ _0215fd8c: ; jump table
 _0215fdb0:
 	tst r11, #8
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	mov r0, sb
-	sub r1, sl, #0x37
+	sub r1, r10, #0x37
 	bl func_ov17_02160274
 	strb r0, [sb, #0xdd]
 	mov r0, sb
-	sub r1, sl, #0x37
+	sub r1, r10, #0x37
 	bl func_ov17_02160274
 	ldr r2, [sb]
 	ldrsh r1, [r2, #0x30]
@@ -5806,11 +5806,11 @@ _0215fe04:
 	mov r0, #0
 	strh r0, [sb, #0xde]
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0215fe20:
 	tst r11, #8
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, _0215ff2c ; =data_027e077c
 	mov r1, #9
 	bl func_0202e740
@@ -5818,15 +5818,15 @@ _0215fe20:
 	mov r1, #0x11
 	bl func_ov00_020d77e4
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0215fe4c:
 	ldrb r0, [sb, #0xe0]
 	cmp r0, #0
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	tst r11, #0x48
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldrsb r0, [sb, #0xe1]
 	add r0, r0, #1
 	strb r0, [sb, #0xe1]
@@ -5845,15 +5845,15 @@ _0215fe90:
 	mov r1, #3
 	bl func_ov00_020d77e4
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0215feb0:
 	ldrb r0, [sb, #0xe0]
 	cmp r0, #0
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	tst r11, #0x48
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldrsb r0, [sb, #0xe1]
 	sub r0, r0, #1
 	strb r0, [sb, #0xe1]
@@ -5872,10 +5872,10 @@ _0215fef4:
 	mov r1, #3
 	bl func_ov00_020d77e4
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0215ff14:
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov17_0215fcd4
 _0215ff1c: .word 0x0001869f
@@ -5887,9 +5887,9 @@ _0215ff2c: .word data_027e077c
 	.global func_ov17_0215ff30
 	arm_func_start func_ov17_0215ff30
 func_ov17_0215ff30: ; 0x0215ff30
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x38
-	mov sl, r0
+	mov r10, r0
 	add r0, sp, #0x18
 	mov r4, r1
 	bl func_01ffbe34
@@ -5910,9 +5910,9 @@ func_ov17_0215ff30: ; 0x0215ff30
 	bl func_0203493c
 	mov r3, r5
 	mov r1, r8
-	add r0, sl, #0x94
+	add r0, r10, #0x94
 	mov r2, #0
-	str sl, [sp]
+	str r10, [sp]
 	bl func_ov00_020d00c4
 	bl func_ov03_020f7fec
 	mov sb, r0
@@ -5924,10 +5924,10 @@ func_ov17_0215ff30: ; 0x0215ff30
 	cmp sb, #0
 	mov r5, #0
 	ble _02160098
-	add r7, sl, #4
+	add r7, r10, #4
 	add r11, r8, #0x14
 _0215ffcc:
-	mov r0, sl
+	mov r0, r10
 	mov r1, r5
 	bl func_ov17_02160274
 	ldr r1, _021600e8 ; =data_027e0e60
@@ -5943,7 +5943,7 @@ _0215ffcc:
 	mov r1, r8
 	mov r2, #0
 	add r3, sp, #0x18
-	str sl, [sp]
+	str r10, [sp]
 	bl func_ov00_020d00c4
 	ldr r0, _021600e0 ; =data_027e0618
 	ldrb r0, [r0, #0x101]
@@ -5951,13 +5951,13 @@ _0215ffcc:
 	ldreq r0, _021600ec ; =data_027e077c
 	ldreq r0, [r0]
 	cmpeq r0, #8
-	ldreq r0, [sl]
+	ldreq r0, [r10]
 	ldreqsb r0, [r0, #0x14]
 	cmpeq r0, #2
 	ldreq r0, [sp, #0x14]
 	cmpeq r4, r0
 	bne _02160088
-	ldrh r0, [sl, #0xde]
+	ldrh r0, [r10, #0xde]
 	mov r1, #0x24
 	bl func_01ff9b88
 	cmp r0, #0x12
@@ -5980,24 +5980,24 @@ _02160088:
 	cmp r5, sb
 	blt _0215ffcc
 _02160098:
-	ldrb r0, [sl, #0xe0]
+	ldrb r0, [r10, #0xe0]
 	cmp r0, #0
 	addeq sp, sp, #0x38
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	mov r2, #0
 	add r3, sp, #0x18
 	mov r1, r8
-	add r0, sl, #0xac
+	add r0, r10, #0xac
 	str r2, [sp]
 	bl func_ov00_020d00c4
 	mov r2, #0
 	add r3, sp, #0x18
 	mov r1, r8
-	add r0, sl, #0xc4
+	add r0, r10, #0xc4
 	str r2, [sp]
 	bl func_ov00_020d00c4
 	add sp, sp, #0x38
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov17_0215ff30
 _021600e0: .word data_027e0618
@@ -10922,10 +10922,10 @@ _02163e20: .word 0x00000b33
 	.global func_ov17_02163e24
 	arm_func_start func_ov17_02163e24
 func_ov17_02163e24: ; 0x02163e24
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	ldrb r0, [r0, #0x71]
 	cmp r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, _02163ecc ; =data_027e0e60
 	ldr r0, [r0]
 	bl func_ov00_0208335c
@@ -10936,11 +10936,11 @@ func_ov17_02163e24: ; 0x02163e24
 	mov r8, r0
 	mov sb, #0
 	cmp r11, #0
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r4, _02163ecc ; =data_027e0e60
 	add r6, sp, #0
 _02163e68:
-	mov sl, #0
+	mov r10, #0
 	cmp r8, #0
 	ble _02163ebc
 	and r7, sb, #0xff
@@ -10948,7 +10948,7 @@ _02163e78:
 	ldr r0, [r4]
 	mov r1, r6
 	strb r7, [sp]
-	strb sl, [sp, #1]
+	strb r10, [sp, #1]
 	bl func_ov00_020840c4
 	movs r5, r0
 	beq _02163eb0
@@ -10960,14 +10960,14 @@ _02163e78:
 	mov r0, r5
 	bl func_ov17_02164284
 _02163eb0:
-	add sl, sl, #1
-	cmp sl, r8
+	add r10, r10, #1
+	cmp r10, r8
 	blt _02163e78
 _02163ebc:
 	add sb, sb, #1
 	cmp sb, r11
 	blt _02163e68
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov17_02163e24
 _02163ecc: .word data_027e0e60
@@ -11260,17 +11260,17 @@ _02164280: .word data_027e0e60
 	.global func_ov17_02164284
 	arm_func_start func_ov17_02164284
 func_ov17_02164284: ; 0x02164284
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x10
-	mov sl, r0
-	ldrb r0, [sl, #0x71]
+	mov r10, r0
+	ldrb r0, [r10, #0x71]
 	cmp r0, #0
 	addne sp, sp, #0x10
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
-	ldrb r0, [sl, #0x14]
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldrb r0, [r10, #0x14]
 	ldr r1, _02164474 ; =data_027e0e60
 	str r0, [sp, #4]
-	ldrb r0, [sl, #0x15]
+	ldrb r0, [r10, #0x15]
 	str r0, [sp]
 	ldr r0, [r1]
 	ldr r1, [sp, #4]
@@ -11305,14 +11305,14 @@ _02164310:
 	mov r4, #0
 	add r6, sp, #0xe
 _0216432c:
-	ldrb r2, [sl, #0x14]
+	ldrb r2, [r10, #0x14]
 	ldr r0, [sb]
 	mov r1, r6
 	strb r2, [sp, #0xe]
 	strb r8, [sp, #0xf]
 	bl func_ov00_020840c4
 	mov r5, r0
-	cmp r5, sl
+	cmp r5, r10
 	beq _02164380
 	cmp r5, #0
 	beq _0216438c
@@ -11323,9 +11323,9 @@ _0216432c:
 	bne _0216438c
 	strb r4, [r5, #0x70]
 	strb r4, [r5, #0x71]
-	ldrb r0, [sl, #0x73]
+	ldrb r0, [r10, #0x73]
 	add r0, r0, #1
-	strb r0, [sl, #0x73]
+	strb r0, [r10, #0x73]
 _02164380:
 	add r8, r8, #1
 	cmp r8, r7
@@ -11333,7 +11333,7 @@ _02164380:
 _0216438c:
 	ldr r1, [sp, #4]
 	ldr r0, [sp, #8]
-	ldrb r2, [sl, #0x73]
+	ldrb r2, [r10, #0x73]
 	cmp r1, r0
 	ldr r0, [sp]
 	add r0, r0, r2
@@ -11342,7 +11342,7 @@ _0216438c:
 	mov r4, #0
 	add r11, sp, #0xc
 _021643b4:
-	ldrb r1, [sl, #0x14]
+	ldrb r1, [r10, #0x14]
 	ldr r0, [sp, #4]
 	cmp r0, r1
 	beq _0216444c
@@ -11361,7 +11361,7 @@ _021643e0:
 	strb sb, [sp, #0xd]
 	bl func_ov00_020840c4
 	mov r5, r0
-	cmp r5, sl
+	cmp r5, r10
 	beq _0216442c
 	cmp r5, #0
 	beq _02164438
@@ -11380,9 +11380,9 @@ _0216442c:
 _02164438:
 	cmp r7, #0
 	beq _02164464
-	ldrb r0, [sl, #0x72]
+	ldrb r0, [r10, #0x72]
 	add r0, r0, #1
-	strb r0, [sl, #0x72]
+	strb r0, [r10, #0x72]
 _0216444c:
 	ldr r0, [sp, #4]
 	add r1, r0, #1
@@ -11392,9 +11392,9 @@ _0216444c:
 	blt _021643b4
 _02164464:
 	mov r0, #1
-	strb r0, [sl, #0x71]
+	strb r0, [r10, #0x71]
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov17_02164284
 _02164474: .word data_027e0e60
@@ -12406,24 +12406,24 @@ _02165178: .word 0x00000dac
 	.global func_ov17_0216517c
 	arm_func_start func_ov17_0216517c
 func_ov17_0216517c: ; 0x0216517c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
-	mov sl, r0
-	ldr r0, [sl, #0x60]
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	mov r10, r0
+	ldr r0, [r10, #0x60]
 	cmp r0, #0
 	bne _021651c0
-	ldrh r0, [sl, #0x24]
+	ldrh r0, [r10, #0x24]
 	cmp r0, #1
-	ldr r0, [sl, #8]
+	ldr r0, [r10, #8]
 	bne _021651b0
 	cmp r0, #0
 	moveq r0, #1
 	movne r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _021651b0:
 	cmp r0, #1
 	moveq r0, #1
 	movne r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _021651c0:
 	ldr r0, _02165280 ; =data_027e0e60
 	ldr r0, [r0]
@@ -12456,15 +12456,15 @@ _02165208:
 	ldr r1, [r1, #0x1c]
 	blx r1
 	cmp r0, #0x80
-	ldreq r1, [sl, #0x60]
+	ldreq r1, [r10, #0x60]
 	ldreq r0, [r5, #0x60]
 	cmpeq r1, r0
 	bne _02165258
-	ldr r1, [sl, #8]
+	ldr r1, [r10, #8]
 	ldr r0, [r5, #8]
 	cmp r1, r0
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02165258:
 	add r0, sb, #1
 	and sb, r0, #0xff
@@ -12477,7 +12477,7 @@ _02165268:
 	blo _021651fc
 _02165278:
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov17_0216517c
 _02165280: .word data_027e0e60
@@ -14062,7 +14062,7 @@ func_ov17_0216649c: ; 0x0216649c
 	.global func_ov17_021664c4
 	arm_func_start func_ov17_021664c4
 func_ov17_021664c4: ; 0x021664c4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #0x38
 	mov r4, r0
 	ldrh r2, [r4, #0x20]
@@ -14106,12 +14106,12 @@ func_ov17_021664c4: ; 0x021664c4
 	strh r0, [r4, #0x9c]
 	ldr sb, [r4, #0x4c]
 	ldr r7, [r4, #0x48]
-	ldr sl, [r4, #0x50]
+	ldr r10, [r4, #0x50]
 	sub r8, r7, #0x1000
-	sub r1, sl, #0x1000
+	sub r1, r10, #0x1000
 	sub r0, sb, #0x800
 	str r8, [sp, #0x2c]
-	add r8, sl, #0x1000
+	add r8, r10, #0x1000
 	add r7, r7, #0x1000
 	str r0, [sp, #0x30]
 	str r1, [sp, #0x34]
@@ -14146,7 +14146,7 @@ _021665f0:
 	mov r0, r4
 	bl func_ov14_02137970
 	add sp, sp, #0x38
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	arm_func_end func_ov17_021664c4
 
 	.global func_ov17_02166614
@@ -14362,7 +14362,7 @@ func_ov17_02166850: ; 0x02166850
 	.global func_ov17_02166878
 	arm_func_start func_ov17_02166878
 func_ov17_02166878: ; 0x02166878
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #0x54
 	mov sb, r0
 	ldr r1, [sb, #4]
@@ -14450,7 +14450,7 @@ func_ov17_02166878: ; 0x02166878
 	add r0, r7, #2
 	cmp r7, r0
 	bge _02166a38
-	ldr sl, _02166a54 ; =data_027e0e60
+	ldr r10, _02166a54 ; =data_027e0e60
 	add r5, sp, #4
 	mov r4, #1
 _021669e4:
@@ -14460,7 +14460,7 @@ _021669e4:
 	bge _02166a24
 	and r6, r7, #0xff
 _021669f8:
-	ldr r0, [sl]
+	ldr r0, [r10]
 	mov r1, r5
 	mov r2, r4
 	strb r6, [sp, #4]
@@ -14484,7 +14484,7 @@ _02166a38:
 	add r1, sb, #0x64
 	bl func_ov00_020823c4
 	add sp, sp, #0x54
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov17_02166878
 _02166a54: .word data_027e0e60
@@ -15246,10 +15246,10 @@ _021674e4: .word data_02050f54
 	.global func_ov17_021674e8
 	arm_func_start func_ov17_021674e8
 func_ov17_021674e8: ; 0x021674e8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x14
-	mov sl, r0
-	ldrh r2, [sl, #0x28]
+	mov r10, r0
+	ldrh r2, [r10, #0x28]
 	ldr r0, _021676a4 ; =data_027e0f6c
 	mov sb, r1
 	and r4, r2, #0xff
@@ -15278,7 +15278,7 @@ _02167544:
 	str r3, [sp, #4]
 	bl func_ov00_02093a3c
 _02167560:
-	ldr r0, [sl, #0x30]
+	ldr r0, [r10, #0x30]
 	ldr r1, _021676a4 ; =data_027e0f6c
 	mov r0, r0, lsl #0x10
 	mov r4, r0, lsr #0x10
@@ -15307,17 +15307,17 @@ _021675ac:
 	str r3, [sp]
 	bl func_ov00_02093a3c
 _021675cc:
-	add r0, sl, #0x18
+	add r0, r10, #0x18
 	add r3, sp, #8
 	ldmia r0, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
-	ldrb r1, [sl, #0x7a]
+	ldrb r1, [r10, #0x7a]
 	ldr r0, _021676a8 ; =data_027e0e60
 	ldr r2, [sp, #8]
 	sub r1, r1, #1
 	sub r1, r2, r1, lsl #11
 	str r1, [sp, #8]
-	ldrb r2, [sl, #0x7a]
+	ldrb r2, [r10, #0x7a]
 	ldr r3, [sp, #0x10]
 	ldr r0, [r0]
 	sub r2, r2, #1
@@ -15329,12 +15329,12 @@ _021675cc:
 	ldr r0, [r1]
 	ldr r1, [sp, #0x10]
 	bl func_ov00_020839f8
-	ldrb r1, [sl, #0x7a]
+	ldrb r1, [r10, #0x7a]
 	mov r6, r0
 	mov r7, #0
 	cmp r1, #0
 	addle sp, sp, #0x14
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r4, _021676a8 ; =data_027e0e60
 	mov r11, #0x14
 _02167644:
@@ -15351,12 +15351,12 @@ _02167650:
 	bl func_ov00_02084d24
 	b _02167680
 _02167670:
-	ldr r3, [sl, #0x70]
+	ldr r3, [r10, #0x70]
 	add r1, r5, r7
 	add r2, r6, r8
 	bl func_ov00_02084d24
 _02167680:
-	ldrb r1, [sl, #0x7a]
+	ldrb r1, [r10, #0x7a]
 	add r8, r8, #1
 	cmp r8, r1
 	blt _02167650
@@ -15365,7 +15365,7 @@ _02167690:
 	cmp r7, r1
 	blt _02167644
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov17_021674e8
 _021676a4: .word data_027e0f6c
@@ -16250,22 +16250,22 @@ func_ov17_0216823c: ; 0x0216823c
 	.global func_ov17_0216826c
 	arm_func_start func_ov17_0216826c
 func_ov17_0216826c: ; 0x0216826c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x54
-	mov sl, r0
-	ldr r1, [sl, #4]
+	mov r10, r0
+	ldr r1, [r10, #4]
 	orr r1, r1, #0x800
-	str r1, [sl, #4]
-	ldr r1, [sl, #0x18]
+	str r1, [r10, #4]
+	ldr r1, [r10, #0x18]
 	add r1, r1, #0x800
-	str r1, [sl, #0x18]
-	ldr r1, [sl, #0x20]
+	str r1, [r10, #0x18]
+	ldr r1, [r10, #0x20]
 	add r1, r1, #0x800
-	str r1, [sl, #0x20]
+	str r1, [r10, #0x20]
 	bl func_ov17_0216857c
-	mov r0, sl
+	mov r0, r10
 	bl func_ov17_021685b8
-	add r5, sl, #0x18
+	add r5, r10, #0x18
 	ldmia r5, {r0, r1, r2}
 	add r4, sp, #0x48
 	stmia r4, {r0, r1, r2}
@@ -16292,7 +16292,7 @@ func_ov17_0216826c: ; 0x0216826c
 	bl func_01ff9bc4
 	mov r0, #0
 	bic r0, r0, #0x1f
-	ldrh r1, [sl, #0x26]
+	ldrh r1, [r10, #0x26]
 	orr r0, r0, #7
 	orr r0, r0, #0x10c00000
 	bic r2, r0, #0x3f0000
@@ -16307,18 +16307,18 @@ func_ov17_0216826c: ; 0x0216826c
 	add r3, sp, #0x18
 	ldmia r4, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
-	mov r0, sl
+	mov r0, r10
 	bl func_ov00_0208b9cc
 	mov r2, r0
 	mov r0, #0
 	str r0, [sp]
-	add r0, sl, #0x38
+	add r0, r10, #0x38
 	ldr r4, [r0]
 	ldr r3, [sp, #8]
 	ldr r4, [r4, #0x14]
 	mov r1, r5
 	blx r4
-	ldrb r8, [sl, #0x14]
+	ldrb r8, [r10, #0x14]
 	add r0, r8, #2
 	cmp r8, r0
 	bge _0216843c
@@ -16326,7 +16326,7 @@ func_ov17_0216826c: ; 0x0216826c
 	mov r5, #1
 	add r11, sp, #4
 _02168398:
-	ldrb sb, [sl, #0x15]
+	ldrb sb, [r10, #0x15]
 	add r0, sb, #2
 	cmp sb, r0
 	bge _02168428
@@ -16345,7 +16345,7 @@ _021683b0:
 	mov r1, r11
 	mov r2, #1
 	bl func_ov00_02082680
-	ldr r0, [sl, #0x68]
+	ldr r0, [r10, #0x68]
 	cmp r0, #1
 	ldr r0, [r4]
 	bne _02168404
@@ -16360,26 +16360,26 @@ _02168404:
 	mov r3, #9
 	bl func_ov00_02084d24
 _02168414:
-	ldrb r0, [sl, #0x15]
+	ldrb r0, [r10, #0x15]
 	add sb, sb, #1
 	add r0, r0, #2
 	cmp sb, r0
 	blt _021683b0
 _02168428:
-	ldrb r0, [sl, #0x14]
+	ldrb r0, [r10, #0x14]
 	add r8, r8, #1
 	add r0, r0, #2
 	cmp r8, r0
 	blt _02168398
 _0216843c:
-	mov r0, sl
+	mov r0, r10
 	ldr r3, [r0]
 	mov r1, #1
 	ldr r3, [r3, #0x80]
 	mov r2, r1
 	blx r3
 	add sp, sp, #0x54
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov17_0216826c
 _0216845c: .word data_027e0e60
@@ -16558,7 +16558,7 @@ func_ov17_02168658: ; 0x02168658
 	.global func_ov17_02168660
 	arm_func_start func_ov17_02168660
 func_ov17_02168660: ; 0x02168660
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0xc
 	str r0, [sp]
 	str r1, [r0]
@@ -16566,14 +16566,14 @@ func_ov17_02168660: ; 0x02168660
 	mov r6, r2
 	add r2, r1, r0
 	ldr r0, [sp]
-	ldrh sl, [sp, #0x34]
+	ldrh r10, [sp, #0x34]
 	str r2, [r0, #0x10]
 	ldr r0, [r1, #0x2c]
 	str r3, [sp, #4]
 	mov r0, r0, lsl #0x10
 	mov r2, r0, lsr #0xd
 	ldr r0, [sp]
-	and r3, sl, #0x3e0
+	and r3, r10, #0x3e0
 	str r2, [r0, #0x20]
 	ldrh r1, [r1, #0x30]
 	ldr r2, [r0, #0x1c]
@@ -16586,13 +16586,13 @@ func_ov17_02168660: ; 0x02168660
 	cmp r0, r2
 	movlo r1, r0
 	ldrlo r0, [sp]
-	and r2, sl, #0x7c00
+	and r2, r10, #0x7c00
 	strlo r1, [r0, #0x1c]
 	ldr r1, [sp, #8]
 	mov r5, r2, asr #0xa
 	ldr r2, [sp]
 	mov sb, r1, lsr #0x1
-	and r1, sl, #0x1f
+	and r1, r10, #0x1f
 	add r1, r1, #0x1f
 	mov r0, #0x1f000
 	mov r1, r1, lsl #0xc
@@ -16615,7 +16615,7 @@ func_ov17_02168660: ; 0x02168660
 	mov r1, r1, lsl #0xc
 	bl Divide
 	ldr r3, [sp, #0x30]
-	mov r1, sl, lsl #0x1b
+	mov r1, r10, lsl #0x1b
 	mul r0, r3, r0
 	add r0, r0, #0x800
 	cmp sb, #0
@@ -16623,23 +16623,23 @@ func_ov17_02168660: ; 0x02168660
 	mov lr, r0, asr #0xc
 	ble _021687d8
 _02168760:
-	ldrh sl, [r7]
+	ldrh r10, [r7]
 	add r2, r2, #1
 	add r7, r7, #2
-	mov r0, sl, asr #0xa
+	mov r0, r10, asr #0xa
 	and r3, r0, #0x1f
-	and r0, sl, #0x1f
-	mov sl, sl, asr #0x5
-	and sl, sl, #0x1f
-	add r0, r0, sl
-	add sl, r3, r0
-	mul r0, sl, r11
+	and r0, r10, #0x1f
+	mov r10, r10, asr #0x5
+	and r10, r10, #0x1f
+	add r0, r0, r10
+	add r10, r3, r0
+	mul r0, r10, r11
 	add r0, r0, r1, lsr #15
 	mov r3, r0, asr #0xc
-	mul r0, sl, r6
+	mul r0, r10, r6
 	add r0, r0, r4, lsl #12
 	mov ip, r0, asr #0xc
-	mul r0, sl, lr
+	mul r0, r10, lr
 	add r0, r0, r5, lsl #12
 	cmp r3, #0x1f
 	movgt r3, #0x1f
@@ -16659,13 +16659,13 @@ _021687d8:
 	ldr r0, [r0, #0x14]
 	bl func_0200e2a4
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	arm_func_end func_ov17_02168660
 
 	.global func_ov17_021687f0
 	arm_func_start func_ov17_021687f0
 func_ov17_021687f0: ; 0x021687f0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x18
 	mov r4, r0
 	ldr r1, [r4, #4]
@@ -16691,7 +16691,7 @@ _02168830:
 	mov r1, r1, asr #0xa
 	and r11, sb, #0x1f
 	mul sb, r0, r2
-	and sl, r3, #0x3e0
+	and r10, r3, #0x3e0
 	and ip, r3, #0x7c00
 	mul r0, r1, r2
 	add r8, r8, #1
@@ -16700,7 +16700,7 @@ _02168830:
 	mul r3, r11, r2
 	rsb r2, r2, #0x1000
 	mla r0, r1, r2, r0
-	mov r1, sl, asr #0x5
+	mov r1, r10, asr #0x5
 	mla sb, r1, r2, sb
 	mov r1, sb, asr #0xc
 	mla r2, ip, r2, r3
@@ -16724,7 +16724,7 @@ _021688c4:
 	ldr r0, [r4, #0xc]
 	cmp r0, #0
 	addle sp, sp, #0x18
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, [r4]
 	str r0, [sp, #8]
 	ldrh r0, [r0, #0x1c]
@@ -16737,7 +16737,7 @@ _021688c4:
 	ldr r2, [r4, #0x24]
 	str r0, [sp, #0xc]
 	ldr r0, [sp, #8]
-	mov sl, #0
+	mov r10, #0
 	ldr r0, [r0, #0x28]
 	str r0, [sp, #0x10]
 	add r8, r1, r0
@@ -16782,10 +16782,10 @@ _02168940:
 	str r1, [sb]
 _021689ac:
 	ldr r1, [sp]
-	add sl, sl, #1
+	add r10, r10, #1
 	add r8, r8, #2
 	add sb, sb, #4
-	cmp sl, r1
+	cmp r10, r1
 	blo _02168940
 _021689c4:
 	ldr r0, [r4]
@@ -16821,7 +16821,7 @@ _02168a24:
 	cmp r0, #0x10
 	strge r1, [r4, #0x24]
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov17_021687f0
 _02168a48: .word 0x00007fff

--- a/asm/ov17.s
+++ b/asm/ov17.s
@@ -437,20 +437,20 @@ _0215b7d0: .word func_ov17_0215b7d4
 	.global func_ov17_0215b7d4
 	arm_func_start func_ov17_0215b7d4
 func_ov17_0215b7d4: ; 0x0215b7d4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x1c
 	mov sl, r0
 	ldr r0, [sl, #0x188]
 	cmp r0, #0
 	addeq sp, sp, #0x1c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldrh r0, [sl, #0x28]
 	ldrh sb, [sl, #0x2a]
 	cmp r0, #0x40
 	str r0, [sp]
 	cmpls sb, #0x30
 	addhi sp, sp, #0x1c
-	ldmhiia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmhiia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	mov r0, #0
 	str r0, [sp, #4]
 	strb r0, [sp, #8]
@@ -458,7 +458,7 @@ func_ov17_0215b7d4: ; 0x0215b7d4
 	ldr r0, [sp]
 	cmp r0, #0
 	addle sp, sp, #0x1c
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0215b82c:
 	cmp sb, #0
 	mov r8, #0
@@ -468,7 +468,7 @@ _0215b82c:
 	and r7, r0, #0xff
 	add r5, sp, #8
 	add r4, sp, #0x12
-	add fp, sp, #0xe
+	add r11, sp, #0xe
 _0215b850:
 	mov r0, r6
 	mov r1, sl
@@ -506,7 +506,7 @@ _0215b850:
 	mov r1, r4
 	ldr r3, [r3, #0xa8]
 	blx r3
-	mov r0, fp
+	mov r0, r11
 	mov r1, sl
 	mov r2, r5
 	mov r3, #2
@@ -520,7 +520,7 @@ _0215b850:
 	mov r2, r0
 	mov r0, sl
 	ldr r3, [r0]
-	mov r1, fp
+	mov r1, r11
 	ldr r3, [r3, #0xa8]
 	blx r3
 	add r0, sp, #0xa
@@ -551,7 +551,7 @@ _0215b974:
 	cmp r1, r0
 	blt _0215b82c
 	add sp, sp, #0x1c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	arm_func_end func_ov17_0215b7d4
 
 	.global func_ov17_0215b994
@@ -3499,14 +3499,14 @@ _0215dfec: .word func_01ff9bc4
 	.global func_ov17_0215dff0
 	arm_func_start func_ov17_0215dff0
 func_ov17_0215dff0: ; 0x0215dff0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #8
 	ldr r2, _0215e1b4 ; =data_027e0e60
-	mov fp, r1
+	mov r11, r1
 	ldr r1, [r2]
 	mov sl, r0
 	add r0, sp, #6
-	mov r2, fp
+	mov r2, r11
 	bl func_ov00_02083a1c
 	mov r7, #0
 	ldr r4, _0215e1b4 ; =data_027e0e60
@@ -3547,15 +3547,15 @@ _0215e090:
 	cmp r0, #0
 	addeq sp, sp, #8
 	mov r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	strb r0, [sl, #0x11b]
-	ldr r1, [fp]
+	ldr r1, [r11]
 	mov r2, #0x14
 	str r1, [sl, #0x1f0]
-	ldr r1, [fp, #4]
+	ldr r1, [r11, #4]
 	add r4, sl, #0x200
 	str r1, [sl, #0x1f4]
-	ldr r1, [fp, #8]
+	ldr r1, [r11, #8]
 	ldr r6, _0215e1b8 ; =data_ov17_0216bc64
 	str r1, [sl, #0x1f8]
 	ldr r1, [sl, #0x1f4]
@@ -3615,7 +3615,7 @@ _0215e090:
 	bl func_ov00_0207c1f8
 	mov r0, #1
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov17_0215dff0
 _0215e1b4: .word data_027e0e60
@@ -3743,13 +3743,13 @@ _0215e334: .word func_ov00_020b7d74
 	.global func_ov17_0215e338
 	arm_func_start func_ov17_0215e338
 func_ov17_0215e338: ; 0x0215e338
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	ldr r2, _0215e460 ; =data_027e0e60
-	mov fp, r1
+	mov r11, r1
 	ldr r1, [r2]
 	mov sl, r0
 	add r0, sp, #2
-	mov r2, fp
+	mov r2, r11
 	bl func_ov00_02083a1c
 	mov r7, #0
 	ldr r4, _0215e460 ; =data_027e0e60
@@ -3788,17 +3788,17 @@ _0215e3bc:
 	ldr r0, [sl, #0x250]
 	cmp r0, #0
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0215e3e4:
 	mov r2, #0
 	str r2, [sl, #0x12c]
-	ldr r0, [fp]
+	ldr r0, [r11]
 	mov r3, #0x1000
 	str r0, [sl, #0x158]
-	ldr r0, [fp, #4]
+	ldr r0, [r11, #4]
 	mov r1, #1
 	str r0, [sl, #0x15c]
-	ldr r4, [fp, #8]
+	ldr r4, [r11, #8]
 	add r0, sl, #0x100
 	str r4, [sl, #0x160]
 	str r3, [sl, #0x15c]
@@ -3820,7 +3820,7 @@ _0215e3e4:
 	str r2, [sl, #0x64]
 	bl func_ov17_0215e9ec
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov17_0215e338
 _0215e460: .word data_027e0e60
@@ -5644,7 +5644,7 @@ _0215fbd4: .word 0x0000ffff
 	.global func_ov17_0215fbd8
 	arm_func_start func_ov17_0215fbd8
 func_ov17_0215fbd8: ; 0x0215fbd8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	mov r7, r0
 	ldrsb r0, [r7, #0xdd]
 	strb r0, [r7, #0xdc]
@@ -5655,7 +5655,7 @@ func_ov17_0215fbd8: ; 0x0215fbd8
 	mov r1, #0
 	movge r6, #6
 	bl func_ov17_02160274
-	ldr fp, _0215fcd0 ; =data_027e0e60
+	ldr r11, _0215fcd0 ; =data_027e0e60
 	mov r4, r7
 	add r5, r7, #4
 	mov sb, #0
@@ -5670,14 +5670,14 @@ _0215fc14:
 	mov r8, r0
 	cmp sb, r6
 	bge _0215fcb4
-	ldr sl, [fp]
+	ldr sl, [r11]
 	bl func_ov03_020f8068
 	mov r1, r0
 	mov r0, sl
 	bl func_ov00_02083614
 	cmp r0, #0
 	beq _0215fcb4
-	ldr sl, [fp]
+	ldr sl, [r11]
 	mov r0, r8
 	bl func_ov03_020f8068
 	mov r1, r0
@@ -5700,7 +5700,7 @@ _0215fc78:
 	bl func_ov17_0215fcd4
 	cmp r0, #0
 	movne r0, #1
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0215fcb4:
 	add sb, sb, #1
 	cmp sb, #9
@@ -5708,7 +5708,7 @@ _0215fcb4:
 	add r5, r5, #0x18
 	blt _0215fc14
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov17_0215fbd8
 _0215fcd0: .word data_027e0e60
@@ -5716,21 +5716,21 @@ _0215fcd0: .word data_027e0e60
 	.global func_ov17_0215fcd4
 	arm_func_start func_ov17_0215fcd4
 func_ov17_0215fcd4: ; 0x0215fcd4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
-	mov fp, r2
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	mov r11, r2
 	mov sb, r0
-	tst fp, #1
+	tst r11, #1
 	mov sl, r1
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	cmp sl, #0x34
 	cmpne sl, #0x35
 	cmpne sl, #0x36
 	bne _0215fd10
-	tst fp, #0x20
+	tst r11, #0x20
 	beq _0215fd1c
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0215fd10:
 	sub r1, sl, #0x37
 	bl func_ov17_02160274
@@ -5778,9 +5778,9 @@ _0215fd8c: ; jump table
 	b _0215fdb0 ; case 7
 	b _0215fdb0 ; case 8
 _0215fdb0:
-	tst fp, #8
+	tst r11, #8
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	mov r0, sb
 	sub r1, sl, #0x37
 	bl func_ov17_02160274
@@ -5806,11 +5806,11 @@ _0215fe04:
 	mov r0, #0
 	strh r0, [sb, #0xde]
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0215fe20:
-	tst fp, #8
+	tst r11, #8
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, _0215ff2c ; =data_027e077c
 	mov r1, #9
 	bl func_0202e740
@@ -5818,15 +5818,15 @@ _0215fe20:
 	mov r1, #0x11
 	bl func_ov00_020d77e4
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0215fe4c:
 	ldrb r0, [sb, #0xe0]
 	cmp r0, #0
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
-	tst fp, #0x48
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	tst r11, #0x48
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldrsb r0, [sb, #0xe1]
 	add r0, r0, #1
 	strb r0, [sb, #0xe1]
@@ -5845,15 +5845,15 @@ _0215fe90:
 	mov r1, #3
 	bl func_ov00_020d77e4
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0215feb0:
 	ldrb r0, [sb, #0xe0]
 	cmp r0, #0
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
-	tst fp, #0x48
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	tst r11, #0x48
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldrsb r0, [sb, #0xe1]
 	sub r0, r0, #1
 	strb r0, [sb, #0xe1]
@@ -5872,10 +5872,10 @@ _0215fef4:
 	mov r1, #3
 	bl func_ov00_020d77e4
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0215ff14:
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov17_0215fcd4
 _0215ff1c: .word 0x0001869f
@@ -5887,7 +5887,7 @@ _0215ff2c: .word data_027e077c
 	.global func_ov17_0215ff30
 	arm_func_start func_ov17_0215ff30
 func_ov17_0215ff30: ; 0x0215ff30
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x38
 	mov sl, r0
 	add r0, sp, #0x18
@@ -5925,7 +5925,7 @@ func_ov17_0215ff30: ; 0x0215ff30
 	mov r5, #0
 	ble _02160098
 	add r7, sl, #4
-	add fp, r8, #0x14
+	add r11, r8, #0x14
 _0215ffcc:
 	mov r0, sl
 	mov r1, r5
@@ -5964,7 +5964,7 @@ _0215ffcc:
 	bge _02160088
 	mov r0, #2
 	str r0, [sp]
-	stmib sp, {r0, fp}
+	stmib sp, {r0, r11}
 	mov r0, #0
 	str r0, [sp, #0xc]
 	add r0, sp, #0x18
@@ -5983,7 +5983,7 @@ _02160098:
 	ldrb r0, [sl, #0xe0]
 	cmp r0, #0
 	addeq sp, sp, #0x38
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	mov r2, #0
 	add r3, sp, #0x18
 	mov r1, r8
@@ -5997,7 +5997,7 @@ _02160098:
 	str r2, [sp]
 	bl func_ov00_020d00c4
 	add sp, sp, #0x38
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov17_0215ff30
 _021600e0: .word data_027e0618
@@ -10922,21 +10922,21 @@ _02163e20: .word 0x00000b33
 	.global func_ov17_02163e24
 	arm_func_start func_ov17_02163e24
 func_ov17_02163e24: ; 0x02163e24
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	ldrb r0, [r0, #0x71]
 	cmp r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, _02163ecc ; =data_027e0e60
 	ldr r0, [r0]
 	bl func_ov00_0208335c
 	ldr r1, _02163ecc ; =data_027e0e60
-	mov fp, r0
+	mov r11, r0
 	ldr r0, [r1]
 	bl func_ov00_02083368
 	mov r8, r0
 	mov sb, #0
-	cmp fp, #0
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	cmp r11, #0
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r4, _02163ecc ; =data_027e0e60
 	add r6, sp, #0
 _02163e68:
@@ -10965,9 +10965,9 @@ _02163eb0:
 	blt _02163e78
 _02163ebc:
 	add sb, sb, #1
-	cmp sb, fp
+	cmp sb, r11
 	blt _02163e68
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov17_02163e24
 _02163ecc: .word data_027e0e60
@@ -11260,13 +11260,13 @@ _02164280: .word data_027e0e60
 	.global func_ov17_02164284
 	arm_func_start func_ov17_02164284
 func_ov17_02164284: ; 0x02164284
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x10
 	mov sl, r0
 	ldrb r0, [sl, #0x71]
 	cmp r0, #0
 	addne sp, sp, #0x10
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldrb r0, [sl, #0x14]
 	ldr r1, _02164474 ; =data_027e0e60
 	str r0, [sp, #4]
@@ -11340,7 +11340,7 @@ _0216438c:
 	add r8, r0, #1
 	bge _02164464
 	mov r4, #0
-	add fp, sp, #0xc
+	add r11, sp, #0xc
 _021643b4:
 	ldrb r1, [sl, #0x14]
 	ldr r0, [sp, #4]
@@ -11355,7 +11355,7 @@ _021643b4:
 	and r6, r0, #0xff
 _021643e0:
 	ldr r0, _02164474 ; =data_027e0e60
-	mov r1, fp
+	mov r1, r11
 	ldr r0, [r0]
 	strb r6, [sp, #0xc]
 	strb sb, [sp, #0xd]
@@ -11394,7 +11394,7 @@ _02164464:
 	mov r0, #1
 	strb r0, [sl, #0x71]
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov17_02164284
 _02164474: .word data_027e0e60
@@ -12406,7 +12406,7 @@ _02165178: .word 0x00000dac
 	.global func_ov17_0216517c
 	arm_func_start func_ov17_0216517c
 func_ov17_0216517c: ; 0x0216517c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	mov sl, r0
 	ldr r0, [sl, #0x60]
 	cmp r0, #0
@@ -12418,24 +12418,24 @@ func_ov17_0216517c: ; 0x0216517c
 	cmp r0, #0
 	moveq r0, #1
 	movne r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _021651b0:
 	cmp r0, #1
 	moveq r0, #1
 	movne r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _021651c0:
 	ldr r0, _02165280 ; =data_027e0e60
 	ldr r0, [r0]
 	bl func_ov00_0208335c
 	ldr r1, _02165280 ; =data_027e0e60
-	and fp, r0, #0xff
+	and r11, r0, #0xff
 	ldr r0, [r1]
 	bl func_ov00_02083368
 	mov r8, #0
 	strb r8, [sp]
 	strb r8, [sp, #1]
-	cmp fp, #0
+	cmp r11, #0
 	and r7, r0, #0xff
 	bls _02165278
 	ldr r4, _02165280 ; =data_027e0e60
@@ -12464,7 +12464,7 @@ _02165208:
 	ldr r0, [r5, #8]
 	cmp r1, r0
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02165258:
 	add r0, sb, #1
 	and sb, r0, #0xff
@@ -12473,11 +12473,11 @@ _02165258:
 _02165268:
 	add r0, r8, #1
 	and r8, r0, #0xff
-	cmp r8, fp
+	cmp r8, r11
 	blo _021651fc
 _02165278:
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov17_0216517c
 _02165280: .word data_027e0e60
@@ -15246,7 +15246,7 @@ _021674e4: .word data_02050f54
 	.global func_ov17_021674e8
 	arm_func_start func_ov17_021674e8
 func_ov17_021674e8: ; 0x021674e8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x14
 	mov sl, r0
 	ldrh r2, [sl, #0x28]
@@ -15334,9 +15334,9 @@ _021675cc:
 	mov r7, #0
 	cmp r1, #0
 	addle sp, sp, #0x14
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r4, _021676a8 ; =data_027e0e60
-	mov fp, #0x14
+	mov r11, #0x14
 _02167644:
 	mov r8, #0
 	cmp r1, #0
@@ -15345,7 +15345,7 @@ _02167650:
 	cmp sb, #0
 	ldr r0, [r4]
 	beq _02167670
-	mov r3, fp
+	mov r3, r11
 	add r1, r5, r7
 	add r2, r6, r8
 	bl func_ov00_02084d24
@@ -15365,7 +15365,7 @@ _02167690:
 	cmp r7, r1
 	blt _02167644
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov17_021674e8
 _021676a4: .word data_027e0f6c
@@ -16250,7 +16250,7 @@ func_ov17_0216823c: ; 0x0216823c
 	.global func_ov17_0216826c
 	arm_func_start func_ov17_0216826c
 func_ov17_0216826c: ; 0x0216826c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x54
 	mov sl, r0
 	ldr r1, [sl, #4]
@@ -16324,7 +16324,7 @@ func_ov17_0216826c: ; 0x0216826c
 	bge _0216843c
 	add r6, sp, #6
 	mov r5, #1
-	add fp, sp, #4
+	add r11, sp, #4
 _02168398:
 	ldrb sb, [sl, #0x15]
 	add r0, sb, #2
@@ -16342,7 +16342,7 @@ _021683b0:
 	ldr r0, [r4]
 	strb r7, [sp, #4]
 	strb sb, [sp, #5]
-	mov r1, fp
+	mov r1, r11
 	mov r2, #1
 	bl func_ov00_02082680
 	ldr r0, [sl, #0x68]
@@ -16379,7 +16379,7 @@ _0216843c:
 	mov r2, r1
 	blx r3
 	add sp, sp, #0x54
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov17_0216826c
 _0216845c: .word data_027e0e60
@@ -16558,7 +16558,7 @@ func_ov17_02168658: ; 0x02168658
 	.global func_ov17_02168660
 	arm_func_start func_ov17_02168660
 func_ov17_02168660: ; 0x02168660
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0xc
 	str r0, [sp]
 	str r1, [r0]
@@ -16602,7 +16602,7 @@ func_ov17_02168660: ; 0x02168660
 	mul r1, r6, r0
 	add r1, r1, #0x800
 	add r0, r4, #0x1f
-	mov fp, r1, asr #0xc
+	mov r11, r1, asr #0xc
 	mov r1, r0, lsl #0xc
 	mov r0, #0x1f000
 	bl Divide
@@ -16633,7 +16633,7 @@ _02168760:
 	and sl, sl, #0x1f
 	add r0, r0, sl
 	add sl, r3, r0
-	mul r0, sl, fp
+	mul r0, sl, r11
 	add r0, r0, r1, lsr #15
 	mov r3, r0, asr #0xc
 	mul r0, sl, r6
@@ -16659,13 +16659,13 @@ _021687d8:
 	ldr r0, [r0, #0x14]
 	bl func_0200e2a4
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	arm_func_end func_ov17_02168660
 
 	.global func_ov17_021687f0
 	arm_func_start func_ov17_021687f0
 func_ov17_021687f0: ; 0x021687f0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x18
 	mov r4, r0
 	ldr r1, [r4, #4]
@@ -16689,7 +16689,7 @@ _02168830:
 	mov r0, r0, asr #0x5
 	and r1, sb, #0x7c00
 	mov r1, r1, asr #0xa
-	and fp, sb, #0x1f
+	and r11, sb, #0x1f
 	mul sb, r0, r2
 	and sl, r3, #0x3e0
 	and ip, r3, #0x7c00
@@ -16697,7 +16697,7 @@ _02168830:
 	add r8, r8, #1
 	mov r1, ip, asr #0xa
 	and ip, r3, #0x1f
-	mul r3, fp, r2
+	mul r3, r11, r2
 	rsb r2, r2, #0x1000
 	mla r0, r1, r2, r0
 	mov r1, sl, asr #0x5
@@ -16724,7 +16724,7 @@ _021688c4:
 	ldr r0, [r4, #0xc]
 	cmp r0, #0
 	addle sp, sp, #0x18
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, [r4]
 	str r0, [sp, #8]
 	ldrh r0, [r0, #0x1c]
@@ -16750,20 +16750,20 @@ _021688c4:
 	str r0, [sp]
 	beq _021689c4
 	ldr r0, _02168a48 ; =0x00007fff
-	ldr fp, _02168a4c ; =data_027e0764
+	ldr r11, _02168a4c ; =data_027e0764
 	rsb r0, r0, #0x9000
 _02168940:
-	ldr r2, [fp]
-	ldmib fp, {r1, ip}
+	ldr r2, [r11]
+	ldmib r11, {r1, ip}
 	umull r5, lr, ip, r2
 	mla lr, ip, r1, lr
-	ldr r3, [fp, #0xc]
-	ldr r7, [fp, #0x10]
+	ldr r3, [r11, #0xc]
+	ldr r7, [r11, #0x10]
 	mla lr, r3, r2, lr
-	ldr r6, [fp, #0x14]
+	ldr r6, [r11, #0x14]
 	adds r1, r7, r5
 	adc r3, r6, lr
-	stmia fp, {r1, r3}
+	stmia r11, {r1, r3}
 	umull r1, r2, r3, r0
 	mov r1, #0
 	mla r2, r3, r1, r2
@@ -16821,7 +16821,7 @@ _02168a24:
 	cmp r0, #0x10
 	strge r1, [r4, #0x24]
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov17_021687f0
 _02168a48: .word 0x00007fff

--- a/asm/ov18.s
+++ b/asm/ov18.s
@@ -292,7 +292,7 @@ _0215b868: .word data_027e0f6c
 	.global func_ov18_0215b86c
 	arm_func_start func_ov18_0215b86c
 func_ov18_0215b86c: ; 0x0215b86c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x70
 	ldrb r5, [sp, #0x98]
 	ldrb r4, [sp, #0x9c]
@@ -341,7 +341,7 @@ func_ov18_0215b86c: ; 0x0215b86c
 	ldr r4, _0215bd70 ; =0xffffd99a
 	mov r7, #0
 	str r0, [sp, #8]
-	mov fp, sl, asr #0xd
+	mov r11, sl, asr #0xd
 _0215b934:
 	mov r0, r8
 	mov r1, r7
@@ -383,7 +383,7 @@ _0215b990:
 	mov r1, #0xff
 	strb r1, [sp, #0x22]
 	mov r1, #0
-	str fp, [sp, #0x1c]
+	str r11, [sp, #0x1c]
 	strb r1, [sp, #0x23]
 	strb r1, [sp, #0x24]
 	strb r1, [sp, #0x25]
@@ -627,7 +627,7 @@ _0215bd54:
 	cmp r7, #4
 	blt _0215b934
 	add sp, sp, #0x70
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov18_0215b86c
 _0215bd68: .word data_027e0e60
@@ -3788,7 +3788,7 @@ _0215e620: .word data_027e0e58
 	.global func_ov18_0215e624
 	arm_func_start func_ov18_0215e624
 func_ov18_0215e624: ; 0x0215e624
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x80
 	mov r4, r0
 	ldr r1, [r4, #4]
@@ -4289,14 +4289,14 @@ _0215ed70:
 	ldr r1, _0215ee88 ; =data_ov18_0216c3cf
 	ldrb r3, [r4, #0x15]
 	ldrb r2, [r0, r8, lsl #1]
-	sub fp, r7, r6
-	add r0, fp, r5
+	sub r11, r7, r6
+	add r0, r11, r5
 	str r0, [sp, #8]
 	sub r0, r3, r2
 	str r0, [sp, #4]
 	ldr r0, [sp, #8]
 	ldrb r1, [r1, r8, lsl #1]
-	cmp fp, r0
+	cmp r11, r0
 	ldr r0, [sp, #4]
 	add sl, r0, r1
 	bge _0215ee18
@@ -4308,7 +4308,7 @@ _0215edd0:
 	mov r0, sb
 	cmp r0, sl
 	bge _0215ee08
-	and r8, fp, #0xff
+	and r8, r11, #0xff
 _0215ede4:
 	ldr r0, [r5]
 	mov r1, r7
@@ -4321,8 +4321,8 @@ _0215ede4:
 	blt _0215ede4
 _0215ee08:
 	ldr r0, [sp, #8]
-	add fp, fp, #1
-	cmp fp, r0
+	add r11, r11, #1
+	cmp r11, r0
 	blt _0215edd0
 _0215ee18:
 	ldrb r0, [r4, #0xac]
@@ -4335,14 +4335,14 @@ _0215ee18:
 	mov r2, r1
 	blx r3
 	add sp, sp, #0x80
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0215ee44:
 	ldr r3, [r3, #0x80]
 	mov r1, #0
 	mov r2, #1
 	blx r3
 	add sp, sp, #0x80
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov18_0215e624
 _0215ee5c: .word data_027e0f68
@@ -6331,18 +6331,18 @@ func_ov18_02160634: ; 0x02160634
 	.global func_ov18_0216065c
 	arm_func_start func_ov18_0216065c
 func_ov18_0216065c: ; 0x0216065c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x68
-	mov fp, r0
-	ldr r1, [fp, #0x18]
+	mov r11, r0
+	ldr r1, [r11, #0x18]
 	add r2, sp, #0x18
 	add r1, r1, #0x1800
-	str r1, [fp, #0x18]
-	ldr r1, [fp, #0x20]
+	str r1, [r11, #0x18]
+	ldr r1, [r11, #0x20]
 	mov r5, #0
 	add r1, r1, #0x1000
 	add r1, r1, #0x800
-	str r1, [fp, #0x20]
+	str r1, [r11, #0x20]
 	str r5, [r2]
 	mov r4, #0x1800
 	str r5, [r2, #4]
@@ -6350,28 +6350,28 @@ func_ov18_0216065c: ; 0x0216065c
 	str r5, [r2, #8]
 	str r4, [sp, #0x18]
 	str r1, [sp, #0x1c]
-	str r4, [fp, #0x98]
+	str r4, [r11, #0x98]
 	ldr r1, [sp, #0x1c]
 	mov r2, #0x3800
-	str r1, [fp, #0x9c]
+	str r1, [r11, #0x9c]
 	ldr r3, [sp, #0x20]
 	mov r1, #0x2000
-	str r3, [fp, #0xa0]
-	str r2, [fp, #0xa4]
+	str r3, [r11, #0xa0]
+	str r2, [r11, #0xa4]
 	str r1, [sp, #0x60]
 	str r5, [sp, #0x5c]
 	str r4, [sp, #0x64]
-	ldr r2, [fp, #0x18]
+	ldr r2, [r11, #0x18]
 	add r0, sp, #0x50
 	str r2, [sp, #0x50]
-	ldr r3, [fp, #0x1c]
+	ldr r3, [r11, #0x1c]
 	add r1, sp, #0x5c
 	str r3, [sp, #0x54]
-	ldr r3, [fp, #0x20]
+	ldr r3, [r11, #0x20]
 	mov r2, r0
 	str r3, [sp, #0x58]
 	bl func_01ff9bc4
-	ldr r0, [fp, #0x30]
+	ldr r0, [r11, #0x30]
 	cmp r0, #0
 	beq _02160774
 	add r0, sp, #0x24
@@ -6398,12 +6398,12 @@ func_ov18_0216065c: ; 0x0216065c
 	bl _ZN12ActorManager8GetActorEP8ActorRef
 	cmp r0, #0
 	beq _02160774
-	ldr r2, [fp, #0x30]
+	ldr r2, [r11, #0x30]
 	ldr r1, _02160818 ; =0x0000099a
 	bl func_ov18_0216a1d0
 _02160774:
-	ldrb r0, [fp, #0x15]
-	ldrb r8, [fp, #0x14]
+	ldrb r0, [r11, #0x15]
+	ldrb r8, [r11, #0x14]
 	str r0, [sp, #4]
 	add r0, r8, #3
 	str r0, [sp, #8]
@@ -6436,14 +6436,14 @@ _021607dc:
 	cmp r8, r0
 	ble _021607a4
 _021607ec:
-	mov r0, fp
+	mov r0, r11
 	ldr r3, [r0]
 	mov r1, #1
 	ldr r3, [r3, #0x80]
 	mov r2, r1
 	blx r3
 	add sp, sp, #0x68
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov18_0216065c
 _0216080c: .word data_027e0fe8
@@ -6762,7 +6762,7 @@ func_ov18_02160b44: ; 0x02160b44
 	.global func_ov18_02160b6c
 	arm_func_start func_ov18_02160b6c
 func_ov18_02160b6c: ; 0x02160b6c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x24
 	mov r4, r0
 	ldrh r1, [r4, #0x24]
@@ -6812,7 +6812,7 @@ _02160bac:
 	cmp r7, r0
 	bge _02160fb0
 	add r5, sp, #0x14
-	mov fp, #1
+	mov r11, #1
 _02160c30:
 	ldrb r0, [r4, #0x14]
 	cmp r7, r0
@@ -6840,7 +6840,7 @@ _02160c80:
 	ldr r0, _02160ffc ; =data_027e0e60
 	mov r1, r5
 	ldr r0, [r0]
-	mov r2, fp
+	mov r2, r11
 	strb r6, [sp, #0x14]
 	strb r8, [sp, #0x15]
 	bl func_ov00_02082680
@@ -6887,7 +6887,7 @@ _02160cbc:
 	cmp r7, r0
 	bge _02160fb0
 	add r5, sp, #0x12
-	mov fp, #1
+	mov r11, #1
 _02160d40:
 	ldrb r0, [r4, #0x14]
 	cmp r7, r0
@@ -6915,7 +6915,7 @@ _02160d90:
 	ldr r0, _02160ffc ; =data_027e0e60
 	mov r1, r5
 	ldr r0, [r0]
-	mov r2, fp
+	mov r2, r11
 	strb r6, [sp, #0x12]
 	strb r8, [sp, #0x13]
 	bl func_ov00_02082680
@@ -6962,7 +6962,7 @@ _02160dcc:
 	cmp r7, r0
 	bge _02160fb0
 	add r5, sp, #0x10
-	mov fp, #1
+	mov r11, #1
 _02160e50:
 	ldrb r0, [r4, #0x14]
 	cmp r7, r0
@@ -6990,7 +6990,7 @@ _02160ea0:
 	ldr r0, _02160ffc ; =data_027e0e60
 	mov r1, r5
 	ldr r0, [r0]
-	mov r2, fp
+	mov r2, r11
 	strb r6, [sp, #0x10]
 	strb r8, [sp, #0x11]
 	bl func_ov00_02082680
@@ -7078,7 +7078,7 @@ _02160fb0:
 	ldr r0, [sp, #0xc]
 	str r0, [r4, #0xa4]
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov18_02160b6c
 _02160ff8: .word data_027e0f68
@@ -8564,7 +8564,7 @@ func_ov18_02162188: ; 0x02162188
 	.global func_ov18_021621b8
 	arm_func_start func_ov18_021621b8
 func_ov18_021621b8: ; 0x021621b8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x1c
 	ldr r1, _0216243c ; =data_027e0764
 	mov r2, #0
@@ -8582,8 +8582,8 @@ func_ov18_021621b8: ; 0x021621b8
 	mov sl, #0x15
 	umull r3, r5, r6, sl
 	mla r5, r6, r2, r5
-	mov fp, r2
-	mla r5, fp, sl, r5
+	mov r11, r2
+	mla r5, r11, sl, r5
 	mov r4, r0
 	str r6, [r1, #4]
 	ldr r6, [r4, #0x18]
@@ -8608,7 +8608,7 @@ func_ov18_021621b8: ; 0x021621b8
 	stmia r1, {r3, r6}
 	umull r1, r3, r6, sl
 	mla r3, r6, r2, r3
-	mla r3, fp, sl, r3
+	mla r3, r11, sl, r3
 	ldr r5, [r4, #0x20]
 	sub r2, r3, #0xa
 	mov r1, #0x29
@@ -8625,7 +8625,7 @@ func_ov18_021621b8: ; 0x021621b8
 	ldr r1, _02162444 ; =0x00002333
 	str r1, [sp, #0x18]
 	bl func_ov00_0208b9cc
-	mov r1, fp
+	mov r1, r11
 	str r1, [sp]
 	mov r2, r0
 	add r0, r4, #0x38
@@ -8640,7 +8640,7 @@ func_ov18_021621b8: ; 0x021621b8
 	strh r0, [r4, #0x76]
 	ldrsh r0, [r4, #0x76]
 	cmp r0, #6
-	movge r0, fp
+	movge r0, r11
 	strgeh r0, [r4, #0x76]
 	ldrsh r0, [r4, #0x76]
 	cmp r0, #5
@@ -8732,7 +8732,7 @@ _0216241c:
 	mov r2, #1
 	blx r3
 	add sp, sp, #0x1c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov18_021621b8
 _0216243c: .word data_027e0764
@@ -9431,7 +9431,7 @@ func_ov18_02162d90: ; 0x02162d90
 	.global func_ov18_02162db8
 	arm_func_start func_ov18_02162db8
 func_ov18_02162db8: ; 0x02162db8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x20
 	ldr r2, [r0, #4]
 	mov r1, #0
@@ -9457,9 +9457,9 @@ _02162e00:
 	ldr r2, [r8, #0xc]
 	ldr ip, [r8, #0x10]
 	mla sb, r2, r1, sb
-	ldr fp, [r8, #0x14]
+	ldr r11, [r8, #0x14]
 	adds sl, ip, sl
-	adc sb, fp, sb
+	adc sb, r11, sb
 	mov r0, #0x15
 	umull r0, r2, sb, r0
 	mov r0, #0
@@ -9480,7 +9480,7 @@ _02162e00:
 	mov r3, r2
 	bl func_02001cc0
 	ldr ip, [r8, #0x10]
-	ldr fp, [r8, #0x14]
+	ldr r11, [r8, #0x14]
 	bls _02162f04
 	ldr r1, [r8, #8]
 	ldr r0, [r8, #0xc]
@@ -9488,7 +9488,7 @@ _02162e00:
 	mla r2, r1, sb, r2
 	mla r2, r0, sl, r2
 	adds r0, ip, r3
-	adc r1, fp, r2
+	adc r1, r11, r2
 	stmia r8, {r0, r1}
 	mov r0, #0x15
 	umull r0, r2, r1, r0
@@ -9522,7 +9522,7 @@ _02162f04:
 	mla r2, r1, sb, r2
 	mla r2, r0, sl, r2
 	adds r0, ip, r3
-	adc r1, fp, r2
+	adc r1, r11, r2
 	stmia r8, {r0, r1}
 	mov r0, #0x15
 	umull r0, r2, r1, r0
@@ -9558,9 +9558,9 @@ _02162f7c:
 	ldr r2, [r8, #0xc]
 	ldr ip, [r8, #0x10]
 	mla sb, r2, r1, sb
-	ldr fp, [r8, #0x14]
+	ldr r11, [r8, #0x14]
 	adds sl, ip, sl
-	adc sb, fp, sb
+	adc sb, r11, sb
 	mov r0, #0x15
 	umull r0, r2, sb, r0
 	mov r0, #0
@@ -9581,7 +9581,7 @@ _02162f7c:
 	mov r3, r2
 	bl func_02001cc0
 	ldr ip, [r8, #0x10]
-	ldr fp, [r8, #0x14]
+	ldr r11, [r8, #0x14]
 	bls _02163090
 	ldr r1, [r8, #8]
 	ldr r0, [r8, #0xc]
@@ -9589,7 +9589,7 @@ _02162f7c:
 	mla r2, r1, sb, r2
 	mla r2, r0, sl, r2
 	adds r0, ip, r3
-	adc r1, fp, r2
+	adc r1, r11, r2
 	stmia r8, {r0, r1}
 	mov r0, #0x15
 	umull r0, r2, r1, r0
@@ -9623,7 +9623,7 @@ _02163090:
 	mla r2, r1, sb, r2
 	mla r2, r0, sl, r2
 	adds r0, ip, r3
-	adc r1, fp, r2
+	adc r1, r11, r2
 	stmia r8, {r0, r1}
 	mov r0, #0x15
 	umull r0, r2, r1, r0
@@ -9668,15 +9668,15 @@ _02163108:
 	mov r1, r0
 	mov r0, #3
 	mla r2, r1, r0, r2
-	ldr fp, [sp, #4]
+	ldr r11, [sp, #4]
 	ldr r0, _0216324c ; =data_ov18_0216b52c
 	mov r1, r2, lsl #0x1
-	add fp, fp, r6, lsl #1
+	add r11, r11, r6, lsl #1
 	ldrsh r0, [r0, r1]
 	add r6, r6, #1
 	add r7, r7, #0xc
 	cmp r6, #2
-	strh r0, [fp, #0x7a]
+	strh r0, [r11, #0x7a]
 	blt _02162e00
 	ldr r0, [sp, #4]
 	mov r1, #0
@@ -9711,20 +9711,20 @@ _02163108:
 	ldrh r1, [r0, #0x26]
 	cmp r1, #0
 	addeq sp, sp, #0x20
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, _02163254 ; =data_027e0f74
 	ldr r0, [r0]
 	bl func_ov00_02097760
 	cmp r0, #0
 	addne sp, sp, #0x20
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, [sp, #4]
 	ldr r0, [r0, #4]
 	bic r1, r0, #1
 	ldr r0, [sp, #4]
 	str r1, [r0, #4]
 	add sp, sp, #0x20
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov18_02162db8
 _0216323c: .word 0x40b00000
@@ -9793,7 +9793,7 @@ _021632f4:
 	.global func_ov18_021632fc
 	arm_func_start func_ov18_021632fc
 func_ov18_021632fc: ; 0x021632fc
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x50
 	mov sl, r0
 	add r0, sp, #0x34
@@ -9816,7 +9816,7 @@ func_ov18_021632fc: ; 0x021632fc
 	add r6, sp, #0x28
 	mov r5, r7
 	mov r4, #0x20
-	add fp, sp, #0x34
+	add r11, sp, #0x34
 _0216335c:
 	ldr r0, [r8, #0x60]
 	add r1, sp, #0x1c
@@ -9833,7 +9833,7 @@ _0216335c:
 	str r5, [sp, #8]
 	str r4, [sp, #0xc]
 	str r4, [sp, #0x10]
-	str fp, [sp, #0x14]
+	str r11, [sp, #0x14]
 	str r5, [sp, #0x18]
 	add r0, sl, r7, lsl #1
 	ldrsh r2, [r0, #0x7a]
@@ -9846,7 +9846,7 @@ _0216335c:
 	add r8, r8, #0xc
 	blt _0216335c
 	add sp, sp, #0x50
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov18_021632fc
 _021633d0: .word 0x00000533
@@ -9855,7 +9855,7 @@ _021633d4: .word data_ov00_020ec9d6
 	.global func_ov18_021633d8
 	arm_func_start func_ov18_021633d8
 func_ov18_021633d8: ; 0x021633d8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x64
 	ldr r2, _021635c4 ; =0x020ec9d6
 	ldr r1, _021635c8 ; =data_ov00_020ec9d4
@@ -9917,7 +9917,7 @@ func_ov18_021633d8: ; 0x021633d8
 	mov sb, sl
 	rsb r7, r7, #0
 	add r6, sp, #0x4c
-	add fp, sp, #0x58
+	add r11, sp, #0x58
 	mov r5, #4
 	mov r4, #0x20
 _021634dc:
@@ -9927,7 +9927,7 @@ _021634dc:
 	str r1, [sp, #0x4c]
 	str r2, [sp, #0x54]
 	mov r1, r6
-	mov r2, fp
+	mov r2, r11
 	str r7, [sp, #0x50]
 	bl func_01ff9bc4
 	mov r1, #0
@@ -9978,7 +9978,7 @@ _021634dc:
 	cmp r8, #2
 	blt _021634dc
 	add sp, sp, #0x64
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov18_021633d8
 _021635c4: .word data_ov00_020ec9d6
@@ -9989,7 +9989,7 @@ _021635d0: .word 0x001e4081
 	.global func_ov18_021635d4
 	arm_func_start func_ov18_021635d4
 func_ov18_021635d4: ; 0x021635d4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x14
 	mov r5, r0
 	str r1, [r5, #8]
@@ -10005,7 +10005,7 @@ _021635f4:
 	add sl, sp, #8
 	mov r8, r4
 	mov r7, #0x1ec
-	mov fp, #4
+	mov r11, #4
 _02163614:
 	ldr r0, [r5, #0x64]
 	ldr lr, [r5, #0x68]
@@ -10024,7 +10024,7 @@ _02163614:
 	ldr r0, [r6]
 	mov r1, r7
 	mov r2, sl
-	mov r3, fp
+	mov r3, r11
 	bl func_ov00_0207c1b0
 	add r4, r4, #1
 	cmp r4, #2
@@ -10033,7 +10033,7 @@ _02163614:
 _02163670:
 	mov r0, #1
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov18_021635d4
 _0216367c: .word data_027e0e58
@@ -10245,7 +10245,7 @@ func_ov18_021638b8: ; 0x021638b8
 	.global func_ov18_021638e0
 	arm_func_start func_ov18_021638e0
 func_ov18_021638e0: ; 0x021638e0
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x1c
 	ldr r3, [r0]
 	mov r1, #0
@@ -10266,9 +10266,9 @@ _02163914:
 	ldr r2, [r8, #0xc]
 	ldr ip, [r8, #0x10]
 	mla sb, r2, r1, sb
-	ldr fp, [r8, #0x14]
+	ldr r11, [r8, #0x14]
 	adds sl, ip, sl
-	adc sb, fp, sb
+	adc sb, r11, sb
 	mov r0, #0x15
 	umull r0, r2, sb, r0
 	mov r0, #0
@@ -10289,7 +10289,7 @@ _02163914:
 	mov r3, r2
 	bl func_02001cc0
 	ldr ip, [r8, #0x10]
-	ldr fp, [r8, #0x14]
+	ldr r11, [r8, #0x14]
 	bls _02163a18
 	ldr r1, [r8, #8]
 	ldr r0, [r8, #0xc]
@@ -10297,7 +10297,7 @@ _02163914:
 	mla r2, r1, sb, r2
 	mla r2, r0, sl, r2
 	adds r0, ip, r3
-	adc r1, fp, r2
+	adc r1, r11, r2
 	stmia r8, {r0, r1}
 	mov r0, #0x15
 	umull r0, r2, r1, r0
@@ -10331,7 +10331,7 @@ _02163a18:
 	mla r2, r1, sb, r2
 	mla r2, r0, sl, r2
 	adds r0, ip, r3
-	adc r1, fp, r2
+	adc r1, r11, r2
 	stmia r8, {r0, r1}
 	mov r0, #0x15
 	umull r0, r2, r1, r0
@@ -10367,9 +10367,9 @@ _02163a90:
 	ldr r2, [r8, #0xc]
 	ldr ip, [r8, #0x10]
 	mla sb, r2, r1, sb
-	ldr fp, [r8, #0x14]
+	ldr r11, [r8, #0x14]
 	adds sl, ip, sl
-	adc sb, fp, sb
+	adc sb, r11, sb
 	mov r0, #0x15
 	umull r0, r2, sb, r0
 	mov r0, #0
@@ -10390,7 +10390,7 @@ _02163a90:
 	mov r3, r2
 	bl func_02001cc0
 	ldr ip, [r8, #0x10]
-	ldr fp, [r8, #0x14]
+	ldr r11, [r8, #0x14]
 	bls _02163ba4
 	ldr r1, [r8, #8]
 	ldr r0, [r8, #0xc]
@@ -10398,7 +10398,7 @@ _02163a90:
 	mla r2, r1, sb, r2
 	mla r2, r0, sl, r2
 	adds r0, ip, r3
-	adc r1, fp, r2
+	adc r1, r11, r2
 	stmia r8, {r0, r1}
 	mov r0, #0x15
 	umull r0, r2, r1, r0
@@ -10432,7 +10432,7 @@ _02163ba4:
 	mla r2, r1, sb, r2
 	mla r2, r0, sl, r2
 	adds r0, ip, r3
-	adc r1, fp, r2
+	adc r1, r11, r2
 	stmia r8, {r0, r1}
 	mov r0, #0x15
 	umull r0, r2, r1, r0
@@ -10487,8 +10487,8 @@ _02163c3c:
 	ldr r0, _02163d58 ; =data_ov18_0216b534
 	mov r1, r2, lsl #0x1
 	ldrsh r0, [r0, r1]
-	add fp, r7, r5, lsl #1
-	strh r0, [fp, #0x7a]
+	add r11, r7, r5, lsl #1
+	strh r0, [r11, #0x7a]
 _02163c98:
 	add r6, r6, #0xc
 	add r5, r5, #1
@@ -10524,7 +10524,7 @@ _02163c98:
 	ldrh r1, [r7, #0x26]
 	cmp r1, #0
 	addeq sp, sp, #0x1c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, _02163d60 ; =data_027e0f74
 	ldr r0, [r0]
 	bl func_ov00_02097760
@@ -10533,7 +10533,7 @@ _02163c98:
 	biceq r0, r0, #1
 	streq r0, [r7, #4]
 	add sp, sp, #0x1c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov18_021638e0
 _02163d48: .word 0x40b00000
@@ -10602,7 +10602,7 @@ _02163e00:
 	.global func_ov18_02163e08
 	arm_func_start func_ov18_02163e08
 func_ov18_02163e08: ; 0x02163e08
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x50
 	mov sl, r0
 	add r0, sp, #0x34
@@ -10625,7 +10625,7 @@ func_ov18_02163e08: ; 0x02163e08
 	add r6, sp, #0x28
 	mov r5, r7
 	mov r4, #0x20
-	add fp, sp, #0x34
+	add r11, sp, #0x34
 _02163e68:
 	ldr r0, [r8, #0x60]
 	add r1, sp, #0x1c
@@ -10642,7 +10642,7 @@ _02163e68:
 	str r5, [sp, #8]
 	str r4, [sp, #0xc]
 	str r4, [sp, #0x10]
-	str fp, [sp, #0x14]
+	str r11, [sp, #0x14]
 	str r5, [sp, #0x18]
 	add r0, sl, r7, lsl #1
 	ldrsh r2, [r0, #0x7a]
@@ -10655,7 +10655,7 @@ _02163e68:
 	add r8, r8, #0xc
 	blt _02163e68
 	add sp, sp, #0x50
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov18_02163e08
 _02163edc: .word 0x00000533
@@ -10664,7 +10664,7 @@ _02163ee0: .word data_ov00_020ec9d6
 	.global func_ov18_02163ee4
 	arm_func_start func_ov18_02163ee4
 func_ov18_02163ee4: ; 0x02163ee4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x64
 	ldr r2, _021640d0 ; =0x020ec9d6
 	ldr r1, _021640d4 ; =data_ov00_020ec9d4
@@ -10726,7 +10726,7 @@ func_ov18_02163ee4: ; 0x02163ee4
 	mov sb, sl
 	rsb r7, r7, #0
 	add r6, sp, #0x4c
-	add fp, sp, #0x58
+	add r11, sp, #0x58
 	mov r5, #4
 	mov r4, #0x20
 _02163fe8:
@@ -10736,7 +10736,7 @@ _02163fe8:
 	str r1, [sp, #0x4c]
 	str r2, [sp, #0x54]
 	mov r1, r6
-	mov r2, fp
+	mov r2, r11
 	str r7, [sp, #0x50]
 	bl func_01ff9bc4
 	mov r1, #0
@@ -10787,7 +10787,7 @@ _02163fe8:
 	cmp r8, #2
 	blt _02163fe8
 	add sp, sp, #0x64
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov18_02163ee4
 _021640d0: .word data_ov00_020ec9d6
@@ -10798,7 +10798,7 @@ _021640dc: .word 0x001e4081
 	.global func_ov18_021640e0
 	arm_func_start func_ov18_021640e0
 func_ov18_021640e0: ; 0x021640e0
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x14
 	mov r5, r0
 	str r1, [r5, #8]
@@ -10814,7 +10814,7 @@ _02164100:
 	add sl, sp, #8
 	mov r8, r4
 	mov r7, #0x1ec
-	mov fp, #4
+	mov r11, #4
 _02164120:
 	ldr r0, [r5, #0x64]
 	ldr lr, [r5, #0x68]
@@ -10833,7 +10833,7 @@ _02164120:
 	ldr r0, [r6]
 	mov r1, r7
 	mov r2, sl
-	mov r3, fp
+	mov r3, r11
 	bl func_ov00_0207c1b0
 	add r4, r4, #1
 	cmp r4, #2
@@ -10842,7 +10842,7 @@ _02164120:
 _0216417c:
 	mov r0, #1
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov18_021640e0
 _02164188: .word data_027e0e58
@@ -14444,7 +14444,7 @@ _02166f1c: .word data_027e0fe4
 	.global func_ov18_02166f20
 	arm_func_start func_ov18_02166f20
 func_ov18_02166f20: ; 0x02166f20
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0xc
 	mov r4, r0
 	mov r2, #0
@@ -14498,9 +14498,9 @@ func_ov18_02166f20: ; 0x02166f20
 	mov r5, r5, lsr #0xc
 	orr r5, r5, r0, lsl #20
 	add r0, r6, r5
-	ldr fp, _0216705c ; =data_ov18_0216d0bc
+	ldr r11, _0216705c ; =data_ov18_0216d0bc
 	str r0, [r4, #0x50]
-	ldrsh r0, [fp, #4]
+	ldrsh r0, [r11, #4]
 	add ip, r4, #0x500
 	mov r2, r1
 	strh r0, [ip, #0x18]
@@ -14520,7 +14520,7 @@ func_ov18_02166f20: ; 0x02166f20
 	bl func_01ffa0f4
 	strh r0, [r4, #0x78]
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov18_02166f20
 _02167054: .word data_ov18_0216d604
@@ -15843,7 +15843,7 @@ _021682dc:
 	.global func_ov18_021682f8
 	arm_func_start func_ov18_021682f8
 func_ov18_021682f8: ; 0x021682f8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0xf4
 	mov r6, r0
 	cmp r1, #0
@@ -15851,7 +15851,7 @@ func_ov18_021682f8: ; 0x021682f8
 	ldreqb r0, [r6, #0xa4]
 	cmp r0, #0
 	addeq sp, sp, #0xf4
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, _021686c8 ; =data_027e0fec
 	ldr r0, [r0]
 	add r0, r0, #0xbf0
@@ -15936,7 +15936,7 @@ _02168388:
 	cmp r0, #0
 	str r0, [r1, #0x2c]
 	addeq sp, sp, #0xf4
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r1, _021686e0 ; =data_02051054
 	add r0, sp, #0x34
 	ldrsh r2, [r1, #0xf6]
@@ -15959,7 +15959,7 @@ _02168388:
 	str r3, [sp, #0x2c]
 	bl func_01ff8e84
 	ldr r0, _021686e4 ; =0x00001ccd
-	add fp, sp, #0
+	add r11, sp, #0
 	add r4, sp, #0xc
 	add r5, sp, #0x18
 	bl func_01ff991c
@@ -15994,7 +15994,7 @@ _02168388:
 	mov sb, r7, lsr #0xc
 	adc r6, r6, #0
 	orr sb, sb, r6, lsl #20
-	ldmia fp, {r7, ip}
+	ldmia r11, {r7, ip}
 	smull r6, lr, r7, sb
 	adds r6, r6, #0x800
 	umull r3, r2, sl, r0
@@ -16002,14 +16002,14 @@ _02168388:
 	adc r7, lr, #0
 	mov r6, r6, lsr #0xc
 	orr r6, r6, r7, lsl #20
-	str r6, [fp]
+	str r6, [r11]
 	smull r7, r6, ip, sb
 	adds r7, r7, #0x800
 	adc r6, r6, #0
 	mov r7, r7, lsr #0xc
 	orr r7, r7, r6, lsl #20
-	ldr ip, [fp, #8]
-	str r7, [fp, #4]
+	ldr ip, [r11, #8]
+	str r7, [r11, #4]
 	smull r7, r6, ip, sb
 	adds r7, r7, #0x800
 	mla r2, r8, r0, r2
@@ -16019,7 +16019,7 @@ _02168388:
 	adds r6, r3, #0x800
 	adc r3, r2, #0
 	mov r2, r6, lsr #0xc
-	str r7, [fp, #8]
+	str r7, [r11, #8]
 	ldr sb, [r4]
 	orr r2, r2, r3, lsl #20
 	smull r6, r3, sb, r2
@@ -16059,12 +16059,12 @@ _02168388:
 	umull r6, r4, sl, r3
 	mla r4, sl, r1, r4
 	ldmib r5, {r0, sl}
-	smull sb, fp, r0, r7
+	smull sb, r11, r0, r7
 	mov r0, #0x800
 	adds r0, sb, r0
 	smull sb, r7, sl, r7
 	mla r4, r8, r3, r4
-	adc sl, fp, r1
+	adc sl, r11, r1
 	adds sb, sb, #0x800
 	adc r7, r7, r1
 	mov r3, r0, lsr #0xc
@@ -16088,7 +16088,7 @@ _02168388:
 	strb r2, [sp, #0x33]
 	bl func_ov18_0216941c
 	add sp, sp, #0xf4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov18_021682f8
 _021686c8: .word data_027e0fec
@@ -17171,7 +17171,7 @@ func_ov18_0216941c: ; 0x0216941c
 	.global func_ov18_0216945c
 	arm_func_start func_ov18_0216945c
 func_ov18_0216945c: ; 0x0216945c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x20
 	ldr r1, _021695dc ; =data_027e0d44
 	add r4, r0, #0x900
@@ -17197,7 +17197,7 @@ func_ov18_0216945c: ; 0x0216945c
 	cmp r1, #0
 	mov sl, #0
 	addle sp, sp, #0x20
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r8, _021695e0 ; =0x040004a8
 	sub r0, r8, #0x10
 	str r0, [sp]
@@ -17210,7 +17210,7 @@ func_ov18_0216945c: ; 0x0216945c
 	rsb r0, r0, #0x10000
 	str r0, [sp, #8]
 	sub r0, r8, #0x60
-	sub fp, r8, #0xa8
+	sub r11, r8, #0xa8
 	sub r5, r8, #0x20
 	str r0, [sp, #0xc]
 _02169504:
@@ -17239,7 +17239,7 @@ _02169504:
 	mov r0, #1
 	str r0, [r8, #0x58]
 	ldr r0, _021695ec ; =0x04000040
-	str fp, [r5]
+	str r11, [r5]
 	str r0, [r0, #0x450]
 	mov r0, #0x400
 	str r0, [r5]
@@ -17267,7 +17267,7 @@ _02169504:
 	cmp sl, r0
 	blt _02169504
 	add sp, sp, #0x20
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov18_0216945c
 _021695dc: .word data_027e0d44
@@ -17418,7 +17418,7 @@ _021697e0: .word data_ov00_020ee6f8
 	.global func_ov18_021697e4
 	arm_func_start func_ov18_021697e4
 func_ov18_021697e4: ; 0x021697e4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x10
 	ldr r8, [sp, #0x40]
 	mov r7, r1
@@ -17430,7 +17430,7 @@ func_ov18_021697e4: ; 0x021697e4
 	cmp r8, #0
 	str r1, [sp, #0x38]
 	addeq sp, sp, #0x10
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	mov r1, r3
 	subs r6, r1, r7
 	ldr r1, [sp, #0x38]
@@ -17443,18 +17443,18 @@ func_ov18_021697e4: ; 0x021697e4
 	str r8, [sp]
 	bl func_ov18_021699e4
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0216984c:
 	cmp r6, #0
 	strge r6, [sp, #8]
 	rsblt r0, r6, #0
 	strlt r0, [sp, #8]
 	cmp r5, #0
-	movge fp, r5
+	movge r11, r5
 	ldr r1, [sp, #8]
-	rsblt fp, r5, #0
+	rsblt r11, r5, #0
 	mov r1, r1, lsl #0xc
-	mov r0, fp, lsl #0xc
+	mov r0, r11, lsl #0xc
 	smull ip, r3, r1, r1
 	smull r2, r1, r0, r0
 	adds r0, ip, #0x800
@@ -17468,7 +17468,7 @@ _0216984c:
 	add r0, r0, r2
 	bl func_01ff9a80
 	ldr r0, [sp, #8]
-	cmp r0, fp
+	cmp r0, r11
 	blt _02169948
 	mov r0, r5, lsl #0xc
 	mov r1, r6, lsl #0xc
@@ -17476,8 +17476,8 @@ _0216984c:
 	ldr r0, [sp, #4]
 	mov r5, sl, lsl #0xc
 	cmp r7, r0
-	movle fp, #1
-	mvngt fp, #0
+	movle r11, #1
+	mvngt r11, #0
 	bl func_01ff9a18
 	mov r6, r0
 	ldr r0, [sp, #0x38]
@@ -17494,7 +17494,7 @@ _021698f8:
 	mov sl, #0
 	cmp r0, #0
 	addlt sp, sp, #0x10
-	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0216990c:
 	add r2, r5, #0x800
 	mov r0, r4
@@ -17506,11 +17506,11 @@ _0216990c:
 	ldr r0, [sp, #8]
 	add sl, sl, #1
 	cmp sl, r0
-	add r7, r7, fp
+	add r7, r7, r11
 	add r5, r5, r6
 	ble _0216990c
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02169948:
 	mov r0, r6, lsl #0xc
 	mov r1, r5, lsl #0xc
@@ -17534,10 +17534,10 @@ _02169990:
 	cmp r6, #0
 	rsbgt r6, r6, #0
 _02169998:
-	cmp fp, #0
+	cmp r11, #0
 	mov r7, #0
 	addlt sp, sp, #0x10
-	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _021699a8:
 	add r1, r5, #0x800
 	mov r0, r4
@@ -17548,12 +17548,12 @@ _021699a8:
 	bl func_ov18_021699e4
 	ldr r0, [sp, #0xc]
 	add r7, r7, #1
-	cmp r7, fp
+	cmp r7, r11
 	add r5, r5, r6
 	add sl, sl, r0
 	ble _021699a8
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	arm_func_end func_ov18_021697e4
 
 	.global func_ov18_021699e4
@@ -17691,7 +17691,7 @@ _02169ba8: .word data_ov00_020e899c
 	.global func_ov18_02169bac
 	arm_func_start func_ov18_02169bac
 func_ov18_02169bac: ; 0x02169bac
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x1c
 	mov r4, r0
 	str r1, [sp]
@@ -17732,7 +17732,7 @@ func_ov18_02169bac: ; 0x02169bac
 	mov r5, r6
 	mov r8, r7
 	mov sb, r7
-	mov fp, r7
+	mov r11, r7
 	mov r3, sl
 	mov r6, sl
 _02169c5c:
@@ -17742,7 +17742,7 @@ _02169c5c:
 	and r1, sb, #0x1f
 	tst r2, r6, lsl r1
 	movne r1, r5
-	moveq r1, fp
+	moveq r1, r11
 	and ip, r1, #0xff
 	ldrb lr, [r0, r8]
 	mov r1, sl, lsr #0x5
@@ -17786,7 +17786,7 @@ _02169d10:
 	ldr r0, [sp]
 	strb r0, [r4, #0x58a]
 	add sp, sp, #0x1c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov18_02169bac
 _02169d20: .word data_027e0c68
@@ -17797,32 +17797,32 @@ _02169d2c: .word data_027e103c
 	.global func_ov18_02169d30
 	arm_func_start func_ov18_02169d30
 func_ov18_02169d30: ; 0x02169d30
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	mov sl, r0
 	ldrb r0, [sl, #0x58a]
 	cmp r0, #0
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, [sl, #0x554]
 	cmp r0, #0
 	beq _02169d64
 	bl func_0203951c
 	cmp r0, #0
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02169d64:
 	ldr r0, _02169e20 ; =data_027e0cbc
 	mov r1, #0x16
 	bl func_0203d7e0
 	cmp r0, #0
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	mov sb, #0
 	add r0, sl, #0x158
 	mov r6, sb
 	mov r8, sl
 	add r7, r0, #0x400
-	mov fp, sb
+	mov r11, sb
 	mov r4, #1
 	mov r5, sb
 _02169d9c:
@@ -17854,7 +17854,7 @@ _02169df8:
 	mov sb, r4
 	b _02169e04
 _02169e00:
-	mov sb, fp
+	mov sb, r11
 _02169e04:
 	add r6, r6, #1
 	cmp r6, #2
@@ -17862,7 +17862,7 @@ _02169e04:
 	add r8, r8, #0x18
 	blt _02169d9c
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov18_02169d30
 _02169e20: .word data_027e0cbc
@@ -17962,7 +17962,7 @@ _02169f54: .word data_027e0cbc
 	.global func_ov18_02169f58
 	arm_func_start func_ov18_02169f58
 func_ov18_02169f58: ; 0x02169f58
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	mov r4, r0
 	cmp r1, #0x90
 	beq _02169f74
@@ -17984,7 +17984,7 @@ _02169f74:
 	mov lr, #1
 	mov r3, #0
 	mov ip, r3
-	mov fp, r3
+	mov r11, r3
 	mov r2, lr
 	mov sb, lr
 	mov r1, lr
@@ -17995,7 +17995,7 @@ _02169fc4:
 	and r6, r6, #0xf
 	cmp r6, #0
 	movgt r6, r2
-	movle r6, fp
+	movle r6, r11
 	cmp r6, #0
 	mov r6, ip, lsr #0x5
 	beq _02169ffc
@@ -18064,7 +18064,7 @@ _0216a0a0:
 	strb r1, [r0, #0x57e]
 _0216a0cc:
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov18_02169f58
 _0216a0d4: .word data_ov00_020eec9c
@@ -20248,7 +20248,7 @@ _0216b8ac: .word data_ov18_0216d484
 	.global func_ov18_0216b8b0
 	arm_func_start func_ov18_0216b8b0
 func_ov18_0216b8b0: ; 0x0216b8b0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	ldr r0, _0216bab0 ; =data_ov18_0216d490
 	ldr r2, _0216bab4 ; =func_ov18_0215e4dc
 	mov r1, #0x2f
@@ -20320,7 +20320,7 @@ func_ov18_0216b8b0: ; 0x0216b8b0
 	strb r2, [r3, #0x26]
 	ldr r1, _0216bb0c ; =data_ov18_0216c3d0
 	strb r2, [r3, #0x27]
-	ldr fp, _0216bb10 ; =data_ov18_0216c3d2
+	ldr r11, _0216bb10 ; =data_ov18_0216c3d2
 	ldr sl, _0216bb14 ; =data_ov18_0216c3d4
 	ldr r8, _0216bb18 ; =data_ov18_0216c3d8
 	ldr r7, _0216bb1c ; =data_ov18_0216c3da
@@ -20334,8 +20334,8 @@ func_ov18_0216b8b0: ; 0x0216b8b0
 	mov r0, #5
 	strb r2, [r1]
 	strb r2, [r1, #1]
-	strb r2, [fp]
-	strb r2, [fp, #1]
+	strb r2, [r11]
+	strb r2, [r11, #1]
 	strb r2, [sl]
 	strb r2, [sl, #1]
 	strb r0, [sb]
@@ -20375,7 +20375,7 @@ func_ov18_0216b8b0: ; 0x0216b8b0
 	strb r2, [r3, #1]
 	strb r2, [r1]
 	strb r2, [r1, #1]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov18_0216b8b0
 _0216bab0: .word data_ov18_0216d490

--- a/asm/ov18.s
+++ b/asm/ov18.s
@@ -6,7 +6,7 @@
 	.global func_ov18_0215b4a0
 	arm_func_start func_ov18_0215b4a0
 func_ov18_0215b4a0: ; 0x0215b4a0
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	mov sb, r0
 	mov r8, r1
 	mov r7, r2
@@ -39,11 +39,11 @@ func_ov18_0215b4a0: ; 0x0215b4a0
 	cmp r8, #0
 	mov r5, #0
 	ble _0215b554
-	ldr sl, _0215b63c ; =data_027e0ce0
+	ldr r10, _0215b63c ; =data_027e0ce0
 	mov r6, r7, lsl #0x2
 	mov r4, #4
 _0215b530:
-	ldr r1, [sl, #4]
+	ldr r1, [r10, #4]
 	mov r0, r6
 	mov r2, r4
 	bl func_0202e9f4
@@ -116,7 +116,7 @@ _0215b5e4:
 	bl func_ov18_0216927c
 _0215b630:
 	mov r0, sb
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov18_0215b4a0
 _0215b638: .word data_ov18_0216c0e0
@@ -292,7 +292,7 @@ _0215b868: .word data_027e0f6c
 	.global func_ov18_0215b86c
 	arm_func_start func_ov18_0215b86c
 func_ov18_0215b86c: ; 0x0215b86c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x70
 	ldrb r5, [sp, #0x98]
 	ldrb r4, [sp, #0x9c]
@@ -334,14 +334,14 @@ func_ov18_0215b86c: ; 0x0215b86c
 	mov r5, r0
 	ldr r0, [r1]
 	bl func_ov00_02083384
-	mov sl, #0x4000
-	rsb sl, sl, #0
+	mov r10, #0x4000
+	rsb r10, r10, #0
 	mov r6, r0
-	sub r0, sl, #0x4000
+	sub r0, r10, #0x4000
 	ldr r4, _0215bd70 ; =0xffffd99a
 	mov r7, #0
 	str r0, [sp, #8]
-	mov r11, sl, asr #0xd
+	mov r11, r10, asr #0xd
 _0215b934:
 	mov r0, r8
 	mov r1, r7
@@ -450,7 +450,7 @@ _0215ba94:
 	str r0, [sp, #0x3c]
 	b _0215bce4
 _0215bac8:
-	strh sl, [sp, #0x20]
+	strh r10, [sp, #0x20]
 	strb r0, [sp, #0x23]
 	ldrb r0, [r8, #0x87]
 	cmp r0, #1
@@ -627,7 +627,7 @@ _0215bd54:
 	cmp r7, #4
 	blt _0215b934
 	add sp, sp, #0x70
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov18_0215b86c
 _0215bd68: .word data_027e0e60
@@ -3788,7 +3788,7 @@ _0215e620: .word data_027e0e58
 	.global func_ov18_0215e624
 	arm_func_start func_ov18_0215e624
 func_ov18_0215e624: ; 0x0215e624
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x80
 	mov r4, r0
 	ldr r1, [r4, #4]
@@ -4298,7 +4298,7 @@ _0215ed70:
 	ldrb r1, [r1, r8, lsl #1]
 	cmp r11, r0
 	ldr r0, [sp, #4]
-	add sl, r0, r1
+	add r10, r0, r1
 	bge _0215ee18
 	ldr r5, _0215ee8c ; =data_027e0e60
 	add r7, sp, #0xc
@@ -4306,7 +4306,7 @@ _0215ed70:
 _0215edd0:
 	ldr sb, [sp, #4]
 	mov r0, sb
-	cmp r0, sl
+	cmp r0, r10
 	bge _0215ee08
 	and r8, r11, #0xff
 _0215ede4:
@@ -4317,7 +4317,7 @@ _0215ede4:
 	strb sb, [sp, #0xd]
 	bl func_ov00_02082680
 	add sb, sb, #1
-	cmp sb, sl
+	cmp sb, r10
 	blt _0215ede4
 _0215ee08:
 	ldr r0, [sp, #8]
@@ -4335,14 +4335,14 @@ _0215ee18:
 	mov r2, r1
 	blx r3
 	add sp, sp, #0x80
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0215ee44:
 	ldr r3, [r3, #0x80]
 	mov r1, #0
 	mov r2, #1
 	blx r3
 	add sp, sp, #0x80
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov18_0215e624
 _0215ee5c: .word data_027e0f68
@@ -6331,7 +6331,7 @@ func_ov18_02160634: ; 0x02160634
 	.global func_ov18_0216065c
 	arm_func_start func_ov18_0216065c
 func_ov18_0216065c: ; 0x0216065c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x68
 	mov r11, r0
 	ldr r1, [r11, #0x18]
@@ -6409,7 +6409,7 @@ _02160774:
 	str r0, [sp, #8]
 	cmp r8, r0
 	ldr r0, [sp, #4]
-	add sl, r0, #3
+	add r10, r0, #3
 	bgt _021607ec
 	ldr r4, _0216081c ; =data_027e0e60
 	add r6, sp, #0xc
@@ -6417,7 +6417,7 @@ _02160774:
 _021607a4:
 	ldr sb, [sp, #4]
 	mov r0, sb
-	cmp r0, sl
+	cmp r0, r10
 	bgt _021607dc
 	and r7, r8, #0xff
 _021607b8:
@@ -6428,7 +6428,7 @@ _021607b8:
 	strb sb, [sp, #0xd]
 	bl func_ov00_02082680
 	add sb, sb, #1
-	cmp sb, sl
+	cmp sb, r10
 	ble _021607b8
 _021607dc:
 	ldr r0, [sp, #8]
@@ -6443,7 +6443,7 @@ _021607ec:
 	mov r2, r1
 	blx r3
 	add sp, sp, #0x68
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov18_0216065c
 _0216080c: .word data_027e0fe8
@@ -6762,7 +6762,7 @@ func_ov18_02160b44: ; 0x02160b44
 	.global func_ov18_02160b6c
 	arm_func_start func_ov18_02160b6c
 func_ov18_02160b6c: ; 0x02160b6c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x24
 	mov r4, r0
 	ldrh r1, [r4, #0x24]
@@ -6808,7 +6808,7 @@ _02160bac:
 	add r0, r1, #5
 	sub r7, r1, #5
 	str r0, [sp, #8]
-	mov sl, sb
+	mov r10, sb
 	cmp r7, r0
 	bge _02160fb0
 	add r5, sp, #0x14
@@ -6818,12 +6818,12 @@ _02160c30:
 	cmp r7, r0
 	beq _02160c4c
 	addge sb, sb, #1
-	subge sl, sl, #1
+	subge r10, r10, #1
 	sublt sb, sb, #1
-	addlt sl, sl, #1
+	addlt r10, r10, #1
 _02160c4c:
 	mov r8, sb
-	cmp sb, sl
+	cmp sb, r10
 	bge _02160ca8
 	and r6, r7, #0xff
 _02160c5c:
@@ -6846,7 +6846,7 @@ _02160c80:
 	bl func_ov00_02082680
 _02160c9c:
 	add r8, r8, #1
-	cmp r8, sl
+	cmp r8, r10
 	blt _02160c5c
 _02160ca8:
 	ldr r0, [sp, #8]
@@ -6883,7 +6883,7 @@ _02160cbc:
 	add r0, r1, #9
 	sub r7, r1, #9
 	str r0, [sp, #4]
-	mov sl, sb
+	mov r10, sb
 	cmp r7, r0
 	bge _02160fb0
 	add r5, sp, #0x12
@@ -6893,12 +6893,12 @@ _02160d40:
 	cmp r7, r0
 	beq _02160d5c
 	addgt sb, sb, #1
-	subgt sl, sl, #1
+	subgt r10, r10, #1
 	suble sb, sb, #1
-	addle sl, sl, #1
+	addle r10, r10, #1
 _02160d5c:
 	mov r8, sb
-	cmp sb, sl
+	cmp sb, r10
 	bge _02160db8
 	and r6, r7, #0xff
 _02160d6c:
@@ -6921,7 +6921,7 @@ _02160d90:
 	bl func_ov00_02082680
 _02160dac:
 	add r8, r8, #1
-	cmp r8, sl
+	cmp r8, r10
 	blt _02160d6c
 _02160db8:
 	ldr r0, [sp, #4]
@@ -6958,7 +6958,7 @@ _02160dcc:
 	add r0, r1, #8
 	sub r7, r1, #8
 	str r0, [sp]
-	mov sl, sb
+	mov r10, sb
 	cmp r7, r0
 	bge _02160fb0
 	add r5, sp, #0x10
@@ -6968,12 +6968,12 @@ _02160e50:
 	cmp r7, r0
 	beq _02160e6c
 	addgt sb, sb, #1
-	subgt sl, sl, #1
+	subgt r10, r10, #1
 	suble sb, sb, #1
-	addle sl, sl, #1
+	addle r10, r10, #1
 _02160e6c:
 	mov r8, sb
-	cmp sb, sl
+	cmp sb, r10
 	bge _02160ec8
 	and r6, r7, #0xff
 _02160e7c:
@@ -6996,7 +6996,7 @@ _02160ea0:
 	bl func_ov00_02082680
 _02160ebc:
 	add r8, r8, #1
-	cmp r8, sl
+	cmp r8, r10
 	blt _02160e7c
 _02160ec8:
 	ldr r0, [sp]
@@ -7078,7 +7078,7 @@ _02160fb0:
 	ldr r0, [sp, #0xc]
 	str r0, [r4, #0xa4]
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov18_02160b6c
 _02160ff8: .word data_027e0f68
@@ -8564,7 +8564,7 @@ func_ov18_02162188: ; 0x02162188
 	.global func_ov18_021621b8
 	arm_func_start func_ov18_021621b8
 func_ov18_021621b8: ; 0x021621b8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x1c
 	ldr r1, _0216243c ; =data_027e0764
 	mov r2, #0
@@ -8579,11 +8579,11 @@ func_ov18_021621b8: ; 0x021621b8
 	adds r4, r5, r7
 	str r4, [r1]
 	adc r6, r3, r6
-	mov sl, #0x15
-	umull r3, r5, r6, sl
+	mov r10, #0x15
+	umull r3, r5, r6, r10
 	mla r5, r6, r2, r5
 	mov r11, r2
-	mla r5, r11, sl, r5
+	mla r5, r11, r10, r5
 	mov r4, r0
 	str r6, [r1, #4]
 	ldr r6, [r4, #0x18]
@@ -8606,9 +8606,9 @@ func_ov18_021621b8: ; 0x021621b8
 	adds r3, sb, r7
 	adc r6, r8, r6
 	stmia r1, {r3, r6}
-	umull r1, r3, r6, sl
+	umull r1, r3, r6, r10
 	mla r3, r6, r2, r3
-	mla r3, r11, sl, r3
+	mla r3, r11, r10, r3
 	ldr r5, [r4, #0x20]
 	sub r2, r3, #0xa
 	mov r1, #0x29
@@ -8732,7 +8732,7 @@ _0216241c:
 	mov r2, #1
 	blx r3
 	add sp, sp, #0x1c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov18_021621b8
 _0216243c: .word data_027e0764
@@ -9431,7 +9431,7 @@ func_ov18_02162d90: ; 0x02162d90
 	.global func_ov18_02162db8
 	arm_func_start func_ov18_02162db8
 func_ov18_02162db8: ; 0x02162db8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x20
 	ldr r2, [r0, #4]
 	mov r1, #0
@@ -9452,18 +9452,18 @@ func_ov18_02162db8: ; 0x02162db8
 _02162e00:
 	ldr r1, [r8]
 	ldmib r8, {r0, r3}
-	umull sl, sb, r3, r1
+	umull r10, sb, r3, r1
 	mla sb, r3, r0, sb
 	ldr r2, [r8, #0xc]
 	ldr ip, [r8, #0x10]
 	mla sb, r2, r1, sb
 	ldr r11, [r8, #0x14]
-	adds sl, ip, sl
+	adds r10, ip, r10
 	adc sb, r11, sb
 	mov r0, #0x15
 	umull r0, r2, sb, r0
 	mov r0, #0
-	str sl, [r8]
+	str r10, [r8]
 	mla r2, sb, r0, r2
 	mov r1, r0
 	mov r0, #0x15
@@ -9484,9 +9484,9 @@ _02162e00:
 	bls _02162f04
 	ldr r1, [r8, #8]
 	ldr r0, [r8, #0xc]
-	umull r3, r2, r1, sl
+	umull r3, r2, r1, r10
 	mla r2, r1, sb, r2
-	mla r2, r0, sl, r2
+	mla r2, r0, r10, r2
 	adds r0, ip, r3
 	adc r1, r11, r2
 	stmia r8, {r0, r1}
@@ -9518,9 +9518,9 @@ _02162e00:
 _02162f04:
 	ldr r1, [r8, #8]
 	ldr r0, [r8, #0xc]
-	umull r3, r2, r1, sl
+	umull r3, r2, r1, r10
 	mla r2, r1, sb, r2
-	mla r2, r0, sl, r2
+	mla r2, r0, r10, r2
 	adds r0, ip, r3
 	adc r1, r11, r2
 	stmia r8, {r0, r1}
@@ -9553,18 +9553,18 @@ _02162f7c:
 	str r0, [r7, #0x64]
 	ldr r1, [r8]
 	ldmib r8, {r0, r3}
-	umull sl, sb, r3, r1
+	umull r10, sb, r3, r1
 	mla sb, r3, r0, sb
 	ldr r2, [r8, #0xc]
 	ldr ip, [r8, #0x10]
 	mla sb, r2, r1, sb
 	ldr r11, [r8, #0x14]
-	adds sl, ip, sl
+	adds r10, ip, r10
 	adc sb, r11, sb
 	mov r0, #0x15
 	umull r0, r2, sb, r0
 	mov r0, #0
-	str sl, [r8]
+	str r10, [r8]
 	mla r2, sb, r0, r2
 	mov r1, r0
 	mov r0, #0x15
@@ -9585,9 +9585,9 @@ _02162f7c:
 	bls _02163090
 	ldr r1, [r8, #8]
 	ldr r0, [r8, #0xc]
-	umull r3, r2, r1, sl
+	umull r3, r2, r1, r10
 	mla r2, r1, sb, r2
-	mla r2, r0, sl, r2
+	mla r2, r0, r10, r2
 	adds r0, ip, r3
 	adc r1, r11, r2
 	stmia r8, {r0, r1}
@@ -9619,9 +9619,9 @@ _02162f7c:
 _02163090:
 	ldr r1, [r8, #8]
 	ldr r0, [r8, #0xc]
-	umull r3, r2, r1, sl
+	umull r3, r2, r1, r10
 	mla r2, r1, sb, r2
-	mla r2, r0, sl, r2
+	mla r2, r0, r10, r2
 	adds r0, ip, r3
 	adc r1, r11, r2
 	stmia r8, {r0, r1}
@@ -9655,10 +9655,10 @@ _02163108:
 	umull lr, ip, r3, r1
 	mla ip, r3, r0, ip
 	ldr r2, [r8, #0xc]
-	ldr sl, [r8, #0x10]
+	ldr r10, [r8, #0x10]
 	mla ip, r2, r1, ip
 	ldr sb, [r8, #0x14]
-	adds r0, sl, lr
+	adds r0, r10, lr
 	adc r1, sb, ip
 	stmia r8, {r0, r1}
 	mov r0, #3
@@ -9711,20 +9711,20 @@ _02163108:
 	ldrh r1, [r0, #0x26]
 	cmp r1, #0
 	addeq sp, sp, #0x20
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, _02163254 ; =data_027e0f74
 	ldr r0, [r0]
 	bl func_ov00_02097760
 	cmp r0, #0
 	addne sp, sp, #0x20
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, [sp, #4]
 	ldr r0, [r0, #4]
 	bic r1, r0, #1
 	ldr r0, [sp, #4]
 	str r1, [r0, #4]
 	add sp, sp, #0x20
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov18_02162db8
 _0216323c: .word 0x40b00000
@@ -9793,9 +9793,9 @@ _021632f4:
 	.global func_ov18_021632fc
 	arm_func_start func_ov18_021632fc
 func_ov18_021632fc: ; 0x021632fc
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x50
-	mov sl, r0
+	mov r10, r0
 	add r0, sp, #0x34
 	mov sb, r1
 	bl func_ov00_0207a13c
@@ -9807,7 +9807,7 @@ func_ov18_021632fc: ; 0x021632fc
 	mov r0, #5
 	mov r7, #0
 	strh r4, [sp, #0x34]
-	mov r8, sl
+	mov r8, r10
 	str r0, [sp, #0x38]
 	str r3, [sp, #0x3c]
 	str r3, [sp, #0x40]
@@ -9825,7 +9825,7 @@ _0216335c:
 	mov r2, r6
 	str r0, [sp, #0x20]
 	ldr r3, [r8, #0x68]
-	add r0, sl, #0x18
+	add r0, r10, #0x18
 	str r3, [sp, #0x24]
 	bl func_01ff9bc4
 	str r5, [sp]
@@ -9835,9 +9835,9 @@ _0216335c:
 	str r4, [sp, #0x10]
 	str r11, [sp, #0x14]
 	str r5, [sp, #0x18]
-	add r0, sl, r7, lsl #1
+	add r0, r10, r7, lsl #1
 	ldrsh r2, [r0, #0x7a]
-	mov r0, sl
+	mov r0, r10
 	mov r1, sb
 	mov r3, r6
 	bl func_ov00_0208ba68
@@ -9846,7 +9846,7 @@ _0216335c:
 	add r8, r8, #0xc
 	blt _0216335c
 	add sp, sp, #0x50
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov18_021632fc
 _021633d0: .word 0x00000533
@@ -9855,13 +9855,13 @@ _021633d4: .word data_ov00_020ec9d6
 	.global func_ov18_021633d8
 	arm_func_start func_ov18_021633d8
 func_ov18_021633d8: ; 0x021633d8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x64
 	ldr r2, _021635c4 ; =0x020ec9d6
 	ldr r1, _021635c8 ; =data_ov00_020ec9d4
 	ldrh r3, [r2]
 	ldrh r2, [r1]
-	mov sl, r0
+	mov r10, r0
 	add r1, sp, #0x30
 	orr r0, r3, r2, lsl #16
 	orr r3, r0, #0x8000
@@ -9914,7 +9914,7 @@ func_ov18_021633d8: ; 0x021633d8
 	bl func_01ffa9fc
 	mov r7, #0x800
 	mov r8, #0
-	mov sb, sl
+	mov sb, r10
 	rsb r7, r7, #0
 	add r6, sp, #0x4c
 	add r11, sp, #0x58
@@ -9923,7 +9923,7 @@ func_ov18_021633d8: ; 0x021633d8
 _021634dc:
 	ldr r2, [sb, #0x68]
 	ldr r1, [sb, #0x60]
-	add r0, sl, #0x18
+	add r0, r10, #0x18
 	str r1, [sp, #0x4c]
 	str r2, [sp, #0x54]
 	mov r1, r6
@@ -9957,7 +9957,7 @@ _021634dc:
 	str r0, [sp, #8]
 	str r0, [sp, #0xc]
 	str r4, [sp, #0x10]
-	mov r0, sl
+	mov r0, r10
 	mov r1, #0
 	mov r2, #1
 	mov r3, #5
@@ -9978,7 +9978,7 @@ _021634dc:
 	cmp r8, #2
 	blt _021634dc
 	add sp, sp, #0x64
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov18_021633d8
 _021635c4: .word data_ov00_020ec9d6
@@ -9989,7 +9989,7 @@ _021635d0: .word 0x001e4081
 	.global func_ov18_021635d4
 	arm_func_start func_ov18_021635d4
 func_ov18_021635d4: ; 0x021635d4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x14
 	mov r5, r0
 	str r1, [r5, #8]
@@ -10002,7 +10002,7 @@ _021635f4:
 	ldr r6, _0216367c ; =data_027e0e58
 	strh r4, [r5, #0x78]
 	add sb, r5, #0x18
-	add sl, sp, #8
+	add r10, sp, #8
 	mov r8, r4
 	mov r7, #0x1ec
 	mov r11, #4
@@ -10012,9 +10012,9 @@ _02163614:
 	ldr r3, [r5, #0x60]
 	add r0, r0, #0x9a
 	add ip, r0, #0x500
-	mov r0, sl
+	mov r0, r10
 	mov r1, sb
-	mov r2, sl
+	mov r2, r10
 	str r3, [sp, #8]
 	str ip, [sp, #0xc]
 	str lr, [sp, #0x10]
@@ -10023,7 +10023,7 @@ _02163614:
 	str r8, [sp, #4]
 	ldr r0, [r6]
 	mov r1, r7
-	mov r2, sl
+	mov r2, r10
 	mov r3, r11
 	bl func_ov00_0207c1b0
 	add r4, r4, #1
@@ -10033,7 +10033,7 @@ _02163614:
 _02163670:
 	mov r0, #1
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov18_021635d4
 _0216367c: .word data_027e0e58
@@ -10245,7 +10245,7 @@ func_ov18_021638b8: ; 0x021638b8
 	.global func_ov18_021638e0
 	arm_func_start func_ov18_021638e0
 func_ov18_021638e0: ; 0x021638e0
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x1c
 	ldr r3, [r0]
 	mov r1, #0
@@ -10261,18 +10261,18 @@ func_ov18_021638e0: ; 0x021638e0
 _02163914:
 	ldr r1, [r8]
 	ldmib r8, {r0, r3}
-	umull sl, sb, r3, r1
+	umull r10, sb, r3, r1
 	mla sb, r3, r0, sb
 	ldr r2, [r8, #0xc]
 	ldr ip, [r8, #0x10]
 	mla sb, r2, r1, sb
 	ldr r11, [r8, #0x14]
-	adds sl, ip, sl
+	adds r10, ip, r10
 	adc sb, r11, sb
 	mov r0, #0x15
 	umull r0, r2, sb, r0
 	mov r0, #0
-	str sl, [r8]
+	str r10, [r8]
 	mla r2, sb, r0, r2
 	mov r1, r0
 	mov r0, #0x15
@@ -10293,9 +10293,9 @@ _02163914:
 	bls _02163a18
 	ldr r1, [r8, #8]
 	ldr r0, [r8, #0xc]
-	umull r3, r2, r1, sl
+	umull r3, r2, r1, r10
 	mla r2, r1, sb, r2
-	mla r2, r0, sl, r2
+	mla r2, r0, r10, r2
 	adds r0, ip, r3
 	adc r1, r11, r2
 	stmia r8, {r0, r1}
@@ -10327,9 +10327,9 @@ _02163914:
 _02163a18:
 	ldr r1, [r8, #8]
 	ldr r0, [r8, #0xc]
-	umull r3, r2, r1, sl
+	umull r3, r2, r1, r10
 	mla r2, r1, sb, r2
-	mla r2, r0, sl, r2
+	mla r2, r0, r10, r2
 	adds r0, ip, r3
 	adc r1, r11, r2
 	stmia r8, {r0, r1}
@@ -10362,18 +10362,18 @@ _02163a90:
 	str r0, [r6, #0x64]
 	ldr r1, [r8]
 	ldmib r8, {r0, r3}
-	umull sl, sb, r3, r1
+	umull r10, sb, r3, r1
 	mla sb, r3, r0, sb
 	ldr r2, [r8, #0xc]
 	ldr ip, [r8, #0x10]
 	mla sb, r2, r1, sb
 	ldr r11, [r8, #0x14]
-	adds sl, ip, sl
+	adds r10, ip, r10
 	adc sb, r11, sb
 	mov r0, #0x15
 	umull r0, r2, sb, r0
 	mov r0, #0
-	str sl, [r8]
+	str r10, [r8]
 	mla r2, sb, r0, r2
 	mov r1, r0
 	mov r0, #0x15
@@ -10394,9 +10394,9 @@ _02163a90:
 	bls _02163ba4
 	ldr r1, [r8, #8]
 	ldr r0, [r8, #0xc]
-	umull r3, r2, r1, sl
+	umull r3, r2, r1, r10
 	mla r2, r1, sb, r2
-	mla r2, r0, sl, r2
+	mla r2, r0, r10, r2
 	adds r0, ip, r3
 	adc r1, r11, r2
 	stmia r8, {r0, r1}
@@ -10428,9 +10428,9 @@ _02163a90:
 _02163ba4:
 	ldr r1, [r8, #8]
 	ldr r0, [r8, #0xc]
-	umull r3, r2, r1, sl
+	umull r3, r2, r1, r10
 	mla r2, r1, sb, r2
-	mla r2, r0, sl, r2
+	mla r2, r0, r10, r2
 	adds r0, ip, r3
 	adc r1, r11, r2
 	stmia r8, {r0, r1}
@@ -10471,10 +10471,10 @@ _02163c3c:
 	umull lr, ip, r3, r1
 	mla ip, r3, r0, ip
 	ldr r2, [r8, #0xc]
-	ldr sl, [r8, #0x10]
+	ldr r10, [r8, #0x10]
 	mla ip, r2, r1, ip
 	ldr sb, [r8, #0x14]
-	adds r0, sl, lr
+	adds r0, r10, lr
 	adc r1, sb, ip
 	stmia r8, {r0, r1}
 	mov r0, #3
@@ -10524,7 +10524,7 @@ _02163c98:
 	ldrh r1, [r7, #0x26]
 	cmp r1, #0
 	addeq sp, sp, #0x1c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, _02163d60 ; =data_027e0f74
 	ldr r0, [r0]
 	bl func_ov00_02097760
@@ -10533,7 +10533,7 @@ _02163c98:
 	biceq r0, r0, #1
 	streq r0, [r7, #4]
 	add sp, sp, #0x1c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov18_021638e0
 _02163d48: .word 0x40b00000
@@ -10602,9 +10602,9 @@ _02163e00:
 	.global func_ov18_02163e08
 	arm_func_start func_ov18_02163e08
 func_ov18_02163e08: ; 0x02163e08
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x50
-	mov sl, r0
+	mov r10, r0
 	add r0, sp, #0x34
 	mov sb, r1
 	bl func_ov00_0207a13c
@@ -10616,7 +10616,7 @@ func_ov18_02163e08: ; 0x02163e08
 	mov r0, #5
 	mov r7, #0
 	strh r4, [sp, #0x34]
-	mov r8, sl
+	mov r8, r10
 	str r0, [sp, #0x38]
 	str r3, [sp, #0x3c]
 	str r3, [sp, #0x40]
@@ -10634,7 +10634,7 @@ _02163e68:
 	mov r2, r6
 	str r0, [sp, #0x20]
 	ldr r3, [r8, #0x68]
-	add r0, sl, #0x18
+	add r0, r10, #0x18
 	str r3, [sp, #0x24]
 	bl func_01ff9bc4
 	str r5, [sp]
@@ -10644,9 +10644,9 @@ _02163e68:
 	str r4, [sp, #0x10]
 	str r11, [sp, #0x14]
 	str r5, [sp, #0x18]
-	add r0, sl, r7, lsl #1
+	add r0, r10, r7, lsl #1
 	ldrsh r2, [r0, #0x7a]
-	mov r0, sl
+	mov r0, r10
 	mov r1, sb
 	mov r3, r6
 	bl func_ov00_0208ba68
@@ -10655,7 +10655,7 @@ _02163e68:
 	add r8, r8, #0xc
 	blt _02163e68
 	add sp, sp, #0x50
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov18_02163e08
 _02163edc: .word 0x00000533
@@ -10664,13 +10664,13 @@ _02163ee0: .word data_ov00_020ec9d6
 	.global func_ov18_02163ee4
 	arm_func_start func_ov18_02163ee4
 func_ov18_02163ee4: ; 0x02163ee4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x64
 	ldr r2, _021640d0 ; =0x020ec9d6
 	ldr r1, _021640d4 ; =data_ov00_020ec9d4
 	ldrh r3, [r2]
 	ldrh r2, [r1]
-	mov sl, r0
+	mov r10, r0
 	add r1, sp, #0x30
 	orr r0, r3, r2, lsl #16
 	orr r3, r0, #0x8000
@@ -10723,7 +10723,7 @@ func_ov18_02163ee4: ; 0x02163ee4
 	bl func_01ffa9fc
 	mov r7, #0x800
 	mov r8, #0
-	mov sb, sl
+	mov sb, r10
 	rsb r7, r7, #0
 	add r6, sp, #0x4c
 	add r11, sp, #0x58
@@ -10732,7 +10732,7 @@ func_ov18_02163ee4: ; 0x02163ee4
 _02163fe8:
 	ldr r2, [sb, #0x68]
 	ldr r1, [sb, #0x60]
-	add r0, sl, #0x18
+	add r0, r10, #0x18
 	str r1, [sp, #0x4c]
 	str r2, [sp, #0x54]
 	mov r1, r6
@@ -10766,7 +10766,7 @@ _02163fe8:
 	str r0, [sp, #8]
 	str r0, [sp, #0xc]
 	str r4, [sp, #0x10]
-	mov r0, sl
+	mov r0, r10
 	mov r1, #0
 	mov r2, #1
 	mov r3, #5
@@ -10787,7 +10787,7 @@ _02163fe8:
 	cmp r8, #2
 	blt _02163fe8
 	add sp, sp, #0x64
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov18_02163ee4
 _021640d0: .word data_ov00_020ec9d6
@@ -10798,7 +10798,7 @@ _021640dc: .word 0x001e4081
 	.global func_ov18_021640e0
 	arm_func_start func_ov18_021640e0
 func_ov18_021640e0: ; 0x021640e0
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x14
 	mov r5, r0
 	str r1, [r5, #8]
@@ -10811,7 +10811,7 @@ _02164100:
 	ldr r6, _02164188 ; =data_027e0e58
 	strh r4, [r5, #0x78]
 	add sb, r5, #0x18
-	add sl, sp, #8
+	add r10, sp, #8
 	mov r8, r4
 	mov r7, #0x1ec
 	mov r11, #4
@@ -10821,9 +10821,9 @@ _02164120:
 	ldr r3, [r5, #0x60]
 	add r0, r0, #0x9a
 	add ip, r0, #0x500
-	mov r0, sl
+	mov r0, r10
 	mov r1, sb
-	mov r2, sl
+	mov r2, r10
 	str r3, [sp, #8]
 	str ip, [sp, #0xc]
 	str lr, [sp, #0x10]
@@ -10832,7 +10832,7 @@ _02164120:
 	str r8, [sp, #4]
 	ldr r0, [r6]
 	mov r1, r7
-	mov r2, sl
+	mov r2, r10
 	mov r3, r11
 	bl func_ov00_0207c1b0
 	add r4, r4, #1
@@ -10842,7 +10842,7 @@ _02164120:
 _0216417c:
 	mov r0, #1
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov18_021640e0
 _02164188: .word data_027e0e58
@@ -14444,7 +14444,7 @@ _02166f1c: .word data_027e0fe4
 	.global func_ov18_02166f20
 	arm_func_start func_ov18_02166f20
 func_ov18_02166f20: ; 0x02166f20
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0xc
 	mov r4, r0
 	mov r2, #0
@@ -14482,11 +14482,11 @@ func_ov18_02166f20: ; 0x02166f20
 	adds r7, sb, #0x800
 	mla r8, r6, r0, r8
 	mov r1, #1
-	ldr sl, [r4, #0x48]
+	ldr r10, [r4, #0x48]
 	adc r6, r8, #0
 	mov r7, r7, lsr #0xc
 	orr r7, r7, r6, lsl #20
-	add r6, sl, r7
+	add r6, r10, r7
 	umull r8, r7, r5, r0
 	str r6, [r4, #0x48]
 	mla r7, r5, r3, r7
@@ -14520,7 +14520,7 @@ func_ov18_02166f20: ; 0x02166f20
 	bl func_01ffa0f4
 	strh r0, [r4, #0x78]
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov18_02166f20
 _02167054: .word data_ov18_0216d604
@@ -15094,7 +15094,7 @@ _02167834: .word func_ov14_02145f0c
 	.global func_ov18_02167838
 	arm_func_start func_ov18_02167838
 func_ov18_02167838: ; 0x02167838
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #0x44
 	mov r4, r0
 	add r0, r4, #0x400
@@ -15280,7 +15280,7 @@ _02167a98:
 	ldr r0, [r0, #4]
 	bl func_ov00_02087d98
 	add sp, sp, #0x44
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 _02167aec:
 	add r0, r4, #0x118
 	ldr r1, _02167df4 ; =0x00001555
@@ -15358,7 +15358,7 @@ _02167bdc:
 	mov r0, #0
 	add sp, sp, #0x44
 	strb r0, [r4, #0x118]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 _02167c18:
 	ldrb r0, [r4, #0x475]
 	cmp r0, #0
@@ -15366,7 +15366,7 @@ _02167c18:
 	cmp r0, #1
 	beq _02167c78
 	add sp, sp, #0x44
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 _02167c34:
 	ldr r1, [r4, #0x34]
 	mvn r0, #0
@@ -15385,7 +15385,7 @@ _02167c58:
 	ldrb r0, [r4, #0x474]
 	add r0, r0, #1
 	strb r0, [r4, #0x474]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 _02167c78:
 	ldr ip, _02167de4 ; =data_ov18_0216d604
 	ldr r6, [r4, #0x48]
@@ -15406,18 +15406,18 @@ _02167c78:
 	mov r1, r1, lsl #0x1
 	mov r0, #0x13000
 	ldrsh r1, [r5, r1]
-	umull r2, sl, r7, r0
+	umull r2, r10, r7, r0
 	mov r3, #0
 	umull r5, lr, r1, r0
 	mla lr, r1, r3, lr
 	str r6, [sp, #0x38]
 	mov r1, r1, asr #0x1f
 	mla lr, r1, r0, lr
-	mla sl, r7, r3, sl
+	mla r10, r7, r3, r10
 	mov r6, r7, asr #0x1f
-	mla sl, r6, r0, sl
+	mla r10, r6, r0, r10
 	adds r2, r2, #0x800
-	adc r6, sl, #0
+	adc r6, r10, #0
 	mov r7, r2, lsr #0xc
 	ldr sb, [r4, #0x4c]
 	str r8, [sp, #0x40]
@@ -15474,7 +15474,7 @@ _02167c78:
 	ldmia r1, {r1, r2, r3}
 	bl func_ov18_02166910
 	add sp, sp, #0x44
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov18_02167838
 _02167dd8: .word data_027e0ffc
@@ -15843,7 +15843,7 @@ _021682dc:
 	.global func_ov18_021682f8
 	arm_func_start func_ov18_021682f8
 func_ov18_021682f8: ; 0x021682f8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0xf4
 	mov r6, r0
 	cmp r1, #0
@@ -15851,7 +15851,7 @@ func_ov18_021682f8: ; 0x021682f8
 	ldreqb r0, [r6, #0xa4]
 	cmp r0, #0
 	addeq sp, sp, #0xf4
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, _021686c8 ; =data_027e0fec
 	ldr r0, [r0]
 	add r0, r0, #0xbf0
@@ -15936,7 +15936,7 @@ _02168388:
 	cmp r0, #0
 	str r0, [r1, #0x2c]
 	addeq sp, sp, #0xf4
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r1, _021686e0 ; =data_02051054
 	add r0, sp, #0x34
 	ldrsh r2, [r1, #0xf6]
@@ -15980,15 +15980,15 @@ _02168388:
 	mla r3, r2, r0, r3
 	adds r2, r6, #0x800
 	adc r0, r3, #0
-	mov sl, r2, lsr #0xc
-	orr sl, sl, r0, lsl #20
-	cmp sl, #0
-	movle sl, r1
+	mov r10, r2, lsr #0xc
+	orr r10, r10, r0, lsl #20
+	cmp r10, #0
+	movle r10, r1
 	ldr r0, _021686e8 ; =0x000004cd
 	mov r1, #0
-	umull r7, r6, sl, r0
-	mla r6, sl, r1, r6
-	mov r8, sl, asr #0x1f
+	umull r7, r6, r10, r0
+	mla r6, r10, r1, r6
+	mov r8, r10, asr #0x1f
 	adds r7, r7, #0x800
 	mla r6, r8, r0, r6
 	mov sb, r7, lsr #0xc
@@ -15997,8 +15997,8 @@ _02168388:
 	ldmia r11, {r7, ip}
 	smull r6, lr, r7, sb
 	adds r6, r6, #0x800
-	umull r3, r2, sl, r0
-	mla r2, sl, r1, r2
+	umull r3, r2, r10, r0
+	mla r2, r10, r1, r2
 	adc r7, lr, #0
 	mov r6, r6, lsr #0xc
 	orr r6, r6, r7, lsl #20
@@ -16042,8 +16042,8 @@ _02168388:
 	mov r6, r6, lsr #0xc
 	orr r6, r6, r2, lsl #20
 	str r6, [r4, #8]
-	umull r4, r2, sl, r0
-	mla r2, sl, r1, r2
+	umull r4, r2, r10, r0
+	mla r2, r10, r1, r2
 	adds r4, r4, #0x800
 	mla r2, r8, r0, r2
 	ldr r3, [r5]
@@ -16056,15 +16056,15 @@ _02168388:
 	mov r2, r2, lsr #0xc
 	orr r2, r2, r0, lsl #20
 	mov r3, #0x1f000
-	umull r6, r4, sl, r3
-	mla r4, sl, r1, r4
-	ldmib r5, {r0, sl}
+	umull r6, r4, r10, r3
+	mla r4, r10, r1, r4
+	ldmib r5, {r0, r10}
 	smull sb, r11, r0, r7
 	mov r0, #0x800
 	adds r0, sb, r0
-	smull sb, r7, sl, r7
+	smull sb, r7, r10, r7
 	mla r4, r8, r3, r4
-	adc sl, r11, r1
+	adc r10, r11, r1
 	adds sb, sb, #0x800
 	adc r7, r7, r1
 	mov r3, r0, lsr #0xc
@@ -16073,7 +16073,7 @@ _02168388:
 	adc r0, r4, r1
 	mov r4, r6, lsr #0xc
 	orr r4, r4, r0, lsl #20
-	orr r3, r3, sl, lsl #20
+	orr r3, r3, r10, lsl #20
 	orr r8, r8, r7, lsl #20
 	stmia r5, {r2, r3, r8}
 	mov r4, r4, asr #0xc
@@ -16088,7 +16088,7 @@ _02168388:
 	strb r2, [sp, #0x33]
 	bl func_ov18_0216941c
 	add sp, sp, #0xf4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov18_021682f8
 _021686c8: .word data_027e0fec
@@ -17171,7 +17171,7 @@ func_ov18_0216941c: ; 0x0216941c
 	.global func_ov18_0216945c
 	arm_func_start func_ov18_0216945c
 func_ov18_0216945c: ; 0x0216945c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x20
 	ldr r1, _021695dc ; =data_027e0d44
 	add r4, r0, #0x900
@@ -17195,9 +17195,9 @@ func_ov18_0216945c: ; 0x0216945c
 	str r3, [sp, #0x10]
 	str r2, [sp, #0x14]
 	cmp r1, #0
-	mov sl, #0
+	mov r10, #0
 	addle sp, sp, #0x20
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r8, _021695e0 ; =0x040004a8
 	sub r0, r8, #0x10
 	str r0, [sp]
@@ -17245,7 +17245,7 @@ _02169504:
 	str r0, [r5]
 	ldr r1, _021695e4 ; =0xf0001000
 	ldr r0, [sp]
-	add sl, sl, #1
+	add r10, r10, #1
 	str r1, [r0]
 	mov r0, #0
 	str r0, [r5]
@@ -17264,10 +17264,10 @@ _02169504:
 	mov r1, #1
 	str r1, [r0]
 	ldrsh r0, [r4, #8]
-	cmp sl, r0
+	cmp r10, r0
 	blt _02169504
 	add sp, sp, #0x20
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov18_0216945c
 _021695dc: .word data_027e0d44
@@ -17418,23 +17418,23 @@ _021697e0: .word data_ov00_020ee6f8
 	.global func_ov18_021697e4
 	arm_func_start func_ov18_021697e4
 func_ov18_021697e4: ; 0x021697e4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x10
 	ldr r8, [sp, #0x40]
 	mov r7, r1
 	ldr r1, [sp, #0x38]
 	ldr sb, [sp, #0x3c]
 	mov r4, r0
-	mov sl, r2
+	mov r10, r2
 	str r3, [sp, #4]
 	cmp r8, #0
 	str r1, [sp, #0x38]
 	addeq sp, sp, #0x10
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	mov r1, r3
 	subs r6, r1, r7
 	ldr r1, [sp, #0x38]
-	sub r5, r1, sl
+	sub r5, r1, r10
 	cmpeq r5, #0
 	bne _0216984c
 	ldr r2, [sp, #0x38]
@@ -17443,7 +17443,7 @@ func_ov18_021697e4: ; 0x021697e4
 	str r8, [sp]
 	bl func_ov18_021699e4
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0216984c:
 	cmp r6, #0
 	strge r6, [sp, #8]
@@ -17474,14 +17474,14 @@ _0216984c:
 	mov r1, r6, lsl #0xc
 	bl func_01ff9b24
 	ldr r0, [sp, #4]
-	mov r5, sl, lsl #0xc
+	mov r5, r10, lsl #0xc
 	cmp r7, r0
 	movle r11, #1
 	mvngt r11, #0
 	bl func_01ff9a18
 	mov r6, r0
 	ldr r0, [sp, #0x38]
-	cmp sl, r0
+	cmp r10, r0
 	bgt _021698f0
 	cmp r6, #0
 	rsblt r6, r6, #0
@@ -17491,10 +17491,10 @@ _021698f0:
 	rsbgt r6, r6, #0
 _021698f8:
 	ldr r0, [sp, #8]
-	mov sl, #0
+	mov r10, #0
 	cmp r0, #0
 	addlt sp, sp, #0x10
-	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0216990c:
 	add r2, r5, #0x800
 	mov r0, r4
@@ -17504,20 +17504,20 @@ _0216990c:
 	str r8, [sp]
 	bl func_ov18_021699e4
 	ldr r0, [sp, #8]
-	add sl, sl, #1
-	cmp sl, r0
+	add r10, r10, #1
+	cmp r10, r0
 	add r7, r7, r11
 	add r5, r5, r6
 	ble _0216990c
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02169948:
 	mov r0, r6, lsl #0xc
 	mov r1, r5, lsl #0xc
 	bl func_01ff9b24
 	ldr r0, [sp, #0x38]
 	mov r5, r7, lsl #0xc
-	cmp sl, r0
+	cmp r10, r0
 	movle r0, #1
 	strle r0, [sp, #0xc]
 	mvngt r0, #0
@@ -17537,11 +17537,11 @@ _02169998:
 	cmp r11, #0
 	mov r7, #0
 	addlt sp, sp, #0x10
-	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _021699a8:
 	add r1, r5, #0x800
 	mov r0, r4
-	mov r2, sl
+	mov r2, r10
 	mov r3, sb
 	mov r1, r1, asr #0xc
 	str r8, [sp]
@@ -17550,16 +17550,16 @@ _021699a8:
 	add r7, r7, #1
 	cmp r7, r11
 	add r5, r5, r6
-	add sl, sl, r0
+	add r10, r10, r0
 	ble _021699a8
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	arm_func_end func_ov18_021697e4
 
 	.global func_ov18_021699e4
 	arm_func_start func_ov18_021699e4
 func_ov18_021699e4: ; 0x021699e4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #4
 	mov r7, r0
 	ldr r0, [r7, #0x18]
@@ -17572,22 +17572,22 @@ func_ov18_021699e4: ; 0x021699e4
 	addmi sp, sp, #4
 	sub r1, r1, #2
 	sub r0, r0, #2
-	ldmmiia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmmiia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	cmp r6, r1
 	addgt sp, sp, #4
-	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	cmp r5, #0
 	addlt sp, sp, #4
-	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	cmp r5, r0
 	addgt sp, sp, #4
-	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
-	ldrb sl, [sp, #0x28]
+	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldrb r10, [sp, #0x28]
 	mov sb, #0
-	cmp sl, #0
+	cmp r10, #0
 	addle sp, sp, #4
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
-	sub r8, sl, #1
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	sub r8, r10, #1
 _02169a58:
 	mov r0, r7
 	mov r1, r6
@@ -17596,10 +17596,10 @@ _02169a58:
 	str r4, [sp]
 	bl func_0203e2e8
 	add sb, sb, #1
-	cmp sb, sl
+	cmp sb, r10
 	blt _02169a58
 	add sp, sp, #4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	arm_func_end func_ov18_021699e4
 
 	.global func_ov18_02169a84
@@ -17691,7 +17691,7 @@ _02169ba8: .word data_ov00_020e899c
 	.global func_ov18_02169bac
 	arm_func_start func_ov18_02169bac
 func_ov18_02169bac: ; 0x02169bac
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x1c
 	mov r4, r0
 	str r1, [sp]
@@ -17728,13 +17728,13 @@ func_ov18_02169bac: ; 0x02169bac
 	ldr r0, [r0, #0x114]
 	bl func_0203d1b4
 	mov r7, #0
-	mov sl, #1
+	mov r10, #1
 	mov r5, r6
 	mov r8, r7
 	mov sb, r7
 	mov r11, r7
-	mov r3, sl
-	mov r6, sl
+	mov r3, r10
+	mov r6, r10
 _02169c5c:
 	mov r2, sb, lsr #0x5
 	add r2, r4, r2, lsl #2
@@ -17745,8 +17745,8 @@ _02169c5c:
 	moveq r1, r11
 	and ip, r1, #0xff
 	ldrb lr, [r0, r8]
-	mov r1, sl, lsr #0x5
-	and r2, sl, #0x1f
+	mov r1, r10, lsr #0x5
+	and r2, r10, #0x1f
 	orr ip, lr, ip
 	strb ip, [r0, r8]
 	add r1, r4, r1, lsl #2
@@ -17757,7 +17757,7 @@ _02169c5c:
 	moveq r1, #0
 	ldrb r2, [r0, r8]
 	and r1, r1, #0xff
-	add sl, sl, #2
+	add r10, r10, #2
 	orr r1, r2, r1, lsl #4
 	strb r1, [r0, r8]
 	tst r1, #0xff
@@ -17786,7 +17786,7 @@ _02169d10:
 	ldr r0, [sp]
 	strb r0, [r4, #0x58a]
 	add sp, sp, #0x1c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov18_02169bac
 _02169d20: .word data_027e0c68
@@ -17797,30 +17797,30 @@ _02169d2c: .word data_027e103c
 	.global func_ov18_02169d30
 	arm_func_start func_ov18_02169d30
 func_ov18_02169d30: ; 0x02169d30
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
-	mov sl, r0
-	ldrb r0, [sl, #0x58a]
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	mov r10, r0
+	ldrb r0, [r10, #0x58a]
 	cmp r0, #0
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
-	ldr r0, [sl, #0x554]
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldr r0, [r10, #0x554]
 	cmp r0, #0
 	beq _02169d64
 	bl func_0203951c
 	cmp r0, #0
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02169d64:
 	ldr r0, _02169e20 ; =data_027e0cbc
 	mov r1, #0x16
 	bl func_0203d7e0
 	cmp r0, #0
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	mov sb, #0
-	add r0, sl, #0x158
+	add r0, r10, #0x158
 	mov r6, sb
-	mov r8, sl
+	mov r8, r10
 	add r7, r0, #0x400
 	mov r11, sb
 	mov r4, #1
@@ -17828,8 +17828,8 @@ _02169d64:
 _02169d9c:
 	cmp r6, #0
 	bne _02169db4
-	ldrsh r1, [sl]
-	ldrsh r0, [sl, #2]
+	ldrsh r1, [r10]
+	ldrsh r0, [r10, #2]
 	cmp r1, r0
 	bne _02169e04
 _02169db4:
@@ -17846,7 +17846,7 @@ _02169db4:
 	bne _02169df8
 	add r0, r8, #0x500
 	ldrh r1, [r0, #0x62]
-	mov r0, sl
+	mov r0, r10
 	bl func_ov18_02169f58
 	cmp r0, #0
 	beq _02169e00
@@ -17862,7 +17862,7 @@ _02169e04:
 	add r8, r8, #0x18
 	blt _02169d9c
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov18_02169d30
 _02169e20: .word data_027e0cbc
@@ -17962,7 +17962,7 @@ _02169f54: .word data_027e0cbc
 	.global func_ov18_02169f58
 	arm_func_start func_ov18_02169f58
 func_ov18_02169f58: ; 0x02169f58
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	mov r4, r0
 	cmp r1, #0x90
 	beq _02169f74
@@ -17999,18 +17999,18 @@ _02169fc4:
 	cmp r6, #0
 	mov r6, ip, lsr #0x5
 	beq _02169ffc
-	add sl, r4, r6, lsl #2
-	ldr r7, [sl, #0x14]
+	add r10, r4, r6, lsl #2
+	ldr r7, [r10, #0x14]
 	and r6, ip, #0x1f
 	orr r6, r7, r1, lsl r6
-	str r6, [sl, #0x14]
+	str r6, [r10, #0x14]
 	b _0216a014
 _02169ffc:
 	add r7, r4, r6, lsl #2
-	and sl, ip, #0x1f
+	and r10, ip, #0x1f
 	ldr r6, [r7, #0x14]
-	mvn sl, sb, lsl sl
-	and r6, r6, sl
+	mvn r10, sb, lsl r10
+	and r6, r6, r10
 	str r6, [r7, #0x14]
 _0216a014:
 	ldrb r6, [r0, r3]
@@ -18021,18 +18021,18 @@ _0216a014:
 	cmp r6, #0
 	mov r6, lr, lsr #0x5
 	beq _0216a04c
-	add sl, r4, r6, lsl #2
-	ldr r7, [sl, #0x14]
+	add r10, r4, r6, lsl #2
+	ldr r7, [r10, #0x14]
 	and r6, lr, #0x1f
 	orr r6, r7, r8, lsl r6
-	str r6, [sl, #0x14]
+	str r6, [r10, #0x14]
 	b _0216a064
 _0216a04c:
 	add r7, r4, r6, lsl #2
-	and sl, lr, #0x1f
+	and r10, lr, #0x1f
 	ldr r6, [r7, #0x14]
-	mvn sl, r5, lsl sl
-	and r6, r6, sl
+	mvn r10, r5, lsl r10
+	and r6, r6, r10
 	str r6, [r7, #0x14]
 _0216a064:
 	add r3, r3, #1
@@ -18064,7 +18064,7 @@ _0216a0a0:
 	strb r1, [r0, #0x57e]
 _0216a0cc:
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov18_02169f58
 _0216a0d4: .word data_ov00_020eec9c
@@ -20248,7 +20248,7 @@ _0216b8ac: .word data_ov18_0216d484
 	.global func_ov18_0216b8b0
 	arm_func_start func_ov18_0216b8b0
 func_ov18_0216b8b0: ; 0x0216b8b0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	ldr r0, _0216bab0 ; =data_ov18_0216d490
 	ldr r2, _0216bab4 ; =func_ov18_0215e4dc
 	mov r1, #0x2f
@@ -20267,7 +20267,7 @@ func_ov18_0216b8b0: ; 0x0216b8b0
 	ldr r2, _0216bad0 ; =data_ov18_0216c3b0
 	ldr r1, _0216bad4 ; =data_ov18_0216c3b2
 	ldr r6, _0216bad8 ; =data_ov18_0216c3b4
-	ldr sl, _0216badc ; =data_ov18_0216c3b6
+	ldr r10, _0216badc ; =data_ov18_0216c3b6
 	ldr sb, _0216bae0 ; =data_ov18_0216c3b8
 	mov r8, #0
 	strb r0, [r7]
@@ -20288,8 +20288,8 @@ func_ov18_0216b8b0: ; 0x0216b8b0
 	strb r0, [r6]
 	strb r0, [r6, #1]
 	ldr r6, _0216baf8 ; =data_ov18_0216c3c4
-	strb r0, [sl]
-	strb r0, [sl, #1]
+	strb r0, [r10]
+	strb r0, [r10, #1]
 	strb r8, [sb]
 	strb r8, [sb, #1]
 	strb r8, [r7]
@@ -20321,7 +20321,7 @@ func_ov18_0216b8b0: ; 0x0216b8b0
 	ldr r1, _0216bb0c ; =data_ov18_0216c3d0
 	strb r2, [r3, #0x27]
 	ldr r11, _0216bb10 ; =data_ov18_0216c3d2
-	ldr sl, _0216bb14 ; =data_ov18_0216c3d4
+	ldr r10, _0216bb14 ; =data_ov18_0216c3d4
 	ldr r8, _0216bb18 ; =data_ov18_0216c3d8
 	ldr r7, _0216bb1c ; =data_ov18_0216c3da
 	ldr lr, _0216bb20 ; =data_ov18_0216c3dc
@@ -20336,8 +20336,8 @@ func_ov18_0216b8b0: ; 0x0216b8b0
 	strb r2, [r1, #1]
 	strb r2, [r11]
 	strb r2, [r11, #1]
-	strb r2, [sl]
-	strb r2, [sl, #1]
+	strb r2, [r10]
+	strb r2, [r10, #1]
 	strb r0, [sb]
 	strb r2, [sb, #1]
 	strb r2, [r8]
@@ -20375,7 +20375,7 @@ func_ov18_0216b8b0: ; 0x0216b8b0
 	strb r2, [r3, #1]
 	strb r2, [r1]
 	strb r2, [r1, #1]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov18_0216b8b0
 _0216bab0: .word data_ov18_0216d490

--- a/asm/ov18.s
+++ b/asm/ov18.s
@@ -6,36 +6,36 @@
 	.global func_ov18_0215b4a0
 	arm_func_start func_ov18_0215b4a0
 func_ov18_0215b4a0: ; 0x0215b4a0
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
-	mov sb, r0
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
+	mov r9, r0
 	mov r8, r1
 	mov r7, r2
 	blx func_ov04_0210be04
 	ldr r0, _0215b638 ; =data_ov18_0216c0e0
 	mov r1, #0
-	str r0, [sb]
-	str r1, [sb, #0x188]
+	str r0, [r9]
+	str r1, [r9, #0x188]
 	sub r0, r1, #1
-	str r0, [sb, #0x1ac]
-	str r1, [sb, #0x1b0]
-	str r1, [sb, #0x1b4]
-	str r1, [sb, #0x1b8]
-	str r1, [sb, #0x1bc]
-	str r1, [sb, #0x1c0]
-	str r1, [sb, #0x1c4]
-	str r1, [sb, #0x1c8]
-	strb r1, [sb, #0x1cc]
-	strb r1, [sb, #0x1cd]
-	str r1, [sb, #0x1d0]
+	str r0, [r9, #0x1ac]
+	str r1, [r9, #0x1b0]
+	str r1, [r9, #0x1b4]
+	str r1, [r9, #0x1b8]
+	str r1, [r9, #0x1bc]
+	str r1, [r9, #0x1c0]
+	str r1, [r9, #0x1c4]
+	str r1, [r9, #0x1c8]
+	strb r1, [r9, #0x1cc]
+	strb r1, [r9, #0x1cd]
+	str r1, [r9, #0x1d0]
 	mov r1, #0x10000
-	str r1, [sb, #0x1d4]
+	str r1, [r9, #0x1d4]
 	ldr r0, _0215b63c ; =data_027e0ce0
-	str r1, [sb, #0x1d8]
+	str r1, [r9, #0x1d8]
 	ldr r1, [r0, #4]
 	mov r0, r8, lsl #0x2
 	mov r2, #4
 	bl func_0202e9f4
-	str r0, [sb, #0x18c]
+	str r0, [r9, #0x18c]
 	cmp r8, #0
 	mov r5, #0
 	ble _0215b554
@@ -47,7 +47,7 @@ _0215b530:
 	mov r0, r6
 	mov r2, r4
 	bl func_0202e9f4
-	ldr r1, [sb, #0x18c]
+	ldr r1, [r9, #0x18c]
 	str r0, [r1, r5, lsl #2]
 	add r5, r5, #1
 	cmp r5, r8
@@ -63,7 +63,7 @@ _0215b568:
 	cmp r7, #0
 	ble _0215b58c
 _0215b574:
-	ldr r0, [sb, #0x18c]
+	ldr r0, [r9, #0x18c]
 	ldr r0, [r0, r4, lsl #2]
 	str r1, [r0, r3, lsl #2]
 	add r3, r3, #1
@@ -77,16 +77,16 @@ _0215b598:
 	mov r2, #0
 	mov r1, r2
 _0215b5a0:
-	add r0, sb, r2, lsl #2
+	add r0, r9, r2, lsl #2
 	add r2, r2, #1
 	str r1, [r0, #0x190]
 	cmp r2, #4
 	blo _0215b5a0
-	mov r0, sb
+	mov r0, r9
 	bl func_ov18_0215c650
-	mov r0, sb
+	mov r0, r9
 	bl func_ov18_0215c6d0
-	ldr r0, [sb, #0x1c0]
+	ldr r0, [r9, #0x1c0]
 	ldr r1, [r0]
 	ldr r1, [r1, #8]
 	blx r1
@@ -98,7 +98,7 @@ _0215b5e4:
 	mov r1, r5
 	add r0, r4, #4
 	bl func_0201e388
-	add r1, sb, r6, lsl #2
+	add r1, r9, r6, lsl #2
 	add r6, r6, #1
 	str r0, [r1, #0x1a0]
 	cmp r6, #3
@@ -108,15 +108,15 @@ _0215b5e4:
 	add r0, r4, #4
 	bl func_0201e388
 	ldr r1, _0215b648 ; =data_027e0d38
-	str r0, [sb, #0x1ac]
+	str r0, [r9, #0x1ac]
 	ldr r0, [r1]
 	ldr r0, [r0, #0x14]
 	cmp r0, #1
 	beq _0215b630
 	bl func_ov18_0216927c
 _0215b630:
-	mov r0, sb
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	mov r0, r9
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov18_0215b4a0
 _0215b638: .word data_ov18_0216c0e0
@@ -292,20 +292,20 @@ _0215b868: .word data_027e0f6c
 	.global func_ov18_0215b86c
 	arm_func_start func_ov18_0215b86c
 func_ov18_0215b86c: ; 0x0215b86c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x70
 	ldrb r5, [sp, #0x98]
 	ldrb r4, [sp, #0x9c]
-	mov sb, r0
+	mov r9, r0
 	str r5, [sp]
 	mov r8, r3
 	str r4, [sp, #4]
 	blx func_ov04_0210c1f8
 	ldr r0, _0215bd68 ; =data_027e0e60
-	add r1, sb, #0x1b0
+	add r1, r9, #0x1b0
 	ldr r0, [r0]
 	bl func_ov00_0208344c
-	ldrb r2, [sb, #0x12]
+	ldrb r2, [r9, #0x12]
 	ldr r0, _0215bd6c ; =0x00001333
 	mov r1, #0
 	sub r2, r2, #1
@@ -318,7 +318,7 @@ func_ov18_0215b86c: ; 0x0215b86c
 	adc r0, r3, #0
 	mov r1, r4, lsr #0xc
 	orr r1, r1, r0, lsl #20
-	str r1, [sb, #0x1b4]
+	str r1, [r9, #0x1b4]
 	ldr r0, _0215bd68 ; =data_027e0e60
 	add r1, sp, #0x64
 	ldr r0, [r0]
@@ -367,7 +367,7 @@ _0215b934:
 	ldr r1, _0215bd7c ; =data_ov00_020e2dd8
 	str r1, [r0]
 _0215b990:
-	add r1, sb, r7, lsl #2
+	add r1, r9, r7, lsl #2
 	str r0, [r1, #0x190]
 	mov r0, r8
 	mov r1, r7
@@ -594,7 +594,7 @@ _0215bcb4:
 	str r1, [sp, #0x38]
 	str r0, [sp, #0x3c]
 _0215bce4:
-	mov r0, sb
+	mov r0, r9
 	add r1, sp, #0x10
 	bl func_ov00_02080140
 	strb r0, [sp, #0x24]
@@ -609,7 +609,7 @@ _0215bce4:
 	orr r0, r0, #0x8000
 	bic r0, r0, #0x6000
 	orr r3, r0, #0x31c00000
-	add r0, sb, r7, lsl #2
+	add r0, r9, r7, lsl #2
 	ldr r0, [r0, #0x190]
 	add r1, sp, #0x28
 	ldr ip, [r0]
@@ -618,7 +618,7 @@ _0215bce4:
 	str r3, [sp, #0xc]
 	blx ip
 	ldr r0, _0215bd80 ; =data_027e0f6c
-	add r1, sb, r7, lsl #2
+	add r1, r9, r7, lsl #2
 	ldr r0, [r0]
 	ldr r1, [r1, #0x190]
 	bl func_ov00_02093a5c
@@ -627,7 +627,7 @@ _0215bd54:
 	cmp r7, #4
 	blt _0215b934
 	add sp, sp, #0x70
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov18_0215b86c
 _0215bd68: .word data_027e0e60
@@ -641,89 +641,89 @@ _0215bd80: .word data_027e0f6c
 	.global func_ov18_0215bd84
 	arm_func_start func_ov18_0215bd84
 func_ov18_0215bd84: ; 0x0215bd84
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
-	mov sb, r0
-	ldrh r0, [sb, #0x28]
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
+	mov r9, r0
+	ldrh r0, [r9, #0x28]
 	mov r7, #0
 	cmp r0, #0
 	ble _0215be0c
 	add r4, sp, #0
 	mov r6, r7
 _0215bda4:
-	ldrh r0, [sb, #0x2a]
+	ldrh r0, [r9, #0x2a]
 	mov r8, r6
 	cmp r0, #0
 	ble _0215bdfc
 	and r5, r7, #0xff
 _0215bdb8:
-	mov r0, sb
+	mov r0, r9
 	strb r5, [sp]
 	strb r8, [sp, #1]
 	ldr r2, [r0]
 	mov r1, r4
 	ldr r2, [r2, #0x60]
 	blx r2
-	ldr r1, [sb, #0x40]
+	ldr r1, [r9, #0x40]
 	add r8, r8, #1
 	cmp r0, r1
-	strgt r0, [sb, #0x40]
-	ldr r1, [sb, #0x44]
+	strgt r0, [r9, #0x40]
+	ldr r1, [r9, #0x44]
 	cmp r0, r1
-	strlt r0, [sb, #0x44]
-	ldrh r0, [sb, #0x2a]
+	strlt r0, [r9, #0x44]
+	ldrh r0, [r9, #0x2a]
 	cmp r8, r0
 	blt _0215bdb8
 _0215bdfc:
-	ldrh r0, [sb, #0x28]
+	ldrh r0, [r9, #0x28]
 	add r7, r7, #1
 	cmp r7, r0
 	blt _0215bda4
 _0215be0c:
-	mov r0, sb
+	mov r0, r9
 	blx func_ov04_0210bfa8
 	mov r1, #0
-	strb r1, [sb, #0x1cd]
-	ldrb r0, [sb, #0xc]
+	strb r1, [r9, #0x1cd]
+	ldrb r0, [r9, #0xc]
 	cmp r0, #0
 	beq _0215bea8
-	ldrb r0, [sb, #4]
+	ldrb r0, [r9, #4]
 	cmp r0, #0
 	movne r0, #1
-	strneb r0, [sb, #0x1cc]
+	strneb r0, [r9, #0x1cc]
 	bne _0215be5c
 	ldr r0, _0215beb0 ; =data_027e0e60
 	ldr r0, [r0]
 	bl func_ov00_020849c0
 	cmp r0, #0
 	movne r0, #1
-	strneb r0, [sb, #0x1cc]
+	strneb r0, [r9, #0x1cc]
 	moveq r0, #0
-	streqb r0, [sb, #0x1cc]
+	streqb r0, [r9, #0x1cc]
 _0215be5c:
-	ldr r0, [sb, #0x1c4]
+	ldr r0, [r9, #0x1c4]
 	cmp r0, #0
 	beq _0215be70
 	mov r1, #0
 	bl func_ov00_020c0e24
 _0215be70:
-	ldr r0, [sb, #0x1c8]
+	ldr r0, [r9, #0x1c8]
 	cmp r0, #0
 	beq _0215be84
 	mov r1, #0
 	bl func_ov00_020c0e24
 _0215be84:
-	ldr r0, [sb, #0x1c0]
+	ldr r0, [r9, #0x1c0]
 	cmp r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
-	str sb, [r0, #0x30]
-	ldr r0, [sb, #0x1c0]
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
+	str r9, [r0, #0x30]
+	ldr r0, [r9, #0x1c0]
 	ldr r1, _0215beb4 ; =func_ov18_0215ca24
 	add r0, r0, #4
 	bl func_02018cb8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _0215bea8:
-	strb r1, [sb, #0x1cc]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	strb r1, [r9, #0x1cc]
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov18_0215bd84
 _0215beb0: .word data_027e0e60
@@ -3788,7 +3788,7 @@ _0215e620: .word data_027e0e58
 	.global func_ov18_0215e624
 	arm_func_start func_ov18_0215e624
 func_ov18_0215e624: ; 0x0215e624
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x80
 	mov r4, r0
 	ldr r1, [r4, #4]
@@ -4304,8 +4304,8 @@ _0215ed70:
 	add r7, sp, #0xc
 	mov r6, #1
 _0215edd0:
-	ldr sb, [sp, #4]
-	mov r0, sb
+	ldr r9, [sp, #4]
+	mov r0, r9
 	cmp r0, r10
 	bge _0215ee08
 	and r8, r11, #0xff
@@ -4314,10 +4314,10 @@ _0215ede4:
 	mov r1, r7
 	mov r2, r6
 	strb r8, [sp, #0xc]
-	strb sb, [sp, #0xd]
+	strb r9, [sp, #0xd]
 	bl func_ov00_02082680
-	add sb, sb, #1
-	cmp sb, r10
+	add r9, r9, #1
+	cmp r9, r10
 	blt _0215ede4
 _0215ee08:
 	ldr r0, [sp, #8]
@@ -4335,14 +4335,14 @@ _0215ee18:
 	mov r2, r1
 	blx r3
 	add sp, sp, #0x80
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0215ee44:
 	ldr r3, [r3, #0x80]
 	mov r1, #0
 	mov r2, #1
 	blx r3
 	add sp, sp, #0x80
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov18_0215e624
 _0215ee5c: .word data_027e0f68
@@ -5753,7 +5753,7 @@ _0215ff6c: .word func_ov18_0215fda4
 	.global func_ov18_0215ff70
 	arm_func_start func_ov18_0215ff70
 func_ov18_0215ff70: ; 0x0215ff70
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #8
 	mov r4, r1
 	mov r6, r0
@@ -5768,7 +5768,7 @@ func_ov18_0215ff70: ; 0x0215ff70
 	ldr r1, _0216011c ; =0x4a554447
 	add r0, sp, #0
 	bl func_ov00_020d15e0
-	mov sb, r0
+	mov r9, r0
 	ldr r1, _02160120 ; =0x4954534e
 	add r0, sp, #0
 	bl func_ov00_020d15e0
@@ -5806,7 +5806,7 @@ _0216000c:
 	add r0, sp, #0
 	bl func_ov00_020d15c0
 	cmp r8, #0
-	cmpeq sb, #0
+	cmpeq r9, #0
 	cmpeq r5, #0
 	cmpeq r7, #0
 	cmpeq r4, #0
@@ -5828,7 +5828,7 @@ _0216000c:
 _02160084:
 	str r0, [r6, #0x3c]
 _02160088:
-	cmp sb, #0
+	cmp r9, #0
 	beq _021600b4
 	ldr r1, _0216013c ; =data_027e0ce0
 	mov r0, #0x154
@@ -5856,7 +5856,7 @@ _021600dc:
 _021600e0:
 	cmp r4, #0
 	addeq sp, sp, #8
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	ldr r1, _0216013c ; =data_027e0ce0
 	ldr r0, _02160140 ; =0x0000058c
 	ldr r1, [r1, #4]
@@ -5868,7 +5868,7 @@ _021600e0:
 _0216010c:
 	str r0, [r6, #0x48]
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov18_0215ff70
 _02160118: .word 0x4d524547
@@ -6331,7 +6331,7 @@ func_ov18_02160634: ; 0x02160634
 	.global func_ov18_0216065c
 	arm_func_start func_ov18_0216065c
 func_ov18_0216065c: ; 0x0216065c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x68
 	mov r11, r0
 	ldr r1, [r11, #0x18]
@@ -6415,8 +6415,8 @@ _02160774:
 	add r6, sp, #0xc
 	mov r5, #1
 _021607a4:
-	ldr sb, [sp, #4]
-	mov r0, sb
+	ldr r9, [sp, #4]
+	mov r0, r9
 	cmp r0, r10
 	bgt _021607dc
 	and r7, r8, #0xff
@@ -6425,10 +6425,10 @@ _021607b8:
 	mov r1, r6
 	mov r2, r5
 	strb r7, [sp, #0xc]
-	strb sb, [sp, #0xd]
+	strb r9, [sp, #0xd]
 	bl func_ov00_02082680
-	add sb, sb, #1
-	cmp sb, r10
+	add r9, r9, #1
+	cmp r9, r10
 	ble _021607b8
 _021607dc:
 	ldr r0, [sp, #8]
@@ -6443,7 +6443,7 @@ _021607ec:
 	mov r2, r1
 	blx r3
 	add sp, sp, #0x68
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov18_0216065c
 _0216080c: .word data_027e0fe8
@@ -6762,7 +6762,7 @@ func_ov18_02160b44: ; 0x02160b44
 	.global func_ov18_02160b6c
 	arm_func_start func_ov18_02160b6c
 func_ov18_02160b6c: ; 0x02160b6c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x24
 	mov r4, r0
 	ldrh r1, [r4, #0x24]
@@ -6804,11 +6804,11 @@ _02160bac:
 	sub r0, r0, #0x800
 	str r0, [r4, #0x20]
 	ldrb r1, [r4, #0x14]
-	ldrb sb, [r4, #0x15]
+	ldrb r9, [r4, #0x15]
 	add r0, r1, #5
 	sub r7, r1, #5
 	str r0, [sp, #8]
-	mov r10, sb
+	mov r10, r9
 	cmp r7, r0
 	bge _02160fb0
 	add r5, sp, #0x14
@@ -6817,13 +6817,13 @@ _02160c30:
 	ldrb r0, [r4, #0x14]
 	cmp r7, r0
 	beq _02160c4c
-	addge sb, sb, #1
+	addge r9, r9, #1
 	subge r10, r10, #1
-	sublt sb, sb, #1
+	sublt r9, r9, #1
 	addlt r10, r10, #1
 _02160c4c:
-	mov r8, sb
-	cmp sb, r10
+	mov r8, r9
+	cmp r9, r10
 	bge _02160ca8
 	and r6, r7, #0xff
 _02160c5c:
@@ -6879,11 +6879,11 @@ _02160cbc:
 	sub r0, r0, #0x800
 	str r0, [r4, #0x20]
 	ldrb r1, [r4, #0x14]
-	ldrb sb, [r4, #0x15]
+	ldrb r9, [r4, #0x15]
 	add r0, r1, #9
 	sub r7, r1, #9
 	str r0, [sp, #4]
-	mov r10, sb
+	mov r10, r9
 	cmp r7, r0
 	bge _02160fb0
 	add r5, sp, #0x12
@@ -6892,13 +6892,13 @@ _02160d40:
 	ldrb r0, [r4, #0x14]
 	cmp r7, r0
 	beq _02160d5c
-	addgt sb, sb, #1
+	addgt r9, r9, #1
 	subgt r10, r10, #1
-	suble sb, sb, #1
+	suble r9, r9, #1
 	addle r10, r10, #1
 _02160d5c:
-	mov r8, sb
-	cmp sb, r10
+	mov r8, r9
+	cmp r9, r10
 	bge _02160db8
 	and r6, r7, #0xff
 _02160d6c:
@@ -6954,11 +6954,11 @@ _02160dcc:
 	sub r0, r0, #0x800
 	str r0, [r4, #0x20]
 	ldrb r1, [r4, #0x14]
-	ldrb sb, [r4, #0x15]
+	ldrb r9, [r4, #0x15]
 	add r0, r1, #8
 	sub r7, r1, #8
 	str r0, [sp]
-	mov r10, sb
+	mov r10, r9
 	cmp r7, r0
 	bge _02160fb0
 	add r5, sp, #0x10
@@ -6967,13 +6967,13 @@ _02160e50:
 	ldrb r0, [r4, #0x14]
 	cmp r7, r0
 	beq _02160e6c
-	addgt sb, sb, #1
+	addgt r9, r9, #1
 	subgt r10, r10, #1
-	suble sb, sb, #1
+	suble r9, r9, #1
 	addle r10, r10, #1
 _02160e6c:
-	mov r8, sb
-	cmp sb, r10
+	mov r8, r9
+	cmp r9, r10
 	bge _02160ec8
 	and r6, r7, #0xff
 _02160e7c:
@@ -7078,7 +7078,7 @@ _02160fb0:
 	ldr r0, [sp, #0xc]
 	str r0, [r4, #0xa4]
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov18_02160b6c
 _02160ff8: .word data_027e0f68
@@ -8564,7 +8564,7 @@ func_ov18_02162188: ; 0x02162188
 	.global func_ov18_021621b8
 	arm_func_start func_ov18_021621b8
 func_ov18_021621b8: ; 0x021621b8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x1c
 	ldr r1, _0216243c ; =data_027e0764
 	mov r2, #0
@@ -8600,10 +8600,10 @@ func_ov18_021621b8: ; 0x021621b8
 	str r6, [sp, #4]
 	umull r7, r6, r5, ip
 	mla r6, r5, r3, r6
-	ldr sb, [r1, #0x10]
+	ldr r9, [r1, #0x10]
 	mla r6, lr, ip, r6
 	ldr r8, [r1, #0x14]
-	adds r3, sb, r7
+	adds r3, r9, r7
 	adc r6, r8, r6
 	stmia r1, {r3, r6}
 	umull r1, r3, r6, r10
@@ -8732,7 +8732,7 @@ _0216241c:
 	mov r2, #1
 	blx r3
 	add sp, sp, #0x1c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov18_021621b8
 _0216243c: .word data_027e0764
@@ -9431,7 +9431,7 @@ func_ov18_02162d90: ; 0x02162d90
 	.global func_ov18_02162db8
 	arm_func_start func_ov18_02162db8
 func_ov18_02162db8: ; 0x02162db8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x20
 	ldr r2, [r0, #4]
 	mov r1, #0
@@ -9452,24 +9452,24 @@ func_ov18_02162db8: ; 0x02162db8
 _02162e00:
 	ldr r1, [r8]
 	ldmib r8, {r0, r3}
-	umull r10, sb, r3, r1
-	mla sb, r3, r0, sb
+	umull r10, r9, r3, r1
+	mla r9, r3, r0, r9
 	ldr r2, [r8, #0xc]
 	ldr ip, [r8, #0x10]
-	mla sb, r2, r1, sb
+	mla r9, r2, r1, r9
 	ldr r11, [r8, #0x14]
 	adds r10, ip, r10
-	adc sb, r11, sb
+	adc r9, r11, r9
 	mov r0, #0x15
-	umull r0, r2, sb, r0
+	umull r0, r2, r9, r0
 	mov r0, #0
 	str r10, [r8]
-	mla r2, sb, r0, r2
+	mla r2, r9, r0, r2
 	mov r1, r0
 	mov r0, #0x15
 	mla r2, r1, r0, r2
 	sub r0, r2, #0xa
-	str sb, [r8, #4]
+	str r9, [r8, #4]
 	bl func_02001154
 	mov r3, r1
 	mov r2, r0
@@ -9485,7 +9485,7 @@ _02162e00:
 	ldr r1, [r8, #8]
 	ldr r0, [r8, #0xc]
 	umull r3, r2, r1, r10
-	mla r2, r1, sb, r2
+	mla r2, r1, r9, r2
 	mla r2, r0, r10, r2
 	adds r0, ip, r3
 	adc r1, r11, r2
@@ -9519,7 +9519,7 @@ _02162f04:
 	ldr r1, [r8, #8]
 	ldr r0, [r8, #0xc]
 	umull r3, r2, r1, r10
-	mla r2, r1, sb, r2
+	mla r2, r1, r9, r2
 	mla r2, r0, r10, r2
 	adds r0, ip, r3
 	adc r1, r11, r2
@@ -9553,24 +9553,24 @@ _02162f7c:
 	str r0, [r7, #0x64]
 	ldr r1, [r8]
 	ldmib r8, {r0, r3}
-	umull r10, sb, r3, r1
-	mla sb, r3, r0, sb
+	umull r10, r9, r3, r1
+	mla r9, r3, r0, r9
 	ldr r2, [r8, #0xc]
 	ldr ip, [r8, #0x10]
-	mla sb, r2, r1, sb
+	mla r9, r2, r1, r9
 	ldr r11, [r8, #0x14]
 	adds r10, ip, r10
-	adc sb, r11, sb
+	adc r9, r11, r9
 	mov r0, #0x15
-	umull r0, r2, sb, r0
+	umull r0, r2, r9, r0
 	mov r0, #0
 	str r10, [r8]
-	mla r2, sb, r0, r2
+	mla r2, r9, r0, r2
 	mov r1, r0
 	mov r0, #0x15
 	mla r2, r1, r0, r2
 	sub r0, r2, #0xa
-	str sb, [r8, #4]
+	str r9, [r8, #4]
 	bl func_02001154
 	mov r3, r1
 	mov r2, r0
@@ -9586,7 +9586,7 @@ _02162f7c:
 	ldr r1, [r8, #8]
 	ldr r0, [r8, #0xc]
 	umull r3, r2, r1, r10
-	mla r2, r1, sb, r2
+	mla r2, r1, r9, r2
 	mla r2, r0, r10, r2
 	adds r0, ip, r3
 	adc r1, r11, r2
@@ -9620,7 +9620,7 @@ _02163090:
 	ldr r1, [r8, #8]
 	ldr r0, [r8, #0xc]
 	umull r3, r2, r1, r10
-	mla r2, r1, sb, r2
+	mla r2, r1, r9, r2
 	mla r2, r0, r10, r2
 	adds r0, ip, r3
 	adc r1, r11, r2
@@ -9657,9 +9657,9 @@ _02163108:
 	ldr r2, [r8, #0xc]
 	ldr r10, [r8, #0x10]
 	mla ip, r2, r1, ip
-	ldr sb, [r8, #0x14]
+	ldr r9, [r8, #0x14]
 	adds r0, r10, lr
-	adc r1, sb, ip
+	adc r1, r9, ip
 	stmia r8, {r0, r1}
 	mov r0, #3
 	umull r0, r2, r1, r0
@@ -9711,20 +9711,20 @@ _02163108:
 	ldrh r1, [r0, #0x26]
 	cmp r1, #0
 	addeq sp, sp, #0x20
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, _02163254 ; =data_027e0f74
 	ldr r0, [r0]
 	bl func_ov00_02097760
 	cmp r0, #0
 	addne sp, sp, #0x20
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, [sp, #4]
 	ldr r0, [r0, #4]
 	bic r1, r0, #1
 	ldr r0, [sp, #4]
 	str r1, [r0, #4]
 	add sp, sp, #0x20
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov18_02162db8
 _0216323c: .word 0x40b00000
@@ -9793,11 +9793,11 @@ _021632f4:
 	.global func_ov18_021632fc
 	arm_func_start func_ov18_021632fc
 func_ov18_021632fc: ; 0x021632fc
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x50
 	mov r10, r0
 	add r0, sp, #0x34
-	mov sb, r1
+	mov r9, r1
 	bl func_ov00_0207a13c
 	ldr r2, _021633d0 ; =0x00000533
 	mov r3, #2
@@ -9838,7 +9838,7 @@ _0216335c:
 	add r0, r10, r7, lsl #1
 	ldrsh r2, [r0, #0x7a]
 	mov r0, r10
-	mov r1, sb
+	mov r1, r9
 	mov r3, r6
 	bl func_ov00_0208ba68
 	add r7, r7, #1
@@ -9846,7 +9846,7 @@ _0216335c:
 	add r8, r8, #0xc
 	blt _0216335c
 	add sp, sp, #0x50
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov18_021632fc
 _021633d0: .word 0x00000533
@@ -9855,7 +9855,7 @@ _021633d4: .word data_ov00_020ec9d6
 	.global func_ov18_021633d8
 	arm_func_start func_ov18_021633d8
 func_ov18_021633d8: ; 0x021633d8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x64
 	ldr r2, _021635c4 ; =0x020ec9d6
 	ldr r1, _021635c8 ; =data_ov00_020ec9d4
@@ -9914,15 +9914,15 @@ func_ov18_021633d8: ; 0x021633d8
 	bl func_01ffa9fc
 	mov r7, #0x800
 	mov r8, #0
-	mov sb, r10
+	mov r9, r10
 	rsb r7, r7, #0
 	add r6, sp, #0x4c
 	add r11, sp, #0x58
 	mov r5, #4
 	mov r4, #0x20
 _021634dc:
-	ldr r2, [sb, #0x68]
-	ldr r1, [sb, #0x60]
+	ldr r2, [r9, #0x68]
+	ldr r1, [r9, #0x60]
 	add r0, r10, #0x18
 	str r1, [sp, #0x4c]
 	str r2, [sp, #0x54]
@@ -9974,11 +9974,11 @@ _021634dc:
 	mov r2, #1
 	bl func_01ffa9fc
 	add r8, r8, #1
-	add sb, sb, #0xc
+	add r9, r9, #0xc
 	cmp r8, #2
 	blt _021634dc
 	add sp, sp, #0x64
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov18_021633d8
 _021635c4: .word data_ov00_020ec9d6
@@ -9989,7 +9989,7 @@ _021635d0: .word 0x001e4081
 	.global func_ov18_021635d4
 	arm_func_start func_ov18_021635d4
 func_ov18_021635d4: ; 0x021635d4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x14
 	mov r5, r0
 	str r1, [r5, #8]
@@ -10001,7 +10001,7 @@ _021635f4:
 	mov r4, #0
 	ldr r6, _0216367c ; =data_027e0e58
 	strh r4, [r5, #0x78]
-	add sb, r5, #0x18
+	add r9, r5, #0x18
 	add r10, sp, #8
 	mov r8, r4
 	mov r7, #0x1ec
@@ -10013,7 +10013,7 @@ _02163614:
 	add r0, r0, #0x9a
 	add ip, r0, #0x500
 	mov r0, r10
-	mov r1, sb
+	mov r1, r9
 	mov r2, r10
 	str r3, [sp, #8]
 	str ip, [sp, #0xc]
@@ -10033,7 +10033,7 @@ _02163614:
 _02163670:
 	mov r0, #1
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov18_021635d4
 _0216367c: .word data_027e0e58
@@ -10245,7 +10245,7 @@ func_ov18_021638b8: ; 0x021638b8
 	.global func_ov18_021638e0
 	arm_func_start func_ov18_021638e0
 func_ov18_021638e0: ; 0x021638e0
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x1c
 	ldr r3, [r0]
 	mov r1, #0
@@ -10261,24 +10261,24 @@ func_ov18_021638e0: ; 0x021638e0
 _02163914:
 	ldr r1, [r8]
 	ldmib r8, {r0, r3}
-	umull r10, sb, r3, r1
-	mla sb, r3, r0, sb
+	umull r10, r9, r3, r1
+	mla r9, r3, r0, r9
 	ldr r2, [r8, #0xc]
 	ldr ip, [r8, #0x10]
-	mla sb, r2, r1, sb
+	mla r9, r2, r1, r9
 	ldr r11, [r8, #0x14]
 	adds r10, ip, r10
-	adc sb, r11, sb
+	adc r9, r11, r9
 	mov r0, #0x15
-	umull r0, r2, sb, r0
+	umull r0, r2, r9, r0
 	mov r0, #0
 	str r10, [r8]
-	mla r2, sb, r0, r2
+	mla r2, r9, r0, r2
 	mov r1, r0
 	mov r0, #0x15
 	mla r2, r1, r0, r2
 	sub r0, r2, #0xa
-	str sb, [r8, #4]
+	str r9, [r8, #4]
 	bl func_02001154
 	mov r2, r0
 	mov r3, r1
@@ -10294,7 +10294,7 @@ _02163914:
 	ldr r1, [r8, #8]
 	ldr r0, [r8, #0xc]
 	umull r3, r2, r1, r10
-	mla r2, r1, sb, r2
+	mla r2, r1, r9, r2
 	mla r2, r0, r10, r2
 	adds r0, ip, r3
 	adc r1, r11, r2
@@ -10328,7 +10328,7 @@ _02163a18:
 	ldr r1, [r8, #8]
 	ldr r0, [r8, #0xc]
 	umull r3, r2, r1, r10
-	mla r2, r1, sb, r2
+	mla r2, r1, r9, r2
 	mla r2, r0, r10, r2
 	adds r0, ip, r3
 	adc r1, r11, r2
@@ -10362,24 +10362,24 @@ _02163a90:
 	str r0, [r6, #0x64]
 	ldr r1, [r8]
 	ldmib r8, {r0, r3}
-	umull r10, sb, r3, r1
-	mla sb, r3, r0, sb
+	umull r10, r9, r3, r1
+	mla r9, r3, r0, r9
 	ldr r2, [r8, #0xc]
 	ldr ip, [r8, #0x10]
-	mla sb, r2, r1, sb
+	mla r9, r2, r1, r9
 	ldr r11, [r8, #0x14]
 	adds r10, ip, r10
-	adc sb, r11, sb
+	adc r9, r11, r9
 	mov r0, #0x15
-	umull r0, r2, sb, r0
+	umull r0, r2, r9, r0
 	mov r0, #0
 	str r10, [r8]
-	mla r2, sb, r0, r2
+	mla r2, r9, r0, r2
 	mov r1, r0
 	mov r0, #0x15
 	mla r2, r1, r0, r2
 	sub r0, r2, #0xa
-	str sb, [r8, #4]
+	str r9, [r8, #4]
 	bl func_02001154
 	mov r2, r0
 	mov r3, r1
@@ -10395,7 +10395,7 @@ _02163a90:
 	ldr r1, [r8, #8]
 	ldr r0, [r8, #0xc]
 	umull r3, r2, r1, r10
-	mla r2, r1, sb, r2
+	mla r2, r1, r9, r2
 	mla r2, r0, r10, r2
 	adds r0, ip, r3
 	adc r1, r11, r2
@@ -10429,7 +10429,7 @@ _02163ba4:
 	ldr r1, [r8, #8]
 	ldr r0, [r8, #0xc]
 	umull r3, r2, r1, r10
-	mla r2, r1, sb, r2
+	mla r2, r1, r9, r2
 	mla r2, r0, r10, r2
 	adds r0, ip, r3
 	adc r1, r11, r2
@@ -10473,9 +10473,9 @@ _02163c3c:
 	ldr r2, [r8, #0xc]
 	ldr r10, [r8, #0x10]
 	mla ip, r2, r1, ip
-	ldr sb, [r8, #0x14]
+	ldr r9, [r8, #0x14]
 	adds r0, r10, lr
-	adc r1, sb, ip
+	adc r1, r9, ip
 	stmia r8, {r0, r1}
 	mov r0, #3
 	umull r0, r2, r1, r0
@@ -10524,7 +10524,7 @@ _02163c98:
 	ldrh r1, [r7, #0x26]
 	cmp r1, #0
 	addeq sp, sp, #0x1c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, _02163d60 ; =data_027e0f74
 	ldr r0, [r0]
 	bl func_ov00_02097760
@@ -10533,7 +10533,7 @@ _02163c98:
 	biceq r0, r0, #1
 	streq r0, [r7, #4]
 	add sp, sp, #0x1c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov18_021638e0
 _02163d48: .word 0x40b00000
@@ -10602,11 +10602,11 @@ _02163e00:
 	.global func_ov18_02163e08
 	arm_func_start func_ov18_02163e08
 func_ov18_02163e08: ; 0x02163e08
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x50
 	mov r10, r0
 	add r0, sp, #0x34
-	mov sb, r1
+	mov r9, r1
 	bl func_ov00_0207a13c
 	ldr r2, _02163edc ; =0x00000533
 	mov r3, #2
@@ -10647,7 +10647,7 @@ _02163e68:
 	add r0, r10, r7, lsl #1
 	ldrsh r2, [r0, #0x7a]
 	mov r0, r10
-	mov r1, sb
+	mov r1, r9
 	mov r3, r6
 	bl func_ov00_0208ba68
 	add r7, r7, #1
@@ -10655,7 +10655,7 @@ _02163e68:
 	add r8, r8, #0xc
 	blt _02163e68
 	add sp, sp, #0x50
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov18_02163e08
 _02163edc: .word 0x00000533
@@ -10664,7 +10664,7 @@ _02163ee0: .word data_ov00_020ec9d6
 	.global func_ov18_02163ee4
 	arm_func_start func_ov18_02163ee4
 func_ov18_02163ee4: ; 0x02163ee4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x64
 	ldr r2, _021640d0 ; =0x020ec9d6
 	ldr r1, _021640d4 ; =data_ov00_020ec9d4
@@ -10723,15 +10723,15 @@ func_ov18_02163ee4: ; 0x02163ee4
 	bl func_01ffa9fc
 	mov r7, #0x800
 	mov r8, #0
-	mov sb, r10
+	mov r9, r10
 	rsb r7, r7, #0
 	add r6, sp, #0x4c
 	add r11, sp, #0x58
 	mov r5, #4
 	mov r4, #0x20
 _02163fe8:
-	ldr r2, [sb, #0x68]
-	ldr r1, [sb, #0x60]
+	ldr r2, [r9, #0x68]
+	ldr r1, [r9, #0x60]
 	add r0, r10, #0x18
 	str r1, [sp, #0x4c]
 	str r2, [sp, #0x54]
@@ -10783,11 +10783,11 @@ _02163fe8:
 	mov r2, #1
 	bl func_01ffa9fc
 	add r8, r8, #1
-	add sb, sb, #0xc
+	add r9, r9, #0xc
 	cmp r8, #2
 	blt _02163fe8
 	add sp, sp, #0x64
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov18_02163ee4
 _021640d0: .word data_ov00_020ec9d6
@@ -10798,7 +10798,7 @@ _021640dc: .word 0x001e4081
 	.global func_ov18_021640e0
 	arm_func_start func_ov18_021640e0
 func_ov18_021640e0: ; 0x021640e0
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x14
 	mov r5, r0
 	str r1, [r5, #8]
@@ -10810,7 +10810,7 @@ _02164100:
 	mov r4, #0
 	ldr r6, _02164188 ; =data_027e0e58
 	strh r4, [r5, #0x78]
-	add sb, r5, #0x18
+	add r9, r5, #0x18
 	add r10, sp, #8
 	mov r8, r4
 	mov r7, #0x1ec
@@ -10822,7 +10822,7 @@ _02164120:
 	add r0, r0, #0x9a
 	add ip, r0, #0x500
 	mov r0, r10
-	mov r1, sb
+	mov r1, r9
 	mov r2, r10
 	str r3, [sp, #8]
 	str ip, [sp, #0xc]
@@ -10842,7 +10842,7 @@ _02164120:
 _0216417c:
 	mov r0, #1
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov18_021640e0
 _02164188: .word data_027e0e58
@@ -14444,7 +14444,7 @@ _02166f1c: .word data_027e0fe4
 	.global func_ov18_02166f20
 	arm_func_start func_ov18_02166f20
 func_ov18_02166f20: ; 0x02166f20
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0xc
 	mov r4, r0
 	mov r2, #0
@@ -14476,10 +14476,10 @@ func_ov18_02166f20: ; 0x02166f20
 	mov r0, r0, lsl #0x1
 	ldrsh r5, [r1, r0]
 	mov r0, #0x5000
-	umull sb, r8, r7, r0
+	umull r9, r8, r7, r0
 	mla r8, r7, r3, r8
 	mov r6, r7, asr #0x1f
-	adds r7, sb, #0x800
+	adds r7, r9, #0x800
 	mla r8, r6, r0, r8
 	mov r1, #1
 	ldr r10, [r4, #0x48]
@@ -14520,7 +14520,7 @@ func_ov18_02166f20: ; 0x02166f20
 	bl func_01ffa0f4
 	strh r0, [r4, #0x78]
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov18_02166f20
 _02167054: .word data_ov18_0216d604
@@ -15094,7 +15094,7 @@ _02167834: .word func_ov14_02145f0c
 	.global func_ov18_02167838
 	arm_func_start func_ov18_02167838
 func_ov18_02167838: ; 0x02167838
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #0x44
 	mov r4, r0
 	add r0, r4, #0x400
@@ -15280,7 +15280,7 @@ _02167a98:
 	ldr r0, [r0, #4]
 	bl func_ov00_02087d98
 	add sp, sp, #0x44
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 _02167aec:
 	add r0, r4, #0x118
 	ldr r1, _02167df4 ; =0x00001555
@@ -15358,7 +15358,7 @@ _02167bdc:
 	mov r0, #0
 	add sp, sp, #0x44
 	strb r0, [r4, #0x118]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 _02167c18:
 	ldrb r0, [r4, #0x475]
 	cmp r0, #0
@@ -15366,7 +15366,7 @@ _02167c18:
 	cmp r0, #1
 	beq _02167c78
 	add sp, sp, #0x44
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 _02167c34:
 	ldr r1, [r4, #0x34]
 	mvn r0, #0
@@ -15385,7 +15385,7 @@ _02167c58:
 	ldrb r0, [r4, #0x474]
 	add r0, r0, #1
 	strb r0, [r4, #0x474]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 _02167c78:
 	ldr ip, _02167de4 ; =data_ov18_0216d604
 	ldr r6, [r4, #0x48]
@@ -15419,9 +15419,9 @@ _02167c78:
 	adds r2, r2, #0x800
 	adc r6, r10, #0
 	mov r7, r2, lsr #0xc
-	ldr sb, [r4, #0x4c]
+	ldr r9, [r4, #0x4c]
 	str r8, [sp, #0x40]
-	add r8, sb, #0x800
+	add r8, r9, #0x800
 	adds r5, r5, #0x800
 	str r8, [sp, #0x3c]
 	orr r7, r7, r6, lsl #20
@@ -15474,7 +15474,7 @@ _02167c78:
 	ldmia r1, {r1, r2, r3}
 	bl func_ov18_02166910
 	add sp, sp, #0x44
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov18_02167838
 _02167dd8: .word data_027e0ffc
@@ -15547,7 +15547,7 @@ _02167ec4: .word data_027e0f74
 	.global func_ov18_02167ec8
 	arm_func_start func_ov18_02167ec8
 func_ov18_02167ec8: ; 0x02167ec8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x34
 	mov r4, r0
 	add r0, r4, #0x400
@@ -15585,7 +15585,7 @@ _02167f1c:
 	str r5, [sp, #0x30]
 	ldrsh r3, [r4, #0x78]
 	mov r8, #0x1800
-	mov sb, #0
+	mov r9, #0
 	add r2, r3, r2
 	mov r2, r2, lsl #0x10
 	mov r2, r2, asr #0x10
@@ -15602,7 +15602,7 @@ _02167f1c:
 	adds r1, r1, #0x800
 	mov lr, r1, lsr #0xc
 	mov r1, r7
-	mla ip, r3, sb, ip
+	mla ip, r3, r9, ip
 	mov r7, r3, asr #0x1f
 	mla ip, r7, r8, ip
 	adc r3, ip, #0
@@ -15610,7 +15610,7 @@ _02167f1c:
 	add r3, r6, lr
 	str r3, [sp, #0x28]
 	umull r6, r3, r2, r8
-	mla r3, r2, sb, r3
+	mla r3, r2, r9, r3
 	mov r2, r2, asr #0x1f
 	mla r3, r2, r8, r3
 	adds r6, r6, #0x800
@@ -15748,12 +15748,12 @@ _021681ac:
 	blx r1
 	cmp r0, #0
 	addeq sp, sp, #0x34
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	mov r0, r4
 	mov r1, #4
 	bl func_ov18_02166b50
 	add sp, sp, #0x34
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov18_02167ec8
 _021681dc: .word data_027e0fc8
@@ -15843,7 +15843,7 @@ _021682dc:
 	.global func_ov18_021682f8
 	arm_func_start func_ov18_021682f8
 func_ov18_021682f8: ; 0x021682f8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0xf4
 	mov r6, r0
 	cmp r1, #0
@@ -15851,7 +15851,7 @@ func_ov18_021682f8: ; 0x021682f8
 	ldreqb r0, [r6, #0xa4]
 	cmp r0, #0
 	addeq sp, sp, #0xf4
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, _021686c8 ; =data_027e0fec
 	ldr r0, [r0]
 	add r0, r0, #0xbf0
@@ -15936,7 +15936,7 @@ _02168388:
 	cmp r0, #0
 	str r0, [r1, #0x2c]
 	addeq sp, sp, #0xf4
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r1, _021686e0 ; =data_02051054
 	add r0, sp, #0x34
 	ldrsh r2, [r1, #0xf6]
@@ -15991,11 +15991,11 @@ _02168388:
 	mov r8, r10, asr #0x1f
 	adds r7, r7, #0x800
 	mla r6, r8, r0, r6
-	mov sb, r7, lsr #0xc
+	mov r9, r7, lsr #0xc
 	adc r6, r6, #0
-	orr sb, sb, r6, lsl #20
+	orr r9, r9, r6, lsl #20
 	ldmia r11, {r7, ip}
-	smull r6, lr, r7, sb
+	smull r6, lr, r7, r9
 	adds r6, r6, #0x800
 	umull r3, r2, r10, r0
 	mla r2, r10, r1, r2
@@ -16003,14 +16003,14 @@ _02168388:
 	mov r6, r6, lsr #0xc
 	orr r6, r6, r7, lsl #20
 	str r6, [r11]
-	smull r7, r6, ip, sb
+	smull r7, r6, ip, r9
 	adds r7, r7, #0x800
 	adc r6, r6, #0
 	mov r7, r7, lsr #0xc
 	orr r7, r7, r6, lsl #20
 	ldr ip, [r11, #8]
 	str r7, [r11, #4]
-	smull r7, r6, ip, sb
+	smull r7, r6, ip, r9
 	adds r7, r7, #0x800
 	mla r2, r8, r0, r2
 	adc r6, r6, #0
@@ -16020,9 +16020,9 @@ _02168388:
 	adc r3, r2, #0
 	mov r2, r6, lsr #0xc
 	str r7, [r11, #8]
-	ldr sb, [r4]
+	ldr r9, [r4]
 	orr r2, r2, r3, lsl #20
-	smull r6, r3, sb, r2
+	smull r6, r3, r9, r2
 	adds r6, r6, #0x800
 	ldr r7, [r4, #4]
 	adc r3, r3, #0
@@ -16059,16 +16059,16 @@ _02168388:
 	umull r6, r4, r10, r3
 	mla r4, r10, r1, r4
 	ldmib r5, {r0, r10}
-	smull sb, r11, r0, r7
+	smull r9, r11, r0, r7
 	mov r0, #0x800
-	adds r0, sb, r0
-	smull sb, r7, r10, r7
+	adds r0, r9, r0
+	smull r9, r7, r10, r7
 	mla r4, r8, r3, r4
 	adc r10, r11, r1
-	adds sb, sb, #0x800
+	adds r9, r9, #0x800
 	adc r7, r7, r1
 	mov r3, r0, lsr #0xc
-	mov r8, sb, lsr #0xc
+	mov r8, r9, lsr #0xc
 	adds r6, r6, #0x800
 	adc r0, r4, r1
 	mov r4, r6, lsr #0xc
@@ -16088,7 +16088,7 @@ _02168388:
 	strb r2, [sp, #0x33]
 	bl func_ov18_0216941c
 	add sp, sp, #0xf4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov18_021682f8
 _021686c8: .word data_027e0fec
@@ -17171,7 +17171,7 @@ func_ov18_0216941c: ; 0x0216941c
 	.global func_ov18_0216945c
 	arm_func_start func_ov18_0216945c
 func_ov18_0216945c: ; 0x0216945c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x20
 	ldr r1, _021695dc ; =data_027e0d44
 	add r4, r0, #0x900
@@ -17189,7 +17189,7 @@ func_ov18_0216945c: ; 0x0216945c
 	mov r5, r5, lsr #0xd
 	mov r3, r3, lsr #0xd
 	mov r2, r2, lsr #0xd
-	ldr sb, [r0, #0x900]
+	ldr r9, [r0, #0x900]
 	str r6, [sp, #0x18]
 	str r5, [sp, #0x1c]
 	str r3, [sp, #0x10]
@@ -17197,7 +17197,7 @@ func_ov18_0216945c: ; 0x0216945c
 	cmp r1, #0
 	mov r10, #0
 	addle sp, sp, #0x20
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r8, _021695e0 ; =0x040004a8
 	sub r0, r8, #0x10
 	str r0, [sp]
@@ -17214,21 +17214,21 @@ func_ov18_0216945c: ; 0x0216945c
 	sub r5, r8, #0x20
 	str r0, [sp, #0xc]
 _02169504:
-	ldrb r2, [sb, #0x30]
+	ldrb r2, [r9, #0x30]
 	add r1, sp, #0x18
-	mov r0, sb
+	mov r0, r9
 	ldr r2, [r1, r2, lsl #2]
 	ldr r1, _021695e8 ; =0x192f0000
 	orr r1, r1, r2, lsr #3
 	str r1, [r8]
-	ldrb r2, [sb, #0x30]
+	ldrb r2, [r9, #0x30]
 	add r1, sp, #0x10
 	ldr r1, [r1, r2, lsl #2]
 	mov r1, r1, lsr #0x4
 	str r1, [r8, #4]
-	ldrb r2, [sb, #0x33]
-	ldrb r3, [sb, #0x32]
-	ldrb r1, [sb, #0x31]
+	ldrb r2, [r9, #0x33]
+	ldrb r3, [r9, #0x32]
+	ldrb r1, [r9, #0x31]
 	orr r2, r2, #0x80
 	orr r2, r2, r3, lsl #24
 	orr r1, r2, r1, lsl #16
@@ -17251,7 +17251,7 @@ _02169504:
 	str r0, [r5]
 	ldr r1, [sp, #4]
 	ldr r0, [sp]
-	add sb, sb, #0x34
+	add r9, r9, #0x34
 	str r1, [r0]
 	mov r0, #0x4000000
 	str r0, [r5]
@@ -17267,7 +17267,7 @@ _02169504:
 	cmp r10, r0
 	blt _02169504
 	add sp, sp, #0x20
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov18_0216945c
 _021695dc: .word data_027e0d44
@@ -17418,19 +17418,19 @@ _021697e0: .word data_ov00_020ee6f8
 	.global func_ov18_021697e4
 	arm_func_start func_ov18_021697e4
 func_ov18_021697e4: ; 0x021697e4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x10
 	ldr r8, [sp, #0x40]
 	mov r7, r1
 	ldr r1, [sp, #0x38]
-	ldr sb, [sp, #0x3c]
+	ldr r9, [sp, #0x3c]
 	mov r4, r0
 	mov r10, r2
 	str r3, [sp, #4]
 	cmp r8, #0
 	str r1, [sp, #0x38]
 	addeq sp, sp, #0x10
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	mov r1, r3
 	subs r6, r1, r7
 	ldr r1, [sp, #0x38]
@@ -17439,11 +17439,11 @@ func_ov18_021697e4: ; 0x021697e4
 	bne _0216984c
 	ldr r2, [sp, #0x38]
 	mov r1, r3
-	mov r3, sb
+	mov r3, r9
 	str r8, [sp]
 	bl func_ov18_021699e4
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0216984c:
 	cmp r6, #0
 	strge r6, [sp, #8]
@@ -17494,12 +17494,12 @@ _021698f8:
 	mov r10, #0
 	cmp r0, #0
 	addlt sp, sp, #0x10
-	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmltia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0216990c:
 	add r2, r5, #0x800
 	mov r0, r4
 	mov r1, r7
-	mov r3, sb
+	mov r3, r9
 	mov r2, r2, asr #0xc
 	str r8, [sp]
 	bl func_ov18_021699e4
@@ -17510,7 +17510,7 @@ _0216990c:
 	add r5, r5, r6
 	ble _0216990c
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02169948:
 	mov r0, r6, lsl #0xc
 	mov r1, r5, lsl #0xc
@@ -17537,12 +17537,12 @@ _02169998:
 	cmp r11, #0
 	mov r7, #0
 	addlt sp, sp, #0x10
-	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmltia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _021699a8:
 	add r1, r5, #0x800
 	mov r0, r4
 	mov r2, r10
-	mov r3, sb
+	mov r3, r9
 	mov r1, r1, asr #0xc
 	str r8, [sp]
 	bl func_ov18_021699e4
@@ -17553,13 +17553,13 @@ _021699a8:
 	add r10, r10, r0
 	ble _021699a8
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	arm_func_end func_ov18_021697e4
 
 	.global func_ov18_021699e4
 	arm_func_start func_ov18_021699e4
 func_ov18_021699e4: ; 0x021699e4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #4
 	mov r7, r0
 	ldr r0, [r7, #0x18]
@@ -17572,34 +17572,34 @@ func_ov18_021699e4: ; 0x021699e4
 	addmi sp, sp, #4
 	sub r1, r1, #2
 	sub r0, r0, #2
-	ldmmiia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmmiia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	cmp r6, r1
 	addgt sp, sp, #4
-	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	cmp r5, #0
 	addlt sp, sp, #4
-	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmltia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	cmp r5, r0
 	addgt sp, sp, #4
-	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	ldrb r10, [sp, #0x28]
-	mov sb, #0
+	mov r9, #0
 	cmp r10, #0
 	addle sp, sp, #4
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	sub r8, r10, #1
 _02169a58:
 	mov r0, r7
 	mov r1, r6
 	add r2, r6, r8
-	add r3, r5, sb
+	add r3, r5, r9
 	str r4, [sp]
 	bl func_0203e2e8
-	add sb, sb, #1
-	cmp sb, r10
+	add r9, r9, #1
+	cmp r9, r10
 	blt _02169a58
 	add sp, sp, #4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	arm_func_end func_ov18_021699e4
 
 	.global func_ov18_02169a84
@@ -17691,7 +17691,7 @@ _02169ba8: .word data_ov00_020e899c
 	.global func_ov18_02169bac
 	arm_func_start func_ov18_02169bac
 func_ov18_02169bac: ; 0x02169bac
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x1c
 	mov r4, r0
 	str r1, [sp]
@@ -17731,15 +17731,15 @@ func_ov18_02169bac: ; 0x02169bac
 	mov r10, #1
 	mov r5, r6
 	mov r8, r7
-	mov sb, r7
+	mov r9, r7
 	mov r11, r7
 	mov r3, r10
 	mov r6, r10
 _02169c5c:
-	mov r2, sb, lsr #0x5
+	mov r2, r9, lsr #0x5
 	add r2, r4, r2, lsl #2
 	ldr r2, [r2, #0x14]
-	and r1, sb, #0x1f
+	and r1, r9, #0x1f
 	tst r2, r6, lsl r1
 	movne r1, r5
 	moveq r1, r11
@@ -17751,7 +17751,7 @@ _02169c5c:
 	strb ip, [r0, r8]
 	add r1, r4, r1, lsl #2
 	ldr r1, [r1, #0x14]
-	add sb, sb, #2
+	add r9, r9, #2
 	tst r1, r3, lsl r2
 	movne r1, #6
 	moveq r1, #0
@@ -17786,7 +17786,7 @@ _02169d10:
 	ldr r0, [sp]
 	strb r0, [r4, #0x58a]
 	add sp, sp, #0x1c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov18_02169bac
 _02169d20: .word data_027e0c68
@@ -17797,34 +17797,34 @@ _02169d2c: .word data_027e103c
 	.global func_ov18_02169d30
 	arm_func_start func_ov18_02169d30
 func_ov18_02169d30: ; 0x02169d30
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	mov r10, r0
 	ldrb r0, [r10, #0x58a]
 	cmp r0, #0
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, [r10, #0x554]
 	cmp r0, #0
 	beq _02169d64
 	bl func_0203951c
 	cmp r0, #0
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02169d64:
 	ldr r0, _02169e20 ; =data_027e0cbc
 	mov r1, #0x16
 	bl func_0203d7e0
 	cmp r0, #0
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
-	mov sb, #0
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
+	mov r9, #0
 	add r0, r10, #0x158
-	mov r6, sb
+	mov r6, r9
 	mov r8, r10
 	add r7, r0, #0x400
-	mov r11, sb
+	mov r11, r9
 	mov r4, #1
-	mov r5, sb
+	mov r5, r9
 _02169d9c:
 	cmp r6, #0
 	bne _02169db4
@@ -17842,7 +17842,7 @@ _02169db4:
 	blx ip
 	tst r0, #8
 	beq _02169e04
-	cmp sb, #0
+	cmp r9, #0
 	bne _02169df8
 	add r0, r8, #0x500
 	ldrh r1, [r0, #0x62]
@@ -17851,10 +17851,10 @@ _02169db4:
 	cmp r0, #0
 	beq _02169e00
 _02169df8:
-	mov sb, r4
+	mov r9, r4
 	b _02169e04
 _02169e00:
-	mov sb, r11
+	mov r9, r11
 _02169e04:
 	add r6, r6, #1
 	cmp r6, #2
@@ -17862,7 +17862,7 @@ _02169e04:
 	add r8, r8, #0x18
 	blt _02169d9c
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov18_02169d30
 _02169e20: .word data_027e0cbc
@@ -17962,7 +17962,7 @@ _02169f54: .word data_027e0cbc
 	.global func_ov18_02169f58
 	arm_func_start func_ov18_02169f58
 func_ov18_02169f58: ; 0x02169f58
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	mov r4, r0
 	cmp r1, #0x90
 	beq _02169f74
@@ -17986,7 +17986,7 @@ _02169f74:
 	mov ip, r3
 	mov r11, r3
 	mov r2, lr
-	mov sb, lr
+	mov r9, lr
 	mov r1, lr
 	mov r5, lr
 	mov r8, lr
@@ -18009,7 +18009,7 @@ _02169ffc:
 	add r7, r4, r6, lsl #2
 	and r10, ip, #0x1f
 	ldr r6, [r7, #0x14]
-	mvn r10, sb, lsl r10
+	mvn r10, r9, lsl r10
 	and r6, r6, r10
 	str r6, [r7, #0x14]
 _0216a014:
@@ -18064,7 +18064,7 @@ _0216a0a0:
 	strb r1, [r0, #0x57e]
 _0216a0cc:
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov18_02169f58
 _0216a0d4: .word data_ov00_020eec9c
@@ -18774,16 +18774,16 @@ _0216a9d8: .word data_02063e4c
 	.global func_ov18_0216a9dc
 	arm_func_start func_ov18_0216a9dc
 func_ov18_0216a9dc: ; 0x0216a9dc
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x4c
-	mov sb, r0
+	mov r9, r0
 	add r0, sp, #0x2c
 	bl func_01ffbe34
 	mov r0, #1
 	mov r1, #2
 	strb r0, [sp, #0x37]
 	str r1, [sp, #0x30]
-	ldrsh r1, [sb, #0x12]
+	ldrsh r1, [r9, #0x12]
 	ldr r3, _0216ab38 ; =data_02050f54
 	add r0, sp, #0x1c
 	add r1, r1, #0xf
@@ -18810,10 +18810,10 @@ func_ov18_0216a9dc: ; 0x0216a9dc
 	bl func_01ff8024
 	mov r1, r4
 	str r1, [sp, #0x2c]
-	ldr r2, [sb, #8]
+	ldr r2, [r9, #8]
 	ldr r0, _0216ab3c ; =data_027e0d3c
 	str r2, [sp, #8]
-	ldr r3, [sb, #0xc]
+	ldr r3, [r9, #0xc]
 	ldr r0, [r0]
 	str r3, [sp, #4]
 	add r1, sp, #8
@@ -18822,8 +18822,8 @@ func_ov18_0216a9dc: ; 0x0216a9dc
 	bl func_ov00_02079680
 	cmp r0, #0
 	addeq sp, sp, #0x4c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, pc}
-	ldr r0, [sb, #4]
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, pc}
+	ldr r0, [r9, #4]
 	mov r6, #5
 	cmp r0, #0xc
 	moveq r6, #3
@@ -18834,18 +18834,18 @@ _0216aabc:
 	cmp r6, #0
 	mov r7, #0
 	addle sp, sp, #0x4c
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	ldr r4, _0216ab40 ; =data_02063e4c
 	mov r8, r7
 	add r5, sp, #0x2c
 _0216aad8:
-	ldr r0, [sb, #4]
+	ldr r0, [r9, #4]
 	cmp r0, #0xb
 	cmpne r0, #0xd
 	str r5, [sp]
 	bne _0216ab08
 	ldr r2, [sp, #4]
-	ldrh r3, [sb, #0x10]
+	ldrh r3, [r9, #0x10]
 	ldr r1, [sp, #8]
 	mov r0, r4
 	add r2, r2, r8
@@ -18853,7 +18853,7 @@ _0216aad8:
 	b _0216ab20
 _0216ab08:
 	ldr r1, [sp, #8]
-	ldrh r3, [sb, #0x10]
+	ldrh r3, [r9, #0x10]
 	ldr r2, [sp, #4]
 	mov r0, r4
 	add r1, r1, r8
@@ -18864,7 +18864,7 @@ _0216ab20:
 	add r8, r8, #2
 	blt _0216aad8
 	add sp, sp, #0x4c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov18_0216a9dc
 _0216ab38: .word data_02050f54
@@ -20248,7 +20248,7 @@ _0216b8ac: .word data_ov18_0216d484
 	.global func_ov18_0216b8b0
 	arm_func_start func_ov18_0216b8b0
 func_ov18_0216b8b0: ; 0x0216b8b0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	ldr r0, _0216bab0 ; =data_ov18_0216d490
 	ldr r2, _0216bab4 ; =func_ov18_0215e4dc
 	mov r1, #0x2f
@@ -20268,7 +20268,7 @@ func_ov18_0216b8b0: ; 0x0216b8b0
 	ldr r1, _0216bad4 ; =data_ov18_0216c3b2
 	ldr r6, _0216bad8 ; =data_ov18_0216c3b4
 	ldr r10, _0216badc ; =data_ov18_0216c3b6
-	ldr sb, _0216bae0 ; =data_ov18_0216c3b8
+	ldr r9, _0216bae0 ; =data_ov18_0216c3b8
 	mov r8, #0
 	strb r0, [r7]
 	strb r0, [r7, #1]
@@ -20290,8 +20290,8 @@ func_ov18_0216b8b0: ; 0x0216b8b0
 	ldr r6, _0216baf8 ; =data_ov18_0216c3c4
 	strb r0, [r10]
 	strb r0, [r10, #1]
-	strb r8, [sb]
-	strb r8, [sb, #1]
+	strb r8, [r9]
+	strb r8, [r9, #1]
 	strb r8, [r7]
 	strb r8, [r7, #1]
 	strb r8, [r5]
@@ -20329,7 +20329,7 @@ func_ov18_0216b8b0: ; 0x0216b8b0
 	ldr r5, _0216bb28 ; =data_ov18_0216c3e2
 	ldr r4, _0216bb2c ; =data_ov18_0216c3e4
 	ldr r3, _0216bb30 ; =data_ov18_0216c3e6
-	ldr sb, _0216bb34 ; =data_ov18_0216c3d6
+	ldr r9, _0216bb34 ; =data_ov18_0216c3d6
 	ldr r6, _0216bb38 ; =data_ov18_0216c3e0
 	mov r0, #5
 	strb r2, [r1]
@@ -20338,8 +20338,8 @@ func_ov18_0216b8b0: ; 0x0216b8b0
 	strb r2, [r11, #1]
 	strb r2, [r10]
 	strb r2, [r10, #1]
-	strb r0, [sb]
-	strb r2, [sb, #1]
+	strb r0, [r9]
+	strb r2, [r9, #1]
 	strb r2, [r8]
 	strb r2, [r8, #1]
 	strb r2, [r7]
@@ -20375,7 +20375,7 @@ func_ov18_0216b8b0: ; 0x0216b8b0
 	strb r2, [r3, #1]
 	strb r2, [r1]
 	strb r2, [r1, #1]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov18_0216b8b0
 _0216bab0: .word data_ov18_0216d490

--- a/asm/ov19.s
+++ b/asm/ov19.s
@@ -978,7 +978,7 @@ func_ov19_0216e310: ; 0x0216e310
 	.global func_ov19_0216e334
 	arm_func_start func_ov19_0216e334
 func_ov19_0216e334: ; 0x0216e334
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x7c
 	mov r4, r0
 	add r0, sp, #0x50
@@ -1101,7 +1101,7 @@ _0216e46c:
 	adds r3, sb, r7
 	adc ip, r8, r6
 	ldr r6, _0216e68c ; =0x00004001
-	ldr fp, [sp, #0x2c]
+	ldr r11, [sp, #0x2c]
 	umull r6, sl, ip, r6
 	mov r6, #0
 	mla sl, ip, r6, sl
@@ -1110,7 +1110,7 @@ _0216e46c:
 	stmia r5, {r3, ip}
 	mla sl, r7, r6, sl
 	sub r6, sl, #0x2000
-	add r6, fp, r6
+	add r6, r11, r6
 	ldr sl, [sp, #0x14]
 	str r6, [sp, #0x2c]
 	umull r7, r6, sl, r3
@@ -1159,10 +1159,10 @@ _0216e46c:
 	add r0, sp, #0x38
 	mla r8, r7, r1, r8
 	ldr r6, [r5, #0xc]
-	ldr fp, [r5, #0x10]
+	ldr r11, [r5, #0x10]
 	mla r8, r6, r3, r8
 	ldr sl, [r5, #0x14]
-	adds r1, fp, sb
+	adds r1, r11, sb
 	adc r3, sl, r8
 	stmia r5, {r1, r3}
 	mov r1, #0x7c
@@ -1183,7 +1183,7 @@ _0216e46c:
 _0216e64c:
 	add sp, sp, #0x7c
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0216e658:
 	ldr r0, [sp, #4]
 	add r4, r4, #0x7b
@@ -1197,7 +1197,7 @@ _0216e658:
 _0216e67c:
 	mov r0, #1
 	add sp, sp, #0x7c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov19_0216e334
 _0216e688: .word data_02050f54
@@ -7824,7 +7824,7 @@ _02173d50: .word data_027e0fe4
 	.global func_ov19_02173d54
 	arm_func_start func_ov19_02173d54
 func_ov19_02173d54: ; 0x02173d54
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0xc
 	mov sl, r0
 	ldrb r7, [sl, #0x14]
@@ -7834,7 +7834,7 @@ func_ov19_02173d54: ; 0x02173d54
 	bge _02173e1c
 	ldr r4, _02173ee8 ; =data_027e0e60
 	add r5, sp, #2
-	mov fp, #1
+	mov r11, #1
 _02173d80:
 	ldrb r8, [sl, #0x15]
 	add r0, r8, #2
@@ -7846,7 +7846,7 @@ _02173d94:
 	ldr r0, [r4]
 	beq _02173dcc
 	mov r1, r5
-	mov r2, fp
+	mov r2, r11
 	strb r6, [sp, #2]
 	strb r8, [sp, #3]
 	bl func_ov00_02082680
@@ -7912,7 +7912,7 @@ _02173e1c:
 	str r3, [sp, #4]
 	bl func_ov00_02093a3c
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02173ea0:
 	ldr r0, _02173eec ; =data_027e0f6c
 	ldr r1, [sp, #8]
@@ -7931,7 +7931,7 @@ _02173ea0:
 	str r3, [sp, #4]
 	bl func_ov00_02093a3c
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov19_02173d54
 _02173ee8: .word data_027e0e60

--- a/asm/ov19.s
+++ b/asm/ov19.s
@@ -978,7 +978,7 @@ func_ov19_0216e310: ; 0x0216e310
 	.global func_ov19_0216e334
 	arm_func_start func_ov19_0216e334
 func_ov19_0216e334: ; 0x0216e334
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x7c
 	mov r4, r0
 	add r0, sp, #0x50
@@ -1090,10 +1090,10 @@ _0216e46c:
 	ldr r0, [sp, #0x34]
 	ldr r3, [r5, #4]
 	str r0, [sp, #0x18]
-	ldr sl, [sp, #0x14]
+	ldr r10, [sp, #0x14]
 	mov r0, r6
-	umull r7, r6, sl, ip
-	mla r6, sl, r3, r6
+	umull r7, r6, r10, ip
+	mla r6, r10, r3, r6
 	ldr lr, [r5, #0xc]
 	ldr sb, [r5, #0x10]
 	mla r6, lr, ip, r6
@@ -1102,19 +1102,19 @@ _0216e46c:
 	adc ip, r8, r6
 	ldr r6, _0216e68c ; =0x00004001
 	ldr r11, [sp, #0x2c]
-	umull r6, sl, ip, r6
+	umull r6, r10, ip, r6
 	mov r6, #0
-	mla sl, ip, r6, sl
+	mla r10, ip, r6, r10
 	mov r7, r6
 	ldr r6, _0216e68c ; =0x00004001
 	stmia r5, {r3, ip}
-	mla sl, r7, r6, sl
-	sub r6, sl, #0x2000
+	mla r10, r7, r6, r10
+	sub r6, r10, #0x2000
 	add r6, r11, r6
-	ldr sl, [sp, #0x14]
+	ldr r10, [sp, #0x14]
 	str r6, [sp, #0x2c]
-	umull r7, r6, sl, r3
-	mla r6, sl, ip, r6
+	umull r7, r6, r10, r3
+	mla r6, r10, ip, r6
 	mla r6, lr, r3, r6
 	adds r3, sb, r7
 	adc r6, r8, r6
@@ -1161,9 +1161,9 @@ _0216e46c:
 	ldr r6, [r5, #0xc]
 	ldr r11, [r5, #0x10]
 	mla r8, r6, r3, r8
-	ldr sl, [r5, #0x14]
+	ldr r10, [r5, #0x14]
 	adds r1, r11, sb
-	adc r3, sl, r8
+	adc r3, r10, r8
 	stmia r5, {r1, r3}
 	mov r1, #0x7c
 	umull r1, r6, r3, r1
@@ -1183,7 +1183,7 @@ _0216e46c:
 _0216e64c:
 	add sp, sp, #0x7c
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0216e658:
 	ldr r0, [sp, #4]
 	add r4, r4, #0x7b
@@ -1197,7 +1197,7 @@ _0216e658:
 _0216e67c:
 	mov r0, #1
 	add sp, sp, #0x7c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov19_0216e334
 _0216e688: .word data_02050f54
@@ -7824,10 +7824,10 @@ _02173d50: .word data_027e0fe4
 	.global func_ov19_02173d54
 	arm_func_start func_ov19_02173d54
 func_ov19_02173d54: ; 0x02173d54
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0xc
-	mov sl, r0
-	ldrb r7, [sl, #0x14]
+	mov r10, r0
+	ldrb r7, [r10, #0x14]
 	mov sb, r1
 	add r0, r7, #2
 	cmp r7, r0
@@ -7836,7 +7836,7 @@ func_ov19_02173d54: ; 0x02173d54
 	add r5, sp, #2
 	mov r11, #1
 _02173d80:
-	ldrb r8, [sl, #0x15]
+	ldrb r8, [r10, #0x15]
 	add r0, r8, #2
 	cmp r8, r0
 	bge _02173e08
@@ -7868,24 +7868,24 @@ _02173dcc:
 	mov r3, #0x15
 	bl func_ov00_02084d24
 _02173df4:
-	ldrb r0, [sl, #0x15]
+	ldrb r0, [r10, #0x15]
 	add r8, r8, #1
 	add r0, r0, #2
 	cmp r8, r0
 	blt _02173d94
 _02173e08:
-	ldrb r0, [sl, #0x14]
+	ldrb r0, [r10, #0x14]
 	add r7, r7, #1
 	add r0, r0, #2
 	cmp r7, r0
 	blt _02173d80
 _02173e1c:
-	ldrh r4, [sl, #0x2a]
+	ldrh r4, [r10, #0x2a]
 	ldr r1, _02173eec ; =data_027e0f6c
 	add r0, sp, #8
 	ldr r1, [r1]
 	mov r2, r4
-	ldrh r5, [sl, #0x28]
+	ldrh r5, [r10, #0x28]
 	bl func_ov00_02093a4c
 	ldr r1, _02173eec ; =data_027e0f6c
 	add r0, sp, #4
@@ -7912,7 +7912,7 @@ _02173e1c:
 	str r3, [sp, #4]
 	bl func_ov00_02093a3c
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02173ea0:
 	ldr r0, _02173eec ; =data_027e0f6c
 	ldr r1, [sp, #8]
@@ -7931,7 +7931,7 @@ _02173ea0:
 	str r3, [sp, #4]
 	bl func_ov00_02093a3c
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov19_02173d54
 _02173ee8: .word data_027e0e60

--- a/asm/ov19.s
+++ b/asm/ov19.s
@@ -322,7 +322,7 @@ func_ov19_0216daa4: ; 0x0216daa4
 	.global func_ov19_0216dac8
 	arm_func_start func_ov19_0216dac8
 func_ov19_0216dac8: ; 0x0216dac8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x24
 	movs r4, r1
 	mov r5, r0
@@ -437,16 +437,16 @@ _0216dc18:
 	ldrsh lr, [r2, r6]
 	ldrsh r6, [r2, r0]
 	ldr r7, [r3, #0x65c]
-	smull r0, sb, r8, lr
+	smull r0, r9, r8, lr
 	adds r0, r0, #0x800
-	adc r8, sb, #0
+	adc r8, r9, #0
 	smull lr, r6, r7, r6
 	adds r7, lr, #0x800
-	mov sb, r0, lsr #0xc
+	mov r9, r0, lsr #0xc
 	adc r0, r6, #0
 	mov r6, r7, lsr #0xc
-	orr sb, sb, r8, lsl #20
-	add r7, sb, #0x7000
+	orr r9, r9, r8, lsl #20
+	add r7, r9, #0x7000
 	orr r6, r6, r0, lsl #20
 	add r0, r7, r6
 	str r0, [sp, #4]
@@ -493,12 +493,12 @@ _0216dc18:
 	cmpne r4, #1
 	cmpne r4, #3
 	addne sp, sp, #0x24
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	mov r0, r5
 	bl _ZN5Actor16XzDistanceToLinkEv
 	cmp r0, #0x800
 	addle sp, sp, #0x24
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	mov r0, r5
 	bl _ZN5Actor14GetAngleToLinkEv
 	mov r1, r0
@@ -506,7 +506,7 @@ _0216dc18:
 	add r0, r5, #0x78
 	bl func_0202b154
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov19_0216dac8
 _0216dd94: .word data_027e0f94
@@ -978,7 +978,7 @@ func_ov19_0216e310: ; 0x0216e310
 	.global func_ov19_0216e334
 	arm_func_start func_ov19_0216e334
 func_ov19_0216e334: ; 0x0216e334
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x7c
 	mov r4, r0
 	add r0, sp, #0x50
@@ -1095,10 +1095,10 @@ _0216e46c:
 	umull r7, r6, r10, ip
 	mla r6, r10, r3, r6
 	ldr lr, [r5, #0xc]
-	ldr sb, [r5, #0x10]
+	ldr r9, [r5, #0x10]
 	mla r6, lr, ip, r6
 	ldr r8, [r5, #0x14]
-	adds r3, sb, r7
+	adds r3, r9, r7
 	adc ip, r8, r6
 	ldr r6, _0216e68c ; =0x00004001
 	ldr r11, [sp, #0x2c]
@@ -1116,7 +1116,7 @@ _0216e46c:
 	umull r7, r6, r10, r3
 	mla r6, r10, ip, r6
 	mla r6, lr, r3, r6
-	adds r3, sb, r7
+	adds r3, r9, r7
 	adc r6, r8, r6
 	stmia r5, {r3, r6}
 	ldr r3, _0216e68c ; =0x00004001
@@ -1155,14 +1155,14 @@ _0216e46c:
 	str r1, [sp, #0x38]
 	str r0, [sp, #0x40]
 	ldmib r5, {r1, r7}
-	umull sb, r8, r7, r3
+	umull r9, r8, r7, r3
 	add r0, sp, #0x38
 	mla r8, r7, r1, r8
 	ldr r6, [r5, #0xc]
 	ldr r11, [r5, #0x10]
 	mla r8, r6, r3, r8
 	ldr r10, [r5, #0x14]
-	adds r1, r11, sb
+	adds r1, r11, r9
 	adc r3, r10, r8
 	stmia r5, {r1, r3}
 	mov r1, #0x7c
@@ -1183,7 +1183,7 @@ _0216e46c:
 _0216e64c:
 	add sp, sp, #0x7c
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0216e658:
 	ldr r0, [sp, #4]
 	add r4, r4, #0x7b
@@ -1197,7 +1197,7 @@ _0216e658:
 _0216e67c:
 	mov r0, #1
 	add sp, sp, #0x7c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov19_0216e334
 _0216e688: .word data_02050f54
@@ -7824,11 +7824,11 @@ _02173d50: .word data_027e0fe4
 	.global func_ov19_02173d54
 	arm_func_start func_ov19_02173d54
 func_ov19_02173d54: ; 0x02173d54
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0xc
 	mov r10, r0
 	ldrb r7, [r10, #0x14]
-	mov sb, r1
+	mov r9, r1
 	add r0, r7, #2
 	cmp r7, r0
 	bge _02173e1c
@@ -7842,7 +7842,7 @@ _02173d80:
 	bge _02173e08
 	and r6, r7, #0xff
 _02173d94:
-	cmp sb, #0
+	cmp r9, #0
 	ldr r0, [r4]
 	beq _02173dcc
 	mov r1, r5
@@ -7892,7 +7892,7 @@ _02173e1c:
 	ldr r1, [r1]
 	mov r2, r5
 	bl func_ov00_02093a4c
-	cmp sb, #0
+	cmp r9, #0
 	add r2, sp, #8
 	beq _02173ea0
 	ldr r1, [sp, #8]
@@ -7912,7 +7912,7 @@ _02173e1c:
 	str r3, [sp, #4]
 	bl func_ov00_02093a3c
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02173ea0:
 	ldr r0, _02173eec ; =data_027e0f6c
 	ldr r1, [sp, #8]
@@ -7931,7 +7931,7 @@ _02173ea0:
 	str r3, [sp, #4]
 	bl func_ov00_02093a3c
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov19_02173d54
 _02173ee8: .word data_027e0e60

--- a/asm/ov20.s
+++ b/asm/ov20.s
@@ -130,7 +130,7 @@ _0216d844: .word func_ov20_0216da18
 	.global func_ov20_0216d848
 	arm_func_start func_ov20_0216d848
 func_ov20_0216d848: ; 0x0216d848
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x44
 	ldr r1, _0216d9fc ; =data_027e0f74
 	mov sl, r0
@@ -140,7 +140,7 @@ func_ov20_0216d848: ; 0x0216d848
 	cmp r0, #0
 	addne sp, sp, #0x44
 	movne r0, #0
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r1, _0216da00 ; =data_ov20_02178320
 	mov r0, sl
 	bl func_ov00_020ca8a4
@@ -157,7 +157,7 @@ func_ov20_0216d848: ; 0x0216d848
 	add r1, sl, #0x21c
 	strh r2, [sl, #0x9c]
 	bl func_ov00_020cb140
-	ldr fp, _0216da04 ; =0x46425331
+	ldr r11, _0216da04 ; =0x46425331
 	ldr r5, _0216da08 ; =data_027e0fe8
 	ldr r4, _0216da0c ; =data_027e0fe4
 	mov sb, #0
@@ -174,7 +174,7 @@ _0216d8d0:
 	str r7, [sp, #4]
 	str r7, [sp, #8]
 	ldr r0, [sl, #8]
-	mov r1, fp
+	mov r1, r11
 	str r0, [sp, #0x34]
 	ldr r0, [sl, #0xc]
 	add r2, sl, #0x48
@@ -202,7 +202,7 @@ _0216d8d0:
 	mov r8, r7
 	add sb, r0, #0x800
 	mov r5, r7
-	mov fp, #0x2000
+	mov r11, #0x2000
 _0216d968:
 	smull r0, r1, r4, r8
 	add r1, r1, r8, lsr #31
@@ -217,7 +217,7 @@ _0216d968:
 	add r0, r6, r0, lsl #1
 	ldrsh r2, [r0, #2]
 	str r3, [sp, #0xc]
-	mov r0, fp
+	mov r0, r11
 	str r2, [sp, #0x14]
 	add r1, sp, #0xc
 	mov r3, sb
@@ -240,7 +240,7 @@ _0216d968:
 	bl func_ov20_0216dae8
 	mov r0, #1
 	add sp, sp, #0x44
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov20_0216d848
 _0216d9fc: .word data_027e0f74
@@ -334,7 +334,7 @@ _0216dae0:
 	.global func_ov20_0216dae8
 	arm_func_start func_ov20_0216dae8
 func_ov20_0216dae8: ; 0x0216dae8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x124
 	mov r7, r0
 	mov r4, #0
@@ -382,7 +382,7 @@ _0216db78:
 	str r4, [r7, #0x12c]
 	strb r4, [r7, #0x11a]
 	str r0, [r7, #0x20c]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0216dba4:
 	mov r1, #1
 	ldr r0, _0216e520 ; =data_027e0fc8
@@ -415,7 +415,7 @@ _0216dba4:
 	mov r1, #0x1000
 	str r1, [r0, #0x10]
 	add sp, sp, #0x124
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0216dc24:
 	add r0, r7, #0x21c
 	mov r1, #5
@@ -424,7 +424,7 @@ _0216dc24:
 	mov r1, #0x1000
 	str r1, [r0, #0x10]
 	add sp, sp, #0x124
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0216dc44:
 	add r0, sp, #0xb0
 	mov r1, #3
@@ -432,7 +432,7 @@ _0216dc44:
 	mov r6, r4
 	ldr r5, _0216e530 ; =data_ov20_0217786c
 	ldr r4, _0216e534 ; =data_02050f54
-	add fp, sp, #0xa4
+	add r11, sp, #0xa4
 _0216dc60:
 	add r0, sp, #0xb0
 	ldr r0, [r0, r6, lsl #2]
@@ -452,7 +452,7 @@ _0216dc60:
 	add r0, r4, r1, lsl #1
 	ldrsh r8, [r0, #2]
 	ldmia r5, {r0, r1, r2}
-	stmia fp, {r0, r1, r2}
+	stmia r11, {r0, r1, r2}
 	ldr r2, [r7, #0xa78]
 	ldr r1, [sp, #0xa8]
 	str r2, [sp, #0x98]
@@ -511,15 +511,15 @@ _0216dc60:
 	strb r1, [r7, #0x11a]
 	add sp, sp, #0x124
 	str r0, [r7, #0x20c]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0216dd98:
 	bl func_ov20_0216f7d0
 	add sp, sp, #0x124
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0216dda4:
 	bl func_ov20_0216f898
 	add sp, sp, #0x124
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0216ddb0:
 	str r4, [r7, #0xa78]
 	str r4, [r7, #0xa7c]
@@ -566,7 +566,7 @@ _0216de34:
 	mov r0, r7
 	bl func_ov20_0216fa20
 	add sp, sp, #0x124
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0216de60:
 	add r0, sp, #0x8c
 	mov r1, #3
@@ -595,11 +595,11 @@ _0216de88:
 	mov r0, r0, asr #0x4
 	mov r1, r0, lsl #0x1
 	mov r0, r1, lsl #0x1
-	ldrsh fp, [r4, r0]
+	ldrsh r11, [r4, r0]
 	add r0, r4, r1, lsl #1
 	ldrsh sb, [r0, #2]
 	ldr r0, _0216e53c ; =data_ov20_02177878
-	rsb r8, fp, #0
+	rsb r8, r11, #0
 	ldmia r0, {r0, r1, r2}
 	stmia sl, {r0, r1, r2}
 	ldr r2, [r7, #0xa78]
@@ -608,31 +608,31 @@ _0216de88:
 	ldr r1, [r7, #0xa7c]
 	ldr ip, [sp, #0x88]
 	add sl, r1, r0
-	smull fp, r0, ip, fp
+	smull r11, r0, ip, r11
 	str r1, [sp, #0x78]
-	adds r1, fp, #0x800
+	adds r1, r11, #0x800
 	adc r0, r0, #0
 	mov r1, r1, lsr #0xc
 	orr r1, r1, r0, lsl #20
 	add r2, r2, r1
-	smull fp, r1, ip, sb
+	smull r11, r1, ip, sb
 	mov r0, #0x800
-	adds fp, fp, r0
+	adds r11, r11, r0
 	mov r0, #0
 	adc r0, r1, r0
-	mov r1, fp, lsr #0xc
+	mov r1, r11, lsr #0xc
 	orr r1, r1, r0, lsl #20
-	ldr fp, [r7, #0xa80]
+	ldr r11, [r7, #0xa80]
 	ldr r0, [sp, #0x80]
-	add r1, fp, r1
+	add r1, r11, r1
 	str sl, [sp, #0x78]
-	smull fp, sl, r0, sb
+	smull r11, sl, r0, sb
 	smull sb, r8, r0, r8
 	mov r0, #0x800
-	adds fp, fp, r0
+	adds r11, r11, r0
 	mov r0, #0
 	adc r0, sl, r0
-	mov sl, fp, lsr #0xc
+	mov sl, r11, lsr #0xc
 	orr sl, sl, r0, lsl #20
 	add r0, r2, sl
 	str r0, [sp, #0x74]
@@ -663,7 +663,7 @@ _0216de88:
 	str r1, [r7, #0x12c]
 	bl func_ov20_0216fc48
 	add sp, sp, #0x124
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0216dfdc:
 	add r0, r7, r4, lsl #2
 	ldr r0, [r0, #0xa40]
@@ -702,25 +702,25 @@ _0216dfdc:
 	cmp r0, #2
 	beq _0216e09c
 	add sp, sp, #0x124
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0216e074:
 	add r0, r7, #0xa00
 	mov r1, #0x190
 	strh r1, [r0, #0x9c]
 	add sp, sp, #0x124
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0216e088:
 	add r0, r7, #0xa00
 	mov r1, #0x12c
 	strh r1, [r0, #0x9c]
 	add sp, sp, #0x124
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0216e09c:
 	add r0, r7, #0xa00
 	mov r1, #0xc8
 	strh r1, [r0, #0x9c]
 	add sp, sp, #0x124
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0216e0b0:
 	mov r1, r4
 	add r0, r7, #0x21c
@@ -733,7 +733,7 @@ _0216e0b0:
 	mov r0, #2
 	add sp, sp, #0x124
 	str r0, [r7, #0x12c]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0216e0e0:
 	str r4, [r7, #0x12c]
 	add r0, r7, #0x21c
@@ -750,7 +750,7 @@ _0216e0e0:
 	str r4, [r7, #0x20c]
 	bl func_ov00_020ceacc
 	add sp, sp, #0x124
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0216e120:
 	ldr r0, _0216e544 ; =data_027e0f94
 	add r3, sp, #0x68
@@ -772,20 +772,20 @@ _0216e120:
 	ldr r8, [r0, #8]
 	ldr r4, [r0]
 	ldr r6, [r0, #0xc]
-	umull ip, fp, r8, r4
+	umull ip, r11, r8, r4
 	ldr r0, [r0, #4]
 	adds ip, sl, ip
-	mla fp, r8, r0, fp
-	mla fp, r6, r4, fp
+	mla r11, r8, r0, r11
+	mla r11, r6, r4, r11
 	ldr r0, _0216e548 ; =data_027e0764
-	adc fp, sb, fp
+	adc r11, sb, r11
 	str ip, [r0]
-	str fp, [r0, #4]
+	str r11, [r0, #4]
 	ldr r0, _0216e54c ; =0x00008001
 	mov r1, #0
-	umull r0, lr, fp, r0
+	umull r0, lr, r11, r0
 	mov r0, #0
-	mla lr, fp, r0, lr
+	mla lr, r11, r0, lr
 	mov r4, r0
 	ldr r0, _0216e54c ; =0x00008001
 	str r1, [sp, #0x60]
@@ -815,7 +815,7 @@ _0216e120:
 	ldr r0, [sp, #0xc]
 	str r0, [sp, #0x5c]
 	umull lr, r0, r8, ip
-	mla r0, r8, fp, r0
+	mla r0, r8, r11, r0
 	mla r0, r6, ip, r0
 	adds r8, sl, lr
 	adc r6, sb, r0
@@ -845,7 +845,7 @@ _0216e120:
 	movne r0, #0
 	cmp r0, #0
 	addeq sp, sp, #0x124
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, _0216e550 ; =data_027e0e60
 	add r2, sp, #0x44
 	ldr r0, [r0]
@@ -868,7 +868,7 @@ _0216e120:
 	add sp, sp, #0x124
 	cmp r0, r1
 	strgt r1, [r7, #0xa94]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0216e2f4:
 	add r0, r7, #0x21c
 	mov r1, #1
@@ -881,7 +881,7 @@ _0216e2f4:
 	mov r0, #2
 	add sp, sp, #0x124
 	str r0, [r7, #0x12c]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0216e324:
 	add r0, r7, #0x21c
 	mov r1, #2
@@ -894,7 +894,7 @@ _0216e324:
 	mov r0, #2
 	add sp, sp, #0x124
 	str r0, [r7, #0x12c]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0216e354:
 	add r0, r7, #0x21c
 	mov r1, #6
@@ -909,7 +909,7 @@ _0216e354:
 	mov r0, #2
 	add sp, sp, #0x124
 	str r0, [r7, #0x12c]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0216e38c:
 	mov r0, #2
 	str r0, [r7, #0x12c]
@@ -920,7 +920,7 @@ _0216e38c:
 	mov r1, #0x1000
 	str r1, [r0, #0x10]
 	add sp, sp, #0x124
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0216e3b4:
 	add r0, r7, #0x21c
 	mov r1, #3
@@ -931,7 +931,7 @@ _0216e3b4:
 	str r2, [r1, #0x10]
 	bl func_ov20_0216fc48
 	add sp, sp, #0x124
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0216e3dc:
 	ldr r0, _0216e554 ; =data_027e0f90
 	mov r1, r4
@@ -992,7 +992,7 @@ _0216e3dc:
 	add r2, sp, #0x14
 	bl func_ov00_020888e8
 	add sp, sp, #0x124
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0216e4cc:
 	add r0, r7, #0x48
 	add r4, sp, #0x2c
@@ -1014,7 +1014,7 @@ _0216e4cc:
 	bl func_ov00_0207c31c
 _0216e514:
 	add sp, sp, #0x124
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov20_0216dae8
 _0216e51c: .word 0x0000ffff
@@ -1087,7 +1087,7 @@ _0216e600: .word data_ov00_020eec68
 	.global func_ov20_0216e604
 	arm_func_start func_ov20_0216e604
 func_ov20_0216e604: ; 0x0216e604
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x1e4
 	mov r4, r0
 	ldr r0, [r4, #0x130]
@@ -1304,7 +1304,7 @@ _0216e858:
 	ldr r3, [r0, #0x28]
 	ldr r2, [r0, #0x2c]
 	ldr r1, [r0, #0x30]
-	ldr fp, [r0, #0x34]
+	ldr r11, [r0, #0x34]
 	ldr r0, [r0]
 	str sl, [sp, #0x28]
 	str r0, [sp, #0x160]
@@ -1343,7 +1343,7 @@ _0216e858:
 	mov r0, sl
 	str r0, [sp, #0x1bc]
 	ldr r0, [sp, #0x2c]
-	str fp, [sp, #0x194]
+	str r11, [sp, #0x194]
 	strb r0, [sp, #0x1c0]
 	ldr r0, [sp, #0x30]
 	add r3, sp, #0x6c
@@ -2069,7 +2069,7 @@ _0216f42c:
 _0216f460:
 	mov r0, #1
 	add sp, sp, #0x1e4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov20_0216e604
 _0216f46c: .word data_027e0fc8
@@ -2577,7 +2577,7 @@ _0216fa68: .word 0x00001003
 	.global func_ov20_0216fa6c
 	arm_func_start func_ov20_0216fa6c
 func_ov20_0216fa6c: ; 0x0216fa6c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x3c
 	mov r4, r0
 	add r0, sp, #0x10
@@ -2608,13 +2608,13 @@ func_ov20_0216fa6c: ; 0x0216fa6c
 	adds sb, r7, ip
 	adc r8, r6, sl
 	ldr sl, _0216fb88 ; =data_027e0764
-	ldr fp, _0216fb8c ; =0x00004001
+	ldr r11, _0216fb8c ; =0x00004001
 	str sb, [sl]
 	str r8, [sl, #4]
-	umull sl, ip, r8, fp
+	umull sl, ip, r8, r11
 	mov sl, #0
 	mla ip, r8, sl, ip
-	mla ip, sl, fp, ip
+	mla ip, sl, r11, ip
 	ldr lr, [sp, #4]
 	sub sl, ip, #0x2000
 	add sl, lr, sl
@@ -2627,10 +2627,10 @@ func_ov20_0216fa6c: ; 0x0216fa6c
 	ldr r4, _0216fb88 ; =data_027e0764
 	adc r6, r6, sl
 	stmia r4, {r5, r6}
-	umull r4, r5, r6, fp
+	umull r4, r5, r6, r11
 	mov r4, #0
 	mla r5, r6, r4, r5
-	mla r5, r4, fp, r5
+	mla r5, r4, r11, r5
 	ldr r0, [sp, #0xc]
 	sub r4, r5, #0x2000
 	add r0, r0, r4
@@ -2646,7 +2646,7 @@ func_ov20_0216fa6c: ; 0x0216fa6c
 	movge r0, #1
 	movlt r0, #0
 	add sp, sp, #0x3c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov20_0216fa6c
 _0216fb84: .word data_027e0f94
@@ -6124,7 +6124,7 @@ _02172958: .word data_027e0764
 	.global func_ov20_0217295c
 	arm_func_start func_ov20_0217295c
 func_ov20_0217295c: ; 0x0217295c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x3c
 	mov r4, r0
 	add r0, sp, #0x10
@@ -6156,13 +6156,13 @@ func_ov20_0217295c: ; 0x0217295c
 	adds sb, r7, ip
 	adc r8, r6, sl
 	ldr sl, _02172a74 ; =data_027e0764
-	ldr fp, _02172a78 ; =0x00006001
+	ldr r11, _02172a78 ; =0x00006001
 	str sb, [sl]
 	str r8, [sl, #4]
-	umull sl, ip, r8, fp
+	umull sl, ip, r8, r11
 	mov sl, #0
 	mla ip, r8, sl, ip
-	mla ip, sl, fp, ip
+	mla ip, sl, r11, ip
 	ldr lr, [sp, #4]
 	sub sl, ip, #0x3000
 	add sl, lr, sl
@@ -6174,10 +6174,10 @@ func_ov20_0217295c: ; 0x0217295c
 	ldr r4, _02172a74 ; =data_027e0764
 	adc r6, r6, sl
 	stmia r4, {r5, r6}
-	umull r4, r5, r6, fp
+	umull r4, r5, r6, r11
 	mov r4, #0
 	mla r5, r6, r4, r5
-	mla r5, r4, fp, r5
+	mla r5, r4, r11, r5
 	ldr r0, [sp, #0xc]
 	sub r4, r5, #0x3000
 	add r0, r0, r4
@@ -6193,7 +6193,7 @@ func_ov20_0217295c: ; 0x0217295c
 	movge r0, #1
 	movlt r0, #0
 	add sp, sp, #0x3c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov20_0217295c
 _02172a74: .word data_027e0764
@@ -6720,7 +6720,7 @@ _0217315c: .word data_027e0d44
 	.global func_ov20_02173160
 	arm_func_start func_ov20_02173160
 func_ov20_02173160: ; 0x02173160
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x14
 	ldr r3, _0217324c ; =0x0000ffff
 	ldr r2, _02173250 ; =0x040004c0
@@ -6732,19 +6732,19 @@ func_ov20_02173160: ; 0x02173160
 	mov sb, #0
 	cmp r0, #0
 	addle sp, sp, #0x14
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r5, _02173258 ; =data_027e0d44
 	ldr r4, _0217325c ; =0x35200000
 	sub r8, r2, #0x18
 	sub r7, r2, #0x14
-	mov fp, #0x31
+	mov r11, #0x31
 	mov r6, #0x20
 _021731ac:
 	add r0, sl, sb, lsl #2
 	ldr r0, [r0, #0x88]
 	add ip, sl, sb, lsl #3
 	cmp r0, #0
-	movge r2, fp
+	movge r2, r11
 	ldr r0, [r5]
 	movlt r2, #0x32
 	add r0, r0, r2, lsl #3
@@ -6779,7 +6779,7 @@ _021731ac:
 	cmp sb, r0
 	blt _021731ac
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov20_02173160
 _0217324c: .word 0x0000ffff
@@ -12022,7 +12022,7 @@ _021774e4: .word data_ov20_021793bc
 	arm_func_start func_ov20_021774e8
 func_ov20_021774e8: ; 0x021774e8
 	stmdb sp!, {r0, r1, r2, r3}
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x24
 	ldr r0, _021775cc ; =data_027e0e60
 	ldrb r1, [sp, #0x4c]
@@ -12039,7 +12039,7 @@ func_ov20_021774e8: ; 0x021774e8
 	mov sb, r8
 	add r5, sp, #0xc
 	mov r7, r8
-	mov fp, #0x400
+	mov r11, #0x400
 	add r6, sp, #0
 _02177538:
 	mov r1, sb, lsl #0x10
@@ -12047,7 +12047,7 @@ _02177538:
 	mov r1, r1, asr #0x10
 	str r7, [sp]
 	str r7, [sp, #4]
-	str fp, [sp, #8]
+	str r11, [sp, #8]
 	bl func_ov00_020a61ac
 	ldr r1, [sp, #0x18]
 	ldr r0, [sp, #0x1c]
@@ -12078,7 +12078,7 @@ _021775a8:
 	blt _02177538
 	mov r0, sl
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	add sp, sp, #0x10
 	bx lr
 	.align 2, 0

--- a/asm/ov20.s
+++ b/asm/ov20.s
@@ -130,7 +130,7 @@ _0216d844: .word func_ov20_0216da18
 	.global func_ov20_0216d848
 	arm_func_start func_ov20_0216d848
 func_ov20_0216d848: ; 0x0216d848
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x44
 	ldr r1, _0216d9fc ; =data_027e0f74
 	mov r10, r0
@@ -140,7 +140,7 @@ func_ov20_0216d848: ; 0x0216d848
 	cmp r0, #0
 	addne sp, sp, #0x44
 	movne r0, #0
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r1, _0216da00 ; =data_ov20_02178320
 	mov r0, r10
 	bl func_ov00_020ca8a4
@@ -160,7 +160,7 @@ func_ov20_0216d848: ; 0x0216d848
 	ldr r11, _0216da04 ; =0x46425331
 	ldr r5, _0216da08 ; =data_027e0fe8
 	ldr r4, _0216da0c ; =data_027e0fe4
-	mov sb, #0
+	mov r9, #0
 	add r8, sp, #0x18
 	mvn r7, #0
 	add r6, sp, #4
@@ -186,21 +186,21 @@ _0216d8d0:
 	ldr r0, [r4]
 	mov r1, r6
 	bl _ZN12ActorManager8GetActorEP8ActorRef
-	add r1, r10, sb, lsl #2
+	add r1, r10, r9, lsl #2
 	str r0, [r1, #0xa40]
-	mov r1, sb
+	mov r1, r9
 	bl func_ov20_021702b4
-	add r0, sb, #1
+	add r0, r9, #1
 	mov r0, r0, lsl #0x10
-	mov sb, r0, asr #0x10
-	cmp sb, #3
+	mov r9, r0, asr #0x10
+	cmp r9, #3
 	blt _0216d8d0
 	mov r7, #0
 	add r0, r10, #0x24c
 	ldr r6, _0216da10 ; =data_02050f54
 	ldr r4, _0216da14 ; =0x55555556
 	mov r8, r7
-	add sb, r0, #0x800
+	add r9, r0, #0x800
 	mov r5, r7
 	mov r11, #0x2000
 _0216d968:
@@ -220,7 +220,7 @@ _0216d968:
 	mov r0, r11
 	str r2, [sp, #0x14]
 	add r1, sp, #0xc
-	mov r3, sb
+	mov r3, r9
 	add r2, r10, #0x48
 	str r5, [sp, #0x10]
 	bl func_01ff9e64
@@ -230,7 +230,7 @@ _0216d968:
 	mov r7, r1, asr #0x10
 	cmp r7, #3
 	add r8, r0, #0xff00
-	add sb, sb, #0xc
+	add r9, r9, #0xc
 	blt _0216d968
 	add r2, r10, #0xa00
 	mov r1, #0
@@ -240,7 +240,7 @@ _0216d968:
 	bl func_ov20_0216dae8
 	mov r0, #1
 	add sp, sp, #0x44
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov20_0216d848
 _0216d9fc: .word data_027e0f74
@@ -334,7 +334,7 @@ _0216dae0:
 	.global func_ov20_0216dae8
 	arm_func_start func_ov20_0216dae8
 func_ov20_0216dae8: ; 0x0216dae8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x124
 	mov r7, r0
 	mov r4, #0
@@ -382,7 +382,7 @@ _0216db78:
 	str r4, [r7, #0x12c]
 	strb r4, [r7, #0x11a]
 	str r0, [r7, #0x20c]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0216dba4:
 	mov r1, #1
 	ldr r0, _0216e520 ; =data_027e0fc8
@@ -415,7 +415,7 @@ _0216dba4:
 	mov r1, #0x1000
 	str r1, [r0, #0x10]
 	add sp, sp, #0x124
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0216dc24:
 	add r0, r7, #0x21c
 	mov r1, #5
@@ -424,7 +424,7 @@ _0216dc24:
 	mov r1, #0x1000
 	str r1, [r0, #0x10]
 	add sp, sp, #0x124
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0216dc44:
 	add r0, sp, #0xb0
 	mov r1, #3
@@ -456,29 +456,29 @@ _0216dc60:
 	ldr r2, [r7, #0xa78]
 	ldr r1, [sp, #0xa8]
 	str r2, [sp, #0x98]
-	ldr sb, [r7, #0xa7c]
+	ldr r9, [r7, #0xa7c]
 	ldr r0, [sp, #0xac]
-	add r1, sb, r1
-	str sb, [sp, #0x9c]
-	smull r10, sb, r0, r3
+	add r1, r9, r1
+	str r9, [sp, #0x9c]
+	smull r10, r9, r0, r3
 	adds r10, r10, #0x800
 	rsb lr, r3, #0
-	adc r3, sb, #0
-	mov sb, r10, lsr #0xc
-	orr sb, sb, r3, lsl #20
-	add r3, r2, sb
-	smull sb, r2, r0, r8
+	adc r3, r9, #0
+	mov r9, r10, lsr #0xc
+	orr r9, r9, r3, lsl #20
+	add r3, r2, r9
+	smull r9, r2, r0, r8
 	mov r0, #0x800
-	adds r0, sb, r0
-	mov sb, r0, lsr #0xc
+	adds r0, r9, r0
+	mov r9, r0, lsr #0xc
 	adc r2, r2, #0
-	orr sb, sb, r2, lsl #20
+	orr r9, r9, r2, lsl #20
 	ldr r2, [r7, #0xa80]
 	ldr r0, [sp, #0xa4]
 	str r1, [sp, #0x9c]
-	add r2, r2, sb
+	add r2, r2, r9
 	smull r8, r1, r0, r8
-	smull r10, sb, r0, lr
+	smull r10, r9, r0, lr
 	mov r0, #0x800
 	adds r0, r8, r0
 	adc r1, r1, #0
@@ -490,7 +490,7 @@ _0216dc60:
 	adds r1, r10, r0
 	mov r8, #0
 	mov r0, r8
-	adc r0, sb, r0
+	adc r0, r9, r0
 	mov r1, r1, lsr #0xc
 	orr r1, r1, r0, lsl #20
 	add r0, r2, r1
@@ -511,15 +511,15 @@ _0216dc60:
 	strb r1, [r7, #0x11a]
 	add sp, sp, #0x124
 	str r0, [r7, #0x20c]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0216dd98:
 	bl func_ov20_0216f7d0
 	add sp, sp, #0x124
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0216dda4:
 	bl func_ov20_0216f898
 	add sp, sp, #0x124
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0216ddb0:
 	str r4, [r7, #0xa78]
 	str r4, [r7, #0xa7c]
@@ -566,7 +566,7 @@ _0216de34:
 	mov r0, r7
 	bl func_ov20_0216fa20
 	add sp, sp, #0x124
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0216de60:
 	add r0, sp, #0x8c
 	mov r1, #3
@@ -597,7 +597,7 @@ _0216de88:
 	mov r0, r1, lsl #0x1
 	ldrsh r11, [r4, r0]
 	add r0, r4, r1, lsl #1
-	ldrsh sb, [r0, #2]
+	ldrsh r9, [r0, #2]
 	ldr r0, _0216e53c ; =data_ov20_02177878
 	rsb r8, r11, #0
 	ldmia r0, {r0, r1, r2}
@@ -615,7 +615,7 @@ _0216de88:
 	mov r1, r1, lsr #0xc
 	orr r1, r1, r0, lsl #20
 	add r2, r2, r1
-	smull r11, r1, ip, sb
+	smull r11, r1, ip, r9
 	mov r0, #0x800
 	adds r11, r11, r0
 	mov r0, #0
@@ -626,8 +626,8 @@ _0216de88:
 	ldr r0, [sp, #0x80]
 	add r1, r11, r1
 	str r10, [sp, #0x78]
-	smull r11, r10, r0, sb
-	smull sb, r8, r0, r8
+	smull r11, r10, r0, r9
+	smull r9, r8, r0, r8
 	mov r0, #0x800
 	adds r11, r11, r0
 	mov r0, #0
@@ -637,7 +637,7 @@ _0216de88:
 	add r0, r2, r10
 	str r0, [sp, #0x74]
 	mov r0, #0x800
-	adds r2, sb, r0
+	adds r2, r9, r0
 	mov r0, #0
 	adc r0, r8, r0
 	mov r2, r2, lsr #0xc
@@ -663,7 +663,7 @@ _0216de88:
 	str r1, [r7, #0x12c]
 	bl func_ov20_0216fc48
 	add sp, sp, #0x124
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0216dfdc:
 	add r0, r7, r4, lsl #2
 	ldr r0, [r0, #0xa40]
@@ -702,25 +702,25 @@ _0216dfdc:
 	cmp r0, #2
 	beq _0216e09c
 	add sp, sp, #0x124
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0216e074:
 	add r0, r7, #0xa00
 	mov r1, #0x190
 	strh r1, [r0, #0x9c]
 	add sp, sp, #0x124
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0216e088:
 	add r0, r7, #0xa00
 	mov r1, #0x12c
 	strh r1, [r0, #0x9c]
 	add sp, sp, #0x124
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0216e09c:
 	add r0, r7, #0xa00
 	mov r1, #0xc8
 	strh r1, [r0, #0x9c]
 	add sp, sp, #0x124
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0216e0b0:
 	mov r1, r4
 	add r0, r7, #0x21c
@@ -733,7 +733,7 @@ _0216e0b0:
 	mov r0, #2
 	add sp, sp, #0x124
 	str r0, [r7, #0x12c]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0216e0e0:
 	str r4, [r7, #0x12c]
 	add r0, r7, #0x21c
@@ -750,7 +750,7 @@ _0216e0e0:
 	str r4, [r7, #0x20c]
 	bl func_ov00_020ceacc
 	add sp, sp, #0x124
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0216e120:
 	ldr r0, _0216e544 ; =data_027e0f94
 	add r3, sp, #0x68
@@ -768,7 +768,7 @@ _0216e120:
 	ldr r0, _0216e548 ; =data_027e0764
 	add r3, r7, #0x28c
 	ldr r10, [r0, #0x10]
-	ldr sb, [r0, #0x14]
+	ldr r9, [r0, #0x14]
 	ldr r8, [r0, #8]
 	ldr r4, [r0]
 	ldr r6, [r0, #0xc]
@@ -778,7 +778,7 @@ _0216e120:
 	mla r11, r8, r0, r11
 	mla r11, r6, r4, r11
 	ldr r0, _0216e548 ; =data_027e0764
-	adc r11, sb, r11
+	adc r11, r9, r11
 	str ip, [r0]
 	str r11, [r0, #4]
 	ldr r0, _0216e54c ; =0x00008001
@@ -818,7 +818,7 @@ _0216e120:
 	mla r0, r8, r11, r0
 	mla r0, r6, ip, r0
 	adds r8, r10, lr
-	adc r6, sb, r0
+	adc r6, r9, r0
 	ldr r0, _0216e548 ; =data_027e0764
 	str r4, [sp, #0x64]
 	str r8, [r0]
@@ -845,7 +845,7 @@ _0216e120:
 	movne r0, #0
 	cmp r0, #0
 	addeq sp, sp, #0x124
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, _0216e550 ; =data_027e0e60
 	add r2, sp, #0x44
 	ldr r0, [r0]
@@ -868,7 +868,7 @@ _0216e120:
 	add sp, sp, #0x124
 	cmp r0, r1
 	strgt r1, [r7, #0xa94]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0216e2f4:
 	add r0, r7, #0x21c
 	mov r1, #1
@@ -881,7 +881,7 @@ _0216e2f4:
 	mov r0, #2
 	add sp, sp, #0x124
 	str r0, [r7, #0x12c]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0216e324:
 	add r0, r7, #0x21c
 	mov r1, #2
@@ -894,7 +894,7 @@ _0216e324:
 	mov r0, #2
 	add sp, sp, #0x124
 	str r0, [r7, #0x12c]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0216e354:
 	add r0, r7, #0x21c
 	mov r1, #6
@@ -909,7 +909,7 @@ _0216e354:
 	mov r0, #2
 	add sp, sp, #0x124
 	str r0, [r7, #0x12c]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0216e38c:
 	mov r0, #2
 	str r0, [r7, #0x12c]
@@ -920,7 +920,7 @@ _0216e38c:
 	mov r1, #0x1000
 	str r1, [r0, #0x10]
 	add sp, sp, #0x124
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0216e3b4:
 	add r0, r7, #0x21c
 	mov r1, #3
@@ -931,7 +931,7 @@ _0216e3b4:
 	str r2, [r1, #0x10]
 	bl func_ov20_0216fc48
 	add sp, sp, #0x124
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0216e3dc:
 	ldr r0, _0216e554 ; =data_027e0f90
 	mov r1, r4
@@ -992,7 +992,7 @@ _0216e3dc:
 	add r2, sp, #0x14
 	bl func_ov00_020888e8
 	add sp, sp, #0x124
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0216e4cc:
 	add r0, r7, #0x48
 	add r4, sp, #0x2c
@@ -1014,7 +1014,7 @@ _0216e4cc:
 	bl func_ov00_0207c31c
 _0216e514:
 	add sp, sp, #0x124
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov20_0216dae8
 _0216e51c: .word 0x0000ffff
@@ -1087,7 +1087,7 @@ _0216e600: .word data_ov00_020eec68
 	.global func_ov20_0216e604
 	arm_func_start func_ov20_0216e604
 func_ov20_0216e604: ; 0x0216e604
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x1e4
 	mov r4, r0
 	ldr r0, [r4, #0x130]
@@ -1294,7 +1294,7 @@ _0216e858:
 	str r1, [sp, #0x3c]
 	str r10, [sp, #0x24]
 	ldr r10, [r0, #0x5c]
-	ldr sb, [r0, #4]
+	ldr r9, [r0, #4]
 	ldr r8, [r0, #8]
 	ldr r7, [r0, #0xc]
 	ldr r6, [r0, #0x14]
@@ -1318,7 +1318,7 @@ _0216e858:
 	mov r1, #1
 	str r0, [sp, #0x19c]
 	ldr r0, [sp, #0xc]
-	str sb, [sp, #0x164]
+	str r9, [sp, #0x164]
 	str r0, [sp, #0x1a0]
 	ldr r0, [sp, #0x10]
 	str r8, [sp, #0x168]
@@ -2069,7 +2069,7 @@ _0216f42c:
 _0216f460:
 	mov r0, #1
 	add sp, sp, #0x1e4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov20_0216e604
 _0216f46c: .word data_027e0fc8
@@ -2189,15 +2189,15 @@ _0216f5ac: .word 0x0000071c
 	.global func_ov20_0216f5b0
 	arm_func_start func_ov20_0216f5b0
 func_ov20_0216f5b0: ; 0x0216f5b0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
-	mov sb, r0
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
+	mov r9, r0
 	mov r8, r1
 	bl _ZN5Actor14GetAngleToLinkEv
 	mov r1, r0
 	ldr r2, _0216f70c ; =0x0000071c
-	add r0, sb, #0x78
+	add r0, r9, #0x78
 	bl func_0202b154
-	mov r0, sb
+	mov r0, r9
 	mov r1, r8
 	bl _ZN5Actor10GetAngleToEP5Vec3p
 	mov r0, r0, lsl #0x10
@@ -2208,16 +2208,16 @@ func_ov20_0216f5b0: ; 0x0216f5b0
 	ldr r2, _0216f710 ; =data_02050f54
 	mov r3, r1, lsl #0x1
 	mov r1, r0, lsl #0x1
-	add r0, sb, #0x60
+	add r0, r9, #0x60
 	ldrsh r6, [r2, r3]
 	ldrsh r7, [r2, r1]
 	bl func_01ff9cec
 	mov r4, r0
-	add r0, sb, #0x48
+	add r0, r9, #0x48
 	mov r1, r8
 	bl func_ov00_020ce2f0
 	mov r5, r0
-	mov r0, sb
+	mov r0, r9
 	mov r1, r8
 	bl _ZN5Actor12XzDistanceToEP5Vec3p
 	cmp r0, #0x2000
@@ -2256,30 +2256,30 @@ _0216f694:
 	adds r1, r1, #0x800
 	mov r3, r3, lsr #0xc
 	orr r3, r3, r2, lsl #20
-	str r3, [sb, #0x60]
+	str r3, [r9, #0x60]
 	mov r2, #0
 	adc r0, r0, #0
 	mov r1, r1, lsr #0xc
-	str r2, [sb, #0x64]
+	str r2, [r9, #0x64]
 	orr r1, r1, r0, lsl #20
-	str r1, [sb, #0x68]
+	str r1, [r9, #0x68]
 	ldr r2, [r8, #4]
-	ldr r0, [sb, #0x4c]
+	ldr r0, [r9, #0x4c]
 	ldr r1, _0216f714 ; =0x0000019a
 	sub r2, r2, r0
-	str r2, [sb, #0x64]
+	str r2, [r9, #0x64]
 	cmp r2, r1
-	strgt r1, [sb, #0x64]
+	strgt r1, [r9, #0x64]
 	bgt _0216f6f8
 	sub r0, r1, #0x334
 	cmp r2, r0
-	strlt r0, [sb, #0x64]
+	strlt r0, [r9, #0x64]
 _0216f6f8:
-	mov r0, sb
+	mov r0, r9
 	ldr r1, [r0]
 	ldr r1, [r1, #0x104]
 	blx r1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov20_0216f5b0
 _0216f70c: .word 0x0000071c
@@ -2577,7 +2577,7 @@ _0216fa68: .word 0x00001003
 	.global func_ov20_0216fa6c
 	arm_func_start func_ov20_0216fa6c
 func_ov20_0216fa6c: ; 0x0216fa6c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x3c
 	mov r4, r0
 	add r0, sp, #0x10
@@ -2597,19 +2597,19 @@ func_ov20_0216fa6c: ; 0x0216fa6c
 	ldr r0, _0216fb88 ; =data_027e0764
 	str r4, [sp, #0x30]
 	ldr r5, [r0, #8]
-	ldr sb, [r0]
+	ldr r9, [r0]
 	ldr r8, [r0, #4]
-	umull ip, r10, r5, sb
+	umull ip, r10, r5, r9
 	mla r10, r5, r8, r10
 	ldr r4, [r0, #0xc]
 	ldr r7, [r0, #0x10]
-	mla r10, r4, sb, r10
+	mla r10, r4, r9, r10
 	ldr r6, [r0, #0x14]
-	adds sb, r7, ip
+	adds r9, r7, ip
 	adc r8, r6, r10
 	ldr r10, _0216fb88 ; =data_027e0764
 	ldr r11, _0216fb8c ; =0x00004001
-	str sb, [r10]
+	str r9, [r10]
 	str r8, [r10, #4]
 	umull r10, ip, r8, r11
 	mov r10, #0
@@ -2619,9 +2619,9 @@ func_ov20_0216fa6c: ; 0x0216fa6c
 	sub r10, ip, #0x2000
 	add r10, lr, r10
 	str r10, [sp, #4]
-	umull ip, r10, r5, sb
+	umull ip, r10, r5, r9
 	mla r10, r5, r8, r10
-	mla r10, r4, sb, r10
+	mla r10, r4, r9, r10
 	adds r5, r7, ip
 	mov r2, r3
 	ldr r4, _0216fb88 ; =data_027e0764
@@ -2646,7 +2646,7 @@ func_ov20_0216fa6c: ; 0x0216fa6c
 	movge r0, #1
 	movlt r0, #0
 	add sp, sp, #0x3c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov20_0216fa6c
 _0216fb84: .word data_027e0f94
@@ -6124,7 +6124,7 @@ _02172958: .word data_027e0764
 	.global func_ov20_0217295c
 	arm_func_start func_ov20_0217295c
 func_ov20_0217295c: ; 0x0217295c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x3c
 	mov r4, r0
 	add r0, sp, #0x10
@@ -6145,19 +6145,19 @@ func_ov20_0217295c: ; 0x0217295c
 	ldr r0, _02172a74 ; =data_027e0764
 	mov r2, r3
 	ldr r5, [r0, #8]
-	ldr sb, [r0]
+	ldr r9, [r0]
 	ldr r8, [r0, #4]
-	umull ip, r10, r5, sb
+	umull ip, r10, r5, r9
 	mla r10, r5, r8, r10
 	ldr r4, [r0, #0xc]
 	ldr r7, [r0, #0x10]
-	mla r10, r4, sb, r10
+	mla r10, r4, r9, r10
 	ldr r6, [r0, #0x14]
-	adds sb, r7, ip
+	adds r9, r7, ip
 	adc r8, r6, r10
 	ldr r10, _02172a74 ; =data_027e0764
 	ldr r11, _02172a78 ; =0x00006001
-	str sb, [r10]
+	str r9, [r10]
 	str r8, [r10, #4]
 	umull r10, ip, r8, r11
 	mov r10, #0
@@ -6167,9 +6167,9 @@ func_ov20_0217295c: ; 0x0217295c
 	sub r10, ip, #0x3000
 	add r10, lr, r10
 	str r10, [sp, #4]
-	umull ip, r10, r5, sb
+	umull ip, r10, r5, r9
 	mla r10, r5, r8, r10
-	mla r10, r4, sb, r10
+	mla r10, r4, r9, r10
 	adds r5, r7, ip
 	ldr r4, _02172a74 ; =data_027e0764
 	adc r6, r6, r10
@@ -6193,7 +6193,7 @@ func_ov20_0217295c: ; 0x0217295c
 	movge r0, #1
 	movlt r0, #0
 	add sp, sp, #0x3c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov20_0217295c
 _02172a74: .word data_027e0764
@@ -6720,7 +6720,7 @@ _0217315c: .word data_027e0d44
 	.global func_ov20_02173160
 	arm_func_start func_ov20_02173160
 func_ov20_02173160: ; 0x02173160
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x14
 	ldr r3, _0217324c ; =0x0000ffff
 	ldr r2, _02173250 ; =0x040004c0
@@ -6729,10 +6729,10 @@ func_ov20_02173160: ; 0x02173160
 	mov r10, r0
 	str r1, [r2, #-0x1c]
 	ldrh r0, [r10, #0x64]
-	mov sb, #0
+	mov r9, #0
 	cmp r0, #0
 	addle sp, sp, #0x14
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r5, _02173258 ; =data_027e0d44
 	ldr r4, _0217325c ; =0x35200000
 	sub r8, r2, #0x18
@@ -6740,9 +6740,9 @@ func_ov20_02173160: ; 0x02173160
 	mov r11, #0x31
 	mov r6, #0x20
 _021731ac:
-	add r0, r10, sb, lsl #2
+	add r0, r10, r9, lsl #2
 	ldr r0, [r0, #0x88]
-	add ip, r10, sb, lsl #3
+	add ip, r10, r9, lsl #3
 	cmp r0, #0
 	movge r2, r11
 	ldr r0, [r5]
@@ -6775,11 +6775,11 @@ _021731ac:
 	str r3, [sp]
 	bl func_ov05_0210e344
 	ldrh r0, [r10, #0x64]
-	add sb, sb, #1
-	cmp sb, r0
+	add r9, r9, #1
+	cmp r9, r0
 	blt _021731ac
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov20_02173160
 _0217324c: .word 0x0000ffff
@@ -6791,7 +6791,7 @@ _0217325c: .word 0x35200000
 	.global func_ov20_02173260
 	arm_func_start func_ov20_02173260
 func_ov20_02173260: ; 0x02173260
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #0x118
 	mov r4, r0
 	str r1, [r4, #8]
@@ -6852,7 +6852,7 @@ _021732a8:
 	ldr r6, [sp, #4]
 	ldr r5, [sp, #8]
 	ldr r10, [sp]
-	ldr sb, [sp, #0x24]
+	ldr r9, [sp, #0x24]
 	ldr r8, [sp, #0x28]
 	ldr r7, [sp, #0x2c]
 	ldr lr, [sp, #0x30]
@@ -6863,8 +6863,8 @@ _021732a8:
 	str r10, [sp, #0x94]
 	ldr r10, [sp, #0x34]
 	str ip, [sp, #0xa0]
-	str sb, [sp, #0xb8]
-	ldr sb, [sp, #0x40]
+	str r9, [sp, #0xb8]
+	ldr r9, [sp, #0x40]
 	str r8, [sp, #0xbc]
 	ldr r8, [sp, #0x44]
 	str r7, [sp, #0xc0]
@@ -6877,7 +6877,7 @@ _021732a8:
 	str r5, [sp, #0xd0]
 	ldr r5, [sp, #0x58]
 	str r10, [sp, #0xc8]
-	str sb, [sp, #0xd4]
+	str r9, [sp, #0xd4]
 	str r2, [sp, #0x14]
 	str r1, [sp, #0x18]
 	str r0, [sp, #0x20]
@@ -6993,7 +6993,7 @@ _02173534:
 _0217354c:
 	mov r0, #1
 	add sp, sp, #0x118
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov20_02173260
 _02173558: .word data_027e0f64
@@ -12022,7 +12022,7 @@ _021774e4: .word data_ov20_021793bc
 	arm_func_start func_ov20_021774e8
 func_ov20_021774e8: ; 0x021774e8
 	stmdb sp!, {r0, r1, r2, r3}
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x24
 	ldr r0, _021775cc ; =data_027e0e60
 	ldrb r1, [sp, #0x4c]
@@ -12036,13 +12036,13 @@ func_ov20_021774e8: ; 0x021774e8
 	bl func_ov00_02083c7c
 	mov r8, #0
 	ldr r4, _021775cc ; =data_027e0e60
-	mov sb, r8
+	mov r9, r8
 	add r5, sp, #0xc
 	mov r7, r8
 	mov r11, #0x400
 	add r6, sp, #0
 _02177538:
-	mov r1, sb, lsl #0x10
+	mov r1, r9, lsl #0x10
 	mov r0, r6
 	mov r1, r1, asr #0x10
 	str r7, [sp]
@@ -12074,11 +12074,11 @@ _0217759c:
 _021775a8:
 	add r8, r8, #1
 	cmp r8, #4
-	add sb, sb, #0x4000
+	add r9, r9, #0x4000
 	blt _02177538
 	mov r0, r10
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	add sp, sp, #0x10
 	bx lr
 	.align 2, 0

--- a/asm/ov20.s
+++ b/asm/ov20.s
@@ -130,32 +130,32 @@ _0216d844: .word func_ov20_0216da18
 	.global func_ov20_0216d848
 	arm_func_start func_ov20_0216d848
 func_ov20_0216d848: ; 0x0216d848
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x44
 	ldr r1, _0216d9fc ; =data_027e0f74
-	mov sl, r0
+	mov r10, r0
 	ldr r0, [r1]
 	mov r1, #0x1d
 	bl func_ov00_02097760
 	cmp r0, #0
 	addne sp, sp, #0x44
 	movne r0, #0
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r1, _0216da00 ; =data_ov20_02178320
-	mov r0, sl
+	mov r0, r10
 	bl func_ov00_020ca8a4
-	add r0, sl, #0x100
+	add r0, r10, #0x100
 	ldrh r2, [r0, #0xb0]
 	mov r1, #4
 	bic r2, r2, #4
 	strh r2, [r0, #0xb0]
 	strh r1, [r0, #0x26]
-	strh r1, [sl, #0x7a]
+	strh r1, [r10, #0x7a]
 	mov r2, #0
-	str r2, [sl, #0x6c]
-	mov r0, sl
-	add r1, sl, #0x21c
-	strh r2, [sl, #0x9c]
+	str r2, [r10, #0x6c]
+	mov r0, r10
+	add r1, r10, #0x21c
+	strh r2, [r10, #0x9c]
 	bl func_ov00_020cb140
 	ldr r11, _0216da04 ; =0x46425331
 	ldr r5, _0216da08 ; =data_027e0fe8
@@ -173,11 +173,11 @@ _0216d8d0:
 	bl func_ov00_020c3348
 	str r7, [sp, #4]
 	str r7, [sp, #8]
-	ldr r0, [sl, #8]
+	ldr r0, [r10, #8]
 	mov r1, r11
 	str r0, [sp, #0x34]
-	ldr r0, [sl, #0xc]
-	add r2, sl, #0x48
+	ldr r0, [r10, #0xc]
+	add r2, r10, #0x48
 	str r0, [sp, #0x38]
 	str r6, [sp]
 	ldr r0, [r5]
@@ -186,7 +186,7 @@ _0216d8d0:
 	ldr r0, [r4]
 	mov r1, r6
 	bl _ZN12ActorManager8GetActorEP8ActorRef
-	add r1, sl, sb, lsl #2
+	add r1, r10, sb, lsl #2
 	str r0, [r1, #0xa40]
 	mov r1, sb
 	bl func_ov20_021702b4
@@ -196,7 +196,7 @@ _0216d8d0:
 	cmp sb, #3
 	blt _0216d8d0
 	mov r7, #0
-	add r0, sl, #0x24c
+	add r0, r10, #0x24c
 	ldr r6, _0216da10 ; =data_02050f54
 	ldr r4, _0216da14 ; =0x55555556
 	mov r8, r7
@@ -221,7 +221,7 @@ _0216d968:
 	str r2, [sp, #0x14]
 	add r1, sp, #0xc
 	mov r3, sb
-	add r2, sl, #0x48
+	add r2, r10, #0x48
 	str r5, [sp, #0x10]
 	bl func_01ff9e64
 	add r0, r7, #1
@@ -232,15 +232,15 @@ _0216d968:
 	add r8, r0, #0xff00
 	add sb, sb, #0xc
 	blt _0216d968
-	add r2, sl, #0xa00
+	add r2, r10, #0xa00
 	mov r1, #0
 	strh r1, [r2, #0x98]
-	mov r0, sl
+	mov r0, r10
 	strh r1, [r2, #0x9c]
 	bl func_ov20_0216dae8
 	mov r0, #1
 	add sp, sp, #0x44
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov20_0216d848
 _0216d9fc: .word data_027e0f74
@@ -334,7 +334,7 @@ _0216dae0:
 	.global func_ov20_0216dae8
 	arm_func_start func_ov20_0216dae8
 func_ov20_0216dae8: ; 0x0216dae8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x124
 	mov r7, r0
 	mov r4, #0
@@ -382,7 +382,7 @@ _0216db78:
 	str r4, [r7, #0x12c]
 	strb r4, [r7, #0x11a]
 	str r0, [r7, #0x20c]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0216dba4:
 	mov r1, #1
 	ldr r0, _0216e520 ; =data_027e0fc8
@@ -415,7 +415,7 @@ _0216dba4:
 	mov r1, #0x1000
 	str r1, [r0, #0x10]
 	add sp, sp, #0x124
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0216dc24:
 	add r0, r7, #0x21c
 	mov r1, #5
@@ -424,7 +424,7 @@ _0216dc24:
 	mov r1, #0x1000
 	str r1, [r0, #0x10]
 	add sp, sp, #0x124
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0216dc44:
 	add r0, sp, #0xb0
 	mov r1, #3
@@ -460,11 +460,11 @@ _0216dc60:
 	ldr r0, [sp, #0xac]
 	add r1, sb, r1
 	str sb, [sp, #0x9c]
-	smull sl, sb, r0, r3
-	adds sl, sl, #0x800
+	smull r10, sb, r0, r3
+	adds r10, r10, #0x800
 	rsb lr, r3, #0
 	adc r3, sb, #0
-	mov sb, sl, lsr #0xc
+	mov sb, r10, lsr #0xc
 	orr sb, sb, r3, lsl #20
 	add r3, r2, sb
 	smull sb, r2, r0, r8
@@ -478,7 +478,7 @@ _0216dc60:
 	str r1, [sp, #0x9c]
 	add r2, r2, sb
 	smull r8, r1, r0, r8
-	smull sl, sb, r0, lr
+	smull r10, sb, r0, lr
 	mov r0, #0x800
 	adds r0, r8, r0
 	adc r1, r1, #0
@@ -487,7 +487,7 @@ _0216dc60:
 	add r0, r3, r0
 	str r0, [sp, #0x98]
 	mov r0, #0x800
-	adds r1, sl, r0
+	adds r1, r10, r0
 	mov r8, #0
 	mov r0, r8
 	adc r0, sb, r0
@@ -511,15 +511,15 @@ _0216dc60:
 	strb r1, [r7, #0x11a]
 	add sp, sp, #0x124
 	str r0, [r7, #0x20c]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0216dd98:
 	bl func_ov20_0216f7d0
 	add sp, sp, #0x124
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0216dda4:
 	bl func_ov20_0216f898
 	add sp, sp, #0x124
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0216ddb0:
 	str r4, [r7, #0xa78]
 	str r4, [r7, #0xa7c]
@@ -566,7 +566,7 @@ _0216de34:
 	mov r0, r7
 	bl func_ov20_0216fa20
 	add sp, sp, #0x124
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0216de60:
 	add r0, sp, #0x8c
 	mov r1, #3
@@ -581,7 +581,7 @@ _0216de60:
 _0216de88:
 	add r0, sp, #0x8c
 	ldr r0, [r0, r5, lsl #2]
-	add sl, sp, #0x80
+	add r10, sp, #0x80
 	rsb r2, r0, r0, lsl #16
 	ldr r0, _0216e538 ; =0x55555556
 	add r3, r7, r5, lsl #2
@@ -601,13 +601,13 @@ _0216de88:
 	ldr r0, _0216e53c ; =data_ov20_02177878
 	rsb r8, r11, #0
 	ldmia r0, {r0, r1, r2}
-	stmia sl, {r0, r1, r2}
+	stmia r10, {r0, r1, r2}
 	ldr r2, [r7, #0xa78]
 	ldr r0, [sp, #0x84]
 	str r2, [sp, #0x74]
 	ldr r1, [r7, #0xa7c]
 	ldr ip, [sp, #0x88]
-	add sl, r1, r0
+	add r10, r1, r0
 	smull r11, r0, ip, r11
 	str r1, [sp, #0x78]
 	adds r1, r11, #0x800
@@ -625,16 +625,16 @@ _0216de88:
 	ldr r11, [r7, #0xa80]
 	ldr r0, [sp, #0x80]
 	add r1, r11, r1
-	str sl, [sp, #0x78]
-	smull r11, sl, r0, sb
+	str r10, [sp, #0x78]
+	smull r11, r10, r0, sb
 	smull sb, r8, r0, r8
 	mov r0, #0x800
 	adds r11, r11, r0
 	mov r0, #0
-	adc r0, sl, r0
-	mov sl, r11, lsr #0xc
-	orr sl, sl, r0, lsl #20
-	add r0, r2, sl
+	adc r0, r10, r0
+	mov r10, r11, lsr #0xc
+	orr r10, r10, r0, lsl #20
+	add r0, r2, r10
 	str r0, [sp, #0x74]
 	mov r0, #0x800
 	adds r2, sb, r0
@@ -663,7 +663,7 @@ _0216de88:
 	str r1, [r7, #0x12c]
 	bl func_ov20_0216fc48
 	add sp, sp, #0x124
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0216dfdc:
 	add r0, r7, r4, lsl #2
 	ldr r0, [r0, #0xa40]
@@ -702,25 +702,25 @@ _0216dfdc:
 	cmp r0, #2
 	beq _0216e09c
 	add sp, sp, #0x124
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0216e074:
 	add r0, r7, #0xa00
 	mov r1, #0x190
 	strh r1, [r0, #0x9c]
 	add sp, sp, #0x124
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0216e088:
 	add r0, r7, #0xa00
 	mov r1, #0x12c
 	strh r1, [r0, #0x9c]
 	add sp, sp, #0x124
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0216e09c:
 	add r0, r7, #0xa00
 	mov r1, #0xc8
 	strh r1, [r0, #0x9c]
 	add sp, sp, #0x124
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0216e0b0:
 	mov r1, r4
 	add r0, r7, #0x21c
@@ -733,7 +733,7 @@ _0216e0b0:
 	mov r0, #2
 	add sp, sp, #0x124
 	str r0, [r7, #0x12c]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0216e0e0:
 	str r4, [r7, #0x12c]
 	add r0, r7, #0x21c
@@ -750,7 +750,7 @@ _0216e0e0:
 	str r4, [r7, #0x20c]
 	bl func_ov00_020ceacc
 	add sp, sp, #0x124
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0216e120:
 	ldr r0, _0216e544 ; =data_027e0f94
 	add r3, sp, #0x68
@@ -767,14 +767,14 @@ _0216e120:
 	str r0, [sp, #0x10]
 	ldr r0, _0216e548 ; =data_027e0764
 	add r3, r7, #0x28c
-	ldr sl, [r0, #0x10]
+	ldr r10, [r0, #0x10]
 	ldr sb, [r0, #0x14]
 	ldr r8, [r0, #8]
 	ldr r4, [r0]
 	ldr r6, [r0, #0xc]
 	umull ip, r11, r8, r4
 	ldr r0, [r0, #4]
-	adds ip, sl, ip
+	adds ip, r10, ip
 	mla r11, r8, r0, r11
 	mla r11, r6, r4, r11
 	ldr r0, _0216e548 ; =data_027e0764
@@ -817,7 +817,7 @@ _0216e120:
 	umull lr, r0, r8, ip
 	mla r0, r8, r11, r0
 	mla r0, r6, ip, r0
-	adds r8, sl, lr
+	adds r8, r10, lr
 	adc r6, sb, r0
 	ldr r0, _0216e548 ; =data_027e0764
 	str r4, [sp, #0x64]
@@ -845,7 +845,7 @@ _0216e120:
 	movne r0, #0
 	cmp r0, #0
 	addeq sp, sp, #0x124
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, _0216e550 ; =data_027e0e60
 	add r2, sp, #0x44
 	ldr r0, [r0]
@@ -868,7 +868,7 @@ _0216e120:
 	add sp, sp, #0x124
 	cmp r0, r1
 	strgt r1, [r7, #0xa94]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0216e2f4:
 	add r0, r7, #0x21c
 	mov r1, #1
@@ -881,7 +881,7 @@ _0216e2f4:
 	mov r0, #2
 	add sp, sp, #0x124
 	str r0, [r7, #0x12c]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0216e324:
 	add r0, r7, #0x21c
 	mov r1, #2
@@ -894,7 +894,7 @@ _0216e324:
 	mov r0, #2
 	add sp, sp, #0x124
 	str r0, [r7, #0x12c]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0216e354:
 	add r0, r7, #0x21c
 	mov r1, #6
@@ -909,7 +909,7 @@ _0216e354:
 	mov r0, #2
 	add sp, sp, #0x124
 	str r0, [r7, #0x12c]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0216e38c:
 	mov r0, #2
 	str r0, [r7, #0x12c]
@@ -920,7 +920,7 @@ _0216e38c:
 	mov r1, #0x1000
 	str r1, [r0, #0x10]
 	add sp, sp, #0x124
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0216e3b4:
 	add r0, r7, #0x21c
 	mov r1, #3
@@ -931,7 +931,7 @@ _0216e3b4:
 	str r2, [r1, #0x10]
 	bl func_ov20_0216fc48
 	add sp, sp, #0x124
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0216e3dc:
 	ldr r0, _0216e554 ; =data_027e0f90
 	mov r1, r4
@@ -992,7 +992,7 @@ _0216e3dc:
 	add r2, sp, #0x14
 	bl func_ov00_020888e8
 	add sp, sp, #0x124
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0216e4cc:
 	add r0, r7, #0x48
 	add r4, sp, #0x2c
@@ -1014,7 +1014,7 @@ _0216e4cc:
 	bl func_ov00_0207c31c
 _0216e514:
 	add sp, sp, #0x124
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov20_0216dae8
 _0216e51c: .word 0x0000ffff
@@ -1087,7 +1087,7 @@ _0216e600: .word data_ov00_020eec68
 	.global func_ov20_0216e604
 	arm_func_start func_ov20_0216e604
 func_ov20_0216e604: ; 0x0216e604
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x1e4
 	mov r4, r0
 	ldr r0, [r4, #0x130]
@@ -1265,35 +1265,35 @@ _0216e858:
 	str r1, [sp, #0x138]
 	mov r0, #0x5a
 	bl func_ov00_02087d84
-	ldr sl, [r0, #0x38]
+	ldr r10, [r0, #0x38]
 	ldrb r1, [r0, #0x60]
-	str sl, [sp, #0x40]
-	ldr sl, [r0, #0x3c]
+	str r10, [sp, #0x40]
+	ldr r10, [r0, #0x3c]
 	str r1, [sp, #0x2c]
-	str sl, [sp, #8]
-	ldr sl, [r0, #0x40]
+	str r10, [sp, #8]
+	ldr r10, [r0, #0x40]
 	ldrb r1, [r0, #0x61]
-	str sl, [sp, #0xc]
-	ldr sl, [r0, #0x44]
+	str r10, [sp, #0xc]
+	ldr r10, [r0, #0x44]
 	str r1, [sp, #0x30]
-	str sl, [sp, #0x10]
-	ldr sl, [r0, #0x48]
+	str r10, [sp, #0x10]
+	ldr r10, [r0, #0x48]
 	ldrb r1, [r0, #0x62]
-	str sl, [sp, #0x14]
-	ldr sl, [r0, #0x4c]
+	str r10, [sp, #0x14]
+	ldr r10, [r0, #0x4c]
 	str r1, [sp, #0x34]
 	ldrb r1, [r0, #0x63]
-	str sl, [sp, #0x18]
-	ldr sl, [r0, #0x50]
+	str r10, [sp, #0x18]
+	ldr r10, [r0, #0x50]
 	str r1, [sp, #0x38]
-	str sl, [sp, #0x1c]
-	ldr sl, [r0, #0x54]
+	str r10, [sp, #0x1c]
+	ldr r10, [r0, #0x54]
 	ldrb r1, [r0, #0x64]
-	str sl, [sp, #0x20]
-	ldr sl, [r0, #0x58]
+	str r10, [sp, #0x20]
+	ldr r10, [r0, #0x58]
 	str r1, [sp, #0x3c]
-	str sl, [sp, #0x24]
-	ldr sl, [r0, #0x5c]
+	str r10, [sp, #0x24]
+	ldr r10, [r0, #0x5c]
 	ldr sb, [r0, #4]
 	ldr r8, [r0, #8]
 	ldr r7, [r0, #0xc]
@@ -1306,7 +1306,7 @@ _0216e858:
 	ldr r1, [r0, #0x30]
 	ldr r11, [r0, #0x34]
 	ldr r0, [r0]
-	str sl, [sp, #0x28]
+	str r10, [sp, #0x28]
 	str r0, [sp, #0x160]
 	ldr r0, _0216f470 ; =0x00001388
 	str r3, [sp, #0x188]
@@ -1340,7 +1340,7 @@ _0216e858:
 	str r0, [sp, #0x1b8]
 	mov r0, #0x18000
 	str r0, [sp, #0x178]
-	mov r0, sl
+	mov r0, r10
 	str r0, [sp, #0x1bc]
 	ldr r0, [sp, #0x2c]
 	str r11, [sp, #0x194]
@@ -2069,7 +2069,7 @@ _0216f42c:
 _0216f460:
 	mov r0, #1
 	add sp, sp, #0x1e4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov20_0216e604
 _0216f46c: .word data_027e0fc8
@@ -2577,7 +2577,7 @@ _0216fa68: .word 0x00001003
 	.global func_ov20_0216fa6c
 	arm_func_start func_ov20_0216fa6c
 func_ov20_0216fa6c: ; 0x0216fa6c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x3c
 	mov r4, r0
 	add r0, sp, #0x10
@@ -2599,33 +2599,33 @@ func_ov20_0216fa6c: ; 0x0216fa6c
 	ldr r5, [r0, #8]
 	ldr sb, [r0]
 	ldr r8, [r0, #4]
-	umull ip, sl, r5, sb
-	mla sl, r5, r8, sl
+	umull ip, r10, r5, sb
+	mla r10, r5, r8, r10
 	ldr r4, [r0, #0xc]
 	ldr r7, [r0, #0x10]
-	mla sl, r4, sb, sl
+	mla r10, r4, sb, r10
 	ldr r6, [r0, #0x14]
 	adds sb, r7, ip
-	adc r8, r6, sl
-	ldr sl, _0216fb88 ; =data_027e0764
+	adc r8, r6, r10
+	ldr r10, _0216fb88 ; =data_027e0764
 	ldr r11, _0216fb8c ; =0x00004001
-	str sb, [sl]
-	str r8, [sl, #4]
-	umull sl, ip, r8, r11
-	mov sl, #0
-	mla ip, r8, sl, ip
-	mla ip, sl, r11, ip
+	str sb, [r10]
+	str r8, [r10, #4]
+	umull r10, ip, r8, r11
+	mov r10, #0
+	mla ip, r8, r10, ip
+	mla ip, r10, r11, ip
 	ldr lr, [sp, #4]
-	sub sl, ip, #0x2000
-	add sl, lr, sl
-	str sl, [sp, #4]
-	umull ip, sl, r5, sb
-	mla sl, r5, r8, sl
-	mla sl, r4, sb, sl
+	sub r10, ip, #0x2000
+	add r10, lr, r10
+	str r10, [sp, #4]
+	umull ip, r10, r5, sb
+	mla r10, r5, r8, r10
+	mla r10, r4, sb, r10
 	adds r5, r7, ip
 	mov r2, r3
 	ldr r4, _0216fb88 ; =data_027e0764
-	adc r6, r6, sl
+	adc r6, r6, r10
 	stmia r4, {r5, r6}
 	umull r4, r5, r6, r11
 	mov r4, #0
@@ -2646,7 +2646,7 @@ func_ov20_0216fa6c: ; 0x0216fa6c
 	movge r0, #1
 	movlt r0, #0
 	add sp, sp, #0x3c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov20_0216fa6c
 _0216fb84: .word data_027e0f94
@@ -6124,7 +6124,7 @@ _02172958: .word data_027e0764
 	.global func_ov20_0217295c
 	arm_func_start func_ov20_0217295c
 func_ov20_0217295c: ; 0x0217295c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x3c
 	mov r4, r0
 	add r0, sp, #0x10
@@ -6147,32 +6147,32 @@ func_ov20_0217295c: ; 0x0217295c
 	ldr r5, [r0, #8]
 	ldr sb, [r0]
 	ldr r8, [r0, #4]
-	umull ip, sl, r5, sb
-	mla sl, r5, r8, sl
+	umull ip, r10, r5, sb
+	mla r10, r5, r8, r10
 	ldr r4, [r0, #0xc]
 	ldr r7, [r0, #0x10]
-	mla sl, r4, sb, sl
+	mla r10, r4, sb, r10
 	ldr r6, [r0, #0x14]
 	adds sb, r7, ip
-	adc r8, r6, sl
-	ldr sl, _02172a74 ; =data_027e0764
+	adc r8, r6, r10
+	ldr r10, _02172a74 ; =data_027e0764
 	ldr r11, _02172a78 ; =0x00006001
-	str sb, [sl]
-	str r8, [sl, #4]
-	umull sl, ip, r8, r11
-	mov sl, #0
-	mla ip, r8, sl, ip
-	mla ip, sl, r11, ip
+	str sb, [r10]
+	str r8, [r10, #4]
+	umull r10, ip, r8, r11
+	mov r10, #0
+	mla ip, r8, r10, ip
+	mla ip, r10, r11, ip
 	ldr lr, [sp, #4]
-	sub sl, ip, #0x3000
-	add sl, lr, sl
-	str sl, [sp, #4]
-	umull ip, sl, r5, sb
-	mla sl, r5, r8, sl
-	mla sl, r4, sb, sl
+	sub r10, ip, #0x3000
+	add r10, lr, r10
+	str r10, [sp, #4]
+	umull ip, r10, r5, sb
+	mla r10, r5, r8, r10
+	mla r10, r4, sb, r10
 	adds r5, r7, ip
 	ldr r4, _02172a74 ; =data_027e0764
-	adc r6, r6, sl
+	adc r6, r6, r10
 	stmia r4, {r5, r6}
 	umull r4, r5, r6, r11
 	mov r4, #0
@@ -6193,7 +6193,7 @@ func_ov20_0217295c: ; 0x0217295c
 	movge r0, #1
 	movlt r0, #0
 	add sp, sp, #0x3c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov20_0217295c
 _02172a74: .word data_027e0764
@@ -6720,19 +6720,19 @@ _0217315c: .word data_027e0d44
 	.global func_ov20_02173160
 	arm_func_start func_ov20_02173160
 func_ov20_02173160: ; 0x02173160
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x14
 	ldr r3, _0217324c ; =0x0000ffff
 	ldr r2, _02173250 ; =0x040004c0
 	ldr r1, _02173254 ; =0x001f0080
 	str r3, [r2]
-	mov sl, r0
+	mov r10, r0
 	str r1, [r2, #-0x1c]
-	ldrh r0, [sl, #0x64]
+	ldrh r0, [r10, #0x64]
 	mov sb, #0
 	cmp r0, #0
 	addle sp, sp, #0x14
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r5, _02173258 ; =data_027e0d44
 	ldr r4, _0217325c ; =0x35200000
 	sub r8, r2, #0x18
@@ -6740,9 +6740,9 @@ func_ov20_02173160: ; 0x02173160
 	mov r11, #0x31
 	mov r6, #0x20
 _021731ac:
-	add r0, sl, sb, lsl #2
+	add r0, r10, sb, lsl #2
 	ldr r0, [r0, #0x88]
-	add ip, sl, sb, lsl #3
+	add ip, r10, sb, lsl #3
 	cmp r0, #0
 	movge r2, r11
 	ldr r0, [r5]
@@ -6774,12 +6774,12 @@ _021731ac:
 	mov r3, #0
 	str r3, [sp]
 	bl func_ov05_0210e344
-	ldrh r0, [sl, #0x64]
+	ldrh r0, [r10, #0x64]
 	add sb, sb, #1
 	cmp sb, r0
 	blt _021731ac
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov20_02173160
 _0217324c: .word 0x0000ffff
@@ -6791,7 +6791,7 @@ _0217325c: .word 0x35200000
 	.global func_ov20_02173260
 	arm_func_start func_ov20_02173260
 func_ov20_02173260: ; 0x02173260
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #0x118
 	mov r4, r0
 	str r1, [r4, #8]
@@ -6851,7 +6851,7 @@ _021732a8:
 	add r0, r1, #0x800
 	ldr r6, [sp, #4]
 	ldr r5, [sp, #8]
-	ldr sl, [sp]
+	ldr r10, [sp]
 	ldr sb, [sp, #0x24]
 	ldr r8, [sp, #0x28]
 	ldr r7, [sp, #0x2c]
@@ -6860,8 +6860,8 @@ _021732a8:
 	str r5, [sp, #0x9c]
 	ldr r6, [sp, #0x38]
 	ldr r5, [sp, #0x3c]
-	str sl, [sp, #0x94]
-	ldr sl, [sp, #0x34]
+	str r10, [sp, #0x94]
+	ldr r10, [sp, #0x34]
 	str ip, [sp, #0xa0]
 	str sb, [sp, #0xb8]
 	ldr sb, [sp, #0x40]
@@ -6876,7 +6876,7 @@ _021732a8:
 	ldr r6, [sp, #0x54]
 	str r5, [sp, #0xd0]
 	ldr r5, [sp, #0x58]
-	str sl, [sp, #0xc8]
+	str r10, [sp, #0xc8]
 	str sb, [sp, #0xd4]
 	str r2, [sp, #0x14]
 	str r1, [sp, #0x18]
@@ -6993,7 +6993,7 @@ _02173534:
 _0217354c:
 	mov r0, #1
 	add sp, sp, #0x118
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov20_02173260
 _02173558: .word data_027e0f64
@@ -12022,7 +12022,7 @@ _021774e4: .word data_ov20_021793bc
 	arm_func_start func_ov20_021774e8
 func_ov20_021774e8: ; 0x021774e8
 	stmdb sp!, {r0, r1, r2, r3}
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x24
 	ldr r0, _021775cc ; =data_027e0e60
 	ldrb r1, [sp, #0x4c]
@@ -12065,20 +12065,20 @@ _02177538:
 	mov r1, r5
 	bne _0217759c
 	bl func_ov00_02083f44
-	mov sl, r0
+	mov r10, r0
 	b _021775a8
 _0217759c:
 	bl func_ov00_02083f44
-	cmp sl, r0
-	movge sl, r0
+	cmp r10, r0
+	movge r10, r0
 _021775a8:
 	add r8, r8, #1
 	cmp r8, #4
 	add sb, sb, #0x4000
 	blt _02177538
-	mov r0, sl
+	mov r0, r10
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	add sp, sp, #0x10
 	bx lr
 	.align 2, 0

--- a/asm/ov21.s
+++ b/asm/ov21.s
@@ -2313,14 +2313,14 @@ func_ov21_0216f234: ; 0x0216f234
 	.global func_ov21_0216f25c
 	arm_func_start func_ov21_0216f25c
 func_ov21_0216f25c: ; 0x0216f25c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #0x50
 	mov r4, r0
 	bl func_ov21_02170334
 	cmp r0, #0
 	addeq sp, sp, #0x50
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	mov r1, #0
 	str r1, [r4, #0x16c]
 	ldr r2, [r4, #0x48]
@@ -2364,12 +2364,12 @@ func_ov21_0216f25c: ; 0x0216f25c
 	orr r1, r1, #0xd
 	strh r1, [r4, #0x9c]
 	ldr ip, [r4, #0x4c]
-	ldr sb, [r4, #0x50]
+	ldr r9, [r4, #0x50]
 	ldr r8, [r4, #0x48]
-	sub r10, sb, #0x1000
+	sub r10, r9, #0x1000
 	sub r1, r8, #0x1000
 	sub r2, ip, #0x800
-	add sb, sb, #0x1000
+	add r9, r9, #0x1000
 	add r8, r8, #0x1000
 	str r10, [sp, #0x4c]
 	str r1, [sp, #0x44]
@@ -2378,7 +2378,7 @@ func_ov21_0216f25c: ; 0x0216f25c
 	stmia r7, {r0, r1, r2}
 	str r8, [sp, #0x38]
 	str ip, [sp, #0x3c]
-	str sb, [sp, #0x40]
+	str r9, [sp, #0x40]
 	ldmia r6, {r0, r1, r2}
 	stmia r5, {r0, r1, r2}
 	str lr, [sp]
@@ -2391,7 +2391,7 @@ func_ov21_0216f25c: ; 0x0216f25c
 	mov r0, r4
 	bl func_ov14_02137970
 	add sp, sp, #0x50
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	arm_func_end func_ov21_0216f25c
 
 	.global func_ov21_0216f398
@@ -2724,7 +2724,7 @@ _0216f7c4: .word 0x00000477
 	.global func_ov21_0216f7c8
 	arm_func_start func_ov21_0216f7c8
 func_ov21_0216f7c8: ; 0x0216f7c8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x118
 	mov r10, r0
 	ldr r0, [r10, #0x224]
@@ -2733,14 +2733,14 @@ func_ov21_0216f7c8: ; 0x0216f7c8
 	cmpeq r0, #0
 	addeq sp, sp, #0x118
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	mov r0, r10
 	mov r1, #0
 	bl func_01fffd04
 	cmp r0, #0
 	addeq sp, sp, #0x118
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r0, r10, #0x48
 	add r1, r10, #0x54
 	add r2, r10, #0x60
@@ -2749,7 +2749,7 @@ func_ov21_0216f7c8: ; 0x0216f7c8
 	cmp r0, #0x1e
 	addlt sp, sp, #0x118
 	movlt r0, #0
-	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmltia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, _0216fb80 ; =0x0000ffff
 	mov r5, #0
 	add r4, sp, #0x48
@@ -2804,7 +2804,7 @@ func_ov21_0216f7c8: ; 0x0216f7c8
 	cmp r0, #0
 	addne sp, sp, #0x118
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, _0216fb88 ; =data_ov21_02171bb4
 	ldr r0, [r0, #0x20]
 	tst r0, #1
@@ -2873,7 +2873,7 @@ _0216f9c0:
 	ldr r1, [r10, #0x48]
 	add r0, r0, #0x9a
 	add r0, r0, #0x900
-	ldr sb, _0216fb90 ; =data_ov21_02171750
+	ldr r9, _0216fb90 ; =data_ov21_02171750
 	ldr r4, _0216fb84 ; =data_027e0e60
 	str r1, [sp, #0x3c]
 	str r0, [sp, #0x40]
@@ -2890,7 +2890,7 @@ _0216fa3c:
 	str r0, [sp, #0x34]
 	str r1, [sp, #0x38]
 	mov r0, r7
-	mov r1, sb
+	mov r1, r9
 	mov r2, r7
 	bl func_01ff9bc4
 	ldr r1, [r4]
@@ -2916,11 +2916,11 @@ _0216fa3c:
 	cmp r0, #0
 	addeq sp, sp, #0x118
 	moveq r0, #1
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0216fac4:
 	add r8, r8, #1
 	cmp r8, #4
-	add sb, sb, #0xc
+	add r9, r9, #0xc
 	blt _0216fa3c
 	ldr r0, [r10, #0x224]
 	ldr r1, [r10, #0x228]
@@ -2967,7 +2967,7 @@ _0216fb60:
 _0216fb74:
 	mov r0, #0
 	add sp, sp, #0x118
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov21_0216f7c8
 _0216fb80: .word 0x0000ffff
@@ -3037,7 +3037,7 @@ _0216fc58: .word data_027e0fc8
 	.global func_ov21_0216fc5c
 	arm_func_start func_ov21_0216fc5c
 func_ov21_0216fc5c: ; 0x0216fc5c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x44
 	mov r4, r2
 	ldr r2, [r4]
@@ -3051,7 +3051,7 @@ func_ov21_0216fc5c: ; 0x0216fc5c
 	mov r2, r3
 	bl func_ov21_02170050
 	add sp, sp, #0x44
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0216fc98:
 	ldrb r0, [sp, #0x68]
 	cmp r0, #0
@@ -3062,7 +3062,7 @@ _0216fc98:
 	mov r2, r4
 	bl func_ov21_021701b0
 	add sp, sp, #0x44
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0216fcc0:
 	ldr r0, _0216fffc ; =data_ov21_02171bb4
 	ldr r0, [r0, #0x54]
@@ -3194,7 +3194,7 @@ _0216fe2c:
 	ldr r2, [sp, #0x28]
 	add sp, sp, #0x44
 	str r2, [r1, #4]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0216fec4:
 	rsb r0, r0, #0
 	str r0, [sp, #8]
@@ -3226,7 +3226,7 @@ _0216ff0c:
 	ldr r0, [sp]
 	ldr r1, [r0, #4]
 	ldr r3, [r0]
-	add sb, r2, r1
+	add r9, r2, r1
 	add r0, r6, r3
 	str r0, [sp, #0x10]
 	sub r8, r0, #1
@@ -3234,7 +3234,7 @@ _0216ff44:
 	ldr r6, [sp, #0x20]
 _0216ff48:
 	str r8, [sp, #0x24]
-	add r7, r6, sb
+	add r7, r6, r9
 	str r7, [sp, #0x28]
 	ldr r0, [r4]
 	bl func_ov00_020cf05c
@@ -3251,9 +3251,9 @@ _0216ff48:
 	ldr r1, [sp, #0x10]
 	ldr r0, [sp, #4]
 	add sp, sp, #0x44
-	stmia r0, {r1, sb}
+	stmia r0, {r1, r9}
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0216ff9c:
 	add r6, r6, #1
 	cmp r6, #1
@@ -3280,7 +3280,7 @@ _0216ffdc:
 	ble _0216fe2c
 	mov r0, #0
 	add sp, sp, #0x44
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov21_0216fc5c
 _0216fffc: .word data_ov21_02171bb4
@@ -3313,7 +3313,7 @@ func_ov21_0217004c: ; 0x0217004c
 	.global func_ov21_02170050
 	arm_func_start func_ov21_02170050
 func_ov21_02170050: ; 0x02170050
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x28
 	mov r10, r1
 	ldr r1, [r10]
@@ -3350,11 +3350,11 @@ _021700cc:
 	mov r0, r5
 	cmp r0, r6
 	bgt _02170180
-	rsb sb, r4, #0
+	rsb r9, r4, #0
 _021700e0:
 	cmp r4, #0
 	movge r0, r4
-	movlt r0, sb
+	movlt r0, r9
 	cmp r0, r6
 	bge _02170108
 	cmp r5, #0
@@ -3389,7 +3389,7 @@ _02170108:
 	ldr r2, [sp, #0xc]
 	add sp, sp, #0x28
 	str r2, [r1, #4]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02170174:
 	add r5, r5, #1
 	cmp r5, r6
@@ -3404,7 +3404,7 @@ _0217018c:
 	bgt _021700b8
 	mov r0, #0
 	add sp, sp, #0x28
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov21_02170050
 _021701a4: .word data_027e0d3c
@@ -3414,13 +3414,13 @@ _021701ac: .word data_027e103c
 	.global func_ov21_021701b0
 	arm_func_start func_ov21_021701b0
 func_ov21_021701b0: ; 0x021701b0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x28
-	mov sb, r1
-	ldr r2, [sb]
+	mov r9, r1
+	ldr r2, [r9]
 	ldr r1, _02170328 ; =data_027e0d3c
 	str r2, [sp, #8]
-	ldr r4, [sb, #4]
+	ldr r4, [r9, #4]
 	mov r10, r0
 	ldr r0, [r1]
 	add r1, sp, #8
@@ -3464,11 +3464,11 @@ _02170240:
 	cmp r0, r6
 	blt _021702f8
 _02170268:
-	ldr r0, [sb]
+	ldr r0, [r9]
 	mov r2, #0
 	add r8, r4, r0
 	str r8, [sp, #8]
-	ldr r0, [sb, #4]
+	ldr r0, [r9, #4]
 	add r1, r5, r0
 	str r1, [sp, #0xc]
 	ldr r0, [r10, #0x21c]
@@ -3499,7 +3499,7 @@ _02170268:
 	ldr r2, [sp, #0xc]
 	add sp, sp, #0x28
 	str r2, [r1, #4]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _021702f8:
 	add r5, r5, #1
 	cmp r5, r6
@@ -3514,7 +3514,7 @@ _02170310:
 	bgt _02170218
 	mov r0, #0
 	add sp, sp, #0x28
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov21_021701b0
 _02170328: .word data_027e0d3c

--- a/asm/ov21.s
+++ b/asm/ov21.s
@@ -2724,7 +2724,7 @@ _0216f7c4: .word 0x00000477
 	.global func_ov21_0216f7c8
 	arm_func_start func_ov21_0216f7c8
 func_ov21_0216f7c8: ; 0x0216f7c8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x118
 	mov sl, r0
 	ldr r0, [sl, #0x224]
@@ -2733,14 +2733,14 @@ func_ov21_0216f7c8: ; 0x0216f7c8
 	cmpeq r0, #0
 	addeq sp, sp, #0x118
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	mov r0, sl
 	mov r1, #0
 	bl func_01fffd04
 	cmp r0, #0
 	addeq sp, sp, #0x118
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r0, sl, #0x48
 	add r1, sl, #0x54
 	add r2, sl, #0x60
@@ -2749,7 +2749,7 @@ func_ov21_0216f7c8: ; 0x0216f7c8
 	cmp r0, #0x1e
 	addlt sp, sp, #0x118
 	movlt r0, #0
-	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, _0216fb80 ; =0x0000ffff
 	mov r5, #0
 	add r4, sp, #0x48
@@ -2804,7 +2804,7 @@ func_ov21_0216f7c8: ; 0x0216f7c8
 	cmp r0, #0
 	addne sp, sp, #0x118
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, _0216fb88 ; =data_ov21_02171bb4
 	ldr r0, [r0, #0x20]
 	tst r0, #1
@@ -2880,7 +2880,7 @@ _0216f9c0:
 	str r2, [sp, #0x44]
 	mov r6, #0x800
 	mov r5, #0xd
-	mov fp, r8
+	mov r11, r8
 	add r7, sp, #0x30
 _0216fa3c:
 	ldr r1, [sp, #0x3c]
@@ -2907,8 +2907,8 @@ _0216fa3c:
 	add r1, sp, #0x58
 	stmia sp, {r0, r6}
 	str r5, [sp, #8]
-	str fp, [sp, #0xc]
-	str fp, [sp, #0x10]
+	str r11, [sp, #0xc]
+	str r11, [sp, #0x10]
 	ldr r0, [r4]
 	mov r2, r7
 	add r3, sp, #0x3c
@@ -2916,7 +2916,7 @@ _0216fa3c:
 	cmp r0, #0
 	addeq sp, sp, #0x118
 	moveq r0, #1
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0216fac4:
 	add r8, r8, #1
 	cmp r8, #4
@@ -2967,7 +2967,7 @@ _0216fb60:
 _0216fb74:
 	mov r0, #0
 	add sp, sp, #0x118
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov21_0216f7c8
 _0216fb80: .word 0x0000ffff
@@ -3037,7 +3037,7 @@ _0216fc58: .word data_027e0fc8
 	.global func_ov21_0216fc5c
 	arm_func_start func_ov21_0216fc5c
 func_ov21_0216fc5c: ; 0x0216fc5c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x44
 	mov r4, r2
 	ldr r2, [r4]
@@ -3051,7 +3051,7 @@ func_ov21_0216fc5c: ; 0x0216fc5c
 	mov r2, r3
 	bl func_ov21_02170050
 	add sp, sp, #0x44
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0216fc98:
 	ldrb r0, [sp, #0x68]
 	cmp r0, #0
@@ -3062,7 +3062,7 @@ _0216fc98:
 	mov r2, r4
 	bl func_ov21_021701b0
 	add sp, sp, #0x44
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0216fcc0:
 	ldr r0, _0216fffc ; =data_ov21_02171bb4
 	ldr r0, [r0, #0x54]
@@ -3194,7 +3194,7 @@ _0216fe2c:
 	ldr r2, [sp, #0x28]
 	add sp, sp, #0x44
 	str r2, [r1, #4]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0216fec4:
 	rsb r0, r0, #0
 	str r0, [sp, #8]
@@ -3217,7 +3217,7 @@ _0216fee4:
 	subge r2, r2, #8
 _0216ff0c:
 	ldr r0, _02170004 ; =data_ov21_02171780
-	ldr fp, [sp, #0x1c]
+	ldr r11, [sp, #0x1c]
 	add r1, r0, r2, lsl #3
 	ldr r2, [r0, r2, lsl #3]
 	ldr r0, [r1, #4]
@@ -3253,14 +3253,14 @@ _0216ff48:
 	add sp, sp, #0x44
 	stmia r0, {r1, sb}
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0216ff9c:
 	add r6, r6, #1
 	cmp r6, #1
 	ble _0216ff48
 	add r8, r8, #1
-	add fp, fp, #1
-	cmp fp, #1
+	add r11, r11, #1
+	cmp r11, #1
 	ble _0216ff44
 _0216ffb8:
 	ldr r0, [sp, #0x14]
@@ -3280,7 +3280,7 @@ _0216ffdc:
 	ble _0216fe2c
 	mov r0, #0
 	add sp, sp, #0x44
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov21_0216fc5c
 _0216fffc: .word data_ov21_02171bb4
@@ -3313,7 +3313,7 @@ func_ov21_0217004c: ; 0x0217004c
 	.global func_ov21_02170050
 	arm_func_start func_ov21_02170050
 func_ov21_02170050: ; 0x02170050
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x28
 	mov sl, r1
 	ldr r1, [sl]
@@ -3321,19 +3321,19 @@ func_ov21_02170050: ; 0x02170050
 	str r1, [sp, #8]
 	ldr r3, [sl, #4]
 	ldr r1, _021701a4 ; =data_027e0d3c
-	mov fp, r0
+	mov r11, r0
 	ldr r0, [r1]
 	add r1, sp, #8
 	add r2, sp, #0x1c
 	str r3, [sp, #0xc]
 	bl func_ov00_020793b8
-	ldr r1, [fp, #0x48]
+	ldr r1, [r11, #0x48]
 	ldr r0, _021701a8 ; =data_027e0e60
 	str r1, [sp, #0x10]
-	ldr r1, [fp, #0x4c]
+	ldr r1, [r11, #0x4c]
 	ldr r0, [r0]
 	str r1, [sp, #0x14]
-	ldr r3, [fp, #0x50]
+	ldr r3, [r11, #0x50]
 	add r1, sp, #0x10
 	mov r2, #0
 	str r3, [sp, #0x18]
@@ -3377,7 +3377,7 @@ _02170108:
 	bl func_ov00_02079ab4
 	cmp r0, #0
 	beq _02170174
-	mov r0, fp
+	mov r0, r11
 	add r1, sp, #8
 	bl func_ov21_02170388
 	cmp r0, #0
@@ -3389,7 +3389,7 @@ _02170108:
 	ldr r2, [sp, #0xc]
 	add sp, sp, #0x28
 	str r2, [r1, #4]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02170174:
 	add r5, r5, #1
 	cmp r5, r6
@@ -3404,7 +3404,7 @@ _0217018c:
 	bgt _021700b8
 	mov r0, #0
 	add sp, sp, #0x28
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov21_02170050
 _021701a4: .word data_027e0d3c
@@ -3414,7 +3414,7 @@ _021701ac: .word data_027e103c
 	.global func_ov21_021701b0
 	arm_func_start func_ov21_021701b0
 func_ov21_021701b0: ; 0x021701b0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x28
 	mov sb, r1
 	ldr r2, [sb]
@@ -3451,11 +3451,11 @@ _0217022c:
 	mov r0, r5
 	cmp r0, r6
 	bgt _02170304
-	rsb fp, r4, #0
+	rsb r11, r4, #0
 _02170240:
 	cmp r4, #0
 	movge r0, r4
-	movlt r0, fp
+	movlt r0, r11
 	cmp r0, r6
 	bge _02170268
 	cmp r5, #0
@@ -3499,7 +3499,7 @@ _02170268:
 	ldr r2, [sp, #0xc]
 	add sp, sp, #0x28
 	str r2, [r1, #4]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _021702f8:
 	add r5, r5, #1
 	cmp r5, r6
@@ -3514,7 +3514,7 @@ _02170310:
 	bgt _02170218
 	mov r0, #0
 	add sp, sp, #0x28
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov21_021701b0
 _02170328: .word data_027e0d3c

--- a/asm/ov21.s
+++ b/asm/ov21.s
@@ -2313,14 +2313,14 @@ func_ov21_0216f234: ; 0x0216f234
 	.global func_ov21_0216f25c
 	arm_func_start func_ov21_0216f25c
 func_ov21_0216f25c: ; 0x0216f25c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #0x50
 	mov r4, r0
 	bl func_ov21_02170334
 	cmp r0, #0
 	addeq sp, sp, #0x50
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	mov r1, #0
 	str r1, [r4, #0x16c]
 	ldr r2, [r4, #0x48]
@@ -2366,12 +2366,12 @@ func_ov21_0216f25c: ; 0x0216f25c
 	ldr ip, [r4, #0x4c]
 	ldr sb, [r4, #0x50]
 	ldr r8, [r4, #0x48]
-	sub sl, sb, #0x1000
+	sub r10, sb, #0x1000
 	sub r1, r8, #0x1000
 	sub r2, ip, #0x800
 	add sb, sb, #0x1000
 	add r8, r8, #0x1000
-	str sl, [sp, #0x4c]
+	str r10, [sp, #0x4c]
 	str r1, [sp, #0x44]
 	str r2, [sp, #0x48]
 	ldmia r0, {r0, r1, r2}
@@ -2391,7 +2391,7 @@ func_ov21_0216f25c: ; 0x0216f25c
 	mov r0, r4
 	bl func_ov14_02137970
 	add sp, sp, #0x50
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	arm_func_end func_ov21_0216f25c
 
 	.global func_ov21_0216f398
@@ -2724,32 +2724,32 @@ _0216f7c4: .word 0x00000477
 	.global func_ov21_0216f7c8
 	arm_func_start func_ov21_0216f7c8
 func_ov21_0216f7c8: ; 0x0216f7c8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x118
-	mov sl, r0
-	ldr r0, [sl, #0x224]
+	mov r10, r0
+	ldr r0, [r10, #0x224]
 	cmp r0, #0
-	ldreq r0, [sl, #0x228]
+	ldreq r0, [r10, #0x228]
 	cmpeq r0, #0
 	addeq sp, sp, #0x118
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
-	mov r0, sl
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	mov r0, r10
 	mov r1, #0
 	bl func_01fffd04
 	cmp r0, #0
 	addeq sp, sp, #0x118
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
-	add r0, sl, #0x48
-	add r1, sl, #0x54
-	add r2, sl, #0x60
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	add r0, r10, #0x48
+	add r1, r10, #0x54
+	add r2, r10, #0x60
 	bl func_01ff9bf8
-	ldr r0, [sl, #0x138]
+	ldr r0, [r10, #0x138]
 	cmp r0, #0x1e
 	addlt sp, sp, #0x118
 	movlt r0, #0
-	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, _0216fb80 ; =0x0000ffff
 	mov r5, #0
 	add r4, sp, #0x48
@@ -2768,31 +2768,31 @@ func_ov21_0216f7c8: ; 0x0216f7c8
 	strb r5, [sp, #0x113]
 	strb r5, [sp, #0x114]
 	strb r5, [sp, #0x115]
-	add r0, sl, #0x8c
+	add r0, r10, #0x8c
 	ldmia r0, {r0, r1, r2}
 	stmia r4, {r0, r1, r2}
-	ldr r1, [sl, #0x98]
+	ldr r1, [r10, #0x98]
 	ldr r0, _0216fb84 ; =data_027e0e60
 	str r1, [sp, #0x54]
-	ldr r2, [sl, #0x48]
+	ldr r2, [r10, #0x48]
 	add r1, sp, #0xb8
 	str r2, [sp, #0x24]
-	ldr r3, [sl, #0x4c]
+	ldr r3, [r10, #0x4c]
 	add r2, sp, #0x24
 	str r3, [sp, #0x28]
-	ldr r6, [sl, #0x50]
+	ldr r6, [r10, #0x50]
 	add r3, sp, #0x18
 	str r6, [sp, #0x2c]
-	ldr r6, [sl, #0x54]
+	ldr r6, [r10, #0x54]
 	str r6, [sp, #0x18]
-	ldr r6, [sl, #0x58]
+	ldr r6, [r10, #0x58]
 	str r6, [sp, #0x1c]
-	ldr r6, [sl, #0x5c]
+	ldr r6, [r10, #0x5c]
 	str r6, [sp, #0x20]
 	str r4, [sp]
-	ldr r4, [sl, #8]
+	ldr r4, [r10, #8]
 	str r4, [sp, #4]
-	ldrh r4, [sl, #0x9c]
+	ldrh r4, [r10, #0x9c]
 	str r4, [sp, #8]
 	str r5, [sp, #0xc]
 	str r5, [sp, #0x10]
@@ -2804,7 +2804,7 @@ func_ov21_0216f7c8: ; 0x0216f7c8
 	cmp r0, #0
 	addne sp, sp, #0x118
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, _0216fb88 ; =data_ov21_02171bb4
 	ldr r0, [r0, #0x20]
 	tst r0, #1
@@ -2868,9 +2868,9 @@ _0216f9c0:
 	strh r0, [sp, #0x7e]
 	strh r0, [sp, #0x80]
 	strh r0, [sp, #0x82]
-	ldr r0, [sl, #0x4c]
-	ldr r2, [sl, #0x50]
-	ldr r1, [sl, #0x48]
+	ldr r0, [r10, #0x4c]
+	ldr r2, [r10, #0x50]
+	ldr r1, [r10, #0x48]
 	add r0, r0, #0x9a
 	add r0, r0, #0x900
 	ldr sb, _0216fb90 ; =data_ov21_02171750
@@ -2903,7 +2903,7 @@ _0216fa3c:
 	bl func_ov00_020b199c
 	cmp r0, #0
 	beq _0216fac4
-	ldr r0, [sl, #8]
+	ldr r0, [r10, #8]
 	add r1, sp, #0x58
 	stmia sp, {r0, r6}
 	str r5, [sp, #8]
@@ -2916,19 +2916,19 @@ _0216fa3c:
 	cmp r0, #0
 	addeq sp, sp, #0x118
 	moveq r0, #1
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0216fac4:
 	add r8, r8, #1
 	cmp r8, #4
 	add sb, sb, #0xc
 	blt _0216fa3c
-	ldr r0, [sl, #0x224]
-	ldr r1, [sl, #0x228]
+	ldr r0, [r10, #0x224]
+	ldr r1, [r10, #0x228]
 	rsb r0, r0, #0
-	str r0, [sl, #0x224]
+	str r0, [r10, #0x224]
 	rsb r1, r1, #0
 	ldr r0, _0216fbb8 ; =data_027e0fc8
-	str r1, [sl, #0x228]
+	str r1, [r10, #0x228]
 	ldr r0, [r0]
 	mov r4, #0
 	bl func_ov00_020bc500
@@ -2942,7 +2942,7 @@ _0216fac4:
 	cmp r0, #0
 	moveq r4, #1
 _0216fb20:
-	ldrb r0, [sl, #0x158]
+	ldrb r0, [r10, #0x158]
 	cmp r0, #0
 	bne _0216fb60
 	ldr r0, _0216fbb8 ; =data_027e0fc8
@@ -2952,14 +2952,14 @@ _0216fb20:
 	beq _0216fb60
 	cmp r4, #0
 	bne _0216fb60
-	mov r0, sl
+	mov r0, r10
 	ldr r2, [r0]
 	mov r1, #3
 	ldr r2, [r2, #0xb8]
 	blx r2
 	b _0216fb74
 _0216fb60:
-	mov r0, sl
+	mov r0, r10
 	ldr r2, [r0]
 	mov r1, #6
 	ldr r2, [r2, #0xb8]
@@ -2967,7 +2967,7 @@ _0216fb60:
 _0216fb74:
 	mov r0, #0
 	add sp, sp, #0x118
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov21_0216f7c8
 _0216fb80: .word 0x0000ffff
@@ -3037,11 +3037,11 @@ _0216fc58: .word data_027e0fc8
 	.global func_ov21_0216fc5c
 	arm_func_start func_ov21_0216fc5c
 func_ov21_0216fc5c: ; 0x0216fc5c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x44
 	mov r4, r2
 	ldr r2, [r4]
-	mov sl, r0
+	mov r10, r0
 	cmp r2, #0
 	ldreq r2, [r4, #4]
 	str r1, [sp]
@@ -3051,18 +3051,18 @@ func_ov21_0216fc5c: ; 0x0216fc5c
 	mov r2, r3
 	bl func_ov21_02170050
 	add sp, sp, #0x44
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0216fc98:
 	ldrb r0, [sp, #0x68]
 	cmp r0, #0
 	beq _0216fcc0
 	ldr r1, [sp]
 	ldr r3, [sp, #4]
-	mov r0, sl
+	mov r0, r10
 	mov r2, r4
 	bl func_ov21_021701b0
 	add sp, sp, #0x44
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0216fcc0:
 	ldr r0, _0216fffc ; =data_ov21_02171bb4
 	ldr r0, [r0, #0x54]
@@ -3183,7 +3183,7 @@ _0216fe2c:
 	cmp r0, #0
 	beq _0216ffdc
 	add r1, sp, #0x24
-	mov r0, sl
+	mov r0, r10
 	bl func_ov21_02170388
 	cmp r0, #0
 	beq _0216ffdc
@@ -3194,7 +3194,7 @@ _0216fe2c:
 	ldr r2, [sp, #0x28]
 	add sp, sp, #0x44
 	str r2, [r1, #4]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0216fec4:
 	rsb r0, r0, #0
 	str r0, [sp, #8]
@@ -3243,7 +3243,7 @@ _0216ff48:
 	bl func_ov00_02079ab4
 	cmp r0, #0
 	beq _0216ff9c
-	mov r0, sl
+	mov r0, r10
 	mov r1, r5
 	bl func_ov21_02170388
 	cmp r0, #0
@@ -3253,7 +3253,7 @@ _0216ff48:
 	add sp, sp, #0x44
 	stmia r0, {r1, sb}
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0216ff9c:
 	add r6, r6, #1
 	cmp r6, #1
@@ -3280,7 +3280,7 @@ _0216ffdc:
 	ble _0216fe2c
 	mov r0, #0
 	add sp, sp, #0x44
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov21_0216fc5c
 _0216fffc: .word data_ov21_02171bb4
@@ -3313,13 +3313,13 @@ func_ov21_0217004c: ; 0x0217004c
 	.global func_ov21_02170050
 	arm_func_start func_ov21_02170050
 func_ov21_02170050: ; 0x02170050
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x28
-	mov sl, r1
-	ldr r1, [sl]
+	mov r10, r1
+	ldr r1, [r10]
 	str r2, [sp]
 	str r1, [sp, #8]
-	ldr r3, [sl, #4]
+	ldr r3, [r10, #4]
 	ldr r1, _021701a4 ; =data_027e0d3c
 	mov r11, r0
 	ldr r0, [r1]
@@ -3363,11 +3363,11 @@ _021700e0:
 	cmp r0, r6
 	blt _02170174
 _02170108:
-	ldr r1, [sl]
+	ldr r1, [r10]
 	ldr r0, _021701ac ; =data_027e103c
 	add r8, r4, r1
 	str r8, [sp, #8]
-	ldr r1, [sl, #4]
+	ldr r1, [r10, #4]
 	ldr r0, [r0]
 	add r7, r5, r1
 	str r7, [sp, #0xc]
@@ -3389,7 +3389,7 @@ _02170108:
 	ldr r2, [sp, #0xc]
 	add sp, sp, #0x28
 	str r2, [r1, #4]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02170174:
 	add r5, r5, #1
 	cmp r5, r6
@@ -3404,7 +3404,7 @@ _0217018c:
 	bgt _021700b8
 	mov r0, #0
 	add sp, sp, #0x28
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov21_02170050
 _021701a4: .word data_027e0d3c
@@ -3414,27 +3414,27 @@ _021701ac: .word data_027e103c
 	.global func_ov21_021701b0
 	arm_func_start func_ov21_021701b0
 func_ov21_021701b0: ; 0x021701b0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x28
 	mov sb, r1
 	ldr r2, [sb]
 	ldr r1, _02170328 ; =data_027e0d3c
 	str r2, [sp, #8]
 	ldr r4, [sb, #4]
-	mov sl, r0
+	mov r10, r0
 	ldr r0, [r1]
 	add r1, sp, #8
 	add r2, sp, #0x1c
 	str r4, [sp, #0xc]
 	str r3, [sp]
 	bl func_ov00_020793b8
-	ldr r1, [sl, #0x48]
+	ldr r1, [r10, #0x48]
 	ldr r0, _0217032c ; =data_027e0e60
 	str r1, [sp, #0x10]
-	ldr r1, [sl, #0x4c]
+	ldr r1, [r10, #0x4c]
 	ldr r0, [r0]
 	str r1, [sp, #0x14]
-	ldr r3, [sl, #0x50]
+	ldr r3, [r10, #0x50]
 	add r1, sp, #0x10
 	mov r2, #0
 	str r3, [sp, #0x18]
@@ -3471,9 +3471,9 @@ _02170268:
 	ldr r0, [sb, #4]
 	add r1, r5, r0
 	str r1, [sp, #0xc]
-	ldr r0, [sl, #0x21c]
+	ldr r0, [r10, #0x21c]
 	cmp r0, r8
-	ldreq r0, [sl, #0x220]
+	ldreq r0, [r10, #0x220]
 	cmpeq r0, r1
 	moveq r2, #1
 	cmp r2, #0
@@ -3487,7 +3487,7 @@ _02170268:
 	bl func_ov00_02079ab4
 	cmp r0, #0
 	beq _021702f8
-	mov r0, sl
+	mov r0, r10
 	add r1, sp, #8
 	bl func_ov21_02170388
 	cmp r0, #0
@@ -3499,7 +3499,7 @@ _02170268:
 	ldr r2, [sp, #0xc]
 	add sp, sp, #0x28
 	str r2, [r1, #4]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _021702f8:
 	add r5, r5, #1
 	cmp r5, r6
@@ -3514,7 +3514,7 @@ _02170310:
 	bgt _02170218
 	mov r0, #0
 	add sp, sp, #0x28
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov21_021701b0
 _02170328: .word data_027e0d3c

--- a/asm/ov22.s
+++ b/asm/ov22.s
@@ -927,7 +927,7 @@ func_ov22_0216e278: ; 0x0216e278
 	.global func_ov22_0216e2a8
 	arm_func_start func_ov22_0216e2a8
 func_ov22_0216e2a8: ; 0x0216e2a8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x68
 	mov sl, r0
 	ldr r1, [sl, #4]
@@ -1027,7 +1027,7 @@ _0216e404:
 	ldrh r2, [sl, #0x28]
 	ldrh r1, [sl, #0x2a]
 	mov r6, sb
-	add fp, sp, #0x24
+	add r11, sp, #0x24
 	strh r2, [sp, #0x28]
 	strh r1, [sp, #0x2a]
 	ldrb r2, [sl, #0x2c]
@@ -1072,7 +1072,7 @@ _0216e4a8:
 	ldr r1, [r0]
 	ldr r1, [r1, #0x1c]
 	blx r1
-	str fp, [sp]
+	str r11, [sp]
 	mov r1, r0
 	mov r0, r8
 	mov r2, r5
@@ -1109,13 +1109,13 @@ _0216e53c:
 	mov r1, #3
 	blx r3
 	add sp, sp, #0x68
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0216e56c:
 	ldr r3, [r3, #0x80]
 	mov r1, #0
 	blx r3
 	add sp, sp, #0x68
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov22_0216e2a8
 _0216e580: .word 0x00001334
@@ -1272,7 +1272,7 @@ _0216e774: .word 0xffffe4cd
 	.global func_ov22_0216e778
 	arm_func_start func_ov22_0216e778
 func_ov22_0216e778: ; 0x0216e778
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x188
 	mov r4, r0
 	str r1, [r4, #8]
@@ -1351,7 +1351,7 @@ _0216e87c:
 	cmp r0, #0
 	ble _0216e958
 	mov r5, #2
-	mov fp, sb
+	mov r11, sb
 	add r8, sp, #0xa
 _0216e8ac:
 	ldrb r0, [r4, #0x67]
@@ -1388,7 +1388,7 @@ _0216e8bc:
 	ldr r3, [r0]
 	mov r1, r5
 	ldr r3, [r3, #0x80]
-	mov r2, fp
+	mov r2, r11
 	blx r3
 _0216e938:
 	ldrb r0, [r4, #0x67]
@@ -1516,7 +1516,7 @@ _0216eae8:
 	cmp r0, #0
 	ble _0216ebc4
 	mov r5, #5
-	mov fp, sb
+	mov r11, sb
 	add r8, sp, #8
 _0216eb18:
 	ldrb r0, [r4, #0x67]
@@ -1553,7 +1553,7 @@ _0216eb28:
 	ldr r3, [r0]
 	mov r1, r5
 	ldr r3, [r3, #0x80]
-	mov r2, fp
+	mov r2, r11
 	blx r3
 _0216eba4:
 	ldrb r0, [r4, #0x67]
@@ -1617,7 +1617,7 @@ _0216ec74:
 	mov r0, #1
 	str r1, [r4, #0x44]
 	add sp, sp, #0x188
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov22_0216e778
 _0216ec88: .word data_027e0f74
@@ -1800,7 +1800,7 @@ func_ov22_0216ee60: ; 0x0216ee60
 	.global func_ov22_0216ee88
 	arm_func_start func_ov22_0216ee88
 func_ov22_0216ee88: ; 0x0216ee88
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x20
 	mov r4, r0
 	ldr r0, [r4, #0x18]
@@ -1886,7 +1886,7 @@ _0216efa0:
 	ldr r5, _0216f0b0 ; =data_027e0e60
 	add r8, sp, #6
 	add r6, sp, #4
-	mov fp, r7
+	mov r11, r7
 _0216efcc:
 	ldrb sl, [r4, #0x15]
 	ldrb r0, [r4, #0x39]
@@ -1906,7 +1906,7 @@ _0216efe8:
 	mov r1, r6
 	strb sb, [sp, #4]
 	strb sl, [sp, #5]
-	mov r2, fp
+	mov r2, r11
 	bl func_ov00_020826a0
 	ldrb r1, [r4, #0x15]
 	ldrb r0, [r4, #0x39]
@@ -1947,7 +1947,7 @@ _0216f050:
 	str r0, [r4, #0x68]
 	str r6, [r4, #0x6c]
 	add sp, sp, #0x20
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov22_0216ee88
 _0216f0b0: .word data_027e0e60
@@ -1982,7 +1982,7 @@ func_ov22_0216f0d8: ; 0x0216f0d8
 	.global func_ov22_0216f0e0
 	arm_func_start func_ov22_0216f0e0
 func_ov22_0216f0e0: ; 0x0216f0e0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x48
 	ldr r2, [r0]
 	mov sl, r0
@@ -1990,7 +1990,7 @@ func_ov22_0216f0e0: ; 0x0216f0e0
 	blx r2
 	cmp r0, #0
 	addeq sp, sp, #0x48
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldrh r1, [sl, #0xc]
 	ldr r3, _0216f2b8 ; =data_02050f54
 	add r0, sp, #0x24
@@ -2015,7 +2015,7 @@ func_ov22_0216f0e0: ; 0x0216f0e0
 	mvn r5, #0
 	mov r6, r7
 	add r4, sp, #0x24
-	add fp, sp, #0x18
+	add r11, sp, #0x18
 _0216f168:
 	cmp r7, #0
 	ldrne r0, [sp, #0x18]
@@ -2040,7 +2040,7 @@ _0216f18c:
 	ldr r3, [r0]
 	mov r1, r4
 	ldr r3, [r3, #0x14]
-	mov r2, fp
+	mov r2, r11
 	blx r3
 	ldrb r0, [sl, #0x39]
 	add r8, r8, #1
@@ -2105,7 +2105,7 @@ _0216f22c:
 	orr r3, r3, r4, lsl #20
 	bl func_ov05_02102c2c
 	add sp, sp, #0x48
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov22_0216f0e0
 _0216f2b8: .word data_02050f54
@@ -2952,7 +2952,7 @@ _0216fd98: .word func_ov22_0216f41c
 	.global func_ov22_0216fd9c
 	arm_func_start func_ov22_0216fd9c
 func_ov22_0216fd9c: ; 0x0216fd9c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x48
 	mov r6, r0
 	cmp r1, #8
@@ -3132,7 +3132,7 @@ _0216ffdc:
 	add r4, r6, #0x284
 	ldr r1, [r0, #0xec]
 	ldr r0, [r0, #0xf0]
-	ldr fp, _021701d4 ; =data_027e0e58
+	ldr r11, _021701d4 ; =data_027e0e58
 	add r8, sp, #8
 	str r1, [sp, #8]
 	str r0, [sp, #0xc]
@@ -3171,7 +3171,7 @@ _021700b4:
 	b _021700f4
 _021700c4:
 	str r5, [sp]
-	ldr r0, [fp]
+	ldr r0, [r11]
 	ldr r2, [r8, sb, lsl #2]
 	mov r1, sl
 	add r3, r4, #0x400
@@ -3203,7 +3203,7 @@ _02170120:
 _0217012c:
 	add sp, sp, #0x48
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02170138:
 	add r0, r6, #0x1d8
 	mov r1, #5
@@ -3244,11 +3244,11 @@ _021701b0:
 	mov r2, r2, asr #0x10
 	bl func_0202b154
 	add sp, sp, #0x48
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _021701c8:
 	mov r0, #1
 	add sp, sp, #0x48
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov22_0216fd9c
 _021701d4: .word data_027e0e58
@@ -4258,7 +4258,7 @@ _02170ef4: .word data_ov22_021793cc
 	.global func_ov22_02170ef8
 	arm_func_start func_ov22_02170ef8
 func_ov22_02170ef8: ; 0x02170ef8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x38
 	mov r4, r0
 	ldr r1, [r4, #0x14]
@@ -4426,7 +4426,7 @@ _021710fc:
 	ldrsh r1, [r1, #0x78]
 	bl func_ov00_020a61ac
 	ldr r0, _021712c8 ; =data_ov22_0217871c
-	ldr fp, _021712b8 ; =data_027e0e58
+	ldr r11, _021712b8 ; =data_027e0e58
 	ldr r1, [r0, #0x130]
 	ldr r0, [r0, #0x134]
 	add r8, sp, #0x10
@@ -4467,7 +4467,7 @@ _021711dc:
 	b _0217121c
 _021711ec:
 	str r5, [sp]
-	ldr r0, [fp]
+	ldr r0, [r11]
 	ldr r2, [r8, sb, lsl #2]
 	mov r1, sl
 	add r3, r4, #0x7c
@@ -4521,7 +4521,7 @@ _02171280:
 	add r0, r4, #0x360
 	bl func_ov00_020c5e20
 	add sp, sp, #0x38
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov22_02170ef8
 _021712ac: .word data_027e0ffc
@@ -9155,14 +9155,14 @@ func_ov22_02174ea0: ; 0x02174ea0
 	.global func_ov22_02174f00
 	arm_func_start func_ov22_02174f00
 func_ov22_02174f00: ; 0x02174f00
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x18
 	mov r5, r0
 	mov r4, r1
 	bl _ZN5Actor18func_ov00_020c313cEj
 	cmp r0, #0
 	addeq sp, sp, #0x18
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, _02175058 ; =data_027e0f64
 	mov r1, #0
 	ldr r0, [r0]
@@ -9183,7 +9183,7 @@ func_ov22_02174f00: ; 0x02174f00
 	str r0, [sp]
 	cmp r0, r1
 	addge sp, sp, #0x18
-	ldmgeia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmgeia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02174f74:
 	ldrb r4, [sp, #4]
 	ldrb r1, [sp, #5]
@@ -9194,7 +9194,7 @@ _02174f74:
 	ldr r7, _0217505c ; =data_027e0e60
 	ldr r6, _02175060 ; =data_027e0764
 	sub r8, sp, #4
-	mov fp, #5
+	mov r11, #5
 _02174f9c:
 	ldr r0, [r7]
 	add r1, sp, #8
@@ -9213,10 +9213,10 @@ _02174f9c:
 	adds r0, sl, lr
 	adc r2, sb, ip
 	stmia r6, {r0, r2}
-	umull r0, r1, r2, fp
+	umull r0, r1, r2, r11
 	mov r0, #0
 	mla r1, r2, r0, r1
-	mlas r1, r0, fp, r1
+	mlas r1, r0, r11, r1
 	bne _02175028
 	ldrb r3, [sp, #8]
 	ldrb r2, [sp, #9]
@@ -9244,7 +9244,7 @@ _02175038:
 	cmp r0, r1
 	blt _02174f74
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov22_02174f00
 _02175058: .word data_027e0f64
@@ -12878,7 +12878,7 @@ func_ov22_02177ddc: ; 0x02177ddc
 	.global func_ov22_02177e04
 	arm_func_start func_ov22_02177e04
 func_ov22_02177e04: ; 0x02177e04
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x20
 	mov r4, r1
 	mov r8, r0
@@ -12906,7 +12906,7 @@ func_ov22_02177e04: ; 0x02177e04
 	add r7, sp, #0x14
 	mov r6, #4
 	mov r5, sl
-	mov fp, #0xf8
+	mov r11, #0xf8
 _02177e78:
 	str sb, [sp]
 	str sb, [sp, #4]
@@ -12918,7 +12918,7 @@ _02177e78:
 	str r5, [sp]
 	str r5, [sp, #4]
 	ldr r0, [r4]
-	mov r1, fp
+	mov r1, r11
 	mov r2, r7
 	mov r3, #4
 	bl func_ov00_0207c1b0
@@ -12964,7 +12964,7 @@ _02177f10:
 _02177f44:
 	mov r0, #1
 	add sp, sp, #0x20
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov22_02177e04
 _02177f50: .word data_027e0ffc

--- a/asm/ov22.s
+++ b/asm/ov22.s
@@ -927,30 +927,30 @@ func_ov22_0216e278: ; 0x0216e278
 	.global func_ov22_0216e2a8
 	arm_func_start func_ov22_0216e2a8
 func_ov22_0216e2a8: ; 0x0216e2a8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x68
-	mov sl, r0
-	ldr r1, [sl, #4]
+	mov r10, r0
+	ldr r1, [r10, #4]
 	orr r1, r1, #0x10
-	str r1, [sl, #4]
+	str r1, [r10, #4]
 	bl func_ov00_0208c214
-	ldr r0, [sl, #4]
-	add r6, sl, #0x18
+	ldr r0, [r10, #4]
+	add r6, r10, #0x18
 	orr r0, r0, #0x800
-	str r0, [sl, #4]
-	ldrh r0, [sl, #0x2a]
+	str r0, [r10, #4]
+	ldrh r0, [r10, #0x2a]
 	add r5, sp, #0x5c
 	add r3, sp, #0x50
 	cmp r0, #0
 	moveq r0, #1
-	streqb r0, [sl, #0x64]
-	ldrh r0, [sl, #0x24]
+	streqb r0, [r10, #0x64]
+	ldrh r0, [r10, #0x24]
 	mov r4, #0x800
 	add r0, r0, #1
-	strb r0, [sl, #0x66]
-	ldrh r0, [sl, #0x26]
+	strb r0, [r10, #0x66]
+	ldrh r0, [r10, #0x26]
 	add r0, r0, #1
-	strb r0, [sl, #0x67]
+	strb r0, [r10, #0x67]
 	ldmia r6, {r0, r1, r2}
 	stmia r5, {r0, r1, r2}
 	ldmia r6, {r0, r1, r2}
@@ -984,28 +984,28 @@ func_ov22_0216e2a8: ; 0x0216e2a8
 	add r3, sp, #0x44
 	ldmia r4, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
-	mov r0, sl
+	mov r0, r10
 	bl func_ov00_0208b9cc
 	mov r2, r0
 	mov r0, #0
 	str r0, [sp]
-	add r0, sl, #0x38
+	add r0, r10, #0x38
 	ldr r4, [r0]
 	ldr r3, [sp, #8]
 	ldr r4, [r4, #0x14]
 	mov r1, r5
 	blx r4
-	ldrb r2, [sl, #0x66]
+	ldrb r2, [r10, #0x66]
 	cmp r2, #1
-	ldreqb r0, [sl, #0x67]
+	ldreqb r0, [r10, #0x67]
 	cmpeq r0, #1
 	beq _0216e404
-	ldrb r0, [sl, #0x67]
+	ldrb r0, [r10, #0x67]
 	cmp r2, r0
 	beq _0216e404
 	cmp r2, #1
 	mvneq r0, #1
-	streq r0, [sl, #0x78]
+	streq r0, [r10, #0x78]
 	beq _0216e404
 	cmp r0, #1
 	bne _0216e404
@@ -1013,46 +1013,46 @@ func_ov22_0216e2a8: ; 0x0216e2a8
 	rsb r0, r1, r2, lsl #31
 	adds r0, r1, r0, ror #31
 	moveq r0, #2
-	streq r0, [sl, #0x78]
+	streq r0, [r10, #0x78]
 _0216e404:
-	ldrb r0, [sl, #0x64]
+	ldrb r0, [r10, #0x64]
 	cmp r0, #0
 	beq _0216e53c
-	ldrh r2, [sl, #0x24]
-	ldrh r1, [sl, #0x26]
+	ldrh r2, [r10, #0x24]
+	ldrh r1, [r10, #0x26]
 	mov sb, #0
 	mov r0, #1
 	strh r2, [sp, #0x24]
 	strh r1, [sp, #0x26]
-	ldrh r2, [sl, #0x28]
-	ldrh r1, [sl, #0x2a]
+	ldrh r2, [r10, #0x28]
+	ldrh r1, [r10, #0x2a]
 	mov r6, sb
 	add r11, sp, #0x24
 	strh r2, [sp, #0x28]
 	strh r1, [sp, #0x2a]
-	ldrb r2, [sl, #0x2c]
-	ldrb r1, [sl, #0x2d]
+	ldrb r2, [r10, #0x2c]
+	ldrb r1, [r10, #0x2d]
 	strb r2, [sp, #0x2c]
 	strb r1, [sp, #0x2d]
-	ldrb r2, [sl, #0x2e]
-	ldrb r1, [sl, #0x2f]
+	ldrb r2, [r10, #0x2e]
+	ldrb r1, [r10, #0x2f]
 	strb r2, [sp, #0x2e]
 	strb r1, [sp, #0x2f]
-	ldr r1, [sl, #0x30]
+	ldr r1, [r10, #0x30]
 	str r1, [sp, #0x30]
-	ldrsh r1, [sl, #0x34]
+	ldrsh r1, [r10, #0x34]
 	strh r1, [sp, #0x34]
-	ldrb r1, [sl, #0x36]
+	ldrb r1, [r10, #0x36]
 	strb r1, [sp, #0x36]
 	strb sb, [sp, #4]
 	strb sb, [sp, #5]
 	strh r0, [sp, #0x2a]
-	ldrb r0, [sl, #0x66]
+	ldrb r0, [r10, #0x66]
 	cmp r0, #0
 	ble _0216e53c
 	add r5, sp, #4
 _0216e494:
-	ldrb r0, [sl, #0x67]
+	ldrb r0, [r10, #0x67]
 	mov r7, #0
 	cmp r0, #0
 	ble _0216e52c
@@ -1061,12 +1061,12 @@ _0216e4a8:
 	cmp r6, #0
 	cmpeq r7, #0
 	beq _0216e51c
-	ldrb r1, [sl, #0x14]
-	mov r0, sl
+	ldrb r1, [r10, #0x14]
+	mov r0, r10
 	ldr r8, [r4]
 	add r1, r6, r1
 	strb r1, [sp, #4]
-	ldrb r1, [sl, #0x15]
+	ldrb r1, [r10, #0x15]
 	add r1, r7, r1
 	strb r1, [sp, #5]
 	ldr r1, [r0]
@@ -1076,7 +1076,7 @@ _0216e4a8:
 	mov r1, r0
 	mov r0, r8
 	mov r2, r5
-	ldrsh r3, [sl, #0xc]
+	ldrsh r3, [r10, #0xc]
 	bl func_ov00_020828c0
 	ldr r0, [r4]
 	mov r1, r5
@@ -1088,20 +1088,20 @@ _0216e4a8:
 	moveq sb, #1
 	movne sb, #0
 _0216e51c:
-	ldrb r0, [sl, #0x67]
+	ldrb r0, [r10, #0x67]
 	add r7, r7, #1
 	cmp r7, r0
 	blt _0216e4a8
 _0216e52c:
-	ldrb r0, [sl, #0x66]
+	ldrb r0, [r10, #0x66]
 	add r6, r6, #1
 	cmp r6, r0
 	blt _0216e494
 _0216e53c:
-	mov r0, sl
+	mov r0, r10
 	bl func_ov22_0216ed28
 	cmp r0, #0
-	mov r0, sl
+	mov r0, r10
 	mov r2, #1
 	ldr r3, [r0]
 	beq _0216e56c
@@ -1109,13 +1109,13 @@ _0216e53c:
 	mov r1, #3
 	blx r3
 	add sp, sp, #0x68
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0216e56c:
 	ldr r3, [r3, #0x80]
 	mov r1, #0
 	blx r3
 	add sp, sp, #0x68
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov22_0216e2a8
 _0216e580: .word 0x00001334
@@ -1272,7 +1272,7 @@ _0216e774: .word 0xffffe4cd
 	.global func_ov22_0216e778
 	arm_func_start func_ov22_0216e778
 func_ov22_0216e778: ; 0x0216e778
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x188
 	mov r4, r0
 	str r1, [r4, #8]
@@ -1355,12 +1355,12 @@ _0216e87c:
 	add r8, sp, #0xa
 _0216e8ac:
 	ldrb r0, [r4, #0x67]
-	mov sl, #0
+	mov r10, #0
 	cmp r0, #0
 	ble _0216e948
 _0216e8bc:
 	cmp sb, #0
-	cmpeq sl, #0
+	cmpeq r10, #0
 	beq _0216e938
 	ldrb r2, [r4, #0x14]
 	ldr r0, _0216ec8c ; =data_027e0e60
@@ -1369,7 +1369,7 @@ _0216e8bc:
 	strb r2, [sp, #0xa]
 	ldrb r2, [r4, #0x15]
 	ldr r0, [r0]
-	add r2, sl, r2
+	add r2, r10, r2
 	strb r2, [sp, #0xb]
 	bl func_ov00_020840c4
 	movs r7, r0
@@ -1392,8 +1392,8 @@ _0216e8bc:
 	blx r3
 _0216e938:
 	ldrb r0, [r4, #0x67]
-	add sl, sl, #1
-	cmp sl, r0
+	add r10, r10, #1
+	cmp r10, r0
 	blt _0216e8bc
 _0216e948:
 	ldrb r0, [r4, #0x66]
@@ -1520,12 +1520,12 @@ _0216eae8:
 	add r8, sp, #8
 _0216eb18:
 	ldrb r0, [r4, #0x67]
-	mov sl, #0
+	mov r10, #0
 	cmp r0, #0
 	ble _0216ebb4
 _0216eb28:
 	cmp sb, #0
-	cmpeq sl, #0
+	cmpeq r10, #0
 	beq _0216eba4
 	ldrb r2, [r4, #0x14]
 	ldr r0, _0216ec8c ; =data_027e0e60
@@ -1534,7 +1534,7 @@ _0216eb28:
 	strb r2, [sp, #8]
 	ldrb r2, [r4, #0x15]
 	ldr r0, [r0]
-	add r2, sl, r2
+	add r2, r10, r2
 	strb r2, [sp, #9]
 	bl func_ov00_020840c4
 	movs r7, r0
@@ -1557,8 +1557,8 @@ _0216eb28:
 	blx r3
 _0216eba4:
 	ldrb r0, [r4, #0x67]
-	add sl, sl, #1
-	cmp sl, r0
+	add r10, r10, #1
+	cmp r10, r0
 	blt _0216eb28
 _0216ebb4:
 	ldrb r0, [r4, #0x66]
@@ -1617,7 +1617,7 @@ _0216ec74:
 	mov r0, #1
 	str r1, [r4, #0x44]
 	add sp, sp, #0x188
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov22_0216e778
 _0216ec88: .word data_027e0f74
@@ -1800,7 +1800,7 @@ func_ov22_0216ee60: ; 0x0216ee60
 	.global func_ov22_0216ee88
 	arm_func_start func_ov22_0216ee88
 func_ov22_0216ee88: ; 0x0216ee88
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x20
 	mov r4, r0
 	ldr r0, [r4, #0x18]
@@ -1888,10 +1888,10 @@ _0216efa0:
 	add r6, sp, #4
 	mov r11, r7
 _0216efcc:
-	ldrb sl, [r4, #0x15]
+	ldrb r10, [r4, #0x15]
 	ldrb r0, [r4, #0x39]
-	add r0, sl, r0
-	cmp sl, r0
+	add r0, r10, r0
+	cmp r10, r0
 	bge _0216f030
 	ldr r0, [sp]
 	and sb, r0, #0xff
@@ -1900,19 +1900,19 @@ _0216efe8:
 	mov r1, r8
 	mov r2, r7
 	strb sb, [sp, #6]
-	strb sl, [sp, #7]
+	strb r10, [sp, #7]
 	bl func_ov00_02082680
 	ldr r0, [r5]
 	mov r1, r6
 	strb sb, [sp, #4]
-	strb sl, [sp, #5]
+	strb r10, [sp, #5]
 	mov r2, r11
 	bl func_ov00_020826a0
 	ldrb r1, [r4, #0x15]
 	ldrb r0, [r4, #0x39]
-	add sl, sl, #1
+	add r10, r10, #1
 	add r0, r1, r0
-	cmp sl, r0
+	cmp r10, r0
 	blt _0216efe8
 _0216f030:
 	ldrb sb, [r4, #0x38]
@@ -1947,7 +1947,7 @@ _0216f050:
 	str r0, [r4, #0x68]
 	str r6, [r4, #0x6c]
 	add sp, sp, #0x20
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov22_0216ee88
 _0216f0b0: .word data_027e0e60
@@ -1982,16 +1982,16 @@ func_ov22_0216f0d8: ; 0x0216f0d8
 	.global func_ov22_0216f0e0
 	arm_func_start func_ov22_0216f0e0
 func_ov22_0216f0e0: ; 0x0216f0e0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x48
 	ldr r2, [r0]
-	mov sl, r0
+	mov r10, r0
 	ldr r2, [r2, #0x88]
 	blx r2
 	cmp r0, #0
 	addeq sp, sp, #0x48
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
-	ldrh r1, [sl, #0xc]
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldrh r1, [r10, #0xc]
 	ldr r3, _0216f2b8 ; =data_02050f54
 	add r0, sp, #0x24
 	mov r1, r1, asr #0x4
@@ -2002,14 +2002,14 @@ func_ov22_0216f0e0: ; 0x0216f0e0
 	ldrsh r1, [r3, r4]
 	ldrsh r2, [r3, r2]
 	blx func_01ff8214
-	ldr r2, [sl, #0x4c]
-	ldr r1, [sl, #0x1c]
-	ldr r0, [sl, #0x44]
+	ldr r2, [r10, #0x4c]
+	ldr r1, [r10, #0x1c]
+	ldr r0, [r10, #0x44]
 	mov r7, #0
 	str r1, [sp, #0x1c]
 	str r2, [sp, #0x20]
 	str r0, [sp, #0x18]
-	ldrb r0, [sl, #0x38]
+	ldrb r0, [r10, #0x38]
 	cmp r0, #0
 	ble _0216f1ec
 	mvn r5, #0
@@ -2022,56 +2022,56 @@ _0216f168:
 	mov r8, #0
 	addne r0, r0, #0x1000
 	strne r0, [sp, #0x18]
-	ldrb r0, [sl, #0x39]
+	ldrb r0, [r10, #0x39]
 	cmp r0, #0
 	ble _0216f1dc
 	mov sb, r8
 _0216f18c:
-	ldr r0, [sl, #0x4c]
+	ldr r0, [r10, #0x4c]
 	cmp r8, #0
 	streq r0, [sp, #0x20]
 	addne r0, r0, sb
 	strne r0, [sp, #0x20]
 	cmp r7, #0
 	cmpeq r8, #0
-	streqh r6, [sl, #0x5a]
-	strneh r5, [sl, #0x5a]
-	add r0, sl, #0x50
+	streqh r6, [r10, #0x5a]
+	strneh r5, [r10, #0x5a]
+	add r0, r10, #0x50
 	ldr r3, [r0]
 	mov r1, r4
 	ldr r3, [r3, #0x14]
 	mov r2, r11
 	blx r3
-	ldrb r0, [sl, #0x39]
+	ldrb r0, [r10, #0x39]
 	add r8, r8, #1
 	add sb, sb, #0x1000
 	cmp r8, r0
 	blt _0216f18c
 _0216f1dc:
-	ldrb r0, [sl, #0x38]
+	ldrb r0, [r10, #0x38]
 	add r7, r7, #1
 	cmp r7, r0
 	blt _0216f168
 _0216f1ec:
-	ldrsh r0, [sl, #0xc]
-	ldr r1, [sl, #0x48]
-	ldr r2, [sl, #0x20]
+	ldrsh r0, [r10, #0xc]
+	ldr r1, [r10, #0x48]
+	ldr r2, [r10, #0x20]
 	cmp r0, #0x4000
 	bne _0216f218
-	ldr r0, [sl, #0x18]
+	ldr r0, [r10, #0x18]
 	sub r1, r1, #0x800
 	str r0, [sp, #0x18]
 	str r1, [sp, #0x1c]
 	str r2, [sp, #0x20]
 	b _0216f22c
 _0216f218:
-	ldr r0, [sl, #0x18]
+	ldr r0, [r10, #0x18]
 	sub r1, r1, #0x800
 	str r0, [sp, #0x18]
 	str r1, [sp, #0x1c]
 	str r2, [sp, #0x20]
 _0216f22c:
-	ldrb r0, [sl, #0x39]
+	ldrb r0, [r10, #0x39]
 	ldr r3, _0216f2bc ; =0x0000099a
 	mov r1, #0
 	mov r0, r0, lsl #0xc
@@ -2091,7 +2091,7 @@ _0216f22c:
 	str r0, [sp, #0xc]
 	str r0, [sp, #0x10]
 	str r0, [sp, #0x14]
-	ldrb r4, [sl, #0x38]
+	ldrb r4, [r10, #0x38]
 	ldr r0, _0216f2c0 ; =data_ov00_020e9370
 	add r2, sp, #0x18
 	mov r4, r4, lsl #0xc
@@ -2105,7 +2105,7 @@ _0216f22c:
 	orr r3, r3, r4, lsl #20
 	bl func_ov05_02102c2c
 	add sp, sp, #0x48
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov22_0216f0e0
 _0216f2b8: .word data_02050f54
@@ -2952,7 +2952,7 @@ _0216fd98: .word func_ov22_0216f41c
 	.global func_ov22_0216fd9c
 	arm_func_start func_ov22_0216fd9c
 func_ov22_0216fd9c: ; 0x0216fd9c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x48
 	mov r6, r0
 	cmp r1, #8
@@ -3141,8 +3141,8 @@ _0216ffdc:
 	mov r5, #2
 	add r7, sp, #0x10
 _02170058:
-	ldr sl, [r7, sb, lsl #2]
-	ldr r0, [sl]
+	ldr r10, [r7, sb, lsl #2]
+	ldr r0, [r10]
 	cmp r0, #0
 	beq _021700c4
 	beq _021700b4
@@ -3165,7 +3165,7 @@ _02170058:
 	add r1, r2, r1
 	str r1, [r0, #0x30]
 _021700b4:
-	mov r0, sl
+	mov r0, r10
 	mov r1, r6
 	bl func_ov00_020b7ea4
 	b _021700f4
@@ -3173,13 +3173,13 @@ _021700c4:
 	str r5, [sp]
 	ldr r0, [r11]
 	ldr r2, [r8, sb, lsl #2]
-	mov r1, sl
+	mov r1, r10
 	add r3, r4, #0x400
 	bl func_ov00_0207c1f8
-	ldr r0, [sl]
+	ldr r0, [r10]
 	cmp r0, #0
 	beq _021700f4
-	mov r0, sl
+	mov r0, r10
 	mov r1, r6
 	bl func_ov00_020b7ea4
 _021700f4:
@@ -3203,7 +3203,7 @@ _02170120:
 _0217012c:
 	add sp, sp, #0x48
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02170138:
 	add r0, r6, #0x1d8
 	mov r1, #5
@@ -3244,11 +3244,11 @@ _021701b0:
 	mov r2, r2, asr #0x10
 	bl func_0202b154
 	add sp, sp, #0x48
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _021701c8:
 	mov r0, #1
 	add sp, sp, #0x48
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov22_0216fd9c
 _021701d4: .word data_027e0e58
@@ -4258,7 +4258,7 @@ _02170ef4: .word data_ov22_021793cc
 	.global func_ov22_02170ef8
 	arm_func_start func_ov22_02170ef8
 func_ov22_02170ef8: ; 0x02170ef8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x38
 	mov r4, r0
 	ldr r1, [r4, #0x14]
@@ -4437,8 +4437,8 @@ _021710fc:
 	mov r5, #2
 	add r7, sp, #0x18
 _02171180:
-	ldr sl, [r7, sb, lsl #2]
-	ldr r0, [sl]
+	ldr r10, [r7, sb, lsl #2]
+	ldr r0, [r10]
 	cmp r0, #0
 	beq _021711ec
 	beq _021711dc
@@ -4461,7 +4461,7 @@ _02171180:
 	add r1, r2, r1
 	str r1, [r0, #0x30]
 _021711dc:
-	mov r0, sl
+	mov r0, r10
 	mov r1, r6
 	bl func_ov00_020b7ea4
 	b _0217121c
@@ -4469,13 +4469,13 @@ _021711ec:
 	str r5, [sp]
 	ldr r0, [r11]
 	ldr r2, [r8, sb, lsl #2]
-	mov r1, sl
+	mov r1, r10
 	add r3, r4, #0x7c
 	bl func_ov00_0207c1f8
-	ldr r0, [sl]
+	ldr r0, [r10]
 	cmp r0, #0
 	beq _0217121c
-	mov r0, sl
+	mov r0, r10
 	mov r1, r6
 	bl func_ov00_020b7ea4
 _0217121c:
@@ -4521,7 +4521,7 @@ _02171280:
 	add r0, r4, #0x360
 	bl func_ov00_020c5e20
 	add sp, sp, #0x38
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov22_02170ef8
 _021712ac: .word data_027e0ffc
@@ -9155,14 +9155,14 @@ func_ov22_02174ea0: ; 0x02174ea0
 	.global func_ov22_02174f00
 	arm_func_start func_ov22_02174f00
 func_ov22_02174f00: ; 0x02174f00
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x18
 	mov r5, r0
 	mov r4, r1
 	bl _ZN5Actor18func_ov00_020c313cEj
 	cmp r0, #0
 	addeq sp, sp, #0x18
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, _02175058 ; =data_027e0f64
 	mov r1, #0
 	ldr r0, [r0]
@@ -9183,7 +9183,7 @@ func_ov22_02174f00: ; 0x02174f00
 	str r0, [sp]
 	cmp r0, r1
 	addge sp, sp, #0x18
-	ldmgeia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmgeia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02174f74:
 	ldrb r4, [sp, #4]
 	ldrb r1, [sp, #5]
@@ -9207,10 +9207,10 @@ _02174f9c:
 	umull lr, ip, r3, r1
 	mla ip, r3, r0, ip
 	ldr r2, [r6, #0xc]
-	ldr sl, [r6, #0x10]
+	ldr r10, [r6, #0x10]
 	mla ip, r2, r1, ip
 	ldr sb, [r6, #0x14]
-	adds r0, sl, lr
+	adds r0, r10, lr
 	adc r2, sb, ip
 	stmia r6, {r0, r2}
 	umull r0, r1, r2, r11
@@ -9244,7 +9244,7 @@ _02175038:
 	cmp r0, r1
 	blt _02174f74
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov22_02174f00
 _02175058: .word data_027e0f64
@@ -10214,7 +10214,7 @@ _02175c40: .word data_027e0e58
 	.global func_ov22_02175c44
 	arm_func_start func_ov22_02175c44
 func_ov22_02175c44: ; 0x02175c44
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #4
 	mov sb, r0
 	ldr r0, [sb, #0x18]
@@ -10233,8 +10233,8 @@ func_ov22_02175c44: ; 0x02175c44
 	add r0, r7, #2
 	cmp r7, r0
 	addge sp, sp, #4
-	ldmgeia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
-	ldr sl, _02175cfc ; =data_027e0e60
+	ldmgeia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldr r10, _02175cfc ; =data_027e0e60
 	add r5, sp, #0
 	mov r4, #1
 _02175ca0:
@@ -10244,7 +10244,7 @@ _02175ca0:
 	bge _02175ce0
 	and r6, r7, #0xff
 _02175cb4:
-	ldr r0, [sl]
+	ldr r0, [r10]
 	mov r1, r5
 	mov r2, r4
 	strb r6, [sp]
@@ -10262,7 +10262,7 @@ _02175ce0:
 	cmp r7, r0
 	blt _02175ca0
 	add sp, sp, #4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov22_02175c44
 _02175cfc: .word data_027e0e60
@@ -12878,7 +12878,7 @@ func_ov22_02177ddc: ; 0x02177ddc
 	.global func_ov22_02177e04
 	arm_func_start func_ov22_02177e04
 func_ov22_02177e04: ; 0x02177e04
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x20
 	mov r4, r1
 	mov r8, r0
@@ -12892,7 +12892,7 @@ func_ov22_02177e04: ; 0x02177e04
 	add r2, r8, #0x18
 	mov r3, #0
 	bl func_ov00_020ceacc
-	mov sl, #0
+	mov r10, #0
 	ldr r0, [r8, #0x18]
 	ldr r2, [r8, #0x20]
 	ldr r1, [r8, #0x1c]
@@ -12901,11 +12901,11 @@ func_ov22_02177e04: ; 0x02177e04
 	str r0, [sp, #0x14]
 	str r1, [sp, #0x18]
 	str r2, [sp, #0x1c]
-	mov sb, sl
+	mov sb, r10
 	mov r8, #0xf7
 	add r7, sp, #0x14
 	mov r6, #4
-	mov r5, sl
+	mov r5, r10
 	mov r11, #0xf8
 _02177e78:
 	str sb, [sp]
@@ -12923,10 +12923,10 @@ _02177e78:
 	mov r3, #4
 	bl func_ov00_0207c1b0
 	ldr r0, [sp, #0x14]
-	add sl, sl, #1
+	add r10, r10, #1
 	add r0, r0, #0x1000
 	str r0, [sp, #0x14]
-	cmp sl, #2
+	cmp r10, #2
 	blt _02177e78
 	b _02177f44
 _02177ecc:
@@ -12964,7 +12964,7 @@ _02177f10:
 _02177f44:
 	mov r0, #1
 	add sp, sp, #0x20
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov22_02177e04
 _02177f50: .word data_027e0ffc

--- a/asm/ov22.s
+++ b/asm/ov22.s
@@ -927,7 +927,7 @@ func_ov22_0216e278: ; 0x0216e278
 	.global func_ov22_0216e2a8
 	arm_func_start func_ov22_0216e2a8
 func_ov22_0216e2a8: ; 0x0216e2a8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x68
 	mov r10, r0
 	ldr r1, [r10, #4]
@@ -1020,13 +1020,13 @@ _0216e404:
 	beq _0216e53c
 	ldrh r2, [r10, #0x24]
 	ldrh r1, [r10, #0x26]
-	mov sb, #0
+	mov r9, #0
 	mov r0, #1
 	strh r2, [sp, #0x24]
 	strh r1, [sp, #0x26]
 	ldrh r2, [r10, #0x28]
 	ldrh r1, [r10, #0x2a]
-	mov r6, sb
+	mov r6, r9
 	add r11, sp, #0x24
 	strh r2, [sp, #0x28]
 	strh r1, [sp, #0x2a]
@@ -1044,8 +1044,8 @@ _0216e404:
 	strh r1, [sp, #0x34]
 	ldrb r1, [r10, #0x36]
 	strb r1, [sp, #0x36]
-	strb sb, [sp, #4]
-	strb sb, [sp, #5]
+	strb r9, [sp, #4]
+	strb r9, [sp, #5]
 	strh r0, [sp, #0x2a]
 	ldrb r0, [r10, #0x66]
 	cmp r0, #0
@@ -1083,10 +1083,10 @@ _0216e4a8:
 	bl func_ov00_020840c4
 	cmp r0, #0
 	beq _0216e51c
-	strb sb, [r0, #0x65]
-	cmp sb, #0
-	moveq sb, #1
-	movne sb, #0
+	strb r9, [r0, #0x65]
+	cmp r9, #0
+	moveq r9, #1
+	movne r9, #0
 _0216e51c:
 	ldrb r0, [r10, #0x67]
 	add r7, r7, #1
@@ -1109,13 +1109,13 @@ _0216e53c:
 	mov r1, #3
 	blx r3
 	add sp, sp, #0x68
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0216e56c:
 	ldr r3, [r3, #0x80]
 	mov r1, #0
 	blx r3
 	add sp, sp, #0x68
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov22_0216e2a8
 _0216e580: .word 0x00001334
@@ -1272,7 +1272,7 @@ _0216e774: .word 0xffffe4cd
 	.global func_ov22_0216e778
 	arm_func_start func_ov22_0216e778
 func_ov22_0216e778: ; 0x0216e778
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x188
 	mov r4, r0
 	str r1, [r4, #8]
@@ -1344,14 +1344,14 @@ _0216e87c:
 	ldrb r0, [r4, #0x64]
 	cmp r0, #0
 	beq _0216e9d8
-	mov sb, #0
-	strb sb, [sp, #0xa]
-	strb sb, [sp, #0xb]
+	mov r9, #0
+	strb r9, [sp, #0xa]
+	strb r9, [sp, #0xb]
 	ldrb r0, [r4, #0x66]
 	cmp r0, #0
 	ble _0216e958
 	mov r5, #2
-	mov r11, sb
+	mov r11, r9
 	add r8, sp, #0xa
 _0216e8ac:
 	ldrb r0, [r4, #0x67]
@@ -1359,13 +1359,13 @@ _0216e8ac:
 	cmp r0, #0
 	ble _0216e948
 _0216e8bc:
-	cmp sb, #0
+	cmp r9, #0
 	cmpeq r10, #0
 	beq _0216e938
 	ldrb r2, [r4, #0x14]
 	ldr r0, _0216ec8c ; =data_027e0e60
 	mov r1, r8
-	add r2, sb, r2
+	add r2, r9, r2
 	strb r2, [sp, #0xa]
 	ldrb r2, [r4, #0x15]
 	ldr r0, [r0]
@@ -1397,8 +1397,8 @@ _0216e938:
 	blt _0216e8bc
 _0216e948:
 	ldrb r0, [r4, #0x66]
-	add sb, sb, #1
-	cmp sb, r0
+	add r9, r9, #1
+	cmp r9, r0
 	blt _0216e8ac
 _0216e958:
 	ldrb r1, [r4, #0x67]
@@ -1509,14 +1509,14 @@ _0216eae8:
 	ldrb r0, [r4, #0x64]
 	cmp r0, #0
 	beq _0216ec44
-	mov sb, #0
-	strb sb, [sp, #8]
-	strb sb, [sp, #9]
+	mov r9, #0
+	strb r9, [sp, #8]
+	strb r9, [sp, #9]
 	ldrb r0, [r4, #0x66]
 	cmp r0, #0
 	ble _0216ebc4
 	mov r5, #5
-	mov r11, sb
+	mov r11, r9
 	add r8, sp, #8
 _0216eb18:
 	ldrb r0, [r4, #0x67]
@@ -1524,13 +1524,13 @@ _0216eb18:
 	cmp r0, #0
 	ble _0216ebb4
 _0216eb28:
-	cmp sb, #0
+	cmp r9, #0
 	cmpeq r10, #0
 	beq _0216eba4
 	ldrb r2, [r4, #0x14]
 	ldr r0, _0216ec8c ; =data_027e0e60
 	mov r1, r8
-	add r2, sb, r2
+	add r2, r9, r2
 	strb r2, [sp, #8]
 	ldrb r2, [r4, #0x15]
 	ldr r0, [r0]
@@ -1562,8 +1562,8 @@ _0216eba4:
 	blt _0216eb28
 _0216ebb4:
 	ldrb r0, [r4, #0x66]
-	add sb, sb, #1
-	cmp sb, r0
+	add r9, r9, #1
+	cmp r9, r0
 	blt _0216eb18
 _0216ebc4:
 	ldrb r1, [r4, #0x67]
@@ -1617,7 +1617,7 @@ _0216ec74:
 	mov r0, #1
 	str r1, [r4, #0x44]
 	add sp, sp, #0x188
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov22_0216e778
 _0216ec88: .word data_027e0f74
@@ -1800,7 +1800,7 @@ func_ov22_0216ee60: ; 0x0216ee60
 	.global func_ov22_0216ee88
 	arm_func_start func_ov22_0216ee88
 func_ov22_0216ee88: ; 0x0216ee88
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x20
 	mov r4, r0
 	ldr r0, [r4, #0x18]
@@ -1877,9 +1877,9 @@ _0216ef5c:
 	str r1, [r4, #0x40]
 _0216efa0:
 	ldrb r0, [r4, #0x14]
-	ldrb sb, [r4, #0x38]
+	ldrb r9, [r4, #0x38]
 	str r0, [sp]
-	add r1, r0, sb
+	add r1, r0, r9
 	cmp r0, r1
 	bge _0216f050
 	mov r7, #1
@@ -1894,17 +1894,17 @@ _0216efcc:
 	cmp r10, r0
 	bge _0216f030
 	ldr r0, [sp]
-	and sb, r0, #0xff
+	and r9, r0, #0xff
 _0216efe8:
 	ldr r0, [r5]
 	mov r1, r8
 	mov r2, r7
-	strb sb, [sp, #6]
+	strb r9, [sp, #6]
 	strb r10, [sp, #7]
 	bl func_ov00_02082680
 	ldr r0, [r5]
 	mov r1, r6
-	strb sb, [sp, #4]
+	strb r9, [sp, #4]
 	strb r10, [sp, #5]
 	mov r2, r11
 	bl func_ov00_020826a0
@@ -1915,17 +1915,17 @@ _0216efe8:
 	cmp r10, r0
 	blt _0216efe8
 _0216f030:
-	ldrb sb, [r4, #0x38]
+	ldrb r9, [r4, #0x38]
 	ldrb r1, [r4, #0x14]
 	ldr r0, [sp]
 	add r0, r0, #1
-	add r1, r1, sb
+	add r1, r1, r9
 	str r0, [sp]
 	cmp r0, r1
 	blt _0216efcc
 _0216f050:
 	ldrb r0, [r4, #0x39]
-	mov r6, sb, lsl #0xc
+	mov r6, r9, lsl #0xc
 	mov r1, r6, asr #0x1
 	mov r5, r0, lsl #0xc
 	mov r0, r5, asr #0x1
@@ -1942,12 +1942,12 @@ _0216f050:
 	mov r0, #0
 	str r0, [r4, #0x60]
 	str r0, [r4, #0x64]
-	cmp r5, sb, lsl #12
+	cmp r5, r9, lsl #12
 	movgt r6, r5
 	str r0, [r4, #0x68]
 	str r6, [r4, #0x6c]
 	add sp, sp, #0x20
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov22_0216ee88
 _0216f0b0: .word data_027e0e60
@@ -1982,7 +1982,7 @@ func_ov22_0216f0d8: ; 0x0216f0d8
 	.global func_ov22_0216f0e0
 	arm_func_start func_ov22_0216f0e0
 func_ov22_0216f0e0: ; 0x0216f0e0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x48
 	ldr r2, [r0]
 	mov r10, r0
@@ -1990,7 +1990,7 @@ func_ov22_0216f0e0: ; 0x0216f0e0
 	blx r2
 	cmp r0, #0
 	addeq sp, sp, #0x48
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldrh r1, [r10, #0xc]
 	ldr r3, _0216f2b8 ; =data_02050f54
 	add r0, sp, #0x24
@@ -2025,12 +2025,12 @@ _0216f168:
 	ldrb r0, [r10, #0x39]
 	cmp r0, #0
 	ble _0216f1dc
-	mov sb, r8
+	mov r9, r8
 _0216f18c:
 	ldr r0, [r10, #0x4c]
 	cmp r8, #0
 	streq r0, [sp, #0x20]
-	addne r0, r0, sb
+	addne r0, r0, r9
 	strne r0, [sp, #0x20]
 	cmp r7, #0
 	cmpeq r8, #0
@@ -2044,7 +2044,7 @@ _0216f18c:
 	blx r3
 	ldrb r0, [r10, #0x39]
 	add r8, r8, #1
-	add sb, sb, #0x1000
+	add r9, r9, #0x1000
 	cmp r8, r0
 	blt _0216f18c
 _0216f1dc:
@@ -2105,7 +2105,7 @@ _0216f22c:
 	orr r3, r3, r4, lsl #20
 	bl func_ov05_02102c2c
 	add sp, sp, #0x48
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov22_0216f0e0
 _0216f2b8: .word data_02050f54
@@ -2952,7 +2952,7 @@ _0216fd98: .word func_ov22_0216f41c
 	.global func_ov22_0216fd9c
 	arm_func_start func_ov22_0216fd9c
 func_ov22_0216fd9c: ; 0x0216fd9c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x48
 	mov r6, r0
 	cmp r1, #8
@@ -3089,11 +3089,11 @@ _0216ff6c:
 	mov r8, #0
 	ldr r0, [r0]
 	sub r7, r8, #2
-	mov sb, #0x47
+	mov r9, #0x47
 	mov r3, #0xff
 	add r2, sp, #0x24
 	mov r1, #2
-	str sb, [sp, #0x24]
+	str r9, [sp, #0x24]
 	str r8, [sp, #0x28]
 	str r8, [sp, #0x2c]
 	str r7, [sp, #0x30]
@@ -3136,12 +3136,12 @@ _0216ffdc:
 	add r8, sp, #8
 	str r1, [sp, #8]
 	str r0, [sp, #0xc]
-	mov sb, #0
+	mov r9, #0
 	add r6, sp, #0x18
 	mov r5, #2
 	add r7, sp, #0x10
 _02170058:
-	ldr r10, [r7, sb, lsl #2]
+	ldr r10, [r7, r9, lsl #2]
 	ldr r0, [r10]
 	cmp r0, #0
 	beq _021700c4
@@ -3172,7 +3172,7 @@ _021700b4:
 _021700c4:
 	str r5, [sp]
 	ldr r0, [r11]
-	ldr r2, [r8, sb, lsl #2]
+	ldr r2, [r8, r9, lsl #2]
 	mov r1, r10
 	add r3, r4, #0x400
 	bl func_ov00_0207c1f8
@@ -3183,8 +3183,8 @@ _021700c4:
 	mov r1, r6
 	bl func_ov00_020b7ea4
 _021700f4:
-	add sb, sb, #1
-	cmp sb, #2
+	add r9, r9, #1
+	cmp r9, #2
 	blt _02170058
 	b _0217012c
 _02170104:
@@ -3203,7 +3203,7 @@ _02170120:
 _0217012c:
 	add sp, sp, #0x48
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02170138:
 	add r0, r6, #0x1d8
 	mov r1, #5
@@ -3244,11 +3244,11 @@ _021701b0:
 	mov r2, r2, asr #0x10
 	bl func_0202b154
 	add sp, sp, #0x48
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _021701c8:
 	mov r0, #1
 	add sp, sp, #0x48
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov22_0216fd9c
 _021701d4: .word data_027e0e58
@@ -4258,7 +4258,7 @@ _02170ef4: .word data_ov22_021793cc
 	.global func_ov22_02170ef8
 	arm_func_start func_ov22_02170ef8
 func_ov22_02170ef8: ; 0x02170ef8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x38
 	mov r4, r0
 	ldr r1, [r4, #0x14]
@@ -4432,12 +4432,12 @@ _021710fc:
 	add r8, sp, #0x10
 	str r1, [sp, #0x10]
 	str r0, [sp, #0x14]
-	mov sb, #0
+	mov r9, #0
 	add r6, sp, #0x20
 	mov r5, #2
 	add r7, sp, #0x18
 _02171180:
-	ldr r10, [r7, sb, lsl #2]
+	ldr r10, [r7, r9, lsl #2]
 	ldr r0, [r10]
 	cmp r0, #0
 	beq _021711ec
@@ -4468,7 +4468,7 @@ _021711dc:
 _021711ec:
 	str r5, [sp]
 	ldr r0, [r11]
-	ldr r2, [r8, sb, lsl #2]
+	ldr r2, [r8, r9, lsl #2]
 	mov r1, r10
 	add r3, r4, #0x7c
 	bl func_ov00_0207c1f8
@@ -4479,8 +4479,8 @@ _021711ec:
 	mov r1, r6
 	bl func_ov00_020b7ea4
 _0217121c:
-	add sb, sb, #1
-	cmp sb, #2
+	add r9, r9, #1
+	cmp r9, #2
 	blt _02171180
 	b _02171280
 _0217122c:
@@ -4521,7 +4521,7 @@ _02171280:
 	add r0, r4, #0x360
 	bl func_ov00_020c5e20
 	add sp, sp, #0x38
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov22_02170ef8
 _021712ac: .word data_027e0ffc
@@ -9155,14 +9155,14 @@ func_ov22_02174ea0: ; 0x02174ea0
 	.global func_ov22_02174f00
 	arm_func_start func_ov22_02174f00
 func_ov22_02174f00: ; 0x02174f00
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x18
 	mov r5, r0
 	mov r4, r1
 	bl _ZN5Actor18func_ov00_020c313cEj
 	cmp r0, #0
 	addeq sp, sp, #0x18
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, _02175058 ; =data_027e0f64
 	mov r1, #0
 	ldr r0, [r0]
@@ -9183,7 +9183,7 @@ func_ov22_02174f00: ; 0x02174f00
 	str r0, [sp]
 	cmp r0, r1
 	addge sp, sp, #0x18
-	ldmgeia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmgeia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02174f74:
 	ldrb r4, [sp, #4]
 	ldrb r1, [sp, #5]
@@ -9209,9 +9209,9 @@ _02174f9c:
 	ldr r2, [r6, #0xc]
 	ldr r10, [r6, #0x10]
 	mla ip, r2, r1, ip
-	ldr sb, [r6, #0x14]
+	ldr r9, [r6, #0x14]
 	adds r0, r10, lr
-	adc r2, sb, ip
+	adc r2, r9, ip
 	stmia r6, {r0, r2}
 	umull r0, r1, r2, r11
 	mov r0, #0
@@ -9244,7 +9244,7 @@ _02175038:
 	cmp r0, r1
 	blt _02174f74
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov22_02174f00
 _02175058: .word data_027e0f64
@@ -9969,7 +9969,7 @@ _02175954: .word data_ov22_0217a568
 	.global func_ov22_02175958
 	arm_func_start func_ov22_02175958
 func_ov22_02175958: ; 0x02175958
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	mov r4, r0
 	bl _ZN13LinkStateBase10GetStateIdEv
 	cmp r0, #6
@@ -10000,10 +10000,10 @@ func_ov22_02175958: ; 0x02175958
 	ldrsh r5, [r6, r5]
 	mov r6, r7, asr #0x1f
 	mov lr, r5, asr #0x1f
-	umull sb, r8, r7, r2
+	umull r9, r8, r7, r2
 	mla r8, r7, ip, r8
 	mla r8, r6, r2, r8
-	adds r6, sb, #0x800
+	adds r6, r9, #0x800
 	adc r2, r8, #0
 	mov r6, r6, lsr #0xc
 	orr r6, r6, r2, lsl #20
@@ -10036,7 +10036,7 @@ func_ov22_02175958: ; 0x02175958
 	bl _ZN13LinkStateBase15ChangeLinkStateEi
 _02175a5c:
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov22_02175958
 _02175a64: .word data_ov22_0217a568
@@ -10214,31 +10214,31 @@ _02175c40: .word data_027e0e58
 	.global func_ov22_02175c44
 	arm_func_start func_ov22_02175c44
 func_ov22_02175c44: ; 0x02175c44
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #4
-	mov sb, r0
-	ldr r0, [sb, #0x18]
-	ldr r2, [sb, #0x20]
-	ldr r1, [sb, #0x1c]
+	mov r9, r0
+	ldr r0, [r9, #0x18]
+	ldr r2, [r9, #0x20]
+	ldr r1, [r9, #0x1c]
 	add r0, r0, #0x800
-	str r0, [sb, #0x40]
-	str r1, [sb, #0x44]
+	str r0, [r9, #0x40]
+	str r1, [r9, #0x44]
 	add r1, r2, #0x7800
-	str r1, [sb, #0x48]
+	str r1, [r9, #0x48]
 	ldr r0, _02175cfc ; =data_027e0e60
-	add r1, sb, #0x18
+	add r1, r9, #0x18
 	ldr r0, [r0]
 	bl func_ov00_0208344c
-	ldrb r7, [sb, #0x14]
+	ldrb r7, [r9, #0x14]
 	add r0, r7, #2
 	cmp r7, r0
 	addge sp, sp, #4
-	ldmgeia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmgeia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	ldr r10, _02175cfc ; =data_027e0e60
 	add r5, sp, #0
 	mov r4, #1
 _02175ca0:
-	ldrb r8, [sb, #0x15]
+	ldrb r8, [r9, #0x15]
 	add r0, r8, #0x10
 	cmp r8, r0
 	bge _02175ce0
@@ -10250,19 +10250,19 @@ _02175cb4:
 	strb r6, [sp]
 	strb r8, [sp, #1]
 	bl func_ov00_02082680
-	ldrb r0, [sb, #0x15]
+	ldrb r0, [r9, #0x15]
 	add r8, r8, #1
 	add r0, r0, #0x10
 	cmp r8, r0
 	blt _02175cb4
 _02175ce0:
-	ldrb r0, [sb, #0x14]
+	ldrb r0, [r9, #0x14]
 	add r7, r7, #1
 	add r0, r0, #2
 	cmp r7, r0
 	blt _02175ca0
 	add sp, sp, #4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov22_02175c44
 _02175cfc: .word data_027e0e60
@@ -12102,7 +12102,7 @@ _021774c0:
 	.global func_ov22_021774c8
 	arm_func_start func_ov22_021774c8
 func_ov22_021774c8: ; 0x021774c8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x54
 	mov r4, r0
 	add r0, r4, #0x48
@@ -12169,23 +12169,23 @@ _02177548:
 	ldr r2, [r7, #0x14]
 	ldr r6, _021776fc ; =0x00001001
 	adc ip, r2, r8
-	umull sb, r8, r1, lr
+	umull r9, r8, r1, lr
 	mla r8, r1, ip, r8
 	mla r8, r0, lr, r8
-	adds r3, r3, sb
+	adds r3, r3, r9
 	adc r8, r2, r8
 	str lr, [r7]
 	str ip, [r7, #4]
-	umull r2, sb, ip, r6
+	umull r2, r9, ip, r6
 	mov r1, #0
-	mla sb, ip, r1, sb
+	mla r9, ip, r1, r9
 	sub r0, r6, #0x800
 	stmia r7, {r3, r8}
 	umull r2, r3, r8, r0
 	mla r3, r8, r1, r3
-	mla sb, r1, r6, sb
+	mla r9, r1, r6, r9
 	mla r3, r1, r0, r3
-	sub r0, sb, #0x800
+	sub r0, r9, #0x800
 	add r2, r5, r0
 	ldr r1, [sp, #0x50]
 	sub r0, r3, #0x3000
@@ -12241,11 +12241,11 @@ _02177684:
 	mov r0, #1
 	add r1, r1, #1
 	str r1, [r4, #0x328]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _021776d4:
 	mov r0, #0
 	add sp, sp, #0x54
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov22_021774c8
 _021776e0: .word data_ov22_02178880
@@ -12878,7 +12878,7 @@ func_ov22_02177ddc: ; 0x02177ddc
 	.global func_ov22_02177e04
 	arm_func_start func_ov22_02177e04
 func_ov22_02177e04: ; 0x02177e04
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x20
 	mov r4, r1
 	mov r8, r0
@@ -12901,15 +12901,15 @@ func_ov22_02177e04: ; 0x02177e04
 	str r0, [sp, #0x14]
 	str r1, [sp, #0x18]
 	str r2, [sp, #0x1c]
-	mov sb, r10
+	mov r9, r10
 	mov r8, #0xf7
 	add r7, sp, #0x14
 	mov r6, #4
 	mov r5, r10
 	mov r11, #0xf8
 _02177e78:
-	str sb, [sp]
-	str sb, [sp, #4]
+	str r9, [sp]
+	str r9, [sp, #4]
 	ldr r0, [r4]
 	mov r1, r8
 	mov r2, r7
@@ -12940,7 +12940,7 @@ _02177ecc:
 	ldr r1, [r8, #0x1c]
 	sub r0, r0, #0x800
 	mov r7, #0
-	ldr sb, _02177f58 ; =data_027e0e58
+	ldr r9, _02177f58 ; =data_027e0e58
 	str r0, [sp, #8]
 	str r1, [sp, #0xc]
 	str r2, [sp, #0x10]
@@ -12950,7 +12950,7 @@ _02177ecc:
 _02177f10:
 	str r6, [sp]
 	str r6, [sp, #4]
-	ldr r0, [sb]
+	ldr r0, [r9]
 	mov r1, r5
 	mov r3, r4
 	add r2, r8, #0x18
@@ -12964,7 +12964,7 @@ _02177f10:
 _02177f44:
 	mov r0, #1
 	add sp, sp, #0x20
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov22_02177e04
 _02177f50: .word data_027e0ffc

--- a/asm/ov23.s
+++ b/asm/ov23.s
@@ -6957,7 +6957,7 @@ _02173120: .word data_02050f54
 	.global func_ov23_02173124
 	arm_func_start func_ov23_02173124
 func_ov23_02173124: ; 0x02173124
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x10c
 	mov r6, r0
 	bl func_ov23_02173014
@@ -7054,7 +7054,7 @@ _02173260:
 	cmp r0, #0
 	beq _02173330
 	ldrh r1, [r6, #0x78]
-	mov fp, #0
+	mov r11, #0
 	add r0, r4, #0x48
 	mov r1, r1, asr #0x4
 	mov r3, r1, lsl #0x1
@@ -7063,11 +7063,11 @@ _02173260:
 	ldrsh r2, [r1, r2]
 	add r1, r1, r3, lsl #1
 	umull sl, r3, r2, r8
-	mla r3, r2, fp, r3
+	mla r3, r2, r11, r3
 	mov ip, r2, asr #0x1f
 	mla r3, ip, r8, r3
 	adds sl, sl, #0x800
-	mov r2, fp
+	mov r2, r11
 	adc r2, r3, r2
 	mov r3, sl, lsr #0xc
 	orr r3, r3, r2, lsl #20
@@ -7076,11 +7076,11 @@ _02173260:
 	str r2, [r4, #0x64]
 	ldrsh r3, [r1, #2]
 	mov r1, #0
-	umull fp, sl, r3, sb
+	umull r11, sl, r3, sb
 	mla sl, r3, r1, sl
 	mov r2, r3, asr #0x1f
 	mla sl, r2, sb, sl
-	adds r2, fp, #0x800
+	adds r2, r11, #0x800
 	adc r1, sl, #0
 	mov r2, r2, lsr #0xc
 	orr r2, r2, r1, lsl #20
@@ -7112,7 +7112,7 @@ _02173364:
 	sub r0, r0, #0x4c0
 	str r0, [sp, #8]
 	ldr r0, _021734dc ; =0x00000733
-	mov fp, r5
+	mov r11, r5
 	sub r7, r0, #0x400
 	add sb, r6, #0x184
 	mov r8, r7
@@ -7141,8 +7141,8 @@ _02173388:
 	beq _021734a8
 	mov r0, sl
 	add r1, sp, #0x14
-	str fp, [sp, #0x14]
-	str fp, [sp, #0x18]
+	str r11, [sp, #0x14]
+	str r11, [sp, #0x18]
 	bl func_ov14_0212de90
 	cmp r0, #0
 	beq _021734a8
@@ -7197,7 +7197,7 @@ _021734a8:
 	cmp r4, #1
 	ble _02173364
 	add sp, sp, #0x10c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov23_02173124
 _021734c8: .word data_02050f54
@@ -13670,7 +13670,7 @@ _02178aac: .word data_027e0ffc
 	.global func_ov23_02178ab0
 	arm_func_start func_ov23_02178ab0
 func_ov23_02178ab0: ; 0x02178ab0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x50
 	mov sl, r0
 	bl _ZN13LinkStateBase18func_ov00_020a8d40Ev
@@ -13685,7 +13685,7 @@ func_ov23_02178ab0: ; 0x02178ab0
 	mov r0, r4
 	bl func_ov00_02083e58
 	mov r7, #0
-	ldr fp, _02179018 ; =data_02050f54
+	ldr r11, _02179018 ; =data_02050f54
 	str r0, [sp]
 	mov r8, r7
 	str r7, [sp, #0x44]
@@ -13702,8 +13702,8 @@ _02178b10:
 	mov r0, r0, asr #0x4
 	mov r1, r0, lsl #0x1
 	mov r0, r1, lsl #0x1
-	ldrsh r2, [fp, r0]
-	add r0, fp, r1, lsl #1
+	ldrsh r2, [r11, r0]
+	add r0, r11, r1, lsl #1
 	ldrsh r1, [r0, #2]
 	mov r0, r2, asr #0x1f
 	mov r3, r0, lsl #0xb
@@ -14000,14 +14000,14 @@ _02178f80:
 	ldrb r0, [sl, #0x31]
 	cmp r0, #0
 	addeq sp, sp, #0x50
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, _02179020 ; =data_027e0d38
 	ldr r0, [r0]
 	add r0, r0, #0xc
 	bl func_ov00_020a5e9c
 	cmp r0, #0x2e
 	addne sp, sp, #0x50
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	mov r0, sl
 	bl _ZN13LinkStateBase12GetPlayerVelEv
 	ldr r0, [r0]
@@ -14018,7 +14018,7 @@ _02178f80:
 	ldr r0, [r0, #8]
 	cmp r0, #0
 	addeq sp, sp, #0x50
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02178fd8:
 	mov r0, sl
 	bl _ZN13LinkStateBase12GetPlayerVelEv
@@ -14034,7 +14034,7 @@ _02178fd8:
 	mov r2, #0x3e8
 	bl func_0202b154
 	add sp, sp, #0x50
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov23_02178ab0
 _02179014: .word data_027e0e60

--- a/asm/ov23.s
+++ b/asm/ov23.s
@@ -2368,7 +2368,7 @@ _0216f424: .word func_ov00_020cd028
 	.global func_ov23_0216f428
 	arm_func_start func_ov23_0216f428
 func_ov23_0216f428: ; 0x0216f428
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x1fc
 	mov r6, r1
 	mov r5, r0
@@ -2404,8 +2404,8 @@ func_ov23_0216f428: ; 0x0216f428
 	cmp r4, r0
 	addne sp, sp, #0x1fc
 	mov r0, #0
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, pc}
-	ldr sb, _0216f87c ; =0x0000ffff
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, pc}
+	ldr r9, _0216f87c ; =0x0000ffff
 	ldr lr, [sp, #0xc8]
 	ldr ip, [sp, #0xd0]
 	ldr r7, [sp, #0xbc]
@@ -2413,10 +2413,10 @@ func_ov23_0216f428: ; 0x0216f428
 	str r4, [sp, #0xc0]
 	str r4, [sp, #0xcc]
 	add r1, sp, #0x114
-	strh sb, [r1, #0xac]
-	strh sb, [r1, #0xae]
-	strh sb, [r1, #0xb0]
-	strh sb, [r1, #0xb2]
+	strh r9, [r1, #0xac]
+	strh r9, [r1, #0xae]
+	strh r9, [r1, #0xb0]
+	strh r9, [r1, #0xb2]
 	strh r0, [r1, #0xb4]
 	ldr r8, _0216f880 ; =0x00000733
 	add r2, sp, #0xac
@@ -2460,7 +2460,7 @@ func_ov23_0216f428: ; 0x0216f428
 	cmp r0, #0
 	addne sp, sp, #0x1fc
 	movne r0, #0
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	ldr r1, _0216f884 ; =data_027e0fe4
 	ldr r2, _0216f888 ; =0x4e545250
 	ldr r1, [r1]
@@ -2497,7 +2497,7 @@ func_ov23_0216f428: ; 0x0216f428
 	cmp r0, #0
 	addne sp, sp, #0x1fc
 	movne r0, #0
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _0216f630:
 	ldr r1, _0216f884 ; =data_027e0fe4
 	ldr r2, _0216f88c ; =0x50534241
@@ -2533,7 +2533,7 @@ _0216f630:
 	strb r2, [sp, #0x1f]
 	addeq sp, sp, #0x1fc
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _0216f6bc:
 	ldr r0, _0216f878 ; =data_027e0e60
 	mov r1, r6
@@ -2548,7 +2548,7 @@ _0216f6bc:
 	bne _0216f6f4
 	add sp, sp, #0x1fc
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _0216f6f4:
 	ldr r4, _0216f890 ; =_ZTV11FilterActor
 	mov r1, #0
@@ -2641,7 +2641,7 @@ _0216f7b4:
 _0216f84c:
 	add sp, sp, #0x1fc
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _0216f858:
 	ldr r0, [sp, #0x98]
 	add r4, r4, #1
@@ -2651,7 +2651,7 @@ _0216f858:
 _0216f86c:
 	mov r0, #1
 	add sp, sp, #0x1fc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov23_0216f428
 _0216f878: .word data_027e0e60
@@ -3814,14 +3814,14 @@ func_ov23_021707dc: ; 0x021707dc
 	.global func_ov23_021707e0
 	arm_func_start func_ov23_021707e0
 func_ov23_021707e0: ; 0x021707e0
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #0x18
 	mov r5, r0
 	ldr r0, [r5, #0x1bc]
 	mov r4, r1
 	cmp r0, #0
 	addeq sp, sp, #0x18
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	ldr r1, [r4]
 	mov r0, #0
 	str r1, [sp, #0xc]
@@ -3844,16 +3844,16 @@ func_ov23_021707e0: ; 0x021707e0
 	add r1, sp, #0
 	mov r0, r4
 	bl func_01ff9d4c
-	ldr sb, [sp]
+	ldr r9, [sp]
 	mov r1, #0x2800
-	umull r0, r10, sb, r1
+	umull r0, r10, r9, r1
 	mov r2, #0
 	ldr lr, [sp, #4]
 	adds r0, r0, #0x800
 	umull r7, r6, lr, r1
 	ldr r3, [sp, #8]
-	mla r10, sb, r2, r10
-	mov r8, sb, asr #0x1f
+	mla r10, r9, r2, r10
+	mov r8, r9, asr #0x1f
 	mla r10, r8, r1, r10
 	umull ip, r4, r3, r1
 	mla r6, lr, r2, r6
@@ -3918,7 +3918,7 @@ _0217093c:
 	str r2, [sp, #0x14]
 	bl func_ov00_020b7ea4
 	add sp, sp, #0x18
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _02170980:
 	ldr r1, [r5, #0x1bc]
 	cmp r1, #0
@@ -3926,7 +3926,7 @@ _02170980:
 	orrne r0, r0, #2
 	strne r0, [r1, #0x24]
 	add sp, sp, #0x18
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov23_021707e0
 _0217099c: .word 0x0000059a
@@ -6401,7 +6401,7 @@ _02172994: .word 0x0000099a
 	.global func_ov23_02172998
 	arm_func_start func_ov23_02172998
 func_ov23_02172998: ; 0x02172998
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #0x2c
 	mov r4, r0
 	bl func_ov23_02173014
@@ -6443,7 +6443,7 @@ func_ov23_02172998: ; 0x02172998
 	cmp r0, #0
 	moveq r0, #2
 	movne r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 _02172a44:
 	add r0, r4, #0x184
 	mov r2, #0
@@ -6453,7 +6453,7 @@ _02172a44:
 	strb r2, [sp, #3]
 	bl func_ov00_020c5374
 	mvn r7, #0
-	ldr sb, _02172b14 ; =data_027e0e60
+	ldr r9, _02172b14 ; =data_027e0e60
 	mov r6, r7
 	add r10, sp, #0x1c
 	add r5, sp, #0
@@ -6462,7 +6462,7 @@ _02172a74:
 _02172a78:
 	ldrb r2, [sp, #2]
 	ldrb r1, [sp, #3]
-	ldr r0, [sb]
+	ldr r0, [r9]
 	add r3, r2, r7
 	add r2, r1, r8
 	mov r1, r5
@@ -6486,7 +6486,7 @@ _02172a78:
 	cmp r0, #0
 	addne sp, sp, #0x2c
 	movne r0, #2
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 _02172ae4:
 	add r8, r8, #1
 	cmp r8, #1
@@ -6496,7 +6496,7 @@ _02172ae4:
 	ble _02172a74
 	mov r0, #0
 	add sp, sp, #0x2c
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov23_02172998
 _02172b08: .word data_027e0fe4
@@ -6957,7 +6957,7 @@ _02173120: .word data_02050f54
 	.global func_ov23_02173124
 	arm_func_start func_ov23_02173124
 func_ov23_02173124: ; 0x02173124
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x10c
 	mov r6, r0
 	bl func_ov23_02173014
@@ -7037,7 +7037,7 @@ _021731ec:
 	str r0, [sp, #4]
 	ldr r0, _021734dc ; =0x00000733
 	sub r8, r0, #0x400
-	mov sb, r8
+	mov r9, r8
 _02173260:
 	ldr r0, _021734d8 ; =data_027e0fe4
 	ldr r1, [sp, #0x2c]
@@ -7076,10 +7076,10 @@ _02173260:
 	str r2, [r4, #0x64]
 	ldrsh r3, [r1, #2]
 	mov r1, #0
-	umull r11, r10, r3, sb
+	umull r11, r10, r3, r9
 	mla r10, r3, r1, r10
 	mov r2, r3, asr #0x1f
-	mla r10, r2, sb, r10
+	mla r10, r2, r9, r10
 	adds r2, r11, #0x800
 	adc r1, r10, #0
 	mov r2, r2, lsr #0xc
@@ -7114,7 +7114,7 @@ _02173364:
 	ldr r0, _021734dc ; =0x00000733
 	mov r11, r5
 	sub r7, r0, #0x400
-	add sb, r6, #0x184
+	add r9, r6, #0x184
 	mov r8, r7
 _02173388:
 	ldrb r1, [sp, #0x13]
@@ -7135,7 +7135,7 @@ _02173388:
 	cmp r0, #0x24
 	bne _021734a8
 	mov r0, r10
-	add r1, sb, #0x400
+	add r1, r9, #0x400
 	bl func_ov00_0208b7d0
 	cmp r0, #0
 	beq _021734a8
@@ -7197,7 +7197,7 @@ _021734a8:
 	cmp r4, #1
 	ble _02173364
 	add sp, sp, #0x10c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov23_02173124
 _021734c8: .word data_02050f54
@@ -7211,7 +7211,7 @@ _021734e0: .word data_027e0e60
 	.global func_ov23_021734e4
 	arm_func_start func_ov23_021734e4
 func_ov23_021734e4: ; 0x021734e4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x18
 	ldr r2, _0217389c ; =0x00000333
 	mov r4, r0
@@ -7232,7 +7232,7 @@ func_ov23_021734e4: ; 0x021734e4
 	bl func_ov00_020cadb0
 	add sp, sp, #0x18
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _0217353c:
 	add r3, r4, #0x100
 	ldrh r6, [r3, #0xb0]
@@ -7256,13 +7256,13 @@ _0217356c:
 	cmpne r0, #0xd
 	addeq sp, sp, #0x18
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	mov r0, r4
 	mov r1, #0xb
 	bl func_ov23_02172cac
 	add sp, sp, #0x18
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _021735ac:
 	ldr r0, [r5, #4]
 	ldr r1, [r5, #0xc]
@@ -7322,20 +7322,20 @@ _0217362c:
 	smull r2, r7, lr, r5
 	orr ip, ip, r6, lsl #20
 	str r1, [sp, #0xc]
-	ldr sb, [r4, #0x4c]
+	ldr r9, [r4, #0x4c]
 	ldr r0, [sp, #4]
 	smull r5, r6, r8, r5
 	adds lr, r2, #0x800
 	add r1, r1, ip
 	adc ip, r7, #0
 	adds r7, r5, #0x800
-	str sb, [sp, #0x10]
+	str r9, [sp, #0x10]
 	smull r5, r3, r8, r3
 	adc r6, r6, #0
 	mov r7, r7, lsr #0xc
 	orr r7, r7, r6, lsl #20
 	ldr r2, [r4, #0x50]
-	add r0, sb, r0
+	add r0, r9, r0
 	str r0, [sp, #0x10]
 	mov r0, lr, lsr #0xc
 	orr r0, r0, ip, lsl #20
@@ -7360,7 +7360,7 @@ _0217362c:
 	bl func_ov23_02172cac
 	add sp, sp, #0x18
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _02173728:
 	mov r2, #4
 	mov r0, r4
@@ -7374,7 +7374,7 @@ _02173728:
 	bl func_ov00_020cadb0
 	add sp, sp, #0x18
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _0217375c:
 	ldr r1, [r5, #0x14]
 	cmp r1, #0
@@ -7432,7 +7432,7 @@ _0217375c:
 	bl func_ov23_02172cac
 	add sp, sp, #0x18
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _02173840:
 	mov r0, r4
 	mov r1, r5
@@ -7444,7 +7444,7 @@ _02173840:
 	bl func_ov00_020cadb0
 	add sp, sp, #0x18
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _0217386c:
 	bl func_ov00_020cb60c
 	cmp r0, #0
@@ -7454,11 +7454,11 @@ _0217386c:
 	bl func_ov00_020cadb0
 	add sp, sp, #0x18
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _02173890:
 	mov r0, #0
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov23_021734e4
 _0217389c: .word 0x00000333
@@ -11638,35 +11638,35 @@ _0217701c: .word data_027e0e58
 	.global func_ov23_02177020
 	arm_func_start func_ov23_02177020
 func_ov23_02177020: ; 0x02177020
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #4
-	mov sb, r0
-	ldr r1, [sb, #0x18]
+	mov r9, r0
+	ldr r1, [r9, #0x18]
 	ldr r0, _021770e8 ; =data_027e0e60
-	str r1, [sb, #0x38]
-	ldr r2, [sb, #0x1c]
-	add r1, sb, #0x18
-	str r2, [sb, #0x3c]
-	ldr r2, [sb, #0x20]
-	str r2, [sb, #0x40]
-	ldr r2, [sb, #0x38]
+	str r1, [r9, #0x38]
+	ldr r2, [r9, #0x1c]
+	add r1, r9, #0x18
+	str r2, [r9, #0x3c]
+	ldr r2, [r9, #0x20]
+	str r2, [r9, #0x40]
+	ldr r2, [r9, #0x38]
 	add r2, r2, #0x800
-	str r2, [sb, #0x38]
-	ldr r2, [sb, #0x40]
+	str r2, [r9, #0x38]
+	ldr r2, [r9, #0x40]
 	add r2, r2, #0x1800
-	str r2, [sb, #0x40]
+	str r2, [r9, #0x40]
 	ldr r0, [r0]
 	bl func_ov00_0208344c
-	ldrb r7, [sb, #0x14]
+	ldrb r7, [r9, #0x14]
 	add r0, r7, #2
 	cmp r7, r0
 	addge sp, sp, #4
-	ldmgeia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmgeia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	ldr r10, _021770e8 ; =data_027e0e60
 	add r5, sp, #0
 	mov r4, #1
 _0217708c:
-	ldrb r8, [sb, #0x15]
+	ldrb r8, [r9, #0x15]
 	add r0, r8, #4
 	cmp r8, r0
 	bge _021770cc
@@ -11678,19 +11678,19 @@ _021770a0:
 	strb r6, [sp]
 	strb r8, [sp, #1]
 	bl func_ov00_02082680
-	ldrb r0, [sb, #0x15]
+	ldrb r0, [r9, #0x15]
 	add r8, r8, #1
 	add r0, r0, #4
 	cmp r8, r0
 	blt _021770a0
 _021770cc:
-	ldrb r0, [sb, #0x14]
+	ldrb r0, [r9, #0x14]
 	add r7, r7, #1
 	add r0, r0, #2
 	cmp r7, r0
 	blt _0217708c
 	add sp, sp, #4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov23_02177020
 _021770e8: .word data_027e0e60
@@ -12786,9 +12786,9 @@ _02177e8c: .word 0x000004cd
 	.global func_ov23_02177e90
 	arm_func_start func_ov23_02177e90
 func_ov23_02177e90: ; 0x02177e90
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	ldr r1, _0217803c ; =data_027e0d38
-	mov sb, r0
+	mov r9, r0
 	ldr r0, [r1]
 	add r0, r0, #0xc
 	bl func_ov00_020a5e9c
@@ -12874,7 +12874,7 @@ _02177fc8:
 _02177fcc:
 	cmp r7, #0
 	beq _02178010
-	ldrb r0, [sb, #0x80]
+	ldrb r0, [r9, #0x80]
 	cmp r0, #0
 	bne _02178018
 	mov r4, #1
@@ -12882,7 +12882,7 @@ _02177fcc:
 	ldr r2, _02178044 ; =data_027e0f94
 	rsb r1, r4, #0x400
 	mov r3, #0
-	strb r4, [sb, #0x80]
+	strb r4, [r9, #0x80]
 	bl func_ov00_020ceacc
 	ldr r0, _02178050 ; =data_027e0fd4
 	mov r1, #0xf
@@ -12891,18 +12891,18 @@ _02177fcc:
 	b _02178018
 _02178010:
 	mov r0, #0
-	strb r0, [sb, #0x80]
+	strb r0, [r9, #0x80]
 _02178018:
 	ldr r0, _02178054 ; =data_027e0fcc
 	ldr r1, _02178048 ; =data_027e0fa0
 	ldr r0, [r0]
 	mov r2, r7
 	bl func_ov23_021707e0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _02178030:
 	mov r0, #0
-	strb r0, [sb, #0x80]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	strb r0, [r9, #0x80]
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov23_02177e90
 _0217803c: .word data_027e0d38
@@ -13670,7 +13670,7 @@ _02178aac: .word data_027e0ffc
 	.global func_ov23_02178ab0
 	arm_func_start func_ov23_02178ab0
 func_ov23_02178ab0: ; 0x02178ab0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x50
 	mov r10, r0
 	bl _ZN13LinkStateBase18func_ov00_020a8d40Ev
@@ -13744,11 +13744,11 @@ _02178b10:
 	bl func_01ff9bc4
 	ldr r0, _02179014 ; =data_027e0e60
 	mov r2, r4
-	ldr sb, [r0]
+	ldr r9, [r0]
 	add r0, sp, #6
-	mov r1, sb
+	mov r1, r9
 	bl func_ov00_02083a1c
-	mov r0, sb
+	mov r0, r9
 	add r1, sp, #6
 	bl func_ov00_02083e58
 	ldr r1, _02179014 ; =data_027e0e60
@@ -14000,14 +14000,14 @@ _02178f80:
 	ldrb r0, [r10, #0x31]
 	cmp r0, #0
 	addeq sp, sp, #0x50
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, _02179020 ; =data_027e0d38
 	ldr r0, [r0]
 	add r0, r0, #0xc
 	bl func_ov00_020a5e9c
 	cmp r0, #0x2e
 	addne sp, sp, #0x50
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	mov r0, r10
 	bl _ZN13LinkStateBase12GetPlayerVelEv
 	ldr r0, [r0]
@@ -14018,7 +14018,7 @@ _02178f80:
 	ldr r0, [r0, #8]
 	cmp r0, #0
 	addeq sp, sp, #0x50
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02178fd8:
 	mov r0, r10
 	bl _ZN13LinkStateBase12GetPlayerVelEv
@@ -14034,7 +14034,7 @@ _02178fd8:
 	mov r2, #0x3e8
 	bl func_0202b154
 	add sp, sp, #0x50
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov23_02178ab0
 _02179014: .word data_027e0e60

--- a/asm/ov23.s
+++ b/asm/ov23.s
@@ -3814,14 +3814,14 @@ func_ov23_021707dc: ; 0x021707dc
 	.global func_ov23_021707e0
 	arm_func_start func_ov23_021707e0
 func_ov23_021707e0: ; 0x021707e0
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #0x18
 	mov r5, r0
 	ldr r0, [r5, #0x1bc]
 	mov r4, r1
 	cmp r0, #0
 	addeq sp, sp, #0x18
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	ldr r1, [r4]
 	mov r0, #0
 	str r1, [sp, #0xc]
@@ -3846,19 +3846,19 @@ func_ov23_021707e0: ; 0x021707e0
 	bl func_01ff9d4c
 	ldr sb, [sp]
 	mov r1, #0x2800
-	umull r0, sl, sb, r1
+	umull r0, r10, sb, r1
 	mov r2, #0
 	ldr lr, [sp, #4]
 	adds r0, r0, #0x800
 	umull r7, r6, lr, r1
 	ldr r3, [sp, #8]
-	mla sl, sb, r2, sl
+	mla r10, sb, r2, r10
 	mov r8, sb, asr #0x1f
-	mla sl, r8, r1, sl
+	mla r10, r8, r1, r10
 	umull ip, r4, r3, r1
 	mla r6, lr, r2, r6
 	mov r0, r0, lsr #0xc
-	adc r8, sl, #0
+	adc r8, r10, #0
 	orr r0, r0, r8, lsl #20
 	str r0, [sp]
 	adds r0, r7, #0x800
@@ -3918,7 +3918,7 @@ _0217093c:
 	str r2, [sp, #0x14]
 	bl func_ov00_020b7ea4
 	add sp, sp, #0x18
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _02170980:
 	ldr r1, [r5, #0x1bc]
 	cmp r1, #0
@@ -3926,7 +3926,7 @@ _02170980:
 	orrne r0, r0, #2
 	strne r0, [r1, #0x24]
 	add sp, sp, #0x18
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov23_021707e0
 _0217099c: .word 0x0000059a
@@ -6401,7 +6401,7 @@ _02172994: .word 0x0000099a
 	.global func_ov23_02172998
 	arm_func_start func_ov23_02172998
 func_ov23_02172998: ; 0x02172998
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #0x2c
 	mov r4, r0
 	bl func_ov23_02173014
@@ -6443,7 +6443,7 @@ func_ov23_02172998: ; 0x02172998
 	cmp r0, #0
 	moveq r0, #2
 	movne r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 _02172a44:
 	add r0, r4, #0x184
 	mov r2, #0
@@ -6455,7 +6455,7 @@ _02172a44:
 	mvn r7, #0
 	ldr sb, _02172b14 ; =data_027e0e60
 	mov r6, r7
-	add sl, sp, #0x1c
+	add r10, sp, #0x1c
 	add r5, sp, #0
 _02172a74:
 	mov r8, r6
@@ -6477,7 +6477,7 @@ _02172a78:
 	cmp r0, #0x24
 	bne _02172ae4
 	mov r0, r4
-	mov r1, sl
+	mov r1, r10
 	bl func_ov00_0208b7d0
 	cmp r0, #0
 	beq _02172ae4
@@ -6486,7 +6486,7 @@ _02172a78:
 	cmp r0, #0
 	addne sp, sp, #0x2c
 	movne r0, #2
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 _02172ae4:
 	add r8, r8, #1
 	cmp r8, #1
@@ -6496,7 +6496,7 @@ _02172ae4:
 	ble _02172a74
 	mov r0, #0
 	add sp, sp, #0x2c
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov23_02172998
 _02172b08: .word data_027e0fe4
@@ -6957,7 +6957,7 @@ _02173120: .word data_02050f54
 	.global func_ov23_02173124
 	arm_func_start func_ov23_02173124
 func_ov23_02173124: ; 0x02173124
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x10c
 	mov r6, r0
 	bl func_ov23_02173014
@@ -7062,26 +7062,26 @@ _02173260:
 	mov r2, r3, lsl #0x1
 	ldrsh r2, [r1, r2]
 	add r1, r1, r3, lsl #1
-	umull sl, r3, r2, r8
+	umull r10, r3, r2, r8
 	mla r3, r2, r11, r3
 	mov ip, r2, asr #0x1f
 	mla r3, ip, r8, r3
-	adds sl, sl, #0x800
+	adds r10, r10, #0x800
 	mov r2, r11
 	adc r2, r3, r2
-	mov r3, sl, lsr #0xc
+	mov r3, r10, lsr #0xc
 	orr r3, r3, r2, lsl #20
 	ldr r2, _021734dc ; =0x00000733
 	str r3, [r4, #0x60]
 	str r2, [r4, #0x64]
 	ldrsh r3, [r1, #2]
 	mov r1, #0
-	umull r11, sl, r3, sb
-	mla sl, r3, r1, sl
+	umull r11, r10, r3, sb
+	mla r10, r3, r1, r10
 	mov r2, r3, asr #0x1f
-	mla sl, r2, sb, sl
+	mla r10, r2, sb, r10
 	adds r2, r11, #0x800
-	adc r1, sl, #0
+	adc r1, r10, #0
 	mov r2, r2, lsr #0xc
 	orr r2, r2, r1, lsl #20
 	str r2, [r4, #0x68]
@@ -7127,19 +7127,19 @@ _02173388:
 	add r1, sp, #0x10
 	strb r2, [sp, #0x10]
 	bl func_ov00_020840c4
-	movs sl, r0
+	movs r10, r0
 	beq _021734a8
 	ldr r1, [r0]
 	ldr r1, [r1, #0x1c]
 	blx r1
 	cmp r0, #0x24
 	bne _021734a8
-	mov r0, sl
+	mov r0, r10
 	add r1, sb, #0x400
 	bl func_ov00_0208b7d0
 	cmp r0, #0
 	beq _021734a8
-	mov r0, sl
+	mov r0, r10
 	add r1, sp, #0x14
 	str r11, [sp, #0x14]
 	str r11, [sp, #0x18]
@@ -7160,11 +7160,11 @@ _02173388:
 	ldrsh ip, [r1, r2]
 	add r2, r1, r3, lsl #1
 	mov r1, #0
-	umull sl, lr, ip, r7
+	umull r10, lr, ip, r7
 	mla lr, ip, r1, lr
 	mov r3, ip, asr #0x1f
 	mla lr, r3, r7, lr
-	adds r3, sl, #0x800
+	adds r3, r10, #0x800
 	adc r1, lr, #0
 	mov r3, r3, lsr #0xc
 	orr r3, r3, r1, lsl #20
@@ -7175,9 +7175,9 @@ _02173388:
 	ldrsh ip, [r2, #2]
 	umull r2, r1, ip, r8
 	mla r1, ip, r3, r1
-	mov sl, ip, asr #0x1f
+	mov r10, ip, asr #0x1f
 	adds r3, r2, #0x800
-	mla r1, sl, r8, r1
+	mla r1, r10, r8, r1
 	adc r1, r1, #0
 	mov r2, r3, lsr #0xc
 	orr r2, r2, r1, lsl #20
@@ -7197,7 +7197,7 @@ _021734a8:
 	cmp r4, #1
 	ble _02173364
 	add sp, sp, #0x10c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov23_02173124
 _021734c8: .word data_02050f54
@@ -11638,7 +11638,7 @@ _0217701c: .word data_027e0e58
 	.global func_ov23_02177020
 	arm_func_start func_ov23_02177020
 func_ov23_02177020: ; 0x02177020
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #4
 	mov sb, r0
 	ldr r1, [sb, #0x18]
@@ -11661,8 +11661,8 @@ func_ov23_02177020: ; 0x02177020
 	add r0, r7, #2
 	cmp r7, r0
 	addge sp, sp, #4
-	ldmgeia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
-	ldr sl, _021770e8 ; =data_027e0e60
+	ldmgeia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldr r10, _021770e8 ; =data_027e0e60
 	add r5, sp, #0
 	mov r4, #1
 _0217708c:
@@ -11672,7 +11672,7 @@ _0217708c:
 	bge _021770cc
 	and r6, r7, #0xff
 _021770a0:
-	ldr r0, [sl]
+	ldr r0, [r10]
 	mov r1, r5
 	mov r2, r4
 	strb r6, [sp]
@@ -11690,7 +11690,7 @@ _021770cc:
 	cmp r7, r0
 	blt _0217708c
 	add sp, sp, #4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov23_02177020
 _021770e8: .word data_027e0e60
@@ -13670,9 +13670,9 @@ _02178aac: .word data_027e0ffc
 	.global func_ov23_02178ab0
 	arm_func_start func_ov23_02178ab0
 func_ov23_02178ab0: ; 0x02178ab0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x50
-	mov sl, r0
+	mov r10, r0
 	bl _ZN13LinkStateBase18func_ov00_020a8d40Ev
 	mov r2, r0
 	ldr r1, _02179014 ; =data_027e0e60
@@ -13730,7 +13730,7 @@ _02178b10:
 	add r0, r6, r1
 	str r0, [r5, #8]
 	str r6, [sp, #0x3c]
-	mov r0, sl
+	mov r0, r10
 	bl _ZN13LinkStateBase12GetPlayerPosEv
 	ldr r2, [r0]
 	mov r1, r5
@@ -13778,25 +13778,25 @@ _02178c2c:
 	ldr r1, _0217901c ; =0x00000333
 	add r0, sp, #0x44
 	bl func_01fffbec
-	mov r0, sl
+	mov r0, r10
 	bl _ZN13LinkStateBase12GetPlayerVelEv
 	ldr r1, [sp, #0x44]
 	str r1, [r0]
-	mov r0, sl
+	mov r0, r10
 	bl _ZN13LinkStateBase12GetPlayerVelEv
 	ldr r1, [sp, #0x4c]
 	b _02178c94
 _02178c78:
-	mov r0, sl
+	mov r0, r10
 	bl _ZN13LinkStateBase12GetPlayerVelEv
 	mov r1, #0
 	str r1, [r0]
-	mov r0, sl
+	mov r0, r10
 	bl _ZN13LinkStateBase12GetPlayerVelEv
 	mov r1, #0
 _02178c94:
 	str r1, [r0, #8]
-	ldrb r0, [sl, #0x31]
+	ldrb r0, [r10, #0x31]
 	cmp r0, #0
 	beq _02178e48
 	ldr r0, _02179020 ; =data_027e0d38
@@ -13805,11 +13805,11 @@ _02178c94:
 	bl func_ov00_020a5e9c
 	cmp r0, #0x2e
 	bne _02178e48
-	mov r0, sl
+	mov r0, r10
 	bl _ZN13LinkStateBase12GetPlayerPosEv
 	ldr r0, [r0]
 	cmp r0, #0x800
-	mov r0, sl
+	mov r0, r10
 	blt _02178ce4
 	bl _ZN13LinkStateBase12GetPlayerVelEv
 	mvn r1, #0xcc
@@ -13821,7 +13821,7 @@ _02178ce4:
 	ldr r0, [r0]
 	rsb r1, r1, #0
 	cmp r0, r1
-	mov r0, sl
+	mov r0, r10
 	bgt _02178d10
 	bl _ZN13LinkStateBase12GetPlayerVelEv
 	mov r1, #0xcd
@@ -13832,11 +13832,11 @@ _02178d10:
 	mov r1, #0
 	str r1, [r0]
 _02178d1c:
-	mov r0, sl
+	mov r0, r10
 	bl _ZN13LinkStateBase12GetPlayerPosEv
 	ldr r0, [r0, #8]
 	cmp r0, #0x5800
-	mov r0, sl
+	mov r0, r10
 	blt _02178d44
 	bl _ZN13LinkStateBase12GetPlayerVelEv
 	mvn r1, #0xcc
@@ -13846,7 +13846,7 @@ _02178d44:
 	bl _ZN13LinkStateBase12GetPlayerPosEv
 	ldr r0, [r0, #8]
 	cmp r0, #0x4800
-	mov r0, sl
+	mov r0, r10
 	bgt _02178d68
 	bl _ZN13LinkStateBase12GetPlayerVelEv
 	mov r1, #0xcd
@@ -13857,20 +13857,20 @@ _02178d68:
 	mov r1, #0
 	str r1, [r0, #8]
 _02178d74:
-	mov r0, sl
+	mov r0, r10
 	bl _ZN13LinkStateBase12GetPlayerPosEv
 	ldr r1, [r0]
 	str r1, [sp, #0x20]
 	ldr r1, [r0, #4]
 	str r1, [sp, #0x24]
 	ldr r1, [r0, #8]
-	mov r0, sl
+	mov r0, r10
 	str r1, [sp, #0x28]
 	bl _ZN13LinkStateBase12GetPlayerVelEv
 	ldr r0, [r0]
 	cmp r0, #0
 	beq _02178e48
-	mov r0, sl
+	mov r0, r10
 	bl _ZN13LinkStateBase12GetPlayerVelEv
 	ldr r0, [r0]
 	cmp r0, #0
@@ -13880,7 +13880,7 @@ _02178d74:
 	str r0, [sp, #0x20]
 	b _02178de8
 _02178dcc:
-	mov r0, sl
+	mov r0, r10
 	bl _ZN13LinkStateBase12GetPlayerVelEv
 	ldr r0, [r0]
 	cmp r0, #0
@@ -13908,12 +13908,12 @@ _02178de8:
 	and r0, r0, #3
 	cmp r0, #2
 	beq _02178e48
-	mov r0, sl
+	mov r0, r10
 	bl _ZN13LinkStateBase12GetPlayerVelEv
 	mov r1, #0
 	str r1, [r0]
 _02178e48:
-	mov r0, sl
+	mov r0, r10
 	bl _ZN13LinkStateBase12GetPlayerPosEv
 	ldr r2, [r0, #4]
 	ldr r1, _02179024 ; =0xfffff99a
@@ -13921,10 +13921,10 @@ _02178e48:
 	add r0, r0, r1
 	cmp r2, r0
 	bgt _02178f10
-	ldrb r0, [sl, #0x31]
+	ldrb r0, [r10, #0x31]
 	cmp r0, #0
 	bne _02178f00
-	mov r0, sl
+	mov r0, r10
 	bl _ZN13LinkStateBase19GetCurrentCharacterEv
 	cmp r0, #0
 	beq _02178e90
@@ -13933,26 +13933,26 @@ _02178e48:
 	b _02178eb4
 _02178e90:
 	ldr r1, _02179028 ; =data_ov23_0217ab30
-	mov r0, sl
+	mov r0, r10
 	mov r2, #1
 	bl _ZN13LinkStateBase18func_ov00_020a8a4cEii
 	b _02178eb4
 _02178ea4:
 	ldr r1, _0217902c ; =data_ov23_0217ab20
-	mov r0, sl
+	mov r0, r10
 	mov r2, #1
 	bl _ZN13LinkStateBase18func_ov00_020a8a4cEii
 _02178eb4:
-	mov r0, sl
+	mov r0, r10
 	bl _ZN13LinkStateBase12GetPlayerPosEv
 	ldr r2, _02179024 ; =0xfffff99a
 	ldr r1, [sp]
 	add r1, r1, r2
 	str r1, [r0, #4]
-	mov r0, sl
+	mov r0, r10
 	bl _ZN13LinkStateBase20GetPlayerControlDataEv
 	mov r4, r0
-	mov r0, sl
+	mov r0, r10
 	bl _ZN13LinkStateBase12GetPlayerPosEv
 	mov r2, r0
 	mov r0, r4
@@ -13961,21 +13961,21 @@ _02178eb4:
 	ldr r3, [r3, #0x70]
 	blx r3
 	mov r0, #1
-	strb r0, [sl, #0x31]
+	strb r0, [r10, #0x31]
 _02178f00:
-	mov r0, sl
+	mov r0, r10
 	bl _ZN13LinkStateBase12GetPlayerVelEv
 	mvn r1, #0x7a
 	str r1, [r0, #4]
 _02178f10:
-	mov r0, sl
+	mov r0, r10
 	bl _ZN13LinkStateBase12GetPlayerPosEv
 	add r3, sp, #0x14
 	ldmia r0, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
 	ldr r0, [sp]
 	str r0, [sp, #0x18]
-	ldr r0, [sl, #0xac]
+	ldr r0, [r10, #0xac]
 	cmp r0, #0
 	beq _02178f80
 	ldr r1, [r0, #0x20]
@@ -13997,44 +13997,44 @@ _02178f10:
 	add r1, r2, r1
 	str r1, [r0, #0x30]
 _02178f80:
-	ldrb r0, [sl, #0x31]
+	ldrb r0, [r10, #0x31]
 	cmp r0, #0
 	addeq sp, sp, #0x50
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, _02179020 ; =data_027e0d38
 	ldr r0, [r0]
 	add r0, r0, #0xc
 	bl func_ov00_020a5e9c
 	cmp r0, #0x2e
 	addne sp, sp, #0x50
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
-	mov r0, sl
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	mov r0, r10
 	bl _ZN13LinkStateBase12GetPlayerVelEv
 	ldr r0, [r0]
 	cmp r0, #0
 	bne _02178fd8
-	mov r0, sl
+	mov r0, r10
 	bl _ZN13LinkStateBase12GetPlayerVelEv
 	ldr r0, [r0, #8]
 	cmp r0, #0
 	addeq sp, sp, #0x50
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02178fd8:
-	mov r0, sl
+	mov r0, r10
 	bl _ZN13LinkStateBase12GetPlayerVelEv
 	mov r1, r0
 	ldr r0, [r1]
 	ldr r1, [r1, #8]
 	bl func_01ffa0f4
 	mov r1, r0, lsl #0x10
-	mov r0, sl
+	mov r0, r10
 	mov r4, r1, asr #0x10
 	bl _ZN13LinkStateBase14GetPlayerAngleEv
 	mov r1, r4
 	mov r2, #0x3e8
 	bl func_0202b154
 	add sp, sp, #0x50
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov23_02178ab0
 _02179014: .word data_027e0e60

--- a/asm/ov24.s
+++ b/asm/ov24.s
@@ -127,7 +127,7 @@ _0216d820: .word data_027e0f6c
 	.global func_ov24_0216d824
 	arm_func_start func_ov24_0216d824
 func_ov24_0216d824: ; 0x0216d824
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #0x54
 	mov r5, r0
 	ldr r0, [r5, #0x18]
@@ -159,10 +159,10 @@ _0216d878:
 	ldrh r0, [r5, #0x26]
 	cmp r0, #0
 	strneb r0, [r5, #0x65]
-	ldrb sb, [r5, #0x14]
+	ldrb r9, [r5, #0x14]
 	ldrb r4, [r5, #0x64]
-	add r0, sb, r4
-	cmp sb, r0
+	add r0, r9, r4
+	cmp r9, r0
 	bge _0216d914
 	ldr r6, _0216da24 ; =data_027e0e60
 	add r8, sp, #4
@@ -173,7 +173,7 @@ _0216d8b4:
 	add r0, r10, r0
 	cmp r10, r0
 	bge _0216d8fc
-	and r4, sb, #0xff
+	and r4, r9, #0xff
 _0216d8cc:
 	ldr r0, [r6]
 	mov r1, r8
@@ -190,9 +190,9 @@ _0216d8cc:
 _0216d8fc:
 	ldrb r4, [r5, #0x64]
 	ldrb r0, [r5, #0x14]
-	add sb, sb, #1
+	add r9, r9, #1
 	add r0, r0, r4
-	cmp sb, r0
+	cmp r9, r0
 	blt _0216d8b4
 _0216d914:
 	ldrb r0, [r5, #0x65]
@@ -214,7 +214,7 @@ _0216d914:
 	ldr r8, [r5, #0x1c]
 	ldr r3, [r5, #0x20]
 	sub r2, r1, r7, asr #1
-	add sb, r1, r7, asr #1
+	add r9, r1, r7, asr #1
 	sub r0, r3, r6, asr #1
 	mov r1, #0
 	sub ip, r8, #0x400
@@ -231,7 +231,7 @@ _0216d914:
 	str r0, [sp, #0x50]
 	ldmia r1, {r0, r1, r2}
 	stmia r8, {r0, r1, r2}
-	str sb, [sp, #0x3c]
+	str r9, [sp, #0x3c]
 	str r10, [sp, #0x40]
 	add r0, sp, #0x3c
 	add r3, sp, #0x30
@@ -262,7 +262,7 @@ _0216d914:
 	str r0, [r5, #0x90]
 	str r7, [r5, #0x94]
 	add sp, sp, #0x54
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov24_0216d824
 _0216da24: .word data_027e0e60
@@ -401,7 +401,7 @@ func_ov24_0216db88: ; 0x0216db88
 	.global func_ov24_0216db90
 	arm_func_start func_ov24_0216db90
 func_ov24_0216db90: ; 0x0216db90
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x30
 	ldr r2, [r0]
 	mov r10, r0
@@ -409,7 +409,7 @@ func_ov24_0216db90: ; 0x0216db90
 	blx r2
 	cmp r0, #0
 	addeq sp, sp, #0x30
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldrh r1, [r10, #0xc]
 	ldr r3, _0216dca8 ; =data_02050f54
 	add r0, sp, #0xc
@@ -431,7 +431,7 @@ func_ov24_0216db90: ; 0x0216db90
 	ldrb r0, [r10, #0x64]
 	cmp r0, #0
 	addle sp, sp, #0x30
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	mvn r5, #0
 	mov r6, r7
 	add r4, sp, #0xc
@@ -445,12 +445,12 @@ _0216dc1c:
 	ldrb r0, [r10, #0x65]
 	cmp r0, #0
 	ble _0216dc90
-	mov sb, r8
+	mov r9, r8
 _0216dc40:
 	ldr r0, [r10, #0x70]
 	cmp r8, #0
 	streq r0, [sp, #8]
-	addne r0, r0, sb
+	addne r0, r0, r9
 	strne r0, [sp, #8]
 	cmp r7, #0
 	cmpeq r8, #0
@@ -464,7 +464,7 @@ _0216dc40:
 	blx r3
 	ldrb r0, [r10, #0x65]
 	add r8, r8, #1
-	add sb, sb, #0x1000
+	add r9, r9, #0x1000
 	cmp r8, r0
 	blt _0216dc40
 _0216dc90:
@@ -473,7 +473,7 @@ _0216dc90:
 	cmp r7, r0
 	blt _0216dc1c
 	add sp, sp, #0x30
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov24_0216db90
 _0216dca8: .word data_02050f54
@@ -851,11 +851,11 @@ _0216e178: .word data_027e0f74
 	.global func_ov24_0216e17c
 	arm_func_start func_ov24_0216e17c
 func_ov24_0216e17c: ; 0x0216e17c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	mov r4, r0
 	bl _ZN5Actor18func_ov00_020c313cEj
 	cmp r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	ldr r0, [r4, #0x130]
 	cmp r0, #3
 	addls pc, pc, r0, lsl #2
@@ -1009,12 +1009,12 @@ _0216e3a0:
 	mov r8, #0
 	add r0, r4, #0x5a
 	ldr r6, _0216e4b8 ; =data_ov24_021791fc
-	add sb, r0, #0x100
+	add r9, r0, #0x100
 	mov r5, r8
 	mov r7, r8
 _0216e3d0:
 	ldr r1, [r4, #0x174]
-	mov r0, sb
+	mov r0, r9
 	ldr r2, [r6, r1, lsl #2]
 	mov r1, r7
 	bl func_0202b3bc
@@ -1024,7 +1024,7 @@ _0216e3d0:
 	add r8, r8, #1
 	strneh r5, [r0, #0x5a]
 	cmp r8, #2
-	add sb, sb, #2
+	add r9, r9, #2
 	blo _0216e3d0
 _0216e404:
 	ldr r0, _0216e49c ; =data_027e0f74
@@ -1066,7 +1066,7 @@ _0216e438:
 	add r5, r5, #1
 	cmp r5, #2
 	blo _0216e438
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov24_0216e17c
 _0216e49c: .word data_027e0f74
@@ -7693,7 +7693,7 @@ _02173b14: .word data_027e0fe4
 	.global func_ov24_02173b18
 	arm_func_start func_ov24_02173b18
 func_ov24_02173b18: ; 0x02173b18
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x5c
 	mov r4, r0
 	add r0, sp, #0x30
@@ -7748,14 +7748,14 @@ _02173bd8:
 	ldmia r0, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
 	ldrh r0, [r4, #0x78]
-	ldr sb, [r4, #0x48]
+	ldr r9, [r4, #0x48]
 	ldr r2, _02173cf0 ; =data_02050f54
 	mov r0, r0, asr #0x4
 	mov r1, r0, lsl #0x1
 	add r0, r1, #1
 	mov r1, r1, lsl #0x1
 	mov r0, r0, lsl #0x1
-	str sb, [sp, #0xc]
+	str r9, [sp, #0xc]
 	ldr r7, [r4, #0x4c]
 	ldrsh r1, [r2, r1]
 	ldrsh ip, [r2, r0]
@@ -7776,12 +7776,12 @@ _02173bd8:
 	str r7, [sp, #0x10]
 	rsb r1, r1, #0
 	adds r4, r4, #0x800
-	add r5, sb, r5
-	adc sb, r3, #0
+	add r5, r9, r5
+	adc r9, r3, #0
 	mov r3, r4, lsr #0xc
 	smull r7, r6, r2, ip
 	adds r7, r7, #0x800
-	orr r3, r3, sb, lsl #20
+	orr r3, r3, r9, lsl #20
 	smull r4, r1, r2, r1
 	adc r6, r6, #0
 	adds r2, r4, #0x800
@@ -7809,7 +7809,7 @@ _02173bd8:
 	movge r0, #1
 	movlt r0, #0
 	add sp, sp, #0x5c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov24_02173b18
 _02173ce4: .word data_027e0f94
@@ -11334,8 +11334,8 @@ func_ov24_02176a80: ; 0x02176a80
 	.global func_ov24_02176a94
 	arm_func_start func_ov24_02176a94
 func_ov24_02176a94: ; 0x02176a94
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
-	mov sb, r0
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
+	mov r9, r0
 	mov r8, r1
 	bl _ZN5Actor10GetAngleToEP5Vec3p
 	mov r0, r0, lsl #0x10
@@ -11346,16 +11346,16 @@ func_ov24_02176a94: ; 0x02176a94
 	ldr r2, _02176bd4 ; =data_02050f54
 	mov r3, r1, lsl #0x1
 	mov r1, r0, lsl #0x1
-	add r0, sb, #0x60
+	add r0, r9, #0x60
 	ldrsh r6, [r2, r3]
 	ldrsh r7, [r2, r1]
 	bl func_01ff9cec
 	mov r4, r0
 	mov r1, r8
-	add r0, sb, #0x48
+	add r0, r9, #0x48
 	bl func_ov00_020ce2f0
 	mov r5, r0
-	mov r0, sb
+	mov r0, r9
 	mov r1, r8
 	bl _ZN5Actor12XzDistanceToEP5Vec3p
 	cmp r0, #0x2000
@@ -11394,30 +11394,30 @@ _02176b5c:
 	adds r1, r1, #0x800
 	mov r3, r3, lsr #0xc
 	orr r3, r3, r2, lsl #20
-	str r3, [sb, #0x60]
+	str r3, [r9, #0x60]
 	mov r2, #0
 	adc r0, r0, #0
 	mov r1, r1, lsr #0xc
-	str r2, [sb, #0x64]
+	str r2, [r9, #0x64]
 	orr r1, r1, r0, lsl #20
-	str r1, [sb, #0x68]
+	str r1, [r9, #0x68]
 	ldr r2, [r8, #4]
-	ldr r0, [sb, #0x4c]
+	ldr r0, [r9, #0x4c]
 	ldr r1, _02176bd8 ; =0x0000019a
 	sub r2, r2, r0
-	str r2, [sb, #0x64]
+	str r2, [r9, #0x64]
 	cmp r2, r1
-	strgt r1, [sb, #0x64]
+	strgt r1, [r9, #0x64]
 	bgt _02176bc0
 	sub r0, r1, #0x334
 	cmp r2, r0
-	strlt r0, [sb, #0x64]
+	strlt r0, [r9, #0x64]
 _02176bc0:
-	add r0, sb, #0x48
-	add r1, sb, #0x60
+	add r0, r9, #0x48
+	add r1, r9, #0x60
 	mov r2, r0
 	bl func_01ff9bc4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov24_02176a94
 _02176bd4: .word data_02050f54
@@ -14054,11 +14054,11 @@ _02178e1c: .word func_ov00_0208b9e4
 	.global func_ov24_02178e20
 	arm_func_start func_ov24_02178e20
 func_ov24_02178e20: ; 0x02178e20
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x10
 	mov r10, r0
 	ldrb r7, [r10, #0x14]
-	mov sb, r1
+	mov r9, r1
 	add r0, r7, #2
 	cmp r7, r0
 	bge _02178ee8
@@ -14072,7 +14072,7 @@ _02178e4c:
 	bge _02178ed4
 	and r6, r7, #0xff
 _02178e60:
-	cmp sb, #0
+	cmp r9, #0
 	ldr r0, [r4]
 	beq _02178e98
 	mov r1, r5
@@ -14128,7 +14128,7 @@ _02178ee8:
 	ldr r1, [r1]
 	mov r2, r6
 	bl func_ov00_02093a4c
-	cmp sb, #0
+	cmp r9, #0
 	add r2, sp, #0xc
 	beq _02178fa4
 	ldr r1, [sp, #0xc]
@@ -14156,7 +14156,7 @@ _02178ee8:
 	str r3, [sp, #4]
 	bl func_ov00_02093a3c
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02178fa4:
 	ldr r0, _02179014 ; =data_027e0f6c
 	ldr r1, [sp, #0xc]
@@ -14184,7 +14184,7 @@ _02178fa4:
 	str r3, [sp, #4]
 	bl func_ov00_02093a3c
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov24_02178e20
 _02179010: .word data_027e0e60

--- a/asm/ov24.s
+++ b/asm/ov24.s
@@ -401,7 +401,7 @@ func_ov24_0216db88: ; 0x0216db88
 	.global func_ov24_0216db90
 	arm_func_start func_ov24_0216db90
 func_ov24_0216db90: ; 0x0216db90
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x30
 	ldr r2, [r0]
 	mov sl, r0
@@ -409,7 +409,7 @@ func_ov24_0216db90: ; 0x0216db90
 	blx r2
 	cmp r0, #0
 	addeq sp, sp, #0x30
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldrh r1, [sl, #0xc]
 	ldr r3, _0216dca8 ; =data_02050f54
 	add r0, sp, #0xc
@@ -431,11 +431,11 @@ func_ov24_0216db90: ; 0x0216db90
 	ldrb r0, [sl, #0x64]
 	cmp r0, #0
 	addle sp, sp, #0x30
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	mvn r5, #0
 	mov r6, r7
 	add r4, sp, #0xc
-	add fp, sp, #0
+	add r11, sp, #0
 _0216dc1c:
 	cmp r7, #0
 	ldrne r0, [sp]
@@ -460,7 +460,7 @@ _0216dc40:
 	ldr r3, [r0]
 	mov r1, r4
 	ldr r3, [r3, #0x14]
-	mov r2, fp
+	mov r2, r11
 	blx r3
 	ldrb r0, [sl, #0x65]
 	add r8, r8, #1
@@ -473,7 +473,7 @@ _0216dc90:
 	cmp r7, r0
 	blt _0216dc1c
 	add sp, sp, #0x30
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov24_0216db90
 _0216dca8: .word data_02050f54
@@ -14054,7 +14054,7 @@ _02178e1c: .word func_ov00_0208b9e4
 	.global func_ov24_02178e20
 	arm_func_start func_ov24_02178e20
 func_ov24_02178e20: ; 0x02178e20
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x10
 	mov sl, r0
 	ldrb r7, [sl, #0x14]
@@ -14064,7 +14064,7 @@ func_ov24_02178e20: ; 0x02178e20
 	bge _02178ee8
 	ldr r4, _02179010 ; =data_027e0e60
 	add r5, sp, #2
-	mov fp, #1
+	mov r11, #1
 _02178e4c:
 	ldrb r8, [sl, #0x15]
 	add r0, r8, #2
@@ -14076,7 +14076,7 @@ _02178e60:
 	ldr r0, [r4]
 	beq _02178e98
 	mov r1, r5
-	mov r2, fp
+	mov r2, r11
 	strb r6, [sp, #2]
 	strb r8, [sp, #3]
 	bl func_ov00_02082680
@@ -14156,7 +14156,7 @@ _02178ee8:
 	str r3, [sp, #4]
 	bl func_ov00_02093a3c
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02178fa4:
 	ldr r0, _02179014 ; =data_027e0f6c
 	ldr r1, [sp, #0xc]
@@ -14184,7 +14184,7 @@ _02178fa4:
 	str r3, [sp, #4]
 	bl func_ov00_02093a3c
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov24_02178e20
 _02179010: .word data_027e0e60

--- a/asm/ov24.s
+++ b/asm/ov24.s
@@ -127,7 +127,7 @@ _0216d820: .word data_027e0f6c
 	.global func_ov24_0216d824
 	arm_func_start func_ov24_0216d824
 func_ov24_0216d824: ; 0x0216d824
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #0x54
 	mov r5, r0
 	ldr r0, [r5, #0x18]
@@ -168,10 +168,10 @@ _0216d878:
 	add r8, sp, #4
 	mov r7, #1
 _0216d8b4:
-	ldrb sl, [r5, #0x15]
+	ldrb r10, [r5, #0x15]
 	ldrb r0, [r5, #0x65]
-	add r0, sl, r0
-	cmp sl, r0
+	add r0, r10, r0
+	cmp r10, r0
 	bge _0216d8fc
 	and r4, sb, #0xff
 _0216d8cc:
@@ -179,13 +179,13 @@ _0216d8cc:
 	mov r1, r8
 	mov r2, r7
 	strb r4, [sp, #4]
-	strb sl, [sp, #5]
+	strb r10, [sp, #5]
 	bl func_ov00_020826a0
 	ldrb r1, [r5, #0x15]
 	ldrb r0, [r5, #0x65]
-	add sl, sl, #1
+	add r10, r10, #1
 	add r0, r1, r0
-	cmp sl, r0
+	cmp r10, r0
 	blt _0216d8cc
 _0216d8fc:
 	ldrb r4, [r5, #0x64]
@@ -218,7 +218,7 @@ _0216d914:
 	sub r0, r3, r6, asr #1
 	mov r1, #0
 	sub ip, r8, #0x400
-	add sl, r8, #0x400
+	add r10, r8, #0x400
 	add r3, r3, r6, asr #1
 	str r3, [sp, #0x44]
 	bic r1, r1, #0x1f
@@ -232,7 +232,7 @@ _0216d914:
 	ldmia r1, {r0, r1, r2}
 	stmia r8, {r0, r1, r2}
 	str sb, [sp, #0x3c]
-	str sl, [sp, #0x40]
+	str r10, [sp, #0x40]
 	add r0, sp, #0x3c
 	add r3, sp, #0x30
 	ldmia r0, {r0, r1, r2}
@@ -262,7 +262,7 @@ _0216d914:
 	str r0, [r5, #0x90]
 	str r7, [r5, #0x94]
 	add sp, sp, #0x54
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov24_0216d824
 _0216da24: .word data_027e0e60
@@ -401,16 +401,16 @@ func_ov24_0216db88: ; 0x0216db88
 	.global func_ov24_0216db90
 	arm_func_start func_ov24_0216db90
 func_ov24_0216db90: ; 0x0216db90
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x30
 	ldr r2, [r0]
-	mov sl, r0
+	mov r10, r0
 	ldr r2, [r2, #0x88]
 	blx r2
 	cmp r0, #0
 	addeq sp, sp, #0x30
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
-	ldrh r1, [sl, #0xc]
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldrh r1, [r10, #0xc]
 	ldr r3, _0216dca8 ; =data_02050f54
 	add r0, sp, #0xc
 	mov r1, r1, asr #0x4
@@ -421,17 +421,17 @@ func_ov24_0216db90: ; 0x0216db90
 	ldrsh r1, [r3, r4]
 	ldrsh r2, [r3, r2]
 	blx func_01ff8214
-	ldr r2, [sl, #0x70]
-	ldr r1, [sl, #0x1c]
-	ldr r0, [sl, #0x68]
+	ldr r2, [r10, #0x70]
+	ldr r1, [r10, #0x1c]
+	ldr r0, [r10, #0x68]
 	mov r7, #0
 	str r1, [sp, #4]
 	str r2, [sp, #8]
 	str r0, [sp]
-	ldrb r0, [sl, #0x64]
+	ldrb r0, [r10, #0x64]
 	cmp r0, #0
 	addle sp, sp, #0x30
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	mvn r5, #0
 	mov r6, r7
 	add r4, sp, #0xc
@@ -442,38 +442,38 @@ _0216dc1c:
 	mov r8, #0
 	addne r0, r0, #0x1000
 	strne r0, [sp]
-	ldrb r0, [sl, #0x65]
+	ldrb r0, [r10, #0x65]
 	cmp r0, #0
 	ble _0216dc90
 	mov sb, r8
 _0216dc40:
-	ldr r0, [sl, #0x70]
+	ldr r0, [r10, #0x70]
 	cmp r8, #0
 	streq r0, [sp, #8]
 	addne r0, r0, sb
 	strne r0, [sp, #8]
 	cmp r7, #0
 	cmpeq r8, #0
-	streqh r6, [sl, #0x82]
-	strneh r5, [sl, #0x82]
-	add r0, sl, #0x78
+	streqh r6, [r10, #0x82]
+	strneh r5, [r10, #0x82]
+	add r0, r10, #0x78
 	ldr r3, [r0]
 	mov r1, r4
 	ldr r3, [r3, #0x14]
 	mov r2, r11
 	blx r3
-	ldrb r0, [sl, #0x65]
+	ldrb r0, [r10, #0x65]
 	add r8, r8, #1
 	add sb, sb, #0x1000
 	cmp r8, r0
 	blt _0216dc40
 _0216dc90:
-	ldrb r0, [sl, #0x64]
+	ldrb r0, [r10, #0x64]
 	add r7, r7, #1
 	cmp r7, r0
 	blt _0216dc1c
 	add sp, sp, #0x30
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov24_0216db90
 _0216dca8: .word data_02050f54
@@ -14054,10 +14054,10 @@ _02178e1c: .word func_ov00_0208b9e4
 	.global func_ov24_02178e20
 	arm_func_start func_ov24_02178e20
 func_ov24_02178e20: ; 0x02178e20
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x10
-	mov sl, r0
-	ldrb r7, [sl, #0x14]
+	mov r10, r0
+	ldrb r7, [r10, #0x14]
 	mov sb, r1
 	add r0, r7, #2
 	cmp r7, r0
@@ -14066,7 +14066,7 @@ func_ov24_02178e20: ; 0x02178e20
 	add r5, sp, #2
 	mov r11, #1
 _02178e4c:
-	ldrb r8, [sl, #0x15]
+	ldrb r8, [r10, #0x15]
 	add r0, r8, #2
 	cmp r8, r0
 	bge _02178ed4
@@ -14098,25 +14098,25 @@ _02178e98:
 	mov r3, #0x35
 	bl func_ov00_02084d24
 _02178ec0:
-	ldrb r0, [sl, #0x15]
+	ldrb r0, [r10, #0x15]
 	add r8, r8, #1
 	add r0, r0, #2
 	cmp r8, r0
 	blt _02178e60
 _02178ed4:
-	ldrb r0, [sl, #0x14]
+	ldrb r0, [r10, #0x14]
 	add r7, r7, #1
 	add r0, r0, #2
 	cmp r7, r0
 	blt _02178e4c
 _02178ee8:
-	ldrh r4, [sl, #0x2a]
+	ldrh r4, [r10, #0x2a]
 	ldr r1, _02179014 ; =data_027e0f6c
 	add r0, sp, #0xc
 	ldr r1, [r1]
 	mov r2, r4
-	ldrh r5, [sl, #0x26]
-	ldrh r6, [sl, #0x28]
+	ldrh r5, [r10, #0x26]
+	ldrh r6, [r10, #0x28]
 	bl func_ov00_02093a4c
 	ldr r1, _02179014 ; =data_027e0f6c
 	add r0, sp, #8
@@ -14156,7 +14156,7 @@ _02178ee8:
 	str r3, [sp, #4]
 	bl func_ov00_02093a3c
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02178fa4:
 	ldr r0, _02179014 ; =data_027e0f6c
 	ldr r1, [sp, #0xc]
@@ -14184,7 +14184,7 @@ _02178fa4:
 	str r3, [sp, #4]
 	bl func_ov00_02093a3c
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov24_02178e20
 _02179010: .word data_027e0e60

--- a/asm/ov25.s
+++ b/asm/ov25.s
@@ -49,28 +49,28 @@ _0216d710: .word data_027e10b8
 	.global func_ov25_0216d714
 	arm_func_start func_ov25_0216d714
 func_ov25_0216d714: ; 0x0216d714
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	mov r4, r0
 	mov r8, #0
-	mov sl, r4
+	mov r10, r4
 	add r5, r4, #0x900
 	mov sb, #0xff
 	mvn r7, #0
 	mov r6, r8
 _0216d734:
-	strb sb, [sl]
-	str r8, [sl, #4]
-	strh r8, [sl, #0x24]
-	add r0, sl, #0x28
+	strb sb, [r10]
+	str r8, [r10, #4]
+	strh r8, [r10, #0x24]
+	add r0, r10, #0x28
 	bl func_ov00_020c1500
-	str r7, [sl, #0x3c]
-	str r7, [sl, #0x40]
-	str r7, [sl, #0x44]
-	str r6, [sl, #0x18]
-	str r6, [sl, #0x1c]
-	str r6, [sl, #0x20]
-	add sl, sl, #0x48
-	cmp sl, r5
+	str r7, [r10, #0x3c]
+	str r7, [r10, #0x40]
+	str r7, [r10, #0x44]
+	str r6, [r10, #0x18]
+	str r6, [r10, #0x1c]
+	str r6, [r10, #0x20]
+	add r10, r10, #0x48
+	cmp r10, r5
 	blo _0216d734
 	mov r0, #0xff
 	strb r0, [r4, #0x900]
@@ -96,7 +96,7 @@ _0216d734:
 	mov r2, #0
 	bl func_ov00_0209779c
 	mov r0, r4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov25_0216d714
 _0216d7d0: .word data_027e0f74
@@ -313,12 +313,12 @@ _0216daa0: .word 0x43425331
 	.global func_ov25_0216daa4
 	arm_func_start func_ov25_0216daa4
 func_ov25_0216daa4: ; 0x0216daa4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x78
-	mov sl, r0
+	mov r10, r0
 	ldr r11, _0216dcc8 ; =data_027e0fe8
 	mov sb, r1
-	mov r8, sl
+	mov r8, r10
 	mov r7, #0
 	mvn r6, #0
 	add r5, sp, #0x4c
@@ -376,12 +376,12 @@ _0216db80:
 	cmp r7, #0x20
 	add r8, r8, #0x48
 	blt _0216dacc
-	ldrb r0, [sl, #0x900]
+	ldrb r0, [r10, #0x900]
 	cmp r0, #0xff
 	addeq sp, sp, #0x78
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	mvn r2, #0
-	add r1, sl, #0x104
+	add r1, r10, #0x104
 	add r0, sp, #0x20
 	str r2, [sp, #4]
 	str r2, [sp, #8]
@@ -447,11 +447,11 @@ _0216db80:
 	strh r4, [sp, #0x34]
 	str r1, [sp]
 	ldr r0, [r0]
-	ldr r1, [sl, #0x904]
+	ldr r1, [r10, #0x904]
 	add r3, sp, #0x20
 	bl func_ov00_020c4048
 	add sp, sp, #0x78
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov25_0216daa4
 _0216dcc8: .word data_027e0fe8
@@ -1711,7 +1711,7 @@ func_ov25_0216ece0: ; 0x0216ece0
 	.global func_ov25_0216ecf4
 	arm_func_start func_ov25_0216ecf4
 func_ov25_0216ecf4: ; 0x0216ecf4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #0xac
 	mov sb, r1
 	mvn r3, #0
@@ -1772,13 +1772,13 @@ func_ov25_0216ecf4: ; 0x0216ecf4
 	str r1, [sp, #0x24]
 	cmp r0, #0
 	ble _0216ee54
-	ldr sl, _0216eedc ; =data_027e0fe4
+	ldr r10, _0216eedc ; =data_027e0fe4
 	mov r8, r6
 	add r4, sp, #8
 	add r5, sp, #0
 _0216edf8:
 	ldr r2, [sp, #0x38]
-	ldr r0, [sl]
+	ldr r0, [r10]
 	ldr r1, [r2, r8]
 	add r2, r2, r8
 	str r1, [sp]
@@ -1804,7 +1804,7 @@ _0216ee40:
 _0216ee54:
 	cmp r6, #0
 	addeq sp, sp, #0xac
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	movle r3, #0
 	ble _0216eeb4
 	ldr r0, _0216eee0 ; =data_027e0764
@@ -1834,7 +1834,7 @@ _0216eeb4:
 	ldr r0, [r1, #4]
 	str r0, [sb, #4]
 	add sp, sp, #0xac
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov25_0216ecf4
 _0216eed4: .word _ZTV11FilterActor
@@ -4087,7 +4087,7 @@ func_ov25_02170e34: ; 0x02170e34
 	.global func_ov25_02170e64
 	arm_func_start func_ov25_02170e64
 func_ov25_02170e64: ; 0x02170e64
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x94
 	mov r8, r0
 	bl func_ov25_0216ecd8
@@ -4123,7 +4123,7 @@ func_ov25_02170e64: ; 0x02170e64
 	ldr r0, [sp, #0x54]
 	str r1, [sp, #0x60]
 	add r0, r1, r0
-	ldr sl, [r8, #0x50]
+	ldr r10, [r8, #0x50]
 	ldr sb, [sp, #0x58]
 	str r0, [sp, #0x60]
 	rsb r0, r2, #0
@@ -4139,12 +4139,12 @@ func_ov25_02170e64: ; 0x02170e64
 	adc r2, r2, #0
 	mov sb, sb, lsr #0xc
 	orr sb, sb, r2, lsl #20
-	add r2, sl, sb
-	smull sl, sb, r1, r3
+	add r2, r10, sb
+	smull r10, sb, r1, r3
 	smull r3, r0, r1, r0
-	adds sl, sl, #0x800
+	adds r10, r10, #0x800
 	adc r1, sb, #0
-	mov sb, sl, lsr #0xc
+	mov sb, r10, lsr #0xc
 	orr sb, sb, r1, lsl #20
 	add r1, r7, sb
 	str r1, [sp, #0x5c]
@@ -4158,14 +4158,14 @@ func_ov25_02170e64: ; 0x02170e64
 	mov r0, #3
 	ldr r2, [lr]
 	ldmib lr, {r1, r7}
-	umull sl, sb, r7, r2
+	umull r10, sb, r7, r2
 	mla sb, r7, r1, sb
 	ldr r3, [lr, #0xc]
 	ldr ip, [lr, #0x10]
 	mla sb, r3, r2, sb
 	ldr r11, [lr, #0x14]
 	sub r0, r0, #4
-	adds r1, ip, sl
+	adds r1, ip, r10
 	adc r2, r11, sb
 	stmia lr, {r1, r2}
 	mov r1, #3
@@ -4222,11 +4222,11 @@ _02171058:
 	ldrsh ip, [r4, r1]
 	mov r1, #0
 	add r2, r4, r2, lsl #1
-	umull sl, lr, ip, sb
+	umull r10, lr, ip, sb
 	mla lr, ip, r1, lr
 	mov r3, ip, asr #0x1f
 	mla lr, r3, sb, lr
-	adds r3, sl, #0x800
+	adds r3, r10, #0x800
 	adc r1, lr, #0
 	mov r3, r3, lsr #0xc
 	orr r3, r3, r1, lsl #20
@@ -4237,9 +4237,9 @@ _02171058:
 	mov r3, #0
 	umull r2, r1, ip, sb
 	mla r1, ip, r3, r1
-	mov sl, ip, asr #0x1f
+	mov r10, ip, asr #0x1f
 	adds r3, r2, #0x800
-	mla r1, sl, sb, r1
+	mla r1, r10, sb, r1
 	adc r1, r1, #0
 	mov r2, r3, lsr #0xc
 	orr r2, r2, r1, lsl #20
@@ -4254,14 +4254,14 @@ _02171058:
 _021710ec:
 	add sp, sp, #0x94
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _021710f8:
 	add r5, r5, #1
 	cmp r5, #3
 	blt _02170fd8
 	add sp, sp, #0x94
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02171110:
 	add r0, sp, #0x24
 	bl func_ov00_020c1500
@@ -4353,11 +4353,11 @@ _02171200:
 	adds r11, r2, #0x800
 	ldr r2, [sp, #0x10]
 	rsb r4, r3, #0
-	add sl, r7, r2
+	add r10, r7, r2
 	ldr r2, [r8, #0x50]
 	adc r7, r5, #0
-	str sl, [sp, #0x1c]
-	smull r5, sl, r0, r6
+	str r10, [sp, #0x1c]
+	smull r5, r10, r0, r6
 	mov r0, r11, lsr #0xc
 	orr r0, r0, r7, lsl #20
 	ldr sb, [sp, #0xc]
@@ -4365,7 +4365,7 @@ _02171200:
 	add r1, r1, r0
 	smull r7, r6, sb, r6
 	smull r5, r4, sb, r4
-	adc r0, sl, #0
+	adc r0, r10, #0
 	mov sb, r11, lsr #0xc
 	orr sb, sb, r0, lsl #20
 	adds r7, r7, #0x800
@@ -4393,7 +4393,7 @@ _02171200:
 	cmp r0, #0
 	addlt sp, sp, #0x94
 	movlt r0, #0
-	ldmltia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmltia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, _02171350 ; =data_027e0fe4
 	add r1, r8, #0x2dc
 	ldr r0, [r0]
@@ -4406,7 +4406,7 @@ _02171200:
 	str r1, [r0, #0x68]
 	mov r0, #1
 	add sp, sp, #0x94
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov25_02170e64
 _02171330: .word data_ov25_02179340
@@ -5801,7 +5801,7 @@ func_ov25_021724f8: ; 0x021724f8
 	.global func_ov25_021724fc
 	arm_func_start func_ov25_021724fc
 func_ov25_021724fc: ; 0x021724fc
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #0x48
 	mov r4, r0
 	add r0, r4, #0x48
@@ -5841,14 +5841,14 @@ func_ov25_021724fc: ; 0x021724fc
 	ldr r8, [sp, #0xc]
 	str r0, [sp, #0x14]
 	rsb r0, r2, #0
-	smull r2, sl, r8, r2
+	smull r2, r10, r8, r2
 	adds r2, r2, #0x800
-	adc sl, sl, #0
+	adc r10, r10, #0
 	mov r2, r2, lsr #0xc
-	orr r2, r2, sl, lsl #20
+	orr r2, r2, r10, lsl #20
 	add r7, r7, r2
-	smull sl, r2, r8, r6
-	adds r8, sl, #0x800
+	smull r10, r2, r8, r6
+	adds r8, r10, #0x800
 	ldr r1, [sp, #4]
 	adc r2, r2, #0
 	mov r8, r8, lsr #0xc
@@ -5881,7 +5881,7 @@ func_ov25_021724fc: ; 0x021724fc
 	cmp r0, #0
 	addlt sp, sp, #0x48
 	movlt r0, r5
-	ldmltia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmltia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	add r0, r4, #0x100
 	ldrsh r2, [r0, #0x70]
 	mov r1, r5
@@ -5897,7 +5897,7 @@ func_ov25_021724fc: ; 0x021724fc
 	cmp r0, #0
 	addlt sp, sp, #0x48
 	movlt r0, r5
-	ldmltia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmltia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	add r0, r4, #0x100
 	ldrsh r2, [r0, #0x70]
 	mov r1, r5
@@ -5914,7 +5914,7 @@ func_ov25_021724fc: ; 0x021724fc
 	movge r0, #1
 	movlt r0, r5
 	add sp, sp, #0x48
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov25_021724fc
 _021726c4: .word data_ov25_02179524
@@ -6948,7 +6948,7 @@ _02173458: .word data_027e0ff0
 	.global func_ov25_0217345c
 	arm_func_start func_ov25_0217345c
 func_ov25_0217345c: ; 0x0217345c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0xd4
 	ldr r7, _02173580 ; =_ZTV11FilterActor
 	mov r4, #0
@@ -6957,7 +6957,7 @@ func_ov25_0217345c: ; 0x0217345c
 	ldr r6, _02173584 ; =0x53504452
 	add r8, sp, #0xc
 	mov r2, #0x10
-	mov sl, r0
+	mov r10, r0
 	mov sb, r1
 	str r7, [sp, #0x8c]
 	str r6, [sp, #0x90]
@@ -6986,14 +6986,14 @@ _021734c4:
 	add r2, sp, #0
 	bl _ZN12ActorManager12FilterActorsEP15ActorFilterBaseP9ActorList
 	mvn r0, #0
-	str r0, [sl]
-	str r0, [sl, #4]
+	str r0, [r10]
+	str r0, [r10, #4]
 	ldr r0, [sp, #8]
 	mov r5, #0x3000
 	cmp r0, #0
 	mov r6, #0
 	addle sp, sp, #0xd4
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r11, _02173588 ; =data_027e0fe4
 	mov r8, r6
 _02173518:
@@ -7013,9 +7013,9 @@ _02173518:
 	ble _02173564
 	ldr r1, [r7]
 	mov r5, r0
-	str r1, [sl]
+	str r1, [r10]
 	ldr r0, [r7, #4]
-	str r0, [sl, #4]
+	str r0, [r10, #4]
 _02173564:
 	ldr r0, [sp, #8]
 	add r6, r6, #1
@@ -7023,7 +7023,7 @@ _02173564:
 	add r8, r8, #8
 	blt _02173518
 	add sp, sp, #0xd4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov25_0217345c
 _02173580: .word _ZTV11FilterActor
@@ -9412,7 +9412,7 @@ func_ov25_02175598: ; 0x02175598
 	.global func_ov25_02175638
 	arm_func_start func_ov25_02175638
 func_ov25_02175638: ; 0x02175638
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #0x38
 	mov r4, r0
 	ldr r0, [r4]
@@ -9423,7 +9423,7 @@ func_ov25_02175638: ; 0x02175638
 	cmp r0, r1
 	addeq sp, sp, #0x38
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	add r1, sp, #0x2c
 	add r0, r4, #0xb0
 	bl func_ov00_020c53e8
@@ -9444,7 +9444,7 @@ func_ov25_02175638: ; 0x02175638
 	cmp r6, r1
 	addeq sp, sp, #0x38
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	ldrh r1, [sp, #0x28]
 	ldr r6, [r4, #0xc]
 	ldrh r0, [sp, #0x2a]
@@ -9459,7 +9459,7 @@ func_ov25_02175638: ; 0x02175638
 	add sp, sp, #0x38
 	str r1, [r4]
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _021756f8:
 	mov r0, #0
 	strh r0, [sp, #0x24]
@@ -9501,7 +9501,7 @@ _02175744:
 	strh r2, [sp, #0x1e]
 	addeq sp, sp, #0x38
 	moveq r0, #1
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	mov r8, #1
 	mov r7, #0
 	add r6, sp, #0x20
@@ -9529,11 +9529,11 @@ _021757ac:
 	strh r1, [sp, #0x20]
 	strh r0, [sp, #0x22]
 _021757fc:
-	ldrh sl, [sp, #0x28]
+	ldrh r10, [sp, #0x28]
 	ldrh r3, [sp, #0x20]
 	ldrh sb, [sp, #0x2a]
 	ldrh r2, [sp, #0x22]
-	strh sl, [sp]
+	strh r10, [sp]
 	strh r3, [sp, #4]
 	ldrsh r1, [sp, #4]
 	ldrsh r0, [sp]
@@ -9542,7 +9542,7 @@ _021757fc:
 	cmp r1, r0
 	ldreqsh r1, [sp, #6]
 	ldreqsh r0, [sp, #2]
-	strh sl, [sp, #0x10]
+	strh r10, [sp, #0x10]
 	strh sb, [sp, #0x12]
 	strh r3, [sp, #0x14]
 	strh r2, [sp, #0x16]
@@ -9564,7 +9564,7 @@ _021757fc:
 _0217587c:
 	add sp, sp, #0x38
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _02175888:
 	mov r0, r6
 	mov r1, r5
@@ -9593,7 +9593,7 @@ _021758d0:
 	cmp r0, r1
 	addeq sp, sp, #0x38
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	ldrh r1, [sp, #0x28]
 	ldr r5, [r4, #0xc]
 	ldrh r0, [sp, #0x2a]
@@ -9608,33 +9608,33 @@ _021758d0:
 	add sp, sp, #0x38
 	str r1, [r4]
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _02175930:
 	add r8, r8, #1
 _02175934:
-	ldr sl, [r4]
+	ldr r10, [r4]
 	ldr sb, [r4, #4]
-	cmp sb, sl
-	suble r0, sl, sb
+	cmp sb, r10
+	suble r0, r10, sb
 	ble _02175954
 	ldr r0, [r4, #8]
-	add r0, sl, r0
+	add r0, r10, r0
 	sub r0, r0, sb
 _02175954:
 	cmp r8, r0
 	blt _021757ac
 	ldr r1, [r4, #8]
-	add r0, sl, #1
+	add r0, r10, #1
 	bl func_02002c14
 	cmp sb, r1
 	addeq sp, sp, #0x38
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	ldrh r1, [sp, #0x28]
 	ldr r5, [r4, #0xc]
 	ldrh r0, [sp, #0x2a]
-	mov r3, sl, lsl #0x2
-	add r2, r5, sl, lsl #2
+	mov r3, r10, lsl #0x2
+	add r2, r5, r10, lsl #2
 	strh r1, [r5, r3]
 	strh r0, [r2, #2]
 	ldr r0, [r4]
@@ -9644,11 +9644,11 @@ _02175954:
 	add sp, sp, #0x38
 	str r1, [r4]
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _021759b4:
 	mov r0, #0
 	add sp, sp, #0x38
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	arm_func_end func_ov25_02175638
 
 	.global func_ov25_021759c0
@@ -9859,7 +9859,7 @@ _02175c50: .word 0x43425330
 	.global func_ov25_02175c54
 	arm_func_start func_ov25_02175c54
 func_ov25_02175c54: ; 0x02175c54
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x28
 	mov r11, r0
 	add r0, r11, #0x100
@@ -9879,8 +9879,8 @@ func_ov25_02175c54: ; 0x02175c54
 	sub r8, r1, r7
 	mov r6, #0
 	addle sp, sp, #0x28
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
-	mov sl, r11
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	mov r10, r11
 	add sb, r11, #0x17c
 _02175cb0:
 	mov r0, r11
@@ -9900,15 +9900,15 @@ _02175cb0:
 	add r1, r5, r5, lsr #31
 	add r0, r7, r0
 	add r0, r0, r1, asr #1
-	str r0, [sl, #0x17c]
+	str r0, [r10, #0x17c]
 	ldrsh r0, [r4, #0x78]
 	add r6, r6, #1
 	add sb, sb, #0xc
 	cmp r6, r0
-	add sl, sl, #0xc
+	add r10, r10, #0xc
 	blt _02175cb0
 	add sp, sp, #0x28
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov25_02175c54
 _02175d18: .word data_027e0e60
@@ -10029,13 +10029,13 @@ _02175e80: .word data_027e0764
 	.global func_ov25_02175e84
 	arm_func_start func_ov25_02175e84
 func_ov25_02175e84: ; 0x02175e84
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x20
-	mov sl, r0
+	mov r10, r0
 	add r0, sp, #0x10
 	mov r1, #4
 	bl func_ov00_020c5a5c
-	add r0, sl, #0x100
+	add r0, r10, #0x100
 	ldrsh r0, [r0, #0x78]
 	mov r2, #0
 	cmp r0, #4
@@ -10063,7 +10063,7 @@ _02175ee4:
 	mov r7, #0
 	ldr r11, _02175fa8 ; =data_027e0fe4
 	mov sb, r7
-	add r5, sl, #0x158
+	add r5, r10, #0x158
 	add r4, sp, #0
 	add r6, sp, #0x10
 _02175f0c:
@@ -10087,12 +10087,12 @@ _02175f40:
 	cmp r3, #4
 	blt _02175f40
 _02175f54:
-	add r2, sl, #0x100
+	add r2, r10, #0x100
 	ldrsh r0, [r2, #0x78]
 	mov r6, #0
 	cmp r0, #0
 	addle sp, sp, #0x20
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	add r5, sp, #0x10
 	mvn r1, #0
 _02175f74:
@@ -10101,7 +10101,7 @@ _02175f74:
 	beq _02175f90
 	mov r0, r6, lsl #0x10
 	mov r3, r0, asr #0x10
-	add r0, sl, r4, lsl #2
+	add r0, r10, r4, lsl #2
 	str r3, [r0, #0x1bc]
 _02175f90:
 	ldrsh r0, [r2, #0x78]
@@ -10109,7 +10109,7 @@ _02175f90:
 	cmp r6, r0
 	blt _02175f74
 	add sp, sp, #0x20
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov25_02175e84
 _02175fa8: .word data_027e0fe4

--- a/asm/ov25.s
+++ b/asm/ov25.s
@@ -313,10 +313,10 @@ _0216daa0: .word 0x43425331
 	.global func_ov25_0216daa4
 	arm_func_start func_ov25_0216daa4
 func_ov25_0216daa4: ; 0x0216daa4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x78
 	mov sl, r0
-	ldr fp, _0216dcc8 ; =data_027e0fe8
+	ldr r11, _0216dcc8 ; =data_027e0fe8
 	mov sb, r1
 	mov r8, sl
 	mov r7, #0
@@ -366,7 +366,7 @@ _0216dacc:
 	ldr r0, [r8, #0x3c]
 	str r0, [sp, #0x70]
 	str r4, [sp]
-	ldr r0, [fp]
+	ldr r0, [r11]
 	ldr r1, [r8, #4]
 	bl func_ov00_020c4048
 _0216db80:
@@ -379,7 +379,7 @@ _0216db80:
 	ldrb r0, [sl, #0x900]
 	cmp r0, #0xff
 	addeq sp, sp, #0x78
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	mvn r2, #0
 	add r1, sl, #0x104
 	add r0, sp, #0x20
@@ -451,7 +451,7 @@ _0216db80:
 	add r3, sp, #0x20
 	bl func_ov00_020c4048
 	add sp, sp, #0x78
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov25_0216daa4
 _0216dcc8: .word data_027e0fe8
@@ -4087,7 +4087,7 @@ func_ov25_02170e34: ; 0x02170e34
 	.global func_ov25_02170e64
 	arm_func_start func_ov25_02170e64
 func_ov25_02170e64: ; 0x02170e64
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x94
 	mov r8, r0
 	bl func_ov25_0216ecd8
@@ -4127,14 +4127,14 @@ func_ov25_02170e64: ; 0x02170e64
 	ldr sb, [sp, #0x58]
 	str r0, [sp, #0x60]
 	rsb r0, r2, #0
-	smull r2, fp, sb, r2
+	smull r2, r11, sb, r2
 	adds r2, r2, #0x800
-	adc fp, fp, #0
+	adc r11, r11, #0
 	mov r2, r2, lsr #0xc
-	orr r2, r2, fp, lsl #20
+	orr r2, r2, r11, lsl #20
 	add r7, r7, r2
-	smull fp, r2, sb, r3
-	adds sb, fp, #0x800
+	smull r11, r2, sb, r3
+	adds sb, r11, #0x800
 	ldr r1, [sp, #0x50]
 	adc r2, r2, #0
 	mov sb, sb, lsr #0xc
@@ -4163,10 +4163,10 @@ func_ov25_02170e64: ; 0x02170e64
 	ldr r3, [lr, #0xc]
 	ldr ip, [lr, #0x10]
 	mla sb, r3, r2, sb
-	ldr fp, [lr, #0x14]
+	ldr r11, [lr, #0x14]
 	sub r0, r0, #4
 	adds r1, ip, sl
-	adc r2, fp, sb
+	adc r2, r11, sb
 	stmia lr, {r1, r2}
 	mov r1, #3
 	umull r1, r7, r2, r1
@@ -4179,7 +4179,7 @@ func_ov25_02170e64: ; 0x02170e64
 	str r0, [sp, #8]
 	ldr r0, _0217133c ; =0xffffeaab
 	ldr sb, _02171340 ; =0x00000266
-	rsb fp, r0, #0
+	rsb r11, r0, #0
 _02170fd8:
 	cmp r7, r5
 	moveq r0, #0
@@ -4209,7 +4209,7 @@ _02170fd8:
 	moveq r6, #0
 	beq _02171058
 	cmp r5, #1
-	moveq r6, fp
+	moveq r6, r11
 	beq _02171058
 	cmp r5, #2
 	ldreq r6, _0217133c ; =0xffffeaab
@@ -4254,14 +4254,14 @@ _02171058:
 _021710ec:
 	add sp, sp, #0x94
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _021710f8:
 	add r5, r5, #1
 	cmp r5, #3
 	blt _02170fd8
 	add sp, sp, #0x94
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02171110:
 	add r0, sp, #0x24
 	bl func_ov00_020c1500
@@ -4350,7 +4350,7 @@ _02171200:
 	ldr r0, [sp, #0x14]
 	str r7, [sp, #0x1c]
 	smull r2, r5, r0, r3
-	adds fp, r2, #0x800
+	adds r11, r2, #0x800
 	ldr r2, [sp, #0x10]
 	rsb r4, r3, #0
 	add sl, r7, r2
@@ -4358,15 +4358,15 @@ _02171200:
 	adc r7, r5, #0
 	str sl, [sp, #0x1c]
 	smull r5, sl, r0, r6
-	mov r0, fp, lsr #0xc
+	mov r0, r11, lsr #0xc
 	orr r0, r0, r7, lsl #20
 	ldr sb, [sp, #0xc]
-	adds fp, r5, #0x800
+	adds r11, r5, #0x800
 	add r1, r1, r0
 	smull r7, r6, sb, r6
 	smull r5, r4, sb, r4
 	adc r0, sl, #0
-	mov sb, fp, lsr #0xc
+	mov sb, r11, lsr #0xc
 	orr sb, sb, r0, lsl #20
 	adds r7, r7, #0x800
 	add r0, r2, sb
@@ -4393,7 +4393,7 @@ _02171200:
 	cmp r0, #0
 	addlt sp, sp, #0x94
 	movlt r0, #0
-	ldmltia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmltia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, _02171350 ; =data_027e0fe4
 	add r1, r8, #0x2dc
 	ldr r0, [r0]
@@ -4406,7 +4406,7 @@ _02171200:
 	str r1, [r0, #0x68]
 	mov r0, #1
 	add sp, sp, #0x94
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov25_02170e64
 _02171330: .word data_ov25_02179340
@@ -6948,7 +6948,7 @@ _02173458: .word data_027e0ff0
 	.global func_ov25_0217345c
 	arm_func_start func_ov25_0217345c
 func_ov25_0217345c: ; 0x0217345c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0xd4
 	ldr r7, _02173580 ; =_ZTV11FilterActor
 	mov r4, #0
@@ -6993,12 +6993,12 @@ _021734c4:
 	cmp r0, #0
 	mov r6, #0
 	addle sp, sp, #0xd4
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
-	ldr fp, _02173588 ; =data_027e0fe4
+	ldmleia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldr r11, _02173588 ; =data_027e0fe4
 	mov r8, r6
 _02173518:
 	ldr r1, [sp]
-	ldr r0, [fp]
+	ldr r0, [r11]
 	add r7, r1, r8
 	mov r1, r7
 	bl _ZN12ActorManager8GetActorEP8ActorRef
@@ -7023,7 +7023,7 @@ _02173564:
 	add r8, r8, #8
 	blt _02173518
 	add sp, sp, #0xd4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov25_0217345c
 _02173580: .word _ZTV11FilterActor
@@ -9859,10 +9859,10 @@ _02175c50: .word 0x43425330
 	.global func_ov25_02175c54
 	arm_func_start func_ov25_02175c54
 func_ov25_02175c54: ; 0x02175c54
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x28
-	mov fp, r0
-	add r0, fp, #0x100
+	mov r11, r0
+	add r0, r11, #0x100
 	ldrsh r1, [r0, #0x78]
 	add r0, sp, #0x18
 	bl func_ov00_020c5a5c
@@ -9871,7 +9871,7 @@ func_ov25_02175c54: ; 0x02175c54
 	ldr r0, [r0]
 	mov r1, #1
 	bl func_ov00_020836bc
-	add r4, fp, #0x100
+	add r4, r11, #0x100
 	ldrsh r0, [r4, #0x78]
 	ldr r7, [sp]
 	ldr r1, [sp, #0xc]
@@ -9879,11 +9879,11 @@ func_ov25_02175c54: ; 0x02175c54
 	sub r8, r1, r7
 	mov r6, #0
 	addle sp, sp, #0x28
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
-	mov sl, fp
-	add sb, fp, #0x17c
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	mov sl, r11
+	add sb, r11, #0x17c
 _02175cb0:
-	mov r0, fp
+	mov r0, r11
 	mov r1, r6
 	mov r2, sb
 	bl func_ov25_02175fac
@@ -9908,7 +9908,7 @@ _02175cb0:
 	add sl, sl, #0xc
 	blt _02175cb0
 	add sp, sp, #0x28
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov25_02175c54
 _02175d18: .word data_027e0e60
@@ -10029,7 +10029,7 @@ _02175e80: .word data_027e0764
 	.global func_ov25_02175e84
 	arm_func_start func_ov25_02175e84
 func_ov25_02175e84: ; 0x02175e84
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x20
 	mov sl, r0
 	add r0, sp, #0x10
@@ -10061,14 +10061,14 @@ _02175ee4:
 	cmp r2, #4
 	blt _02175ee4
 	mov r7, #0
-	ldr fp, _02175fa8 ; =data_027e0fe4
+	ldr r11, _02175fa8 ; =data_027e0fe4
 	mov sb, r7
 	add r5, sl, #0x158
 	add r4, sp, #0
 	add r6, sp, #0x10
 _02175f0c:
 	ldr r8, [r6, sb, lsl #2]
-	ldr r0, [fp]
+	ldr r0, [r11]
 	add r1, r5, r8, lsl #3
 	bl _ZN12ActorManager8GetActorEP8ActorRef
 	cmp r0, #0
@@ -10092,7 +10092,7 @@ _02175f54:
 	mov r6, #0
 	cmp r0, #0
 	addle sp, sp, #0x20
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r5, sp, #0x10
 	mvn r1, #0
 _02175f74:
@@ -10109,7 +10109,7 @@ _02175f90:
 	cmp r6, r0
 	blt _02175f74
 	add sp, sp, #0x20
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov25_02175e84
 _02175fa8: .word data_027e0fe4

--- a/asm/ov25.s
+++ b/asm/ov25.s
@@ -49,16 +49,16 @@ _0216d710: .word data_027e10b8
 	.global func_ov25_0216d714
 	arm_func_start func_ov25_0216d714
 func_ov25_0216d714: ; 0x0216d714
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	mov r4, r0
 	mov r8, #0
 	mov r10, r4
 	add r5, r4, #0x900
-	mov sb, #0xff
+	mov r9, #0xff
 	mvn r7, #0
 	mov r6, r8
 _0216d734:
-	strb sb, [r10]
+	strb r9, [r10]
 	str r8, [r10, #4]
 	strh r8, [r10, #0x24]
 	add r0, r10, #0x28
@@ -96,7 +96,7 @@ _0216d734:
 	mov r2, #0
 	bl func_ov00_0209779c
 	mov r0, r4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov25_0216d714
 _0216d7d0: .word data_027e0f74
@@ -149,7 +149,7 @@ _0216d814:
 	.global func_ov25_0216d844
 	arm_func_start func_ov25_0216d844
 func_ov25_0216d844: ; 0x0216d844
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0xd4
 	mov r5, r0
 	add r2, sp, #0x54
@@ -163,7 +163,7 @@ _0216d860:
 	cmp r2, r0
 	blo _0216d860
 	ldr r0, _0216da98 ; =data_027e0fe4
-	mov sb, #0
+	mov r9, #0
 	ldr lr, _0216da9c ; =_ZTV11FilterActor
 	add r8, sp, #0x40
 	ldr ip, _0216daa0 ; =0x43425331
@@ -172,32 +172,32 @@ _0216d860:
 	ldr r0, [r0]
 	add r1, sp, #0xc
 	add r2, sp, #0
-	str sb, [sp, #8]
+	str r9, [sp, #8]
 	str lr, [sp, #0xc]
 	str ip, [sp, #0x10]
 	str r3, [sp, #0x14]
 	str r3, [sp, #0x18]
-	str sb, [sp, #0x1c]
-	strb sb, [sp, #0x20]
-	strb sb, [sp, #0x3c]
-	str sb, [r8, #0xc]
-	str sb, [r8]
-	str sb, [r8, #4]
-	str sb, [r8, #8]
+	str r9, [sp, #0x1c]
+	strb r9, [sp, #0x20]
+	strb r9, [sp, #0x3c]
+	str r9, [r8, #0xc]
+	str r9, [r8]
+	str r9, [r8, #4]
+	str r9, [r8, #8]
 	str r7, [sp]
 	str r6, [sp, #4]
 	bl _ZN12ActorManager12FilterActorsEP15ActorFilterBaseP9ActorList
 	ldr r0, [sp, #8]
-	mov r7, sb
+	mov r7, r9
 	cmp r0, #0
 	mov r6, r7
 	addle sp, sp, #0xd4
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _0216d8f0:
 	ldr r0, _0216da98 ; =data_027e0fe4
 	ldr r1, [sp]
 	ldr r0, [r0]
-	add r1, r1, sb
+	add r1, r1, r9
 	bl _ZN12ActorManager8GetActorEP8ActorRef
 	mov r8, r0
 	bl func_ov25_02173238
@@ -300,10 +300,10 @@ _0216da7c:
 	ldr r0, [sp, #8]
 	add r6, r6, #1
 	cmp r6, r0
-	add sb, sb, #8
+	add r9, r9, #8
 	blt _0216d8f0
 	add sp, sp, #0xd4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov25_0216d844
 _0216da98: .word data_027e0fe4
@@ -313,11 +313,11 @@ _0216daa0: .word 0x43425331
 	.global func_ov25_0216daa4
 	arm_func_start func_ov25_0216daa4
 func_ov25_0216daa4: ; 0x0216daa4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x78
 	mov r10, r0
 	ldr r11, _0216dcc8 ; =data_027e0fe8
-	mov sb, r1
+	mov r9, r1
 	mov r8, r10
 	mov r7, #0
 	mvn r6, #0
@@ -325,7 +325,7 @@ func_ov25_0216daa4: ; 0x0216daa4
 	add r4, sp, #0xc
 _0216dacc:
 	ldrb r0, [r8]
-	cmp sb, r0
+	cmp r9, r0
 	bne _0216db80
 	mov r0, r5
 	str r6, [sp, #0xc]
@@ -379,7 +379,7 @@ _0216db80:
 	ldrb r0, [r10, #0x900]
 	cmp r0, #0xff
 	addeq sp, sp, #0x78
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	mvn r2, #0
 	add r1, r10, #0x104
 	add r0, sp, #0x20
@@ -451,7 +451,7 @@ _0216db80:
 	add r3, sp, #0x20
 	bl func_ov00_020c4048
 	add sp, sp, #0x78
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov25_0216daa4
 _0216dcc8: .word data_027e0fe8
@@ -1711,12 +1711,12 @@ func_ov25_0216ece0: ; 0x0216ece0
 	.global func_ov25_0216ecf4
 	arm_func_start func_ov25_0216ecf4
 func_ov25_0216ecf4: ; 0x0216ecf4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #0xac
-	mov sb, r1
+	mov r9, r1
 	mvn r3, #0
-	str r3, [sb]
-	str r3, [sb, #4]
+	str r3, [r9]
+	str r3, [r9, #4]
 	mov r5, #0
 	add r4, sp, #0x98
 	ldr r7, _0216eed4 ; =_ZTV11FilterActor
@@ -1804,7 +1804,7 @@ _0216ee40:
 _0216ee54:
 	cmp r6, #0
 	addeq sp, sp, #0xac
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	movle r3, #0
 	ble _0216eeb4
 	ldr r0, _0216eee0 ; =data_027e0764
@@ -1830,11 +1830,11 @@ _0216eeb4:
 	add r1, sp, #8
 	ldr r0, [r1, r3, lsl #3]
 	add r1, r1, r3, lsl #3
-	str r0, [sb]
+	str r0, [r9]
 	ldr r0, [r1, #4]
-	str r0, [sb, #4]
+	str r0, [r9, #4]
 	add sp, sp, #0xac
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov25_0216ecf4
 _0216eed4: .word _ZTV11FilterActor
@@ -3023,7 +3023,7 @@ _0216ff3c:
 	.global func_ov25_0216ff44
 	arm_func_start func_ov25_0216ff44
 func_ov25_0216ff44: ; 0x0216ff44
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x40
 	mov r8, r1
 	ldr r4, [r8, #0x14]
@@ -3062,7 +3062,7 @@ _0216ff80: ; jump table
 _0216ffd0:
 	add sp, sp, #0x40
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _0216ffdc:
 	bl func_ov25_0216ef9c
 	add r0, r6, #0x600
@@ -3125,7 +3125,7 @@ _02170080:
 	cmp r1, r0
 	addne sp, sp, #0x40
 	movne r0, r7
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	mov r7, #1
 _021700c0:
 	mov r0, r4
@@ -3136,22 +3136,22 @@ _021700c0:
 	mov r2, #0
 	ldr r1, [r3]
 	ldmib r3, {r0, ip}
-	umull sb, lr, ip, r1
+	umull r9, lr, ip, r1
 	mla lr, ip, r0, lr
 	ldr r0, [r3, #0xc]
 	ldr ip, [r3, #0x10]
 	mla lr, r0, r1, lr
 	ldr r1, [r3, #0x14]
-	adds r0, ip, sb
-	adc sb, r1, lr
+	adds r0, ip, r9
+	adc r9, r1, lr
 	str r0, [r3]
 	mov r1, #0x64
-	umull ip, lr, sb, r1
-	mla lr, sb, r2, lr
+	umull ip, lr, r9, r1
+	mla lr, r9, r2, lr
 	mov r0, r2
 	mla lr, r0, r1, lr
 	cmp lr, r5
-	str sb, [r3, #4]
+	str r9, [r3, #4]
 	movlt r7, #1
 	blt _02170194
 	mov r0, r6
@@ -3181,7 +3181,7 @@ _0217017c:
 	bl func_ov25_0216f898
 	add sp, sp, #0x40
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _02170194:
 	cmp r7, #0
 	beq _02170390
@@ -3314,13 +3314,13 @@ _02170378:
 	bl func_ov25_0216f898
 	add sp, sp, #0x40
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _02170390:
 	mov r0, r6
 	bl func_ov25_0216ef3c
 	mov r0, #0
 	add sp, sp, #0x40
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov25_0216ff44
 _021703a4: .word 0x43425332
@@ -4087,7 +4087,7 @@ func_ov25_02170e34: ; 0x02170e34
 	.global func_ov25_02170e64
 	arm_func_start func_ov25_02170e64
 func_ov25_02170e64: ; 0x02170e64
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x94
 	mov r8, r0
 	bl func_ov25_0216ecd8
@@ -4124,29 +4124,29 @@ func_ov25_02170e64: ; 0x02170e64
 	str r1, [sp, #0x60]
 	add r0, r1, r0
 	ldr r10, [r8, #0x50]
-	ldr sb, [sp, #0x58]
+	ldr r9, [sp, #0x58]
 	str r0, [sp, #0x60]
 	rsb r0, r2, #0
-	smull r2, r11, sb, r2
+	smull r2, r11, r9, r2
 	adds r2, r2, #0x800
 	adc r11, r11, #0
 	mov r2, r2, lsr #0xc
 	orr r2, r2, r11, lsl #20
 	add r7, r7, r2
-	smull r11, r2, sb, r3
-	adds sb, r11, #0x800
+	smull r11, r2, r9, r3
+	adds r9, r11, #0x800
 	ldr r1, [sp, #0x50]
 	adc r2, r2, #0
-	mov sb, sb, lsr #0xc
-	orr sb, sb, r2, lsl #20
-	add r2, r10, sb
-	smull r10, sb, r1, r3
+	mov r9, r9, lsr #0xc
+	orr r9, r9, r2, lsl #20
+	add r2, r10, r9
+	smull r10, r9, r1, r3
 	smull r3, r0, r1, r0
 	adds r10, r10, #0x800
-	adc r1, sb, #0
-	mov sb, r10, lsr #0xc
-	orr sb, sb, r1, lsl #20
-	add r1, r7, sb
+	adc r1, r9, #0
+	mov r9, r10, lsr #0xc
+	orr r9, r9, r1, lsl #20
+	add r1, r7, r9
 	str r1, [sp, #0x5c]
 	adds r1, r3, #0x800
 	ldr lr, _02171338 ; =data_027e0764
@@ -4158,15 +4158,15 @@ func_ov25_02170e64: ; 0x02170e64
 	mov r0, #3
 	ldr r2, [lr]
 	ldmib lr, {r1, r7}
-	umull r10, sb, r7, r2
-	mla sb, r7, r1, sb
+	umull r10, r9, r7, r2
+	mla r9, r7, r1, r9
 	ldr r3, [lr, #0xc]
 	ldr ip, [lr, #0x10]
-	mla sb, r3, r2, sb
+	mla r9, r3, r2, r9
 	ldr r11, [lr, #0x14]
 	sub r0, r0, #4
 	adds r1, ip, r10
-	adc r2, r11, sb
+	adc r2, r11, r9
 	stmia lr, {r1, r2}
 	mov r1, #3
 	umull r1, r7, r2, r1
@@ -4178,7 +4178,7 @@ func_ov25_02170e64: ; 0x02170e64
 	str r0, [sp, #4]
 	str r0, [sp, #8]
 	ldr r0, _0217133c ; =0xffffeaab
-	ldr sb, _02171340 ; =0x00000266
+	ldr r9, _02171340 ; =0x00000266
 	rsb r11, r0, #0
 _02170fd8:
 	cmp r7, r5
@@ -4222,10 +4222,10 @@ _02171058:
 	ldrsh ip, [r4, r1]
 	mov r1, #0
 	add r2, r4, r2, lsl #1
-	umull r10, lr, ip, sb
+	umull r10, lr, ip, r9
 	mla lr, ip, r1, lr
 	mov r3, ip, asr #0x1f
-	mla lr, r3, sb, lr
+	mla lr, r3, r9, lr
 	adds r3, r10, #0x800
 	adc r1, lr, #0
 	mov r3, r3, lsr #0xc
@@ -4235,11 +4235,11 @@ _02171058:
 	str r1, [r0, #0x64]
 	ldrsh ip, [r2, #2]
 	mov r3, #0
-	umull r2, r1, ip, sb
+	umull r2, r1, ip, r9
 	mla r1, ip, r3, r1
 	mov r10, ip, asr #0x1f
 	adds r3, r2, #0x800
-	mla r1, r10, sb, r1
+	mla r1, r10, r9, r1
 	adc r1, r1, #0
 	mov r2, r3, lsr #0xc
 	orr r2, r2, r1, lsl #20
@@ -4254,14 +4254,14 @@ _02171058:
 _021710ec:
 	add sp, sp, #0x94
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _021710f8:
 	add r5, r5, #1
 	cmp r5, #3
 	blt _02170fd8
 	add sp, sp, #0x94
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02171110:
 	add r0, sp, #0x24
 	bl func_ov00_020c1500
@@ -4360,16 +4360,16 @@ _02171200:
 	smull r5, r10, r0, r6
 	mov r0, r11, lsr #0xc
 	orr r0, r0, r7, lsl #20
-	ldr sb, [sp, #0xc]
+	ldr r9, [sp, #0xc]
 	adds r11, r5, #0x800
 	add r1, r1, r0
-	smull r7, r6, sb, r6
-	smull r5, r4, sb, r4
+	smull r7, r6, r9, r6
+	smull r5, r4, r9, r4
 	adc r0, r10, #0
-	mov sb, r11, lsr #0xc
-	orr sb, sb, r0, lsl #20
+	mov r9, r11, lsr #0xc
+	orr r9, r9, r0, lsl #20
 	adds r7, r7, #0x800
-	add r0, r2, sb
+	add r0, r2, r9
 	adc r6, r6, #0
 	adds r2, r5, #0x800
 	mov r5, r7, lsr #0xc
@@ -4393,7 +4393,7 @@ _02171200:
 	cmp r0, #0
 	addlt sp, sp, #0x94
 	movlt r0, #0
-	ldmltia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmltia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, _02171350 ; =data_027e0fe4
 	add r1, r8, #0x2dc
 	ldr r0, [r0]
@@ -4406,7 +4406,7 @@ _02171200:
 	str r1, [r0, #0x68]
 	mov r0, #1
 	add sp, sp, #0x94
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov25_02170e64
 _02171330: .word data_ov25_02179340
@@ -5801,7 +5801,7 @@ func_ov25_021724f8: ; 0x021724f8
 	.global func_ov25_021724fc
 	arm_func_start func_ov25_021724fc
 func_ov25_021724fc: ; 0x021724fc
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #0x48
 	mov r4, r0
 	add r0, r4, #0x48
@@ -5831,13 +5831,13 @@ func_ov25_021724fc: ; 0x021724fc
 	mov r0, r8, lsl #0x1
 	ldrsh r2, [r6, r0]
 	add r0, r8, #1
-	ldr sb, [r4, #0x4c]
+	ldr r9, [r4, #0x4c]
 	mov r0, r0, lsl #0x1
 	ldr r1, [sp, #8]
 	ldrsh r6, [r6, r0]
-	add r0, sb, r1
-	str sb, [sp, #0x14]
-	ldr sb, [r4, #0x50]
+	add r0, r9, r1
+	str r9, [sp, #0x14]
+	ldr r9, [r4, #0x50]
 	ldr r8, [sp, #0xc]
 	str r0, [sp, #0x14]
 	rsb r0, r2, #0
@@ -5853,12 +5853,12 @@ func_ov25_021724fc: ; 0x021724fc
 	adc r2, r2, #0
 	mov r8, r8, lsr #0xc
 	orr r8, r8, r2, lsl #20
-	add r2, sb, r8
-	smull sb, r8, r1, r6
+	add r2, r9, r8
+	smull r9, r8, r1, r6
 	smull r6, r0, r1, r0
-	adds sb, sb, #0x800
+	adds r9, r9, #0x800
 	adc r1, r8, #0
-	mov r8, sb, lsr #0xc
+	mov r8, r9, lsr #0xc
 	orr r8, r8, r1, lsl #20
 	add r1, r7, r8
 	str r1, [sp, #0x10]
@@ -5881,7 +5881,7 @@ func_ov25_021724fc: ; 0x021724fc
 	cmp r0, #0
 	addlt sp, sp, #0x48
 	movlt r0, r5
-	ldmltia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmltia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	add r0, r4, #0x100
 	ldrsh r2, [r0, #0x70]
 	mov r1, r5
@@ -5897,7 +5897,7 @@ func_ov25_021724fc: ; 0x021724fc
 	cmp r0, #0
 	addlt sp, sp, #0x48
 	movlt r0, r5
-	ldmltia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmltia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	add r0, r4, #0x100
 	ldrsh r2, [r0, #0x70]
 	mov r1, r5
@@ -5914,7 +5914,7 @@ func_ov25_021724fc: ; 0x021724fc
 	movge r0, #1
 	movlt r0, r5
 	add sp, sp, #0x48
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov25_021724fc
 _021726c4: .word data_ov25_02179524
@@ -6948,7 +6948,7 @@ _02173458: .word data_027e0ff0
 	.global func_ov25_0217345c
 	arm_func_start func_ov25_0217345c
 func_ov25_0217345c: ; 0x0217345c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0xd4
 	ldr r7, _02173580 ; =_ZTV11FilterActor
 	mov r4, #0
@@ -6958,7 +6958,7 @@ func_ov25_0217345c: ; 0x0217345c
 	add r8, sp, #0xc
 	mov r2, #0x10
 	mov r10, r0
-	mov sb, r1
+	mov r9, r1
 	str r7, [sp, #0x8c]
 	str r6, [sp, #0x90]
 	str r5, [sp, #0x94]
@@ -6993,7 +6993,7 @@ _021734c4:
 	cmp r0, #0
 	mov r6, #0
 	addle sp, sp, #0xd4
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r11, _02173588 ; =data_027e0fe4
 	mov r8, r6
 _02173518:
@@ -7006,7 +7006,7 @@ _02173518:
 	bl func_ov25_02178cf0
 	cmp r0, #0
 	beq _02173564
-	mov r0, sb
+	mov r0, r9
 	add r1, r4, #0x48
 	bl _ZN5Actor12XzDistanceToEP5Vec3p
 	cmp r5, r0
@@ -7023,7 +7023,7 @@ _02173564:
 	add r8, r8, #8
 	blt _02173518
 	add sp, sp, #0xd4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov25_0217345c
 _02173580: .word _ZTV11FilterActor
@@ -7899,7 +7899,7 @@ _021740f8:
 	.global func_ov25_02174100
 	arm_func_start func_ov25_02174100
 func_ov25_02174100: ; 0x02174100
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x340
 	mov r4, r0
 	ldr r1, [r4, #0x48]
@@ -8770,12 +8770,12 @@ _02174d9c:
 	cmp r0, #0
 	mov r7, #0
 	ble _02174e14
-	ldr sb, _021750a4 ; =data_027e0fe4
+	ldr r9, _021750a4 ; =data_027e0fe4
 	mov r8, r7
 	mov r5, r7
 _02174de4:
 	ldr r1, [sp, #0x154]
-	ldr r0, [sb]
+	ldr r0, [r9]
 	add r1, r1, r8
 	bl _ZN12ActorManager8GetActorEP8ActorRef
 	ldrb r0, [r0, #0x11c]
@@ -9094,13 +9094,13 @@ _02175278:
 	moveq r1, #0
 	cmp r1, #1
 	addne sp, sp, #0x340
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	tst r0, #1
 	movne r0, #1
 	moveq r0, #0
 	cmp r0, #0
 	addne sp, sp, #0x340
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	mov r2, #0
 	add r1, sp, #0xc
 	add r0, r4, #0x48
@@ -9113,13 +9113,13 @@ _02175278:
 	bl func_ov00_02084164
 	cmp r0, #0
 	addeq sp, sp, #0x340
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	ldrb r0, [sp, #0xc]
 	strb r0, [r4, #0x57c]
 	ldrb r0, [sp, #0xd]
 	strb r0, [r4, #0x57d]
 	add sp, sp, #0x340
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 
 	.global func_ov25_021752fc
 	arm_func_start func_ov25_021752fc
@@ -9412,7 +9412,7 @@ func_ov25_02175598: ; 0x02175598
 	.global func_ov25_02175638
 	arm_func_start func_ov25_02175638
 func_ov25_02175638: ; 0x02175638
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #0x38
 	mov r4, r0
 	ldr r0, [r4]
@@ -9423,7 +9423,7 @@ func_ov25_02175638: ; 0x02175638
 	cmp r0, r1
 	addeq sp, sp, #0x38
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	add r1, sp, #0x2c
 	add r0, r4, #0xb0
 	bl func_ov00_020c53e8
@@ -9444,7 +9444,7 @@ func_ov25_02175638: ; 0x02175638
 	cmp r6, r1
 	addeq sp, sp, #0x38
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	ldrh r1, [sp, #0x28]
 	ldr r6, [r4, #0xc]
 	ldrh r0, [sp, #0x2a]
@@ -9459,7 +9459,7 @@ func_ov25_02175638: ; 0x02175638
 	add sp, sp, #0x38
 	str r1, [r4]
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _021756f8:
 	mov r0, #0
 	strh r0, [sp, #0x24]
@@ -9501,7 +9501,7 @@ _02175744:
 	strh r2, [sp, #0x1e]
 	addeq sp, sp, #0x38
 	moveq r0, #1
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	mov r8, #1
 	mov r7, #0
 	add r6, sp, #0x20
@@ -9531,19 +9531,19 @@ _021757ac:
 _021757fc:
 	ldrh r10, [sp, #0x28]
 	ldrh r3, [sp, #0x20]
-	ldrh sb, [sp, #0x2a]
+	ldrh r9, [sp, #0x2a]
 	ldrh r2, [sp, #0x22]
 	strh r10, [sp]
 	strh r3, [sp, #4]
 	ldrsh r1, [sp, #4]
 	ldrsh r0, [sp]
-	strh sb, [sp, #2]
+	strh r9, [sp, #2]
 	strh r2, [sp, #6]
 	cmp r1, r0
 	ldreqsh r1, [sp, #6]
 	ldreqsh r0, [sp, #2]
 	strh r10, [sp, #0x10]
-	strh sb, [sp, #0x12]
+	strh r9, [sp, #0x12]
 	strh r3, [sp, #0x14]
 	strh r2, [sp, #0x16]
 	cmpeq r1, r0
@@ -9564,7 +9564,7 @@ _021757fc:
 _0217587c:
 	add sp, sp, #0x38
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _02175888:
 	mov r0, r6
 	mov r1, r5
@@ -9593,7 +9593,7 @@ _021758d0:
 	cmp r0, r1
 	addeq sp, sp, #0x38
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	ldrh r1, [sp, #0x28]
 	ldr r5, [r4, #0xc]
 	ldrh r0, [sp, #0x2a]
@@ -9608,28 +9608,28 @@ _021758d0:
 	add sp, sp, #0x38
 	str r1, [r4]
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _02175930:
 	add r8, r8, #1
 _02175934:
 	ldr r10, [r4]
-	ldr sb, [r4, #4]
-	cmp sb, r10
-	suble r0, r10, sb
+	ldr r9, [r4, #4]
+	cmp r9, r10
+	suble r0, r10, r9
 	ble _02175954
 	ldr r0, [r4, #8]
 	add r0, r10, r0
-	sub r0, r0, sb
+	sub r0, r0, r9
 _02175954:
 	cmp r8, r0
 	blt _021757ac
 	ldr r1, [r4, #8]
 	add r0, r10, #1
 	bl func_02002c14
-	cmp sb, r1
+	cmp r9, r1
 	addeq sp, sp, #0x38
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	ldrh r1, [sp, #0x28]
 	ldr r5, [r4, #0xc]
 	ldrh r0, [sp, #0x2a]
@@ -9644,11 +9644,11 @@ _02175954:
 	add sp, sp, #0x38
 	str r1, [r4]
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _021759b4:
 	mov r0, #0
 	add sp, sp, #0x38
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	arm_func_end func_ov25_02175638
 
 	.global func_ov25_021759c0
@@ -9859,7 +9859,7 @@ _02175c50: .word 0x43425330
 	.global func_ov25_02175c54
 	arm_func_start func_ov25_02175c54
 func_ov25_02175c54: ; 0x02175c54
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x28
 	mov r11, r0
 	add r0, r11, #0x100
@@ -9879,13 +9879,13 @@ func_ov25_02175c54: ; 0x02175c54
 	sub r8, r1, r7
 	mov r6, #0
 	addle sp, sp, #0x28
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	mov r10, r11
-	add sb, r11, #0x17c
+	add r9, r11, #0x17c
 _02175cb0:
 	mov r0, r11
 	mov r1, r6
-	mov r2, sb
+	mov r2, r9
 	bl func_ov25_02175fac
 	ldrsh r5, [r4, #0x78]
 	mov r0, r8
@@ -9903,12 +9903,12 @@ _02175cb0:
 	str r0, [r10, #0x17c]
 	ldrsh r0, [r4, #0x78]
 	add r6, r6, #1
-	add sb, sb, #0xc
+	add r9, r9, #0xc
 	cmp r6, r0
 	add r10, r10, #0xc
 	blt _02175cb0
 	add sp, sp, #0x28
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov25_02175c54
 _02175d18: .word data_027e0e60
@@ -10029,7 +10029,7 @@ _02175e80: .word data_027e0764
 	.global func_ov25_02175e84
 	arm_func_start func_ov25_02175e84
 func_ov25_02175e84: ; 0x02175e84
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x20
 	mov r10, r0
 	add r0, sp, #0x10
@@ -10062,20 +10062,20 @@ _02175ee4:
 	blt _02175ee4
 	mov r7, #0
 	ldr r11, _02175fa8 ; =data_027e0fe4
-	mov sb, r7
+	mov r9, r7
 	add r5, r10, #0x158
 	add r4, sp, #0
 	add r6, sp, #0x10
 _02175f0c:
-	ldr r8, [r6, sb, lsl #2]
+	ldr r8, [r6, r9, lsl #2]
 	ldr r0, [r11]
 	add r1, r5, r8, lsl #3
 	bl _ZN12ActorManager8GetActorEP8ActorRef
 	cmp r0, #0
 	strne r8, [r4, r7, lsl #2]
-	add sb, sb, #1
+	add r9, r9, #1
 	addne r7, r7, #1
-	cmp sb, #4
+	cmp r9, #4
 	blt _02175f0c
 	mov r3, #0
 	add r2, sp, #0
@@ -10092,7 +10092,7 @@ _02175f54:
 	mov r6, #0
 	cmp r0, #0
 	addle sp, sp, #0x20
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r5, sp, #0x10
 	mvn r1, #0
 _02175f74:
@@ -10109,7 +10109,7 @@ _02175f90:
 	cmp r6, r0
 	blt _02175f74
 	add sp, sp, #0x20
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov25_02175e84
 _02175fa8: .word data_027e0fe4
@@ -10418,7 +10418,7 @@ func_ov25_02176384: ; 0x02176384
 	.global func_ov25_021763a4
 	arm_func_start func_ov25_021763a4
 func_ov25_021763a4: ; 0x021763a4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x24
 	mov r4, r0
 	bl _ZN5Actor20IncreaseActiveFramesEv
@@ -10477,7 +10477,7 @@ _02176464:
 	mov r1, #1
 	bl func_ov25_02176088
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _02176480:
 	ldr r0, _02176958 ; =data_027e0f74
 	ldr r1, [r4, #0x1d0]
@@ -10485,24 +10485,24 @@ _02176480:
 	bl func_ov00_02097b9c
 	cmp r0, #0
 	addeq sp, sp, #0x24
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	mov r0, r4
 	mov r1, #2
 	bl func_ov25_02176088
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _021764b0:
 	ldr r0, _0217695c ; =data_027e0c68
 	mov r1, #0
 	bl func_02036770
 	cmp r0, #0
 	addeq sp, sp, #0x24
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	mov r0, r4
 	mov r1, #3
 	bl func_ov25_02176088
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _021764dc:
 	ldr r0, [r4, #0x138]
 	mvn r6, #0
@@ -10536,11 +10536,11 @@ _02176510:
 	mov r0, r5
 	bl func_ov25_0216eb98
 _02176554:
-	mov sb, #0
+	mov r9, #0
 	ldr r5, _02176960 ; =data_027e0fe4
 	add r8, r4, #0x158
 	mov r7, #1
-	mov r6, sb
+	mov r6, r9
 _02176568:
 	ldr r0, [r5]
 	mov r1, r8
@@ -10551,47 +10551,47 @@ _02176568:
 	cmp r0, #0
 	moveq r7, r6
 _02176588:
-	add sb, sb, #1
-	cmp sb, #4
+	add r9, r9, #1
+	cmp r9, #4
 	add r8, r8, #8
 	blt _02176568
 	cmp r7, #0
 	addeq sp, sp, #0x24
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	mov r0, r4
 	mov r1, #4
 	bl func_ov25_02176088
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _021765b8:
 	ldr r0, _02176958 ; =data_027e0f74
 	ldr r0, [r0]
 	bl func_ov00_020980ac
 	cmp r0, #0
 	addeq sp, sp, #0x24
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	mov r0, r4
 	mov r1, #5
 	bl func_ov25_02176088
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _021765e4:
 	ldr r0, [r4, #0x138]
 	cmp r0, #0x96
 	addle sp, sp, #0x24
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	mov r0, r4
 	mov r1, #6
 	bl func_ov25_02176088
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _02176608:
 	ldr r0, _02176958 ; =data_027e0f74
 	ldr r0, [r0]
 	bl func_ov00_020980ac
 	cmp r0, #0
 	addeq sp, sp, #0x24
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	ldr r0, _02176964 ; =data_027e0f64
 	mov r1, #0
 	ldr r0, [r0]
@@ -10601,7 +10601,7 @@ _02176608:
 	mov r1, #7
 	bl func_ov25_02176088
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _02176648:
 	ldr r0, _02176958 ; =data_027e0f74
 	ldr r1, [r4, #0x1d0]
@@ -10609,13 +10609,13 @@ _02176648:
 	bl func_ov00_02097bac
 	cmp r0, #0
 	addeq sp, sp, #0x24
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	ldr r0, _02176958 ; =data_027e0f74
 	ldr r0, [r0]
 	bl func_ov00_02097738
 	cmp r0, #0
 	addne sp, sp, #0x24
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	ldr r0, _02176968 ; =data_027e0fc8
 	ldr r0, [r0]
 	bl func_ov00_020bd0a8
@@ -10623,12 +10623,12 @@ _02176648:
 	mov r1, #8
 	bl func_ov25_02176088
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _0217669c:
 	ldr r8, _02176960 ; =data_027e0fe4
 	add r7, r4, #0x158
 	mov r6, #0
-	add sb, sp, #0xc
+	add r9, sp, #0xc
 _021766ac:
 	ldr r0, [r8]
 	mov r1, r7
@@ -10638,12 +10638,12 @@ _021766ac:
 	add r0, r4, r6, lsl #2
 	ldr r1, [r0, #0x1bc]
 	mov r0, r4
-	mov r2, sb
+	mov r2, r9
 	bl func_ov25_02175fac
 	add r0, r4, r6, lsl #2
 	ldr r2, [r0, #0x1bc]
 	mov r0, r5
-	mov r1, sb
+	mov r1, r9
 	bl func_ov25_0216ebb8
 _021766e8:
 	add r6, r6, #1
@@ -10654,30 +10654,30 @@ _021766e8:
 	bl func_ov25_02175d1c
 	cmp r0, #0
 	addeq sp, sp, #0x24
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	mov r0, r4
 	mov r1, #9
 	bl func_ov25_02176088
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _02176720:
 	ldr r0, [r4, #0x138]
 	cmp r0, #0x14
 	addle sp, sp, #0x24
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	mov r0, r4
 	mov r1, #0xa
 	bl func_ov25_02176088
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _02176744:
-	ldr sb, _02176960 ; =data_027e0fe4
+	ldr r9, _02176960 ; =data_027e0fe4
 	add r7, r4, #0x158
 	mov r6, #0
 	add r5, r4, #0x17c
 	mov r8, #0xc
 _02176758:
-	ldr r0, [sb]
+	ldr r0, [r9]
 	mov r1, r7
 	bl _ZN12ActorManager8GetActorEP8ActorRef
 	cmp r0, #0
@@ -10695,22 +10695,22 @@ _0217677c:
 	bl func_ov25_02175d6c
 	cmp r0, #0
 	addeq sp, sp, #0x24
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	mov r0, r4
 	mov r1, #0xb
 	bl func_ov25_02176088
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _021767b4:
 	ldr r0, [r4, #0x138]
 	cmp r0, #0x14
 	addle sp, sp, #0x24
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	mov r0, r4
 	mov r1, #0xc
 	bl func_ov25_02176088
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _021767d8:
 	ldr r5, _02176960 ; =data_027e0fe4
 	add r8, r4, #0x158
@@ -10734,14 +10734,14 @@ _021767e4:
 	str r2, [r4, #0x1b8]
 	bl func_ov25_02176088
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _02176830:
 	add r7, r7, #1
 	cmp r7, #4
 	add r8, r8, #8
 	blt _021767e4
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _02176848:
 	ldr r5, _02176960 ; =data_027e0fe4
 	add r7, r4, #0x158
@@ -10781,7 +10781,7 @@ _021768b4:
 _021768c4:
 	cmp r6, #0
 	addeq sp, sp, #0x24
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	add r0, r4, #0x100
 	ldrsh r0, [r0, #0x78]
 	cmp r0, #1
@@ -10812,14 +10812,14 @@ _02176930:
 	mov r0, r4
 	bl _ZN5Actor4KillEv
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _02176940:
 	mov r0, r4
 	mov r1, #8
 	bl func_ov25_02176088
 _0217694c:
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov25_021763a4
 _02176954: .word data_027e0e60

--- a/asm/ov26.s
+++ b/asm/ov26.s
@@ -1019,7 +1019,7 @@ _0216e118: .word data_027e0f6c
 	.global func_ov26_0216e11c
 	arm_func_start func_ov26_0216e11c
 func_ov26_0216e11c: ; 0x0216e11c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #0x6c
 	mov sb, r0
 	mov r0, #0x800
@@ -1045,7 +1045,7 @@ func_ov26_0216e11c: ; 0x0216e11c
 	add r0, r7, #5
 	cmp r7, r0
 	bge _0216e1e4
-	ldr sl, _0216e320 ; =data_027e0e60
+	ldr r10, _0216e320 ; =data_027e0e60
 	add r5, sp, #4
 	mov r4, #1
 _0216e190:
@@ -1055,7 +1055,7 @@ _0216e190:
 	bge _0216e1d0
 	and r6, r7, #0xff
 _0216e1a4:
-	ldr r0, [sl]
+	ldr r0, [r10]
 	mov r1, r5
 	mov r2, r4
 	strb r6, [sp, #4]
@@ -1145,14 +1145,14 @@ _0216e1e4:
 	mov r2, r1
 	blx r3
 	add sp, sp, #0x6c
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 _0216e308:
 	ldr r3, [r3, #0x80]
 	mov r1, #0
 	mov r2, #1
 	blx r3
 	add sp, sp, #0x6c
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov26_0216e11c
 _0216e320: .word data_027e0e60
@@ -2233,10 +2233,10 @@ _0216efb0: .word data_ov00_020eec9c
 	.global func_ov26_0216efb4
 	arm_func_start func_ov26_0216efb4
 func_ov26_0216efb4: ; 0x0216efb4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x44
 	mov r4, r2
-	mov sl, r0
+	mov r10, r0
 	mov r5, r1
 	add r2, sp, #0x20
 	add r3, sp, #0x1c
@@ -2262,19 +2262,19 @@ func_ov26_0216efb4: ; 0x0216efb4
 	add r0, r0, #3
 	strb r0, [sp, #0x2c]
 _0216f024:
-	ldrb r0, [sl, #0xbe]
+	ldrb r0, [r10, #0xbe]
 	mov r1, #0x3c
 	cmp r0, #0
 	moveq r0, #1
 	streqb r0, [sp, #0x2e]
-	ldr r0, [sl, #0xb8]
+	ldr r0, [r10, #0xb8]
 	add r0, r0, #0x3b
 	bl func_01ff9b4c
 	mov r4, r0
-	mov r0, sl
+	mov r0, r10
 	bl func_ov26_0216f334
 	movs r5, r0
-	ldrneb r0, [sl, #0xc2]
+	ldrneb r0, [r10, #0xc2]
 	mov r6, #1
 	cmpne r0, #2
 	beq _0216f0d4
@@ -2283,11 +2283,11 @@ _0216f024:
 	bl func_ov00_02084a50
 	cmp r0, #0
 	bne _0216f0d4
-	ldr r0, [sl, #0xb8]
+	ldr r0, [r10, #0xb8]
 	mov r7, r6
 	cmp r0, #0
 	beq _0216f0cc
-	ldrb r0, [sl, #0xb1]
+	ldrb r0, [r10, #0xb1]
 	mov r1, #0x3c
 	add r0, r0, #0x3b
 	bl func_01ff9b88
@@ -2310,7 +2310,7 @@ _0216f0cc:
 _0216f0d4:
 	cmp r6, #0
 	addeq sp, sp, #0x44
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	mov r0, r4
 	mov r1, #0x3c
 	bl func_01ff9b4c
@@ -2322,7 +2322,7 @@ _0216f0d4:
 	str r8, [sp]
 	add r2, sp, #0x24
 	str r2, [sp, #4]
-	mov r0, sl
+	mov r0, r10
 	mov r1, #0xc5
 	mov r2, #0
 	mov r3, sb
@@ -2380,7 +2380,7 @@ _0216f0d4:
 	str r4, [sp, #0x18]
 	bl func_02034bc8
 	add sp, sp, #0x44
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov26_0216efb4
 _0216f1f8: .word data_027e0c38
@@ -3740,7 +3740,7 @@ _0217031c: .word data_027e0764
 	.global func_ov26_02170320
 	arm_func_start func_ov26_02170320
 func_ov26_02170320: ; 0x02170320
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x14
 	mov r4, r0
 	add r6, r4, #0x400
@@ -3772,7 +3772,7 @@ func_ov26_02170320: ; 0x02170320
 	str r1, [sp]
 	umull r7, r5, r1, r11
 	adds r1, r2, #0x800
-	mov sl, r1, lsr #0xc
+	mov r10, r1, lsr #0xc
 	ldmia r0, {r0, r1, r2}
 	stmia ip, {r0, r1, r2}
 	mov r1, #0
@@ -3780,10 +3780,10 @@ func_ov26_02170320: ; 0x02170320
 	mov r2, r8, asr #0x1f
 	mla sb, r2, r11, sb
 	adc r1, sb, #0
-	orr sl, sl, r1, lsl #20
+	orr r10, r10, r1, lsl #20
 	ldr r0, [sp, #8]
 	ldr r2, [sp]
-	add ip, r0, sl
+	add ip, r0, r10
 	adds r0, r7, #0x800
 	mov r7, #0
 	mla r5, r2, r7, r5
@@ -3793,9 +3793,9 @@ func_ov26_02170320: ; 0x02170320
 	adc r2, r5, #0
 	ldr r1, [sp, #0x10]
 	orr r0, r0, r2, lsl #20
-	add sl, r1, r0
+	add r10, r1, r0
 	str ip, [sp, #8]
-	str sl, [sp, #0x10]
+	str r10, [sp, #0x10]
 	ldrsh r1, [r4, #0x78]
 	add r0, sp, #8
 	ldr r7, [sp, #0xc]
@@ -3834,7 +3834,7 @@ func_ov26_02170320: ; 0x02170320
 	mov r5, r5, lsr #0xc
 	adc r8, r8, #0
 	orr r5, r5, r8, lsl #20
-	add r5, sl, r5
+	add r5, r10, r5
 	str r5, [sp, #0x10]
 	ldrh r5, [r6, #0xe8]
 	mov r5, r5, asr #0x4
@@ -3875,12 +3875,12 @@ func_ov26_02170320: ; 0x02170320
 	bl func_ov00_02084164
 	cmp r0, #0
 	addeq sp, sp, #0x14
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	add r0, r4, #0x48
 	bl func_ov00_020c5288
 	cmp r0, #0
 	addne sp, sp, #0x14
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, [r4, #0x48]
 	str r0, [r4, #0x4d0]
 	ldr r0, [r4, #0x4c]
@@ -3888,7 +3888,7 @@ func_ov26_02170320: ; 0x02170320
 	ldr r0, [r4, #0x50]
 	str r0, [r4, #0x4d8]
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov26_02170320
 _02170574: .word 0x0000071c
@@ -10854,22 +10854,22 @@ _02175b7c:
 	.global func_ov26_02175bb4
 	arm_func_start func_ov26_02175bb4
 func_ov26_02175bb4: ; 0x02175bb4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x18
-	mov sl, r0
-	ldr r0, [sl, #4]
+	mov r10, r0
+	ldr r0, [r10, #4]
 	cmp r0, #1
 	addls sp, sp, #0x18
-	ldmlsia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmlsia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r3, _02175e78 ; =0x04000444
 	mov r1, #0
 	ldr r0, _02175e7c ; =0x21230000
 	str r1, [r3]
 	str r0, [r3, #0x64]
-	add r0, sl, #0x1700
+	add r0, r10, #0x1700
 	ldrh r2, [r0, #0x82]
 	ldr r0, _02175e80 ; =0x42108000
-	add r1, sl, #0x1000
+	add r1, r10, #0x1000
 	orr r2, r2, #0x108000
 	orr r2, r2, #0x42000000
 	str r2, [r3, #0x7c]
@@ -10883,13 +10883,13 @@ func_ov26_02175bb4: ; 0x02175bb4
 	str r0, [r3, #0x28]
 	str r0, [r3, #0x28]
 	str r0, [r3, #0x28]
-	ldr r0, [sl, #4]
-	ldrh sb, [sl, #8]
+	ldr r0, [r10, #4]
+	ldrh sb, [r10, #8]
 	sub r0, r0, #1
 	cmp sb, r0
 	bhs _02175e64
 	mov r0, #0x14
-	mla r7, sb, r0, sl
+	mla r7, sb, r0, r10
 	ldr r0, _02175e84 ; =data_ov03_02100648
 	ldr r8, [r0]
 _02175c4c:
@@ -10897,7 +10897,7 @@ _02175c4c:
 	mov r1, #3
 	str r1, [r0]
 	sub r5, r0, #0x74
-	add r4, sl, #0x1000
+	add r4, r10, #0x1000
 	add r6, sp, #0xc
 	add r11, sp, #0
 _02175c68:
@@ -11015,7 +11015,7 @@ _02175d78:
 	str r0, [r5]
 	mov r0, r1, lsr #0x10
 	str r0, [r5]
-	ldr r0, [sl, #4]
+	ldr r0, [r10, #4]
 	add sb, sb, #1
 	cmp sb, r0
 	add r7, r7, #0x14
@@ -11029,7 +11029,7 @@ _02175e48:
 	ldr r0, _02175e8c ; =0x04000504
 	mov r1, #0
 	str r1, [r0]
-	ldr r0, [sl, #4]
+	ldr r0, [r10, #4]
 	sub r0, r0, #1
 	cmp sb, r0
 	blo _02175c4c
@@ -11038,7 +11038,7 @@ _02175e64:
 	mov r1, #1
 	str r1, [r0]
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov26_02175bb4
 _02175e78: .word 0x04000444
@@ -11551,7 +11551,7 @@ func_ov26_02176330: ; 0x02176330
 	.global func_ov26_02176354
 	arm_func_start func_ov26_02176354
 func_ov26_02176354: ; 0x02176354
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	mov r7, r1
 	ldr r1, [r7, #0xc]
 	ldr r2, [r7, #8]
@@ -11563,18 +11563,18 @@ func_ov26_02176354: ; 0x02176354
 	mov r6, #0
 	bge _021763bc
 _02176380:
-	ldr sl, [r7]
-	cmp sl, sb
+	ldr r10, [r7]
+	cmp r10, sb
 	bge _021763b0
 _0217638c:
 	mov r0, r8
-	mov r1, sl
+	mov r1, r10
 	mov r2, r5
 	bl func_ov00_02079ab4
 	cmp r0, #0
-	add sl, sl, #1
+	add r10, r10, #1
 	addne r6, r6, #1
-	cmp sl, sb
+	cmp r10, sb
 	blt _0217638c
 _021763b0:
 	add r5, r5, #1
@@ -11586,7 +11586,7 @@ _021763bc:
 	mov r0, r6, lsl #0xc
 	mul r1, r2, r1
 	bl func_01ff9b4c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	arm_func_end func_ov26_02176354
 
 	.global func_ov26_021763d4
@@ -11957,15 +11957,15 @@ func_ov26_021767ec: ; 0x021767ec
 	.global func_ov26_02176814
 	arm_func_start func_ov26_02176814
 func_ov26_02176814: ; 0x02176814
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #8
 	ldr r2, _021768ac ; =data_ov26_02179554
 	mov r8, #0
-	mov sl, r0
+	mov r10, r0
 	ldrb r0, [r2, r1]
 	mov r2, #1
-	strb r2, [sl, #0x1a1]
-	strb r1, [sl, #0x1a0]
+	strb r2, [r10, #0x1a1]
+	strb r1, [r10, #0x1a0]
 	add sb, r0, #2
 	mov r7, r8
 	mov r6, #0xa
@@ -11975,27 +11975,27 @@ func_ov26_02176814: ; 0x02176814
 _02176850:
 	sub r2, sb, r8
 	str r7, [sp]
-	mov r0, sl
+	mov r0, r10
 	mov r1, r6
 	mov r3, r7
 	and r2, r2, #0xff
 	str r7, [sp, #4]
 	bl func_020350b4
-	mov r0, sl
+	mov r0, r10
 	mov r1, r5
 	str r11, [sp]
 	mov r2, r11
 	mov r3, r11
 	bl func_020351b8
-	mov r0, sl
-	str r4, [sl, #0x64]
+	mov r0, r10
+	str r4, [r10, #0x64]
 	bl func_020352d8
 	add r8, r8, #1
 	cmp r8, #3
-	add sl, sl, #0x88
+	add r10, r10, #0x88
 	blt _02176850
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov26_02176814
 _021768ac: .word data_ov26_02179554
@@ -12049,22 +12049,22 @@ _02176930:
 	.global func_ov26_02176948
 	arm_func_start func_ov26_02176948
 func_ov26_02176948: ; 0x02176948
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #8
-	mov sl, r0
-	ldrb r0, [sl, #0x1a1]
+	mov r10, r0
+	ldrb r0, [r10, #0x1a1]
 	cmp r0, #0
 	addeq sp, sp, #8
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r7, _021769e0 ; =data_ov26_02179558
 	ldr r4, _021769e4 ; =data_027e0d3c
-	mov sb, sl
+	mov sb, r10
 	mov r8, #0
 	mov r11, #0xde
 	add r6, sp, #4
 	add r5, sp, #0
 _02176980:
-	ldrb r1, [sl, #0x1a0]
+	ldrb r1, [r10, #0x1a0]
 	mov r0, r11
 	mov r2, r6
 	add r1, r1, r1, lsl #1
@@ -12087,7 +12087,7 @@ _02176980:
 	cmp r8, #3
 	blt _02176980
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov26_02176948
 _021769e0: .word data_ov26_02179558
@@ -13027,9 +13027,9 @@ _021775c4: .word func_ov26_02177584 + 1
 	.global func_ov26_021775c8
 	arm_func_start func_ov26_021775c8
 func_ov26_021775c8: ; 0x021775c8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0xc
-	mov sl, r0
+	mov r10, r0
 	mov r3, #0x80000
 	mov r2, #0xc0000
 	mov r1, #0
@@ -13046,7 +13046,7 @@ func_ov26_021775c8: ; 0x021775c8
 	mov r7, #1
 	mov r1, #9
 _02177610:
-	add r0, sl, r1, lsl #1
+	add r0, r10, r1, lsl #1
 	add r0, r0, #0x200
 	ldrsb r0, [r0, #0x35]
 	cmp r0, #0
@@ -13058,8 +13058,8 @@ _02177610:
 _02177634:
 	mov r8, #0
 	ldr r4, _02177798 ; =data_027e0764
-	add sb, sl, #4
-	add r5, sl, #0x234
+	add sb, r10, #4
+	add r5, r10, #0x234
 	mov r11, r8
 	mov r6, r8
 _0217764c:
@@ -13108,11 +13108,11 @@ _021776e0:
 	add sb, sb, #0x1c
 	blt _0217764c
 _021776f0:
-	add r6, sl, #4
+	add r6, r10, #4
 	mov r5, #0
 	add r4, sp, #0
 _021776fc:
-	ldrb r2, [sl]
+	ldrb r2, [r10]
 	mov r0, r6
 	mov r1, r4
 	bl func_ov26_0217710c
@@ -13120,10 +13120,10 @@ _021776fc:
 	cmp r5, #0x14
 	add r6, r6, #0x1c
 	blt _021776fc
-	ldrb r0, [sl]
+	ldrb r0, [r10]
 	cmp r0, #0
 	addne sp, sp, #0xc
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	mov r0, #0
 	mov r3, r0
 	mov r1, r0
@@ -13131,7 +13131,7 @@ _021776fc:
 _0217773c:
 	cmp r0, #0
 	bne _02177758
-	add r0, sl, r3, lsl #1
+	add r0, r10, r3, lsl #1
 	add r0, r0, #0x200
 	ldrsb r0, [r0, #0x35]
 	cmp r0, #0
@@ -13150,9 +13150,9 @@ _02177764:
 _02177778:
 	cmp r0, #0
 	moveq r0, #1
-	streqb r0, [sl]
+	streqb r0, [r10]
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov26_021775c8
 _0217778c: .word data_ov00_020eec60
@@ -13671,7 +13671,7 @@ func_ov26_02177ddc: ; 0x02177ddc
 	.global func_ov26_02177e14
 	arm_func_start func_ov26_02177e14
 func_ov26_02177e14: ; 0x02177e14
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #8
 	mov r7, r0
 	mov r5, #0
@@ -13708,12 +13708,12 @@ _02177e90:
 	ldrb r3, [r4, r5, lsl #1]
 	ldrb r1, [sp, #4]
 	ldrb r0, [sp, #5]
-	add sl, r3, r1
+	add r10, r3, r1
 	add r3, r2, r0
 	ldr r0, [r6]
 	mov r1, sb
 	mov r2, r8
-	strb sl, [sp, #2]
+	strb r10, [sp, #2]
 	strb r3, [sp, #3]
 	bl func_ov00_020826a0
 	add r5, r5, #1
@@ -13724,7 +13724,7 @@ _02177e90:
 	strb r0, [sp]
 	strb r0, [sp, #1]
 	mov r6, #6
-	add sl, sp, #0
+	add r10, sp, #0
 	mov sb, #1
 	mov r4, #3
 _02177ef0:
@@ -13735,7 +13735,7 @@ _02177ef4:
 	ldr r0, [r8]
 	add ip, r2, r5
 	add r3, r1, r6
-	mov r1, sl
+	mov r1, r10
 	mov r2, sb
 	strb ip, [sp]
 	strb r3, [sp, #1]
@@ -13756,7 +13756,7 @@ _02177ef4:
 	str r2, [r7, #0x50]
 	str r1, [r7, #0x4c]
 	add sp, sp, #8
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov26_02177e14
 _02177f60: .word data_027e0e60
@@ -14303,34 +14303,34 @@ func_ov26_02178534: ; 0x02178534
 	.global func_ov26_0217855c
 	arm_func_start func_ov26_0217855c
 func_ov26_0217855c: ; 0x0217855c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x20
-	mov sl, r0
-	ldrb r2, [sl, #0x15]
+	mov r10, r0
+	ldrb r2, [r10, #0x15]
 	ldr r0, _021786d4 ; =data_027e0e60
-	ldrb r1, [sl, #0x14]
+	ldrb r1, [r10, #0x14]
 	ldr r0, [r0]
 	sub r2, r2, #1
 	bl func_ov00_02083e34
-	str r0, [sl, #0x1c]
-	ldr r1, [sl, #0x18]
+	str r0, [r10, #0x1c]
+	ldr r1, [r10, #0x18]
 	ldr r0, _021786d4 ; =data_027e0e60
 	add r1, r1, #0x800
-	str r1, [sl, #0x18]
-	str r1, [sl, #0x50]
-	ldr r2, [sl, #0x1c]
+	str r1, [r10, #0x18]
+	str r1, [r10, #0x50]
+	ldr r2, [r10, #0x1c]
 	add r1, sp, #6
-	str r2, [sl, #0x54]
-	ldr r2, [sl, #0x20]
-	str r2, [sl, #0x58]
-	ldr r2, [sl, #0x50]
-	str r2, [sl, #0x5c]
-	ldr r2, [sl, #0x54]
-	str r2, [sl, #0x60]
-	ldr r2, [sl, #0x58]
-	str r2, [sl, #0x64]
-	ldrb r3, [sl, #0x15]
-	ldrb r2, [sl, #0x14]
+	str r2, [r10, #0x54]
+	ldr r2, [r10, #0x20]
+	str r2, [r10, #0x58]
+	ldr r2, [r10, #0x50]
+	str r2, [r10, #0x5c]
+	ldr r2, [r10, #0x54]
+	str r2, [r10, #0x60]
+	ldr r2, [r10, #0x58]
+	str r2, [r10, #0x64]
+	ldrb r3, [r10, #0x15]
+	ldrb r2, [r10, #0x14]
 	ldr r0, [r0]
 	strb r2, [sp, #6]
 	strb r3, [sp, #7]
@@ -14350,14 +14350,14 @@ _02178604:
 	bne _02178618
 _0217860c:
 	mov r0, #1
-	strb r0, [sl, #0x38]
+	strb r0, [r10, #0x38]
 	b _02178620
 _02178618:
 	mov r0, #0
-	strb r0, [sl, #0x38]
+	strb r0, [r10, #0x38]
 _02178620:
-	ldrb r11, [sl, #0x14]
-	ldrb r1, [sl, #0x15]
+	ldrb r11, [r10, #0x14]
+	ldrb r1, [r10, #0x15]
 	add r0, r11, #2
 	str r0, [sp]
 	cmp r11, r0
@@ -14367,7 +14367,7 @@ _02178620:
 	add r6, sp, #4
 	mov r5, #1
 _02178648:
-	ldrb r8, [sl, #0x15]
+	ldrb r8, [r10, #0x15]
 	cmp r8, sb
 	bge _0217867c
 	and r7, r11, #0xff
@@ -14387,7 +14387,7 @@ _0217867c:
 	cmp r11, r0
 	blt _02178648
 _0217868c:
-	add r0, sl, #0x18
+	add r0, r10, #0x18
 	mov r5, #0x800
 	mov r4, #0
 	mov r3, #0x5800
@@ -14398,13 +14398,13 @@ _0217868c:
 	str r3, [sp, #0x1c]
 	bl func_01ff9bc4
 	mov r0, r4
-	str r0, [sl, #0x78]
-	str r0, [sl, #0x7c]
-	str r0, [sl, #0x80]
+	str r0, [r10, #0x78]
+	str r0, [r10, #0x7c]
+	str r0, [r10, #0x80]
 	mov r0, #0xc000
-	str r0, [sl, #0x84]
+	str r0, [r10, #0x84]
 	add sp, sp, #0x20
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov26_0217855c
 _021786d4: .word data_027e0e60

--- a/asm/ov26.s
+++ b/asm/ov26.s
@@ -1019,29 +1019,29 @@ _0216e118: .word data_027e0f6c
 	.global func_ov26_0216e11c
 	arm_func_start func_ov26_0216e11c
 func_ov26_0216e11c: ; 0x0216e11c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #0x6c
-	mov sb, r0
+	mov r9, r0
 	mov r0, #0x800
 	mov r3, #0x2000
 	mov r2, #0
 	str r0, [sp, #0x38]
-	add r0, sb, #0x18
+	add r0, r9, #0x18
 	str r2, [sp, #0x34]
 	add r1, sp, #0x30
 	str r3, [sp, #0x30]
 	mov r2, r0
 	bl func_01ff9bc4
-	ldrb r0, [sb, #0x14]
-	ldrb r2, [sb, #0x15]
+	ldrb r0, [r9, #0x14]
+	ldrb r2, [r9, #0x15]
 	cmp r0, #0
 	sub r1, r0, #1
 	ldr r0, _0216e320 ; =data_027e0e60
 	moveq r1, #5
 	ldr r0, [r0]
 	bl func_ov00_02083e34
-	str r0, [sb, #0x1c]
-	ldrb r7, [sb, #0x14]
+	str r0, [r9, #0x1c]
+	ldrb r7, [r9, #0x14]
 	add r0, r7, #5
 	cmp r7, r0
 	bge _0216e1e4
@@ -1049,7 +1049,7 @@ func_ov26_0216e11c: ; 0x0216e11c
 	add r5, sp, #4
 	mov r4, #1
 _0216e190:
-	ldrb r8, [sb, #0x15]
+	ldrb r8, [r9, #0x15]
 	add r0, r8, #2
 	cmp r8, r0
 	bge _0216e1d0
@@ -1061,19 +1061,19 @@ _0216e1a4:
 	strb r6, [sp, #4]
 	strb r8, [sp, #5]
 	bl func_ov00_02082680
-	ldrb r0, [sb, #0x15]
+	ldrb r0, [r9, #0x15]
 	add r8, r8, #1
 	add r0, r0, #2
 	cmp r8, r0
 	blt _0216e1a4
 _0216e1d0:
-	ldrb r0, [sb, #0x14]
+	ldrb r0, [r9, #0x14]
 	add r7, r7, #1
 	add r0, r0, #5
 	cmp r7, r0
 	blt _0216e190
 _0216e1e4:
-	add r4, sb, #0x18
+	add r4, r9, #0x18
 	ldmia r4, {r0, r1, r2}
 	add r6, sp, #0x60
 	stmia r6, {r0, r1, r2}
@@ -1113,31 +1113,31 @@ _0216e1e4:
 	add r3, sp, #0x48
 	ldmia r4, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
-	mov r0, sb
+	mov r0, r9
 	bl func_ov00_0208b9cc
 	mov r2, r0
 	mov r0, #0
 	str r0, [sp]
-	add r0, sb, #0x58
+	add r0, r9, #0x58
 	ldr r4, [r0]
 	ldr r3, [sp, #8]
 	ldr r4, [r4, #0x14]
 	mov r1, r5
 	blx r4
 	ldr r0, _0216e324 ; =data_027e0f6c
-	add r1, sb, #0x58
+	add r1, r9, #0x58
 	ldr r0, [r0]
 	bl func_ov00_02093a5c
 	mov r0, #0
-	str r0, [sb, #0x48]
-	str r0, [sb, #0x4c]
-	str r0, [sb, #0x50]
+	str r0, [r9, #0x48]
+	str r0, [r9, #0x4c]
+	str r0, [r9, #0x50]
 	mov r0, #0x4000
-	str r0, [sb, #0x54]
-	mov r0, sb
+	str r0, [r9, #0x54]
+	mov r0, r9
 	bl func_ov26_0216e4d0
 	cmp r0, #0
-	mov r0, sb
+	mov r0, r9
 	ldr r3, [r0]
 	beq _0216e308
 	mov r1, #1
@@ -1145,14 +1145,14 @@ _0216e1e4:
 	mov r2, r1
 	blx r3
 	add sp, sp, #0x6c
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 _0216e308:
 	ldr r3, [r3, #0x80]
 	mov r1, #0
 	mov r2, #1
 	blx r3
 	add sp, sp, #0x6c
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov26_0216e11c
 _0216e320: .word data_027e0e60
@@ -2233,7 +2233,7 @@ _0216efb0: .word data_ov00_020eec9c
 	.global func_ov26_0216efb4
 	arm_func_start func_ov26_0216efb4
 func_ov26_0216efb4: ; 0x0216efb4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x44
 	mov r4, r2
 	mov r10, r0
@@ -2249,7 +2249,7 @@ func_ov26_0216efb4: ; 0x0216efb4
 	ldr r2, [r0, #0x14]
 	sub r3, r5, r3
 	add r0, sp, #0x24
-	sub sb, r3, r2
+	sub r9, r3, r2
 	sub r8, r4, r1
 	bl func_01ffbe34
 	ldr r0, _0216f1fc ; =data_027e0618
@@ -2310,7 +2310,7 @@ _0216f0cc:
 _0216f0d4:
 	cmp r6, #0
 	addeq sp, sp, #0x44
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	mov r0, r4
 	mov r1, #0x3c
 	bl func_01ff9b4c
@@ -2325,14 +2325,14 @@ _0216f0d4:
 	mov r0, r10
 	mov r1, #0xc5
 	mov r2, #0
-	mov r3, sb
+	mov r3, r9
 	bl func_02034b0c
 	cmp r5, #0
 	movne r1, #7
 	moveq r1, #5
 	add r7, sp, #0x24
 	str r8, [sp]
-	mov r3, sb
+	mov r3, r9
 	mov r0, #0xc5
 	mov r2, #5
 	str r7, [sp, #4]
@@ -2342,13 +2342,13 @@ _0216f0d4:
 	moveq r1, #6
 	add r7, sp, #0x24
 	str r8, [sp]
-	mov r3, sb
+	mov r3, r9
 	mov r0, #0xc5
 	mov r2, #6
 	str r7, [sp, #4]
 	bl func_020349cc
 	ldr r0, _0216f208 ; =data_ov26_0217933c
-	str sb, [sp]
+	str r9, [sp]
 	ldrb r5, [r0, r5]
 	str r8, [sp, #4]
 	mov r0, #0xc4
@@ -2364,7 +2364,7 @@ _0216f0d4:
 	mov r2, #0xc5
 	mov r3, #4
 	bl func_02034bc8
-	str sb, [sp]
+	str r9, [sp]
 	mov r1, #2
 	str r8, [sp, #4]
 	mov r0, #0xc4
@@ -2380,7 +2380,7 @@ _0216f0d4:
 	str r4, [sp, #0x18]
 	bl func_02034bc8
 	add sp, sp, #0x44
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov26_0216efb4
 _0216f1f8: .word data_027e0c38
@@ -2541,7 +2541,7 @@ _0216f404: .word data_ov26_02179344
 	.global func_ov26_0216f408
 	arm_func_start func_ov26_0216f408
 func_ov26_0216f408: ; 0x0216f408
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x10
 	mov r7, r0
 	ldr r0, _0216f504 ; =data_ov26_0217a574
@@ -2584,7 +2584,7 @@ _0216f484:
 _0216f490:
 	ldr r1, _0216f534 ; =data_027e0fec
 	ldr r1, [r1]
-	ldr sb, [r1, #0x580]
+	ldr r9, [r1, #0x580]
 	blx func_02016fe8
 	mov r8, r0
 	add r0, sp, #0
@@ -2595,7 +2595,7 @@ _0216f490:
 	mov r0, r8
 	bl func_0201e544
 	mov r1, r0
-	mov r2, sb
+	mov r2, r9
 	mov r3, r5
 	add r0, r7, #0xfc
 	bl func_ov00_020c0cc8
@@ -2610,7 +2610,7 @@ _0216f490:
 	ldr r2, [r2, #0x24]
 	blx r2
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov26_0216f408
 _0216f504: .word data_ov26_0217a574
@@ -3740,7 +3740,7 @@ _0217031c: .word data_027e0764
 	.global func_ov26_02170320
 	arm_func_start func_ov26_02170320
 func_ov26_02170320: ; 0x02170320
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x14
 	mov r4, r0
 	add r6, r4, #0x400
@@ -3767,7 +3767,7 @@ func_ov26_02170320: ; 0x02170320
 	ldrsh r8, [r3, r1]
 	add r1, r2, #1
 	mov r1, r1, lsl #0x1
-	umull r2, sb, r8, r11
+	umull r2, r9, r8, r11
 	ldrsh r1, [r3, r1]
 	str r1, [sp]
 	umull r7, r5, r1, r11
@@ -3776,10 +3776,10 @@ func_ov26_02170320: ; 0x02170320
 	ldmia r0, {r0, r1, r2}
 	stmia ip, {r0, r1, r2}
 	mov r1, #0
-	mla sb, r8, r1, sb
+	mla r9, r8, r1, r9
 	mov r2, r8, asr #0x1f
-	mla sb, r2, r11, sb
-	adc r1, sb, #0
+	mla r9, r2, r11, r9
+	adc r1, r9, #0
 	orr r10, r10, r1, lsl #20
 	ldr r0, [sp, #8]
 	ldr r2, [sp]
@@ -3808,11 +3808,11 @@ func_ov26_02170320: ; 0x02170320
 	ldr r1, _02170588 ; =data_027e0fa0
 	mov r2, r0
 	mov r5, r8, asr #0x1f
-	mov sb, r5, lsl #0xa
+	mov r9, r5, lsl #0xa
 	mov r5, #0x800
 	adds r5, r5, r8, lsl #10
-	orr sb, sb, r8, lsr #22
-	adc r8, sb, #0
+	orr r9, r9, r8, lsr #22
+	adc r8, r9, #0
 	mov r5, r5, lsr #0xc
 	orr r5, r5, r8, lsl #20
 	add r5, ip, r5
@@ -3825,12 +3825,12 @@ func_ov26_02170320: ; 0x02170320
 	mov r5, r5, lsl #0x1
 	add r5, r5, #1
 	mov r5, r5, lsl #0x1
-	ldrsh sb, [r3, r5]
+	ldrsh r9, [r3, r5]
 	mov r5, #0x800
-	mov r8, sb, asr #0x1f
+	mov r8, r9, asr #0x1f
 	mov r8, r8, lsl #0xa
-	adds r5, r5, sb, lsl #10
-	orr r8, r8, sb, lsr #22
+	adds r5, r5, r9, lsl #10
+	orr r8, r8, r9, lsr #22
 	mov r5, r5, lsr #0xc
 	adc r8, r8, #0
 	orr r5, r5, r8, lsl #20
@@ -3841,11 +3841,11 @@ func_ov26_02170320: ; 0x02170320
 	mov r5, r5, lsl #0x2
 	ldrsh r6, [r3, r5]
 	mov r3, #0
-	umull sb, r8, r6, r11
+	umull r9, r8, r6, r11
 	mla r8, r6, r3, r8
 	mov r5, r6, asr #0x1f
 	mla r8, r5, r11, r8
-	adds r5, sb, #0x800
+	adds r5, r9, #0x800
 	adc r3, r8, #0
 	mov r5, r5, lsr #0xc
 	orr r5, r5, r3, lsl #20
@@ -3875,12 +3875,12 @@ func_ov26_02170320: ; 0x02170320
 	bl func_ov00_02084164
 	cmp r0, #0
 	addeq sp, sp, #0x14
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r0, r4, #0x48
 	bl func_ov00_020c5288
 	cmp r0, #0
 	addne sp, sp, #0x14
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, [r4, #0x48]
 	str r0, [r4, #0x4d0]
 	ldr r0, [r4, #0x4c]
@@ -3888,7 +3888,7 @@ func_ov26_02170320: ; 0x02170320
 	ldr r0, [r4, #0x50]
 	str r0, [r4, #0x4d8]
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov26_02170320
 _02170574: .word 0x0000071c
@@ -10854,13 +10854,13 @@ _02175b7c:
 	.global func_ov26_02175bb4
 	arm_func_start func_ov26_02175bb4
 func_ov26_02175bb4: ; 0x02175bb4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x18
 	mov r10, r0
 	ldr r0, [r10, #4]
 	cmp r0, #1
 	addls sp, sp, #0x18
-	ldmlsia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmlsia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r3, _02175e78 ; =0x04000444
 	mov r1, #0
 	ldr r0, _02175e7c ; =0x21230000
@@ -10884,12 +10884,12 @@ func_ov26_02175bb4: ; 0x02175bb4
 	str r0, [r3, #0x28]
 	str r0, [r3, #0x28]
 	ldr r0, [r10, #4]
-	ldrh sb, [r10, #8]
+	ldrh r9, [r10, #8]
 	sub r0, r0, #1
-	cmp sb, r0
+	cmp r9, r0
 	bhs _02175e64
 	mov r0, #0x14
-	mla r7, sb, r0, r10
+	mla r7, r9, r0, r10
 	ldr r0, _02175e84 ; =data_ov03_02100648
 	ldr r8, [r0]
 _02175c4c:
@@ -11016,8 +11016,8 @@ _02175d78:
 	mov r0, r1, lsr #0x10
 	str r0, [r5]
 	ldr r0, [r10, #4]
-	add sb, sb, #1
-	cmp sb, r0
+	add r9, r9, #1
+	cmp r9, r0
 	add r7, r7, #0x14
 	bhs _02175e48
 	ldr r0, [r7, #4]
@@ -11031,14 +11031,14 @@ _02175e48:
 	str r1, [r0]
 	ldr r0, [r10, #4]
 	sub r0, r0, #1
-	cmp sb, r0
+	cmp r9, r0
 	blo _02175c4c
 _02175e64:
 	ldr r0, _02175e90 ; =0x04000448
 	mov r1, #1
 	str r1, [r0]
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov26_02175bb4
 _02175e78: .word 0x04000444
@@ -11551,7 +11551,7 @@ func_ov26_02176330: ; 0x02176330
 	.global func_ov26_02176354
 	arm_func_start func_ov26_02176354
 func_ov26_02176354: ; 0x02176354
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	mov r7, r1
 	ldr r1, [r7, #0xc]
 	ldr r2, [r7, #8]
@@ -11559,12 +11559,12 @@ func_ov26_02176354: ; 0x02176354
 	add r4, r5, r1
 	mov r8, r0
 	cmp r5, r4
-	add sb, r3, r2
+	add r9, r3, r2
 	mov r6, #0
 	bge _021763bc
 _02176380:
 	ldr r10, [r7]
-	cmp r10, sb
+	cmp r10, r9
 	bge _021763b0
 _0217638c:
 	mov r0, r8
@@ -11574,7 +11574,7 @@ _0217638c:
 	cmp r0, #0
 	add r10, r10, #1
 	addne r6, r6, #1
-	cmp r10, sb
+	cmp r10, r9
 	blt _0217638c
 _021763b0:
 	add r5, r5, #1
@@ -11586,7 +11586,7 @@ _021763bc:
 	mov r0, r6, lsl #0xc
 	mul r1, r2, r1
 	bl func_01ff9b4c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	arm_func_end func_ov26_02176354
 
 	.global func_ov26_021763d4
@@ -11957,7 +11957,7 @@ func_ov26_021767ec: ; 0x021767ec
 	.global func_ov26_02176814
 	arm_func_start func_ov26_02176814
 func_ov26_02176814: ; 0x02176814
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #8
 	ldr r2, _021768ac ; =data_ov26_02179554
 	mov r8, #0
@@ -11966,14 +11966,14 @@ func_ov26_02176814: ; 0x02176814
 	mov r2, #1
 	strb r2, [r10, #0x1a1]
 	strb r1, [r10, #0x1a0]
-	add sb, r0, #2
+	add r9, r0, #2
 	mov r7, r8
 	mov r6, #0xa
 	mov r11, r8
 	mov r5, r2
 	mov r4, r8
 _02176850:
-	sub r2, sb, r8
+	sub r2, r9, r8
 	str r7, [sp]
 	mov r0, r10
 	mov r1, r6
@@ -11995,7 +11995,7 @@ _02176850:
 	add r10, r10, #0x88
 	blt _02176850
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov26_02176814
 _021768ac: .word data_ov26_02179554
@@ -12049,16 +12049,16 @@ _02176930:
 	.global func_ov26_02176948
 	arm_func_start func_ov26_02176948
 func_ov26_02176948: ; 0x02176948
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #8
 	mov r10, r0
 	ldrb r0, [r10, #0x1a1]
 	cmp r0, #0
 	addeq sp, sp, #8
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r7, _021769e0 ; =data_ov26_02179558
 	ldr r4, _021769e4 ; =data_027e0d3c
-	mov sb, r10
+	mov r9, r10
 	mov r8, #0
 	mov r11, #0xde
 	add r6, sp, #4
@@ -12079,15 +12079,15 @@ _02176980:
 	bl func_ov00_02079680
 	ldr r1, [sp, #4]
 	ldr r2, [sp]
-	mov r0, sb
+	mov r0, r9
 	mov r3, #0
 	bl func_02034a1c
 	add r8, r8, #1
-	add sb, sb, #0x88
+	add r9, r9, #0x88
 	cmp r8, #3
 	blt _02176980
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov26_02176948
 _021769e0: .word data_ov26_02179558
@@ -12791,10 +12791,10 @@ _0217731c:
 	.global func_ov26_02177324
 	arm_func_start func_ov26_02177324
 func_ov26_02177324: ; 0x02177324
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
-	mov sb, r0
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
+	mov r9, r0
 	mov r0, #0xd0
-	strb r1, [sb]
+	strb r1, [r9]
 	bl func_02034670
 	mov r7, #0
 	ldr r4, _02177380 ; =data_ov26_021795b4
@@ -12809,12 +12809,12 @@ _0217734c:
 	ldrb r1, [r1, #1]
 	cmp r6, r0
 	add r7, r7, r1
-	streqb r7, [sb, #1]
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	streqb r7, [r9, #1]
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	add r8, r8, #1
 	cmp r8, #5
 	blo _0217734c
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov26_02177324
 _02177380: .word data_ov26_021795b4
@@ -12871,7 +12871,7 @@ _02177424: .word data_027e0d3c
 	.global func_ov26_02177428
 	arm_func_start func_ov26_02177428
 func_ov26_02177428: ; 0x02177428
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #8
 	mov r5, r0
 	ldrsb r0, [r5, #1]
@@ -12879,7 +12879,7 @@ func_ov26_02177428: ; 0x02177428
 	cmp r0, #0
 	addle sp, sp, #8
 	movle r0, #0
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	ldrb r1, [r5]
 	add r2, sp, #4
 	add r3, sp, #0
@@ -12889,24 +12889,24 @@ func_ov26_02177428: ; 0x02177428
 	mov r7, #0
 	ldr r8, [r6]
 	ldmib r6, {r0, r1}
-	umull r2, sb, r1, r8
-	mla sb, r1, r0, sb
+	umull r2, r9, r1, r8
+	mla r9, r1, r0, r9
 	ldr r0, [r6, #0xc]
 	ldr r3, [r6, #0x10]
-	mla sb, r0, r8, sb
+	mla r9, r0, r8, r9
 	adds lr, r3, r2
 	ldr r2, [r6, #0x14]
-	adc ip, r2, sb
-	umull sb, r8, r1, lr
+	adc ip, r2, r9
+	umull r9, r8, r1, lr
 	mla r8, r1, ip, r8
 	mla r8, r0, lr, r8
-	adds sb, r3, sb
+	adds r9, r3, r9
 	str lr, [r6]
 	mov r0, #0x14
 	adc r3, r2, r8
 	umull r1, r8, ip, r0
 	umull r1, r2, r3, r0
-	stmia r6, {sb, ip}
+	stmia r6, {r9, ip}
 	mla r8, ip, r7, r8
 	mov r1, r7
 	mla r2, r3, r7, r2
@@ -12934,7 +12934,7 @@ func_ov26_02177428: ; 0x02177428
 	sub r1, r1, #1
 	strb r1, [r5, #1]
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov26_02177428
 _02177528: .word data_027e0764
@@ -13027,7 +13027,7 @@ _021775c4: .word func_ov26_02177584 + 1
 	.global func_ov26_021775c8
 	arm_func_start func_ov26_021775c8
 func_ov26_021775c8: ; 0x021775c8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0xc
 	mov r10, r0
 	mov r3, #0x80000
@@ -13058,12 +13058,12 @@ _02177610:
 _02177634:
 	mov r8, #0
 	ldr r4, _02177798 ; =data_027e0764
-	add sb, r10, #4
+	add r9, r10, #4
 	add r5, r10, #0x234
 	mov r11, r8
 	mov r6, r8
 _0217764c:
-	mov r0, sb
+	mov r0, r9
 	bl func_ov26_021772dc
 	cmp r0, #0
 	beq _021776e0
@@ -13099,13 +13099,13 @@ _021776a0:
 	str r1, [r4, #4]
 	add r2, r0, #9
 _021776d4:
-	mov r1, sb
+	mov r1, r9
 	add r0, r5, r2, lsl #1
 	bl func_ov26_02177428
 _021776e0:
 	add r8, r8, #1
 	cmp r8, #0x14
-	add sb, sb, #0x1c
+	add r9, r9, #0x1c
 	blt _0217764c
 _021776f0:
 	add r6, r10, #4
@@ -13123,7 +13123,7 @@ _021776fc:
 	ldrb r0, [r10]
 	cmp r0, #0
 	addne sp, sp, #0xc
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	mov r0, #0
 	mov r3, r0
 	mov r1, r0
@@ -13152,7 +13152,7 @@ _02177778:
 	moveq r0, #1
 	streqb r0, [r10]
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov26_021775c8
 _0217778c: .word data_ov00_020eec60
@@ -13406,7 +13406,7 @@ func_ov26_02177a70: ; 0x02177a70
 	.global func_ov26_02177a98
 	arm_func_start func_ov26_02177a98
 func_ov26_02177a98: ; 0x02177a98
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	ldr r1, _02177b84 ; =data_027e0f74
 	mov r5, r0
 	ldr r0, [r1]
@@ -13414,7 +13414,7 @@ func_ov26_02177a98: ; 0x02177a98
 	bl func_ov00_02097c18
 	cmp r0, #0
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	mov r6, #0
 	str r6, [r5, #0x7c]
 	mov r4, #0x800
@@ -13447,7 +13447,7 @@ func_ov26_02177a98: ; 0x02177a98
 	ldr r1, [r0, #8]
 	ldr r4, _02177b8c ; =data_ov26_021795c8
 	add r8, r0, r1
-	mov sb, r6
+	mov r9, r6
 _02177b40:
 	mov r1, r4
 	add r0, r8, #4
@@ -13460,12 +13460,12 @@ _02177b40:
 	mov r1, r7
 	mov r2, r6
 	bl func_02019570
-	add sb, sb, #1
-	cmp sb, #6
+	add r9, r9, #1
+	cmp r9, #6
 	add r4, r4, #0x10
 	blo _02177b40
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov26_02177a98
 _02177b84: .word data_027e0f74
@@ -13671,7 +13671,7 @@ func_ov26_02177ddc: ; 0x02177ddc
 	.global func_ov26_02177e14
 	arm_func_start func_ov26_02177e14
 func_ov26_02177e14: ; 0x02177e14
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #8
 	mov r7, r0
 	mov r5, #0
@@ -13700,7 +13700,7 @@ func_ov26_02177e14: ; 0x02177e14
 	bl func_ov00_02083a1c
 	ldr r4, _02177f64 ; =data_ov26_0217af64
 	ldr r6, _02177f60 ; =data_027e0e60
-	add sb, sp, #2
+	add r9, sp, #2
 	mov r8, #1
 _02177e90:
 	add r0, r4, r5, lsl #1
@@ -13711,7 +13711,7 @@ _02177e90:
 	add r10, r3, r1
 	add r3, r2, r0
 	ldr r0, [r6]
-	mov r1, sb
+	mov r1, r9
 	mov r2, r8
 	strb r10, [sp, #2]
 	strb r3, [sp, #3]
@@ -13725,7 +13725,7 @@ _02177e90:
 	strb r0, [sp, #1]
 	mov r6, #6
 	add r10, sp, #0
-	mov sb, #1
+	mov r9, #1
 	mov r4, #3
 _02177ef0:
 	mov r5, r4
@@ -13736,7 +13736,7 @@ _02177ef4:
 	add ip, r2, r5
 	add r3, r1, r6
 	mov r1, r10
-	mov r2, sb
+	mov r2, r9
 	strb ip, [sp]
 	strb r3, [sp, #1]
 	bl func_ov00_020826a0
@@ -13756,7 +13756,7 @@ _02177ef4:
 	str r2, [r7, #0x50]
 	str r1, [r7, #0x4c]
 	add sp, sp, #8
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov26_02177e14
 _02177f60: .word data_027e0e60
@@ -14303,7 +14303,7 @@ func_ov26_02178534: ; 0x02178534
 	.global func_ov26_0217855c
 	arm_func_start func_ov26_0217855c
 func_ov26_0217855c: ; 0x0217855c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x20
 	mov r10, r0
 	ldrb r2, [r10, #0x15]
@@ -14361,14 +14361,14 @@ _02178620:
 	add r0, r11, #2
 	str r0, [sp]
 	cmp r11, r0
-	add sb, r1, #0xc
+	add r9, r1, #0xc
 	bge _0217868c
 	ldr r4, _021786d4 ; =data_027e0e60
 	add r6, sp, #4
 	mov r5, #1
 _02178648:
 	ldrb r8, [r10, #0x15]
-	cmp r8, sb
+	cmp r8, r9
 	bge _0217867c
 	and r7, r11, #0xff
 _02178658:
@@ -14379,7 +14379,7 @@ _02178658:
 	strb r8, [sp, #5]
 	bl func_ov00_02082680
 	add r8, r8, #1
-	cmp r8, sb
+	cmp r8, r9
 	blt _02178658
 _0217867c:
 	ldr r0, [sp]
@@ -14404,7 +14404,7 @@ _0217868c:
 	mov r0, #0xc000
 	str r0, [r10, #0x84]
 	add sp, sp, #0x20
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov26_0217855c
 _021786d4: .word data_027e0e60
@@ -14996,15 +14996,15 @@ _02178e78:
 	.global func_ov26_02178e8c
 	arm_func_start func_ov26_02178e8c
 func_ov26_02178e8c: ; 0x02178e8c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
-	mov sb, r0
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
+	mov r9, r0
 	mov r4, #0
 	mov r8, r1
 	mov r6, r4
-	add r7, sb, #0x450
+	add r7, r9, #0x450
 	mov r5, #0x2d
 _02178ea8:
-	add r0, sb, r6, lsl #2
+	add r0, r9, r6, lsl #2
 	ldr r0, [r0, #0x480]
 	cmp r0, #0
 	ble _02178ecc
@@ -15012,7 +15012,7 @@ _02178ea8:
 	mov r1, r8
 	bl func_01ff9ec0
 	cmp r0, #0x1200
-	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmltia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _02178ecc:
 	add r6, r6, #1
 	cmp r6, #4
@@ -15023,29 +15023,29 @@ _02178ecc:
 	bl func_ov00_020d77e4
 	mov r3, #0
 _02178eec:
-	add r0, sb, r3, lsl #2
+	add r0, r9, r3, lsl #2
 	ldr r1, [r0, #0x480]
 	cmp r1, #0
 	bgt _02178f48
 	mov r1, #0xc
-	mla r5, r3, r1, sb
+	mla r5, r3, r1, r9
 	ldr r2, [r8]
 	mov r1, #0x88
 	str r2, [r5, #0x450]
 	mul r4, r3, r1
 	ldr r2, [r8, #4]
-	add r1, sb, #0x230
+	add r1, r9, #0x230
 	str r2, [r5, #0x454]
 	ldr r3, [r8, #8]
 	mov r2, #0x2d
 	str r3, [r5, #0x458]
 	str r2, [r0, #0x480]
-	add r2, sb, r4
+	add r2, r9, r4
 	mov r3, #0
 	add r0, r1, r4
 	str r3, [r2, #0x294]
 	bl func_020352d8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _02178f48:
 	cmp r1, r5
 	movlt r4, r3
@@ -15054,25 +15054,25 @@ _02178f48:
 	cmp r3, #4
 	blt _02178eec
 	mov r0, #0xc
-	mla r5, r4, r0, sb
+	mla r5, r4, r0, r9
 	ldr r1, [r8]
 	mov r0, #0x88
 	str r1, [r5, #0x450]
 	mul r3, r4, r0
 	ldr r1, [r8, #4]
-	add r0, sb, #0x230
+	add r0, r9, #0x230
 	str r1, [r5, #0x454]
 	ldr r2, [r8, #8]
-	add r1, sb, r4, lsl #2
+	add r1, r9, r4, lsl #2
 	str r2, [r5, #0x458]
 	mov r2, #0x2d
 	str r2, [r1, #0x480]
-	add r1, sb, r3
+	add r1, r9, r3
 	mov r2, #0
 	add r0, r0, r3
 	str r2, [r1, #0x294]
 	bl func_020352d8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov26_02178e8c
 _02178fb0: .word data_ov00_020eec9c
@@ -16664,7 +16664,7 @@ _02179de0: .word data_ov26_0217aea4
 	.global func_ov26_02179de4
 	arm_func_start func_ov26_02179de4
 func_ov26_02179de4: ; 0x02179de4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	ldr r0, _02179f14 ; =data_ov26_0217b554
 	ldr r1, _02179f18 ; =0x42454143
 	ldr r2, _02179f1c ; =func_ov26_02177c08
@@ -16675,8 +16675,8 @@ func_ov26_02179de4: ; 0x02179de4
 	ldr r2, _02179f24 ; =data_ov26_0217b548
 	bl func_0204f8d4
 	ldr r1, _02179f28 ; =data_ov26_0217af64
-	mov sb, #0
-	strb sb, [r1]
+	mov r9, #0
+	strb r9, [r1]
 	mov r0, #3
 	ldr r8, _02179f2c ; =data_ov26_0217af66
 	strb r0, [r1, #1]
@@ -16688,8 +16688,8 @@ func_ov26_02179de4: ; 0x02179de4
 	ldr r4, _02179f40 ; =data_ov26_0217af76
 	ldr ip, _02179f44 ; =data_ov26_0217af7a
 	mov r7, #0x1b
-	strb sb, [r8]
-	strb sb, [r2]
+	strb r9, [r8]
+	strb r9, [r2]
 	ldr lr, _02179f48 ; =data_ov26_0217af78
 	strb r1, [r2, #1]
 	mov r2, #4
@@ -16702,7 +16702,7 @@ func_ov26_02179de4: ; 0x02179de4
 	strb r1, [r3, #1]
 	mov r3, #1
 	strb r3, [r8]
-	ldr sb, _02179f50 ; =data_ov26_0217af6e
+	ldr r9, _02179f50 ; =data_ov26_0217af6e
 	strb r3, [r6]
 	mov r6, #2
 	ldr r8, _02179f54 ; =data_ov26_0217af72
@@ -16712,8 +16712,8 @@ func_ov26_02179de4: ; 0x02179de4
 	ldr r3, _02179f5c ; =data_ov26_0217af7e
 	strb r7, [r4]
 	mov r4, #0x1a
-	strb r6, [sb]
-	strb r2, [sb, #1]
+	strb r6, [r9]
+	strb r2, [r9, #1]
 	mov r0, #6
 	strb r6, [r8]
 	ldr r6, _02179f60 ; =data_ov26_0217af80
@@ -16739,7 +16739,7 @@ func_ov26_02179de4: ; 0x02179de4
 	strb r0, [lr, #1]
 	strb r3, [ip]
 	strb r1, [ip, #1]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov26_02179de4
 _02179f14: .word data_ov26_0217b554

--- a/asm/ov26.s
+++ b/asm/ov26.s
@@ -2233,7 +2233,7 @@ _0216efb0: .word data_ov00_020eec9c
 	.global func_ov26_0216efb4
 	arm_func_start func_ov26_0216efb4
 func_ov26_0216efb4: ; 0x0216efb4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x44
 	mov r4, r2
 	mov sl, r0
@@ -2295,12 +2295,12 @@ _0216f024:
 	bgt _0216f0cc
 	bl func_ov14_0213eee0
 	ldr r0, _0216f204 ; =data_027e0fd4
-	ldr fp, [r0]
-	mov r0, fp
+	ldr r11, [r0]
+	mov r0, r11
 	bl func_ov00_020b510c
 	cmp r0, #0
 	bne _0216f0cc
-	mov r0, fp
+	mov r0, r11
 	bl func_ov00_020b50f8
 	cmp r0, #0
 	moveq r7, #0
@@ -2310,7 +2310,7 @@ _0216f0cc:
 _0216f0d4:
 	cmp r6, #0
 	addeq sp, sp, #0x44
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	mov r0, r4
 	mov r1, #0x3c
 	bl func_01ff9b4c
@@ -2380,7 +2380,7 @@ _0216f0d4:
 	str r4, [sp, #0x18]
 	bl func_02034bc8
 	add sp, sp, #0x44
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov26_0216efb4
 _0216f1f8: .word data_027e0c38
@@ -3740,7 +3740,7 @@ _0217031c: .word data_027e0764
 	.global func_ov26_02170320
 	arm_func_start func_ov26_02170320
 func_ov26_02170320: ; 0x02170320
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x14
 	mov r4, r0
 	add r6, r4, #0x400
@@ -3752,7 +3752,7 @@ func_ov26_02170320: ; 0x02170320
 	strh r0, [r4, #0x78]
 	ldrsh r0, [r6, #0xe8]
 	ldr r3, _0217057c ; =data_02050f54
-	ldr fp, _02170580 ; =0x0000019a
+	ldr r11, _02170580 ; =0x0000019a
 	add r0, r0, #0x31c
 	add r0, r0, #0x400
 	strh r0, [r6, #0xe8]
@@ -3767,10 +3767,10 @@ func_ov26_02170320: ; 0x02170320
 	ldrsh r8, [r3, r1]
 	add r1, r2, #1
 	mov r1, r1, lsl #0x1
-	umull r2, sb, r8, fp
+	umull r2, sb, r8, r11
 	ldrsh r1, [r3, r1]
 	str r1, [sp]
-	umull r7, r5, r1, fp
+	umull r7, r5, r1, r11
 	adds r1, r2, #0x800
 	mov sl, r1, lsr #0xc
 	ldmia r0, {r0, r1, r2}
@@ -3778,7 +3778,7 @@ func_ov26_02170320: ; 0x02170320
 	mov r1, #0
 	mla sb, r8, r1, sb
 	mov r2, r8, asr #0x1f
-	mla sb, r2, fp, sb
+	mla sb, r2, r11, sb
 	adc r1, sb, #0
 	orr sl, sl, r1, lsl #20
 	ldr r0, [sp, #8]
@@ -3788,7 +3788,7 @@ func_ov26_02170320: ; 0x02170320
 	mov r7, #0
 	mla r5, r2, r7, r5
 	mov r8, r2, asr #0x1f
-	mla r5, r8, fp, r5
+	mla r5, r8, r11, r5
 	mov r0, r0, lsr #0xc
 	adc r2, r5, #0
 	ldr r1, [sp, #0x10]
@@ -3841,10 +3841,10 @@ func_ov26_02170320: ; 0x02170320
 	mov r5, r5, lsl #0x2
 	ldrsh r6, [r3, r5]
 	mov r3, #0
-	umull sb, r8, r6, fp
+	umull sb, r8, r6, r11
 	mla r8, r6, r3, r8
 	mov r5, r6, asr #0x1f
-	mla r8, r5, fp, r8
+	mla r8, r5, r11, r8
 	adds r5, sb, #0x800
 	adc r3, r8, #0
 	mov r5, r5, lsr #0xc
@@ -3875,12 +3875,12 @@ func_ov26_02170320: ; 0x02170320
 	bl func_ov00_02084164
 	cmp r0, #0
 	addeq sp, sp, #0x14
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r0, r4, #0x48
 	bl func_ov00_020c5288
 	cmp r0, #0
 	addne sp, sp, #0x14
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, [r4, #0x48]
 	str r0, [r4, #0x4d0]
 	ldr r0, [r4, #0x4c]
@@ -3888,7 +3888,7 @@ func_ov26_02170320: ; 0x02170320
 	ldr r0, [r4, #0x50]
 	str r0, [r4, #0x4d8]
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov26_02170320
 _02170574: .word 0x0000071c
@@ -10854,13 +10854,13 @@ _02175b7c:
 	.global func_ov26_02175bb4
 	arm_func_start func_ov26_02175bb4
 func_ov26_02175bb4: ; 0x02175bb4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x18
 	mov sl, r0
 	ldr r0, [sl, #4]
 	cmp r0, #1
 	addls sp, sp, #0x18
-	ldmlsia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmlsia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r3, _02175e78 ; =0x04000444
 	mov r1, #0
 	ldr r0, _02175e7c ; =0x21230000
@@ -10899,7 +10899,7 @@ _02175c4c:
 	sub r5, r0, #0x74
 	add r4, sl, #0x1000
 	add r6, sp, #0xc
-	add fp, sp, #0
+	add r11, sp, #0
 _02175c68:
 	ldrb r0, [r4, #0x780]
 	cmp r0, #0x58
@@ -10976,7 +10976,7 @@ _02175d78:
 	mov r0, r6
 	mov r1, r8
 	bl func_01fffbec
-	mov r0, fp
+	mov r0, r11
 	mov r1, r8
 	bl func_01fffbec
 	ldr r0, [sp, #0x10]
@@ -11038,7 +11038,7 @@ _02175e64:
 	mov r1, #1
 	str r1, [r0]
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov26_02175bb4
 _02175e78: .word 0x04000444
@@ -11957,7 +11957,7 @@ func_ov26_021767ec: ; 0x021767ec
 	.global func_ov26_02176814
 	arm_func_start func_ov26_02176814
 func_ov26_02176814: ; 0x02176814
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #8
 	ldr r2, _021768ac ; =data_ov26_02179554
 	mov r8, #0
@@ -11969,7 +11969,7 @@ func_ov26_02176814: ; 0x02176814
 	add sb, r0, #2
 	mov r7, r8
 	mov r6, #0xa
-	mov fp, r8
+	mov r11, r8
 	mov r5, r2
 	mov r4, r8
 _02176850:
@@ -11983,9 +11983,9 @@ _02176850:
 	bl func_020350b4
 	mov r0, sl
 	mov r1, r5
-	str fp, [sp]
-	mov r2, fp
-	mov r3, fp
+	str r11, [sp]
+	mov r2, r11
+	mov r3, r11
 	bl func_020351b8
 	mov r0, sl
 	str r4, [sl, #0x64]
@@ -11995,7 +11995,7 @@ _02176850:
 	add sl, sl, #0x88
 	blt _02176850
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov26_02176814
 _021768ac: .word data_ov26_02179554
@@ -12049,23 +12049,23 @@ _02176930:
 	.global func_ov26_02176948
 	arm_func_start func_ov26_02176948
 func_ov26_02176948: ; 0x02176948
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #8
 	mov sl, r0
 	ldrb r0, [sl, #0x1a1]
 	cmp r0, #0
 	addeq sp, sp, #8
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r7, _021769e0 ; =data_ov26_02179558
 	ldr r4, _021769e4 ; =data_027e0d3c
 	mov sb, sl
 	mov r8, #0
-	mov fp, #0xde
+	mov r11, #0xde
 	add r6, sp, #4
 	add r5, sp, #0
 _02176980:
 	ldrb r1, [sl, #0x1a0]
-	mov r0, fp
+	mov r0, r11
 	mov r2, r6
 	add r1, r1, r1, lsl #1
 	add r1, r7, r1
@@ -12087,7 +12087,7 @@ _02176980:
 	cmp r8, #3
 	blt _02176980
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov26_02176948
 _021769e0: .word data_ov26_02179558
@@ -13027,7 +13027,7 @@ _021775c4: .word func_ov26_02177584 + 1
 	.global func_ov26_021775c8
 	arm_func_start func_ov26_021775c8
 func_ov26_021775c8: ; 0x021775c8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0xc
 	mov sl, r0
 	mov r3, #0x80000
@@ -13060,7 +13060,7 @@ _02177634:
 	ldr r4, _02177798 ; =data_027e0764
 	add sb, sl, #4
 	add r5, sl, #0x234
-	mov fp, r8
+	mov r11, r8
 	mov r6, r8
 _0217764c:
 	mov r0, sb
@@ -13093,7 +13093,7 @@ _021776a0:
 	ldr r3, [r4, #0x14]
 	adds r2, r2, r1
 	adc r1, r3, r0
-	mov r0, fp, lsl #0x5
+	mov r0, r11, lsl #0x5
 	str r2, [r4]
 	orr r0, r0, r1, lsr #27
 	str r1, [r4, #4]
@@ -13123,7 +13123,7 @@ _021776fc:
 	ldrb r0, [sl]
 	cmp r0, #0
 	addne sp, sp, #0xc
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	mov r0, #0
 	mov r3, r0
 	mov r1, r0
@@ -13152,7 +13152,7 @@ _02177778:
 	moveq r0, #1
 	streqb r0, [sl]
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov26_021775c8
 _0217778c: .word data_ov00_020eec60
@@ -14303,7 +14303,7 @@ func_ov26_02178534: ; 0x02178534
 	.global func_ov26_0217855c
 	arm_func_start func_ov26_0217855c
 func_ov26_0217855c: ; 0x0217855c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x20
 	mov sl, r0
 	ldrb r2, [sl, #0x15]
@@ -14356,11 +14356,11 @@ _02178618:
 	mov r0, #0
 	strb r0, [sl, #0x38]
 _02178620:
-	ldrb fp, [sl, #0x14]
+	ldrb r11, [sl, #0x14]
 	ldrb r1, [sl, #0x15]
-	add r0, fp, #2
+	add r0, r11, #2
 	str r0, [sp]
-	cmp fp, r0
+	cmp r11, r0
 	add sb, r1, #0xc
 	bge _0217868c
 	ldr r4, _021786d4 ; =data_027e0e60
@@ -14370,7 +14370,7 @@ _02178648:
 	ldrb r8, [sl, #0x15]
 	cmp r8, sb
 	bge _0217867c
-	and r7, fp, #0xff
+	and r7, r11, #0xff
 _02178658:
 	ldr r0, [r4]
 	mov r1, r6
@@ -14383,8 +14383,8 @@ _02178658:
 	blt _02178658
 _0217867c:
 	ldr r0, [sp]
-	add fp, fp, #1
-	cmp fp, r0
+	add r11, r11, #1
+	cmp r11, r0
 	blt _02178648
 _0217868c:
 	add r0, sl, #0x18
@@ -14404,7 +14404,7 @@ _0217868c:
 	mov r0, #0xc000
 	str r0, [sl, #0x84]
 	add sp, sp, #0x20
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov26_0217855c
 _021786d4: .word data_027e0e60

--- a/asm/ov27.s
+++ b/asm/ov27.s
@@ -273,7 +273,7 @@ _0216da34: .word data_027e0fe4
 	.global func_ov27_0216da38
 	arm_func_start func_ov27_0216da38
 func_ov27_0216da38: ; 0x0216da38
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #4
 	sub sp, sp, #0x400
 	mov r5, r0
@@ -553,7 +553,7 @@ _0216de58:
 	cmpne r0, #9
 	addeq sp, sp, #4
 	addeq sp, sp, #0x400
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, _0216e92c ; =data_027e0764
 	ldr r2, [r0]
 	ldmib r0, {r1, r3}
@@ -717,7 +717,7 @@ _0216e084:
 	bl func_ov27_0216da38
 	add sp, sp, #4
 	add sp, sp, #0x400
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0216e0d8:
 	mov r1, #0xc
 	mov r2, #0
@@ -943,7 +943,7 @@ _0216e2b8:
 	str r0, [sp, #0x26c]
 	ldr r0, _0216e928 ; =data_027e0f74
 	ldr r1, [sp, #0x1d4]
-	ldr sl, [sp, #0x1dc]
+	ldr r10, [sp, #0x1dc]
 	ldr sb, [sp, #0x1e0]
 	ldr r8, [sp, #0x1e4]
 	str r7, [sp, #0x264]
@@ -952,7 +952,7 @@ _0216e2b8:
 	str r1, [sp, #0x268]
 	ldr r0, [r0]
 	add r1, sp, #0x1f4
-	str sl, [sp, #0x270]
+	str r10, [sp, #0x270]
 	str sb, [sp, #0x274]
 	str r8, [sp, #0x278]
 	str r7, [sp, #0x27c]
@@ -1083,7 +1083,7 @@ _0216e4f4:
 	ldr r1, [sp, #0xbc]
 	ldr ip, [sp, #0xc4]
 	ldr r11, [sp, #0xc8]
-	ldr sl, [sp, #0xcc]
+	ldr r10, [sp, #0xcc]
 	ldr sb, [sp, #0xd0]
 	mov lr, #1
 	str r1, [sp, #0x150]
@@ -1091,7 +1091,7 @@ _0216e4f4:
 	add r1, sp, #0xdc
 	str ip, [sp, #0x158]
 	str r11, [sp, #0x15c]
-	str sl, [sp, #0x160]
+	str r10, [sp, #0x160]
 	str sb, [sp, #0x164]
 	strb r8, [sp, #0x168]
 	strb r7, [sp, #0x169]
@@ -1257,7 +1257,7 @@ _0216e8fc:
 	str r4, [r5, #0x130]
 	add sp, sp, #4
 	add sp, sp, #0x400
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov27_0216da38
 _0216e914: .word 0x00000ccd
@@ -2660,23 +2660,23 @@ _0216fbfc: .word data_027e0764
 	.global func_ov27_0216fc00
 	arm_func_start func_ov27_0216fc00
 func_ov27_0216fc00: ; 0x0216fc00
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x18
-	mov sl, r0
-	ldr r2, [sl, #0x1e8]
-	ldr r1, [sl, #0x138]
+	mov r10, r0
+	ldr r2, [r10, #0x1e8]
+	ldr r1, [r10, #0x138]
 	ldr r6, [r2, #0x14]
 	cmp r1, #0x23
 	bge _0216fc34
 	bl _ZN5Actor14GetAngleToLinkEv
 	mov r1, r0
 	ldr r2, _0216fe28 ; =0x00000bb8
-	add r0, sl, #0x78
+	add r0, r10, #0x78
 	bl func_0202b154
 _0216fc34:
 	cmp r6, #0xc000
 	bgt _0216fc4c
-	mov r0, sl
+	mov r0, r10
 	mov r1, #0x5f
 	bl func_ov27_021713d4
 	b _0216fd44
@@ -2687,14 +2687,14 @@ _0216fc4c:
 	bgt _0216fce8
 	ldr r8, _0216fe2c ; =data_ov27_02178ee0
 	ldr r4, _0216fe30 ; =data_027e0e58
-	mov sb, sl
-	add r7, sl, #0x470
+	mov sb, r10
+	add r7, r10, #0x470
 	mov r5, #0
 	add r11, sp, #0xc
 _0216fc74:
 	ldr r0, [r4]
 	mov r1, r7
-	add r2, sl, #0x48
+	add r2, r10, #0x48
 	bl func_ov00_0207c474
 	ldr r3, [r8, #4]
 	ldr r2, [r8, #8]
@@ -2703,7 +2703,7 @@ _0216fc74:
 	str r1, [sp, #0xc]
 	str r3, [sp, #0x10]
 	str r2, [sp, #0x14]
-	ldrsh r1, [sl, #0x78]
+	ldrsh r1, [r10, #0x78]
 	bl func_ov00_020a61ac
 	ldr r1, [sb, #0x470]
 	add r5, r5, #1
@@ -2718,32 +2718,32 @@ _0216fc74:
 	add sb, sb, #0xc
 	blt _0216fc74
 	ldr r1, _0216fe34 ; =0x0000099a
-	mov r0, sl
+	mov r0, r10
 	bl func_ov27_021713d4
 	b _0216fd44
 _0216fce8:
 	cmp r6, #0x55000
 	blt _0216fd14
-	mov r0, sl
+	mov r0, r10
 	mvn r1, #0x5e
 	bl func_ov27_021713d4
-	add r0, sl, #0x470
+	add r0, r10, #0x470
 	bl func_ov00_020b7e6c
-	add r0, sl, #0x7c
+	add r0, r10, #0x7c
 	add r0, r0, #0x400
 	bl func_ov00_020b7e6c
 	b _0216fd44
 _0216fd14:
 	ldr r1, _0216fe38 ; =data_027e0d0c
-	add r0, sl, #0x470
+	add r0, r10, #0x470
 	ldr r2, [r1]
-	str r2, [sl, #0x60]
+	str r2, [r10, #0x60]
 	ldr r2, [r1, #4]
-	str r2, [sl, #0x64]
+	str r2, [r10, #0x64]
 	ldr r1, [r1, #8]
-	str r1, [sl, #0x68]
+	str r1, [r10, #0x68]
 	bl func_ov00_020b7e6c
-	add r0, sl, #0x7c
+	add r0, r10, #0x7c
 	add r0, r0, #0x400
 	bl func_ov00_020b7e6c
 _0216fd44:
@@ -2754,29 +2754,29 @@ _0216fd44:
 	cmp r6, #0x31000
 	bne _0216fd70
 	ldr r0, _0216fe3c ; =data_027e0ffc
-	add r2, sl, #0x48
+	add r2, r10, #0x48
 	mov r1, #0x234
 	mov r3, #0
 	bl func_ov00_020ceacc
 _0216fd70:
 	mov r1, #1
-	strb r1, [sl, #0x4ae]
-	mov r0, sl
-	strb r1, [sl, #0x4af]
+	strb r1, [r10, #0x4ae]
+	mov r0, r10
+	strb r1, [r10, #0x4af]
 	mov r3, #4
 	mov r1, #2
 	mov r2, #0
-	strb r3, [sl, #0x124]
+	strb r3, [r10, #0x124]
 	bl _ZN5Actor18func_ov00_020c1e2cEiP5Vec3p
 	mov r0, #0
-	strb r0, [sl, #0x124]
+	strb r0, [r10, #0x124]
 _0216fd9c:
-	ldr r0, [sl, #0x1e8]
+	ldr r0, [r10, #0x1e8]
 	add r0, r0, #0xc
 	bl func_0202e58c
 	cmp r0, #0
 	addeq sp, sp, #0x18
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r2, _0216fe40 ; =data_027e0764
 	mov r1, #0
 	ldr r3, [r2]
@@ -2796,17 +2796,17 @@ _0216fd9c:
 	str r6, [r2]
 	str r5, [r2, #4]
 	cmp r4, #0x14
-	mov r0, sl
+	mov r0, r10
 	bge _0216fe18
 	mov r1, #0xe
 	bl func_ov27_0216da38
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0216fe18:
 	mov r1, #4
 	bl func_ov27_0216da38
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov27_0216fc00
 _0216fe28: .word 0x00000bb8
@@ -2893,23 +2893,23 @@ _0216ff34: .word data_027e0764
 	.global func_ov27_0216ff38
 	arm_func_start func_ov27_0216ff38
 func_ov27_0216ff38: ; 0x0216ff38
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x18
-	mov sl, r0
-	ldr r2, [sl, #0x1e8]
-	ldr r1, [sl, #0x138]
+	mov r10, r0
+	ldr r2, [r10, #0x1e8]
+	ldr r1, [r10, #0x138]
 	ldr r6, [r2, #0x14]
 	cmp r1, #0x23
 	bge _0216ff6c
 	bl _ZN5Actor14GetAngleToLinkEv
 	mov r1, r0
 	ldr r2, _02170178 ; =0x00000bb8
-	add r0, sl, #0x78
+	add r0, r10, #0x78
 	bl func_0202b154
 _0216ff6c:
 	cmp r6, #0xa000
 	bgt _0216ff84
-	mov r0, sl
+	mov r0, r10
 	mov r1, #0x7b
 	bl func_ov27_021713d4
 	b _02170084
@@ -2920,14 +2920,14 @@ _0216ff84:
 	bgt _02170020
 	ldr r8, _0217017c ; =data_ov27_02178ee0
 	ldr r4, _02170180 ; =data_027e0e58
-	mov sb, sl
-	add r7, sl, #0x470
+	mov sb, r10
+	add r7, r10, #0x470
 	mov r5, #0
 	add r11, sp, #0xc
 _0216ffac:
 	ldr r0, [r4]
 	mov r1, r7
-	add r2, sl, #0x48
+	add r2, r10, #0x48
 	bl func_ov00_0207c474
 	ldr r3, [r8, #4]
 	ldr r2, [r8, #8]
@@ -2936,7 +2936,7 @@ _0216ffac:
 	str r1, [sp, #0xc]
 	str r3, [sp, #0x10]
 	str r2, [sp, #0x14]
-	ldrsh r1, [sl, #0x78]
+	ldrsh r1, [r10, #0x78]
 	bl func_ov00_020a61ac
 	ldr r1, [sb, #0x470]
 	add r5, r5, #1
@@ -2951,7 +2951,7 @@ _0216ffac:
 	add sb, sb, #0xc
 	blt _0216ffac
 	ldr r1, _02170184 ; =0x0000099a
-	mov r0, sl
+	mov r0, r10
 	bl func_ov27_021713d4
 	b _02170084
 _02170020:
@@ -2959,26 +2959,26 @@ _02170020:
 	blt _02170054
 	cmp r6, #0x41000
 	bgt _02170054
-	mov r0, sl
+	mov r0, r10
 	mvn r1, #0x99
 	bl func_ov27_021713d4
-	add r0, sl, #0x470
+	add r0, r10, #0x470
 	bl func_ov00_020b7e6c
-	add r0, sl, #0x7c
+	add r0, r10, #0x7c
 	add r0, r0, #0x400
 	bl func_ov00_020b7e6c
 	b _02170084
 _02170054:
 	ldr r1, _02170188 ; =data_027e0d0c
-	add r0, sl, #0x470
+	add r0, r10, #0x470
 	ldr r2, [r1]
-	str r2, [sl, #0x60]
+	str r2, [r10, #0x60]
 	ldr r2, [r1, #4]
-	str r2, [sl, #0x64]
+	str r2, [r10, #0x64]
 	ldr r1, [r1, #8]
-	str r1, [sl, #0x68]
+	str r1, [r10, #0x68]
 	bl func_ov00_020b7e6c
-	add r0, sl, #0x7c
+	add r0, r10, #0x7c
 	add r0, r0, #0x400
 	bl func_ov00_020b7e6c
 _02170084:
@@ -2986,7 +2986,7 @@ _02170084:
 	blt _02170098
 	cmp r6, #0x29000
 	movle r0, #1
-	strleb r0, [sl, #0x4af]
+	strleb r0, [r10, #0x4af]
 _02170098:
 	cmp r6, #0x23000
 	blt _021700ec
@@ -2995,28 +2995,28 @@ _02170098:
 	cmp r6, #0x23000
 	bne _021700c4
 	ldr r0, _0217018c ; =data_027e0ffc
-	add r2, sl, #0x48
+	add r2, r10, #0x48
 	mov r1, #0x234
 	mov r3, #0
 	bl func_ov00_020ceacc
 _021700c4:
 	mov r1, #1
-	mov r0, sl
-	strb r1, [sl, #0x4ae]
+	mov r0, r10
+	strb r1, [r10, #0x4ae]
 	mov r3, #4
 	mov r1, #2
 	mov r2, #0
-	strb r3, [sl, #0x124]
+	strb r3, [r10, #0x124]
 	bl _ZN5Actor18func_ov00_020c1e2cEiP5Vec3p
 	mov r0, #0
-	strb r0, [sl, #0x124]
+	strb r0, [r10, #0x124]
 _021700ec:
-	ldr r0, [sl, #0x1e8]
+	ldr r0, [r10, #0x1e8]
 	add r0, r0, #0xc
 	bl func_0202e58c
 	cmp r0, #0
 	addeq sp, sp, #0x18
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r2, _02170190 ; =data_027e0764
 	mov r1, #0
 	ldr r3, [r2]
@@ -3036,17 +3036,17 @@ _021700ec:
 	str r6, [r2]
 	str r5, [r2, #4]
 	cmp r4, #0x14
-	mov r0, sl
+	mov r0, r10
 	bge _02170168
 	mov r1, #0xe
 	bl func_ov27_0216da38
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02170168:
 	mov r1, #4
 	bl func_ov27_0216da38
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov27_0216ff38
 _02170178: .word 0x00000bb8
@@ -3269,7 +3269,7 @@ _0217047c: .word data_027e0764
 	.global func_ov27_02170480
 	arm_func_start func_ov27_02170480
 func_ov27_02170480: ; 0x02170480
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #0x38
 	ldr r1, _021708a4 ; =data_027e0fac
 	ldr r3, _021708a8 ; =data_02050f54
@@ -3351,7 +3351,7 @@ func_ov27_02170480: ; 0x02170480
 	umull ip, r3, r2, r6
 	mla r3, r2, r7, r3
 	mov r2, r2, asr #0x1f
-	umull sl, sb, r8, r6
+	umull r10, sb, r8, r6
 	mla r3, r2, r6, r3
 	adds ip, ip, #0x800
 	adc r2, r3, #0
@@ -3359,7 +3359,7 @@ func_ov27_02170480: ; 0x02170480
 	orr r3, r3, r2, lsl #20
 	add r2, r5, r3
 	str r2, [sp, #0x2c]
-	adds r3, sl, #0x800
+	adds r3, r10, #0x800
 	mla sb, r8, r7, sb
 	mov r2, r8, asr #0x1f
 	mla sb, r2, r6, sb
@@ -3473,7 +3473,7 @@ _0217078c:
 	bl _ZN5Actor18func_ov00_020c198cEv
 	cmp r0, #0
 	addeq sp, sp, #0x38
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	ldr r0, _021708b8 ; =data_027e0fc8
 	mov r1, #0
 	ldr r0, [r0]
@@ -3492,12 +3492,12 @@ _0217078c:
 	add r0, r0, #0x400
 	bl func_ov00_020b7e6c
 	add sp, sp, #0x38
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _021707f8:
 	ldr r0, [r4, #0x138]
 	cmp r0, #0x78
 	addle sp, sp, #0x38
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	ldrh r2, [r4, #0x78]
 	ldr r0, _021708b8 ; =data_027e0fc8
 	mov r1, #0
@@ -3536,7 +3536,7 @@ _021707f8:
 	add r0, r0, #0x400
 	bl func_ov00_020b7e6c
 	add sp, sp, #0x38
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov27_02170480
 _021708a4: .word data_027e0fac
@@ -4039,30 +4039,30 @@ _02170f84: .word data_027e0e60
 	.global func_ov27_02170f88
 	arm_func_start func_ov27_02170f88
 func_ov27_02170f88: ; 0x02170f88
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x44
-	mov sl, r0
+	mov r10, r0
 	ldr r0, _02171374 ; =data_027e0f94
 	mov sb, r1
 	add r5, sp, #0x38
 	ldmia r0, {r0, r1, r2}
 	add r3, sp, #0x14
-	add r4, sl, #0x48
+	add r4, r10, #0x48
 	stmia r5, {r0, r1, r2}
 	ldmia r4, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
-	mov r0, sl
+	mov r0, r10
 	mov r6, #0
 	bl _ZN5Actor14DistanceToLinkEv
 	mov r8, r0
 	cmp r8, #0x3000
 	subge r8, r8, #0x66
-	mov r0, sl
+	mov r0, r10
 	subge r8, r8, #0x200
 	bl _ZN5Actor14GetAngleToLinkEv
 	mov r1, r0
 	ldr r2, _02171378 ; =0x00000bb8
-	add r0, sl, #0x78
+	add r0, r10, #0x78
 	bl func_0202b154
 	ldr r0, _0217137c ; =data_ov27_021794c0
 	add r4, sp, #0x2c
@@ -4074,7 +4074,7 @@ func_ov27_02170f88: ; 0x02170f88
 	str r0, [sp, #4]
 	add r11, sp, #8
 _02171010:
-	add r0, sl, #0x48
+	add r0, r10, #0x48
 	mov r1, r5
 	mov r2, r4
 	bl func_01ff9bf8
@@ -4141,11 +4141,11 @@ _021710d8:
 	ldrsh r0, [r0, #2]
 	str r1, [sp, #0x2c]
 	str r0, [sp, #0x34]
-	ldrb r0, [sl, #0x110]
+	ldrb r0, [r10, #0x110]
 	cmp r0, #0
-	ldreqb r0, [sl, #0x112]
+	ldreqb r0, [r10, #0x112]
 	cmpeq r0, #0
-	ldreqb r0, [sl, #0x113]
+	ldreqb r0, [r10, #0x113]
 	cmpeq r0, #0
 	beq _02171140
 	mov r0, r8
@@ -4162,7 +4162,7 @@ _02171140:
 	bl func_01ff9e64
 _02171154:
 	mov r0, r4
-	add r1, sl, #0x48
+	add r1, r10, #0x48
 	add r2, sp, #0x20
 	bl func_01ff9bf8
 	mov r0, #0
@@ -4172,43 +4172,43 @@ _02171154:
 	mov r2, r0
 	bl func_0202da8c
 	ldr r1, [sp, #0x20]
-	mov r0, sl
-	str r1, [sl, #0x60]
+	mov r0, r10
+	str r1, [r10, #0x60]
 	ldr r1, [sp, #0x28]
-	str r1, [sl, #0x68]
+	str r1, [r10, #0x68]
 	bl _ZN5Actor12ApplyGravityEv
-	mov r0, sl
+	mov r0, r10
 	bl func_ov14_02145258
-	mov r0, sl
+	mov r0, r10
 	bl func_ov27_02171b14
 	cmp sb, #0
 	beq _02171288
 	cmp r6, #0
 	bne _02171288
-	ldrb r0, [sl, #0x110]
+	ldrb r0, [r10, #0x110]
 	cmp r0, #0
-	ldreqb r0, [sl, #0x112]
+	ldreqb r0, [r10, #0x112]
 	cmpeq r0, #0
-	ldreqb r0, [sl, #0x113]
+	ldreqb r0, [r10, #0x113]
 	cmpeq r0, #0
 	beq _02171288
-	add r0, sl, #0x48
+	add r0, r10, #0x48
 	add r1, sp, #0x14
 	bl func_ov00_020ce2f0
 	mov r6, r0
 	ldr r0, [sp]
 	cmp r6, r0
 	bge _02171288
-	add r0, sl, #0x48
+	add r0, r10, #0x48
 	mov r1, r5
 	mov r2, r4
 	bl func_01ff9bf8
 	cmp sb, #1
-	ldr r0, [sl, #0xc4]
+	ldr r0, [r10, #0xc4]
 	str r0, [sp, #8]
-	ldr r0, [sl, #0xc8]
+	ldr r0, [r10, #0xc8]
 	str r0, [sp, #0xc]
-	ldr r0, [sl, #0xcc]
+	ldr r0, [r10, #0xcc]
 	str r0, [sp, #0x10]
 	beq _02171228
 	cmp sb, #2
@@ -4225,25 +4225,25 @@ _02171238:
 	bl func_ov00_020a61ac
 _02171244:
 	ldr r0, _02171388 ; =0x00000266
-	add r2, sl, #0x48
+	add r2, r10, #0x48
 	sub r0, r0, r6
 	mov r1, r11
 	mov r3, r2
 	bl func_01ff9e64
-	mov r0, sl
+	mov r0, r10
 	bl _ZN5Actor14DistanceToLinkEv
 	mov r8, r0
 	ldr r0, [sp, #0x14]
 	mov r6, #1
-	str r0, [sl, #0x48]
+	str r0, [r10, #0x48]
 	ldr r0, [sp, #0x18]
-	str r0, [sl, #0x4c]
+	str r0, [r10, #0x4c]
 	ldr r0, [sp, #0x1c]
-	str r0, [sl, #0x50]
+	str r0, [r10, #0x50]
 	b _02171010
 _02171288:
 	add r1, sp, #0x14
-	add r0, sl, #0x48
+	add r0, r10, #0x48
 	mov r2, r1
 	bl func_01ff9bf8
 	ldr r2, [sp, #0x1c]
@@ -4261,24 +4261,24 @@ _02171288:
 	add r0, r3, r1
 	bl func_01ff9958
 	cmp r0, #0x29
-	ldr r0, [sl, #0x428]
-	add r0, sl, r0, lsl #2
+	ldr r0, [r10, #0x428]
+	add r0, r10, r0, lsl #2
 	bgt _02171308
 	ldr r0, [r0, #0x420]
 	cmp r0, #4
 	addne sp, sp, #0x44
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
-	mov r0, sl
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	mov r0, r10
 	mov r1, #3
 	mov r2, #1
 	bl func_ov27_0217164c
 	add sp, sp, #0x44
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02171308:
 	ldr r0, [r0, #0x420]
 	cmp r0, #3
 	bne _02171324
-	mov r0, sl
+	mov r0, r10
 	mov r1, #4
 	mov r2, #1
 	bl func_ov27_0217164c
@@ -4299,10 +4299,10 @@ _02171324:
 	bl func_01ff9958
 	ldr r1, _02171388 ; =0x00000266
 	bl Divide
-	ldr r1, [sl, #0x1e8]
+	ldr r1, [r10, #0x1e8]
 	str r0, [r1, #0x10]
 	add sp, sp, #0x44
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov27_02170f88
 _02171374: .word data_027e0f94
@@ -7983,7 +7983,7 @@ _02174450: .word data_027e0e60
 	.global func_ov27_02174454
 	arm_func_start func_ov27_02174454
 func_ov27_02174454: ; 0x02174454
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x124
 	ldr r1, _021746e4 ; =data_027e0f94
 	mov r4, r0
@@ -8089,7 +8089,7 @@ func_ov27_02174454: ; 0x02174454
 	ldr r1, [sp, #0x30]
 	str r6, [sp, #0xc0]
 	ldr r6, [sp, #0x38]
-	mov sl, #5
+	mov r10, #5
 	mov sb, #0x1c000
 	mov r8, #0xfa0
 	str r0, [sp, #0xd4]
@@ -8126,11 +8126,11 @@ func_ov27_02174454: ; 0x02174454
 	ldr r0, [r0]
 	add r1, sp, #0x74
 	str r6, [sp, #0xfc]
-	str sl, [sp, #0x10]
+	str r10, [sp, #0x10]
 	str sb, [sp, #0x24]
 	str r8, [sp, #0x1c]
 	str r7, [sp, #0x20]
-	str sl, [sp, #0xa4]
+	str r10, [sp, #0xa4]
 	str r8, [sp, #0xb0]
 	str r7, [sp, #0xb4]
 	str sb, [sp, #0xb8]
@@ -8146,7 +8146,7 @@ func_ov27_02174454: ; 0x02174454
 	add r0, sp, #0x74
 	bl func_ov00_0209a508
 	add sp, sp, #0x124
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov27_02174454
 _021746e4: .word data_027e0f94
@@ -10852,26 +10852,26 @@ _02176aa8: .word data_027e0dbc
 	.global func_ov27_02176aac
 	arm_func_start func_ov27_02176aac
 func_ov27_02176aac: ; 0x02176aac
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x44
-	mov sl, r0
+	mov r10, r0
 	ldr r0, _02176e74 ; =data_027e0f94
 	mov sb, r1
 	add r5, sp, #0x38
 	ldmia r0, {r0, r1, r2}
 	add r3, sp, #0x14
-	add r4, sl, #0x48
+	add r4, r10, #0x48
 	stmia r5, {r0, r1, r2}
 	ldmia r4, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
-	mov r0, sl
+	mov r0, r10
 	mov r6, #0
 	bl _ZN5Actor14DistanceToLinkEv
 	mov r8, r0
-	mov r0, sl
+	mov r0, r10
 	bl _ZN5Actor14GetAngleToLinkEv
 	mov r1, r0
-	add r0, sl, #0x78
+	add r0, r10, #0x78
 	mov r2, #0x7d0
 	bl func_0202b154
 	ldr r0, _02176e78 ; =data_ov27_02179bc4
@@ -10883,7 +10883,7 @@ func_ov27_02176aac: ; 0x02176aac
 	rsb r0, r0, #0
 	str r0, [sp, #4]
 _02176b24:
-	add r0, sl, #0x48
+	add r0, r10, #0x48
 	mov r1, r5
 	mov r2, r4
 	bl func_01ff9bf8
@@ -10951,11 +10951,11 @@ _02176bec:
 	ldrsh r0, [r0, #2]
 	str r1, [sp, #0x2c]
 	str r0, [sp, #0x34]
-	ldrb r0, [sl, #0x110]
+	ldrb r0, [r10, #0x110]
 	cmp r0, #0
-	ldreqb r0, [sl, #0x112]
+	ldreqb r0, [r10, #0x112]
 	cmpeq r0, #0
-	ldreqb r0, [sl, #0x113]
+	ldreqb r0, [r10, #0x113]
 	cmpeq r0, #0
 	beq _02176c54
 	mov r0, r8
@@ -10972,7 +10972,7 @@ _02176c54:
 	bl func_01ff9e64
 _02176c68:
 	mov r0, r4
-	add r1, sl, #0x48
+	add r1, r10, #0x48
 	add r2, sp, #0x20
 	bl func_01ff9bf8
 	mov r0, #0
@@ -10982,44 +10982,44 @@ _02176c68:
 	mov r2, r0
 	bl func_0202da8c
 	ldr r1, [sp, #0x20]
-	mov r0, sl
-	str r1, [sl, #0x60]
+	mov r0, r10
+	str r1, [r10, #0x60]
 	ldr r1, [sp, #0x28]
-	str r1, [sl, #0x68]
+	str r1, [r10, #0x68]
 	bl _ZN5Actor12ApplyGravityEv
-	mov r0, sl
+	mov r0, r10
 	bl func_ov27_02177bc4
-	mov r0, sl
+	mov r0, r10
 	mov r1, #0
 	bl func_01fffd04
 	cmp sb, #0
 	beq _02176da0
 	cmp r6, #0
 	bne _02176da0
-	ldrb r0, [sl, #0x110]
+	ldrb r0, [r10, #0x110]
 	cmp r0, #0
-	ldreqb r0, [sl, #0x112]
+	ldreqb r0, [r10, #0x112]
 	cmpeq r0, #0
-	ldreqb r0, [sl, #0x113]
+	ldreqb r0, [r10, #0x113]
 	cmpeq r0, #0
 	beq _02176da0
-	add r0, sl, #0x48
+	add r0, r10, #0x48
 	add r1, sp, #0x14
 	bl func_ov00_020ce2f0
 	mov r6, r0
 	ldr r0, [sp]
 	cmp r6, r0
 	bge _02176da0
-	add r0, sl, #0x48
+	add r0, r10, #0x48
 	mov r1, r5
 	mov r2, r4
 	bl func_01ff9bf8
 	cmp sb, #1
-	ldr r0, [sl, #0xc4]
+	ldr r0, [r10, #0xc4]
 	str r0, [sp, #8]
-	ldr r0, [sl, #0xc8]
+	ldr r0, [r10, #0xc8]
 	str r0, [sp, #0xc]
-	ldr r0, [sl, #0xcc]
+	ldr r0, [r10, #0xcc]
 	str r0, [sp, #0x10]
 	beq _02176d40
 	cmp sb, #2
@@ -11036,25 +11036,25 @@ _02176d50:
 	bl func_ov00_020a61ac
 _02176d5c:
 	ldr r0, _02176e84 ; =0x0000019a
-	add r2, sl, #0x48
+	add r2, r10, #0x48
 	sub r0, r0, r6
 	mov r1, r11
 	mov r3, r2
 	bl func_01ff9e64
-	mov r0, sl
+	mov r0, r10
 	bl _ZN5Actor14DistanceToLinkEv
 	mov r8, r0
 	ldr r0, [sp, #0x14]
 	mov r6, #1
-	str r0, [sl, #0x48]
+	str r0, [r10, #0x48]
 	ldr r0, [sp, #0x18]
-	str r0, [sl, #0x4c]
+	str r0, [r10, #0x4c]
 	ldr r0, [sp, #0x1c]
-	str r0, [sl, #0x50]
+	str r0, [r10, #0x50]
 	b _02176b24
 _02176da0:
 	add r1, sp, #0x14
-	add r0, sl, #0x48
+	add r0, r10, #0x48
 	mov r2, r1
 	bl func_01ff9bf8
 	ldr r2, [sp, #0x1c]
@@ -11072,42 +11072,42 @@ _02176da0:
 	add r0, r3, r1
 	bl func_01ff9958
 	cmp r0, #0x29
-	ldr r0, [sl, #0x428]
-	add r0, sl, r0, lsl #2
+	ldr r0, [r10, #0x428]
+	add r0, r10, r0, lsl #2
 	bgt _02176e28
 	ldr r0, [r0, #0x420]
 	cmp r0, #0
 	addeq sp, sp, #0x44
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
-	add r0, sl, #0x1d8
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	add r0, r10, #0x1d8
 	mov r1, #0
 	bl func_ov14_02145f0c
-	ldr r0, [sl, #0x1e8]
+	ldr r0, [r10, #0x1e8]
 	mov r1, #0
 	str r1, [r0, #0x20]
 	add sp, sp, #0x44
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02176e28:
 	ldr r0, [r0, #0x420]
 	cmp r0, #3
 	beq _02176e54
-	add r0, sl, #0x1d8
+	add r0, r10, #0x1d8
 	mov r1, #3
 	bl func_ov14_02145f0c
-	ldr r0, [sl, #0x480]
+	ldr r0, [r10, #0x480]
 	cmp r0, #3
-	ldreq r1, [sl, #0x1e8]
+	ldreq r1, [r10, #0x1e8]
 	ldreq r0, [r1, #0x1c]
 	streq r0, [r1, #0x20]
 _02176e54:
-	ldr r0, [sl, #0x480]
+	ldr r0, [r10, #0x480]
 	mov r1, #0x1000
 	cmp r0, #3
-	ldr r0, [sl, #0x1e8]
+	ldr r0, [r10, #0x1e8]
 	subeq r1, r1, #0x2000
 	str r1, [r0, #0x10]
 	add sp, sp, #0x44
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov27_02176aac
 _02176e74: .word data_027e0f94
@@ -11900,57 +11900,57 @@ _02177938:
 	.global func_ov27_02177940
 	arm_func_start func_ov27_02177940
 func_ov27_02177940: ; 0x02177940
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x28
-	mov sl, r0
+	mov r10, r0
 	mov r4, r1
 	ldr r0, _02177bac ; =data_027e0cbc
 	mov r1, #0x1b
 	bl func_0203d7e0
 	cmp r0, #0
 	addeq sp, sp, #0x28
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, _02177bb0 ; =data_027e0618
 	ldrb r0, [r0, #0x101]
 	cmp r0, #0
 	addne sp, sp, #0x28
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldrh r0, [r4]
 	tst r0, #2
 	addeq sp, sp, #0x28
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, _02177bb4 ; =data_027e0f90
 	ldr r0, [r0]
 	ldrb r0, [r0, #0x12]
 	cmp r0, #0
 	addeq sp, sp, #0x28
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	add r0, sp, #8
 	bl func_01ffbe34
 	ldr r0, _02177bb8 ; =data_027e0c38
 	mov r8, #0x6e
 	ldr r0, [r0, #0x10]
 	cmp r0, #1
-	ldrb r0, [sl, #0x4e3]
+	ldrb r0, [r10, #0x4e3]
 	moveq r8, #0x6f
 	cmp r0, #4
 	bne _02177a9c
 	mov sb, #0
-	add r5, sl, #0xec
-	add r4, sl, #0x500
+	add r5, r10, #0xec
+	add r4, r10, #0x500
 	mov r11, sb
 	mov r7, #1
 	add r6, sp, #8
 _021779e4:
-	ldrb r0, [sl, #0x4e2]
+	ldrb r0, [r10, #0x4e2]
 	rsb r1, r0, #3
 	cmp sb, r1
 	bne _02177a54
 	ldrh r1, [r4, #0x48]
 	mov r3, #0
 	cmp r1, #1
-	ldreq r2, [sl, #0x568]
-	ldreq r1, [sl, #0x550]
+	ldreq r2, [r10, #0x568]
+	ldreq r1, [r10, #0x550]
 	cmpeq r2, r1
 	moveq r1, r7
 	movne r1, r11
@@ -12006,7 +12006,7 @@ _02177a9c:
 	mov r1, #4
 	str r4, [sp]
 	bl func_0203493c
-	add r0, sl, #0x400
+	add r0, r10, #0x400
 	ldrh r4, [r0, #0xdc]
 	ldr r5, _02177bbc ; =0x51eb851f
 	mov r3, #0
@@ -12060,7 +12060,7 @@ _02177a9c:
 	mov r2, #7
 	bl func_020349cc
 	add sp, sp, #0x28
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov27_02177940
 _02177bac: .word data_027e0cbc
@@ -12919,7 +12919,7 @@ func_ov27_0217867c: ; 0x0217867c
 	.global func_ov27_021786ac
 	arm_func_start func_ov27_021786ac
 func_ov27_021786ac: ; 0x021786ac
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #4
 	mov r6, r0
 	cmp r1, #1
@@ -12958,7 +12958,7 @@ _02178718:
 	cmp r0, #0
 	addeq sp, sp, #4
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	ldrb r0, [r6, #0x489]
 	cmp r0, #0
 	beq _02178760
@@ -12966,7 +12966,7 @@ _02178718:
 	strb r0, [r6, #0x489]
 	add sp, sp, #4
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 _02178760:
 	mov r5, #0
 	ldr r7, _02178868 ; =gItemManager
@@ -12974,11 +12974,11 @@ _02178760:
 	mov r1, r5
 	mov r8, #1
 _02178774:
-	ldr sl, [r7]
-	mov r0, sl
+	ldr r10, [r7]
+	mov r0, r10
 	blx _ZNK11ItemManager16GetTreasureCountEj
 	mov sb, r0
-	mov r0, sl
+	mov r0, r10
 	blx _ZNK11ItemManager19GetMaxTreasureCountEv
 	cmp sb, r0
 	ldrge r0, [sp]
@@ -13016,7 +13016,7 @@ _021787f0:
 	strb r0, [r6, #0x489]
 	add sp, sp, #4
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 _02178814:
 	add r0, r6, #0x1d8
 	bl func_ov14_0214610c
@@ -13028,15 +13028,15 @@ _02178814:
 	cmp r0, #0
 	addne sp, sp, #4
 	movne r0, #1
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 _02178840:
 	add sp, sp, #4
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 _0217884c:
 	mov r0, #1
 	add sp, sp, #4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov27_021786ac
 _02178858: .word 0x00001001

--- a/asm/ov27.s
+++ b/asm/ov27.s
@@ -273,7 +273,7 @@ _0216da34: .word data_027e0fe4
 	.global func_ov27_0216da38
 	arm_func_start func_ov27_0216da38
 func_ov27_0216da38: ; 0x0216da38
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #4
 	sub sp, sp, #0x400
 	mov r5, r0
@@ -462,10 +462,10 @@ _0216dce4:
 	umull r8, r7, r6, r3
 	mla r7, r6, r0, r7
 	ldr r0, [r2, #0xc]
-	ldr sb, [r2, #0x10]
+	ldr r9, [r2, #0x10]
 	mla r7, r0, r3, r7
 	ldr r6, [r2, #0x14]
-	adds r8, sb, r8
+	adds r8, r9, r8
 	adc r7, r6, r7
 	mov r0, #0x1f
 	umull r3, r6, r7, r0
@@ -488,10 +488,10 @@ _0216dd48:
 	umull r8, r7, r6, r3
 	mla r7, r6, r0, r7
 	ldr r0, [r2, #0xc]
-	ldr sb, [r2, #0x10]
+	ldr r9, [r2, #0x10]
 	mla r7, r0, r3, r7
 	ldr r6, [r2, #0x14]
-	adds r8, sb, r8
+	adds r8, r9, r8
 	adc r7, r6, r7
 	mov r0, #0x1f
 	umull r3, r6, r7, r0
@@ -514,10 +514,10 @@ _0216ddac:
 	umull r8, r7, r6, r3
 	mla r7, r6, r0, r7
 	ldr r0, [r2, #0xc]
-	ldr sb, [r2, #0x10]
+	ldr r9, [r2, #0x10]
 	mla r7, r0, r3, r7
 	ldr r6, [r2, #0x14]
-	adds r8, sb, r8
+	adds r8, r9, r8
 	adc r7, r6, r7
 	mov r0, #0x15
 	umull r3, r6, r7, r0
@@ -553,7 +553,7 @@ _0216de58:
 	cmpne r0, #9
 	addeq sp, sp, #4
 	addeq sp, sp, #0x400
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, _0216e92c ; =data_027e0764
 	ldr r2, [r0]
 	ldmib r0, {r1, r3}
@@ -717,7 +717,7 @@ _0216e084:
 	bl func_ov27_0216da38
 	add sp, sp, #4
 	add sp, sp, #0x400
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0216e0d8:
 	mov r1, #0xc
 	mov r2, #0
@@ -752,9 +752,9 @@ _0216e0d8:
 	mov r8, r1, lsl #0xb
 	mov r1, #0x800
 	orr r8, r8, r7, lsr #21
-	adds sb, r1, r7, lsl #11
+	adds r9, r1, r7, lsl #11
 	adc r7, r8, #0
-	mov r8, sb, lsr #0xc
+	mov r8, r9, lsr #0xc
 	orr r8, r8, r7, lsl #20
 	ldr r0, [sp, #0x5c]
 	ldr r7, [sp, #0x64]
@@ -944,7 +944,7 @@ _0216e2b8:
 	ldr r0, _0216e928 ; =data_027e0f74
 	ldr r1, [sp, #0x1d4]
 	ldr r10, [sp, #0x1dc]
-	ldr sb, [sp, #0x1e0]
+	ldr r9, [sp, #0x1e0]
 	ldr r8, [sp, #0x1e4]
 	str r7, [sp, #0x264]
 	ldr r7, [sp, #0x1e8]
@@ -953,7 +953,7 @@ _0216e2b8:
 	ldr r0, [r0]
 	add r1, sp, #0x1f4
 	str r10, [sp, #0x270]
-	str sb, [sp, #0x274]
+	str r9, [sp, #0x274]
 	str r8, [sp, #0x278]
 	str r7, [sp, #0x27c]
 	strb r6, [sp, #0x280]
@@ -1084,7 +1084,7 @@ _0216e4f4:
 	ldr ip, [sp, #0xc4]
 	ldr r11, [sp, #0xc8]
 	ldr r10, [sp, #0xcc]
-	ldr sb, [sp, #0xd0]
+	ldr r9, [sp, #0xd0]
 	mov lr, #1
 	str r1, [sp, #0x150]
 	ldr r0, [r0]
@@ -1092,7 +1092,7 @@ _0216e4f4:
 	str ip, [sp, #0x158]
 	str r11, [sp, #0x15c]
 	str r10, [sp, #0x160]
-	str sb, [sp, #0x164]
+	str r9, [sp, #0x164]
 	strb r8, [sp, #0x168]
 	strb r7, [sp, #0x169]
 	strb r6, [sp, #0x16a]
@@ -1257,7 +1257,7 @@ _0216e8fc:
 	str r4, [r5, #0x130]
 	add sp, sp, #4
 	add sp, sp, #0x400
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov27_0216da38
 _0216e914: .word 0x00000ccd
@@ -2660,7 +2660,7 @@ _0216fbfc: .word data_027e0764
 	.global func_ov27_0216fc00
 	arm_func_start func_ov27_0216fc00
 func_ov27_0216fc00: ; 0x0216fc00
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x18
 	mov r10, r0
 	ldr r2, [r10, #0x1e8]
@@ -2687,7 +2687,7 @@ _0216fc4c:
 	bgt _0216fce8
 	ldr r8, _0216fe2c ; =data_ov27_02178ee0
 	ldr r4, _0216fe30 ; =data_027e0e58
-	mov sb, r10
+	mov r9, r10
 	add r7, r10, #0x470
 	mov r5, #0
 	add r11, sp, #0xc
@@ -2705,7 +2705,7 @@ _0216fc74:
 	str r2, [sp, #0x14]
 	ldrsh r1, [r10, #0x78]
 	bl func_ov00_020a61ac
-	ldr r1, [sb, #0x470]
+	ldr r1, [r9, #0x470]
 	add r5, r5, #1
 	ldr r3, [sp, #0x10]
 	ldr r2, [sp, #0x14]
@@ -2715,7 +2715,7 @@ _0216fc74:
 	strh r0, [r1, #0x50]
 	strh r3, [r1, #0x52]
 	strh r2, [r1, #0x54]
-	add sb, sb, #0xc
+	add r9, r9, #0xc
 	blt _0216fc74
 	ldr r1, _0216fe34 ; =0x0000099a
 	mov r0, r10
@@ -2776,7 +2776,7 @@ _0216fd9c:
 	bl func_0202e58c
 	cmp r0, #0
 	addeq sp, sp, #0x18
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r2, _0216fe40 ; =data_027e0764
 	mov r1, #0
 	ldr r3, [r2]
@@ -2801,12 +2801,12 @@ _0216fd9c:
 	mov r1, #0xe
 	bl func_ov27_0216da38
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0216fe18:
 	mov r1, #4
 	bl func_ov27_0216da38
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov27_0216fc00
 _0216fe28: .word 0x00000bb8
@@ -2893,7 +2893,7 @@ _0216ff34: .word data_027e0764
 	.global func_ov27_0216ff38
 	arm_func_start func_ov27_0216ff38
 func_ov27_0216ff38: ; 0x0216ff38
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x18
 	mov r10, r0
 	ldr r2, [r10, #0x1e8]
@@ -2920,7 +2920,7 @@ _0216ff84:
 	bgt _02170020
 	ldr r8, _0217017c ; =data_ov27_02178ee0
 	ldr r4, _02170180 ; =data_027e0e58
-	mov sb, r10
+	mov r9, r10
 	add r7, r10, #0x470
 	mov r5, #0
 	add r11, sp, #0xc
@@ -2938,7 +2938,7 @@ _0216ffac:
 	str r2, [sp, #0x14]
 	ldrsh r1, [r10, #0x78]
 	bl func_ov00_020a61ac
-	ldr r1, [sb, #0x470]
+	ldr r1, [r9, #0x470]
 	add r5, r5, #1
 	ldr r3, [sp, #0x10]
 	ldr r2, [sp, #0x14]
@@ -2948,7 +2948,7 @@ _0216ffac:
 	strh r0, [r1, #0x50]
 	strh r3, [r1, #0x52]
 	strh r2, [r1, #0x54]
-	add sb, sb, #0xc
+	add r9, r9, #0xc
 	blt _0216ffac
 	ldr r1, _02170184 ; =0x0000099a
 	mov r0, r10
@@ -3016,7 +3016,7 @@ _021700ec:
 	bl func_0202e58c
 	cmp r0, #0
 	addeq sp, sp, #0x18
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r2, _02170190 ; =data_027e0764
 	mov r1, #0
 	ldr r3, [r2]
@@ -3041,12 +3041,12 @@ _021700ec:
 	mov r1, #0xe
 	bl func_ov27_0216da38
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02170168:
 	mov r1, #4
 	bl func_ov27_0216da38
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov27_0216ff38
 _02170178: .word 0x00000bb8
@@ -3269,7 +3269,7 @@ _0217047c: .word data_027e0764
 	.global func_ov27_02170480
 	arm_func_start func_ov27_02170480
 func_ov27_02170480: ; 0x02170480
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #0x38
 	ldr r1, _021708a4 ; =data_027e0fac
 	ldr r3, _021708a8 ; =data_02050f54
@@ -3351,7 +3351,7 @@ func_ov27_02170480: ; 0x02170480
 	umull ip, r3, r2, r6
 	mla r3, r2, r7, r3
 	mov r2, r2, asr #0x1f
-	umull r10, sb, r8, r6
+	umull r10, r9, r8, r6
 	mla r3, r2, r6, r3
 	adds ip, ip, #0x800
 	adc r2, r3, #0
@@ -3360,10 +3360,10 @@ func_ov27_02170480: ; 0x02170480
 	add r2, r5, r3
 	str r2, [sp, #0x2c]
 	adds r3, r10, #0x800
-	mla sb, r8, r7, sb
+	mla r9, r8, r7, r9
 	mov r2, r8, asr #0x1f
-	mla sb, r2, r6, sb
-	adc r2, sb, #0
+	mla r9, r2, r6, r9
+	adc r2, r9, #0
 	mov r3, r3, lsr #0xc
 	orr r3, r3, r2, lsl #20
 	add r3, lr, r3
@@ -3473,7 +3473,7 @@ _0217078c:
 	bl _ZN5Actor18func_ov00_020c198cEv
 	cmp r0, #0
 	addeq sp, sp, #0x38
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	ldr r0, _021708b8 ; =data_027e0fc8
 	mov r1, #0
 	ldr r0, [r0]
@@ -3492,12 +3492,12 @@ _0217078c:
 	add r0, r0, #0x400
 	bl func_ov00_020b7e6c
 	add sp, sp, #0x38
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _021707f8:
 	ldr r0, [r4, #0x138]
 	cmp r0, #0x78
 	addle sp, sp, #0x38
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	ldrh r2, [r4, #0x78]
 	ldr r0, _021708b8 ; =data_027e0fc8
 	mov r1, #0
@@ -3536,7 +3536,7 @@ _021707f8:
 	add r0, r0, #0x400
 	bl func_ov00_020b7e6c
 	add sp, sp, #0x38
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov27_02170480
 _021708a4: .word data_027e0fac
@@ -4039,11 +4039,11 @@ _02170f84: .word data_027e0e60
 	.global func_ov27_02170f88
 	arm_func_start func_ov27_02170f88
 func_ov27_02170f88: ; 0x02170f88
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x44
 	mov r10, r0
 	ldr r0, _02171374 ; =data_027e0f94
-	mov sb, r1
+	mov r9, r1
 	add r5, sp, #0x38
 	ldmia r0, {r0, r1, r2}
 	add r3, sp, #0x14
@@ -4114,11 +4114,11 @@ _02171094:
 	bl func_01ffa0f4
 	mov r0, r0, lsl #0x10
 	mov r0, r0, asr #0x10
-	cmp sb, #0
+	cmp r9, #0
 	beq _021710d8
-	cmp sb, #1
+	cmp r9, #1
 	beq _021710cc
-	cmp sb, #2
+	cmp r9, #2
 	subeq r0, r0, r7
 	moveq r0, r0, lsl #0x10
 	moveq r0, r0, asr #0x10
@@ -4181,7 +4181,7 @@ _02171154:
 	bl func_ov14_02145258
 	mov r0, r10
 	bl func_ov27_02171b14
-	cmp sb, #0
+	cmp r9, #0
 	beq _02171288
 	cmp r6, #0
 	bne _02171288
@@ -4203,7 +4203,7 @@ _02171154:
 	mov r1, r5
 	mov r2, r4
 	bl func_01ff9bf8
-	cmp sb, #1
+	cmp r9, #1
 	ldr r0, [r10, #0xc4]
 	str r0, [sp, #8]
 	ldr r0, [r10, #0xc8]
@@ -4211,7 +4211,7 @@ _02171154:
 	ldr r0, [r10, #0xcc]
 	str r0, [sp, #0x10]
 	beq _02171228
-	cmp sb, #2
+	cmp r9, #2
 	beq _02171238
 	b _02171244
 _02171228:
@@ -4267,13 +4267,13 @@ _02171288:
 	ldr r0, [r0, #0x420]
 	cmp r0, #4
 	addne sp, sp, #0x44
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	mov r0, r10
 	mov r1, #3
 	mov r2, #1
 	bl func_ov27_0217164c
 	add sp, sp, #0x44
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02171308:
 	ldr r0, [r0, #0x420]
 	cmp r0, #3
@@ -4302,7 +4302,7 @@ _02171324:
 	ldr r1, [r10, #0x1e8]
 	str r0, [r1, #0x10]
 	add sp, sp, #0x44
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov27_02170f88
 _02171374: .word data_027e0f94
@@ -4682,7 +4682,7 @@ _02171848: .word 0x0000023a
 	.global func_ov27_0217184c
 	arm_func_start func_ov27_0217184c
 func_ov27_0217184c: ; 0x0217184c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x130
 	mov r4, r0
 	add r0, sp, #0x80
@@ -4718,7 +4718,7 @@ func_ov27_0217184c: ; 0x0217184c
 	add r0, sp, #0x80
 	bl func_ov00_0209a508
 	add sp, sp, #0x130
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _021718e0:
 	ldr r0, [r4, #0x488]
 	mvn r7, #0
@@ -4820,13 +4820,13 @@ _021718e0:
 	ldrb lr, [sp, #0x7a]
 	ldrb ip, [sp, #0x7b]
 	ldrb r3, [sp, #0x7c]
-	ldr sb, [sp, #0x6c]
+	ldr r9, [sp, #0x6c]
 	ldr r8, [sp, #0x70]
 	ldr r7, [sp, #0x74]
 	mov r2, #1
 	ldr r0, [r0]
 	add r1, sp, #0x80
-	str sb, [sp, #0x100]
+	str r9, [sp, #0x100]
 	str r8, [sp, #0x104]
 	str r7, [sp, #0x108]
 	strb r6, [sp, #0x10c]
@@ -4843,12 +4843,12 @@ _021718e0:
 	add r0, sp, #0x80
 	bl func_ov00_0209a508
 	add sp, sp, #0x130
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _02171ad0:
 	add r0, sp, #0x80
 	bl func_ov00_0209a508
 	add sp, sp, #0x130
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov27_0217184c
 _02171ae0: .word data_027e0f74
@@ -5641,7 +5641,7 @@ _02172594: .word data_027e0ffc
 	.global func_ov27_02172598
 	arm_func_start func_ov27_02172598
 func_ov27_02172598: ; 0x02172598
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0xa8
 	mov r5, r0
 	cmp r1, #0
@@ -5649,7 +5649,7 @@ func_ov27_02172598: ; 0x02172598
 	ldreqb r0, [r5, #0xa4]
 	cmp r0, #0
 	addeq sp, sp, #0xa8
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	ldr r0, [r5, #0x35c]
 	str r0, [r5, #0x374]
 	ldr r0, [r5, #0x360]
@@ -5665,7 +5665,7 @@ func_ov27_02172598: ; 0x02172598
 	ldr r0, [r5, #0x38c]
 	cmp r0, #0
 	addne sp, sp, #0xa8
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	mov r0, #0x1000
 	str r0, [sp, #0x9c]
 	str r0, [sp, #0xa0]
@@ -5785,11 +5785,11 @@ func_ov27_02172598: ; 0x02172598
 	ldr ip, _0217283c ; =0x00000a8f
 	str r0, [sp, #0x28]
 	mov r1, #0
-	umull sb, r8, r4, ip
+	umull r9, r8, r4, ip
 	mla r8, r4, r1, r8
 	mov r7, r4, asr #0x1f
 	mla r8, r7, ip, r8
-	adds r7, sb, #0x800
+	adds r7, r9, #0x800
 	adc r4, r8, #0
 	mov r7, r7, lsr #0xc
 	orr r7, r7, r4, lsl #20
@@ -5805,7 +5805,7 @@ func_ov27_02172598: ; 0x02172598
 	str lr, [sp, #0x14]
 	bl func_ov05_02102c2c
 	add sp, sp, #0xa8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov27_02172598
 _0217282c: .word data_02050f54
@@ -7983,7 +7983,7 @@ _02174450: .word data_027e0e60
 	.global func_ov27_02174454
 	arm_func_start func_ov27_02174454
 func_ov27_02174454: ; 0x02174454
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x124
 	ldr r1, _021746e4 ; =data_027e0f94
 	mov r4, r0
@@ -8090,7 +8090,7 @@ func_ov27_02174454: ; 0x02174454
 	str r6, [sp, #0xc0]
 	ldr r6, [sp, #0x38]
 	mov r10, #5
-	mov sb, #0x1c000
+	mov r9, #0x1c000
 	mov r8, #0xfa0
 	str r0, [sp, #0xd4]
 	ldr r0, [sp, #0x4c]
@@ -8127,13 +8127,13 @@ func_ov27_02174454: ; 0x02174454
 	add r1, sp, #0x74
 	str r6, [sp, #0xfc]
 	str r10, [sp, #0x10]
-	str sb, [sp, #0x24]
+	str r9, [sp, #0x24]
 	str r8, [sp, #0x1c]
 	str r7, [sp, #0x20]
 	str r10, [sp, #0xa4]
 	str r8, [sp, #0xb0]
 	str r7, [sp, #0xb4]
-	str sb, [sp, #0xb8]
+	str r9, [sp, #0xb8]
 	strb r5, [sp, #0x100]
 	strb lr, [sp, #0x101]
 	strb ip, [sp, #0x102]
@@ -8146,7 +8146,7 @@ func_ov27_02174454: ; 0x02174454
 	add r0, sp, #0x74
 	bl func_ov00_0209a508
 	add sp, sp, #0x124
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov27_02174454
 _021746e4: .word data_027e0f94
@@ -10852,11 +10852,11 @@ _02176aa8: .word data_027e0dbc
 	.global func_ov27_02176aac
 	arm_func_start func_ov27_02176aac
 func_ov27_02176aac: ; 0x02176aac
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x44
 	mov r10, r0
 	ldr r0, _02176e74 ; =data_027e0f94
-	mov sb, r1
+	mov r9, r1
 	add r5, sp, #0x38
 	ldmia r0, {r0, r1, r2}
 	add r3, sp, #0x14
@@ -10924,11 +10924,11 @@ _02176ba8:
 	bl func_01ffa0f4
 	mov r0, r0, lsl #0x10
 	mov r0, r0, asr #0x10
-	cmp sb, #0
+	cmp r9, #0
 	beq _02176bec
-	cmp sb, #1
+	cmp r9, #1
 	beq _02176be0
-	cmp sb, #2
+	cmp r9, #2
 	subeq r0, r0, r7
 	moveq r0, r0, lsl #0x10
 	moveq r0, r0, asr #0x10
@@ -10992,7 +10992,7 @@ _02176c68:
 	mov r0, r10
 	mov r1, #0
 	bl func_01fffd04
-	cmp sb, #0
+	cmp r9, #0
 	beq _02176da0
 	cmp r6, #0
 	bne _02176da0
@@ -11014,7 +11014,7 @@ _02176c68:
 	mov r1, r5
 	mov r2, r4
 	bl func_01ff9bf8
-	cmp sb, #1
+	cmp r9, #1
 	ldr r0, [r10, #0xc4]
 	str r0, [sp, #8]
 	ldr r0, [r10, #0xc8]
@@ -11022,7 +11022,7 @@ _02176c68:
 	ldr r0, [r10, #0xcc]
 	str r0, [sp, #0x10]
 	beq _02176d40
-	cmp sb, #2
+	cmp r9, #2
 	beq _02176d50
 	b _02176d5c
 _02176d40:
@@ -11078,7 +11078,7 @@ _02176da0:
 	ldr r0, [r0, #0x420]
 	cmp r0, #0
 	addeq sp, sp, #0x44
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r0, r10, #0x1d8
 	mov r1, #0
 	bl func_ov14_02145f0c
@@ -11086,7 +11086,7 @@ _02176da0:
 	mov r1, #0
 	str r1, [r0, #0x20]
 	add sp, sp, #0x44
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02176e28:
 	ldr r0, [r0, #0x420]
 	cmp r0, #3
@@ -11107,7 +11107,7 @@ _02176e54:
 	subeq r1, r1, #0x2000
 	str r1, [r0, #0x10]
 	add sp, sp, #0x44
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov27_02176aac
 _02176e74: .word data_027e0f94
@@ -11900,7 +11900,7 @@ _02177938:
 	.global func_ov27_02177940
 	arm_func_start func_ov27_02177940
 func_ov27_02177940: ; 0x02177940
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x28
 	mov r10, r0
 	mov r4, r1
@@ -11909,22 +11909,22 @@ func_ov27_02177940: ; 0x02177940
 	bl func_0203d7e0
 	cmp r0, #0
 	addeq sp, sp, #0x28
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, _02177bb0 ; =data_027e0618
 	ldrb r0, [r0, #0x101]
 	cmp r0, #0
 	addne sp, sp, #0x28
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldrh r0, [r4]
 	tst r0, #2
 	addeq sp, sp, #0x28
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, _02177bb4 ; =data_027e0f90
 	ldr r0, [r0]
 	ldrb r0, [r0, #0x12]
 	cmp r0, #0
 	addeq sp, sp, #0x28
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r0, sp, #8
 	bl func_01ffbe34
 	ldr r0, _02177bb8 ; =data_027e0c38
@@ -11935,16 +11935,16 @@ func_ov27_02177940: ; 0x02177940
 	moveq r8, #0x6f
 	cmp r0, #4
 	bne _02177a9c
-	mov sb, #0
+	mov r9, #0
 	add r5, r10, #0xec
 	add r4, r10, #0x500
-	mov r11, sb
+	mov r11, r9
 	mov r7, #1
 	add r6, sp, #8
 _021779e4:
 	ldrb r0, [r10, #0x4e2]
 	rsb r1, r0, #3
-	cmp sb, r1
+	cmp r9, r1
 	bne _02177a54
 	ldrh r1, [r4, #0x48]
 	mov r3, #0
@@ -11961,14 +11961,14 @@ _021779e4:
 	stmia sp, {r0, r6}
 	mov r0, r8
 	mov r1, #0x12
-	mov r2, sb
+	mov r2, r9
 	bl func_020349cc
 	b _02177a90
 _02177a3c:
 	stmia sp, {r0, r6}
 	add r0, r5, #0x400
 	mov r1, r8
-	mov r2, sb
+	mov r2, r9
 	bl func_02034b0c
 	b _02177a90
 _02177a54:
@@ -11977,20 +11977,20 @@ _02177a54:
 	stmia sp, {r0, r6}
 	mov r0, r8
 	mov r1, #0x12
-	mov r2, sb
+	mov r2, r9
 	mov r3, #0
 	bl func_020349cc
 	b _02177a90
 _02177a78:
 	mov r2, #0
 	mov r0, r8
-	mov r1, sb
+	mov r1, r9
 	mov r3, r2
 	str r6, [sp]
 	bl func_0203493c
 _02177a90:
-	add sb, sb, #1
-	cmp sb, #3
+	add r9, r9, #1
+	cmp r9, #3
 	blt _021779e4
 _02177a9c:
 	mov r2, #0
@@ -12060,7 +12060,7 @@ _02177a9c:
 	mov r2, #7
 	bl func_020349cc
 	add sp, sp, #0x28
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov27_02177940
 _02177bac: .word data_027e0cbc
@@ -12919,7 +12919,7 @@ func_ov27_0217867c: ; 0x0217867c
 	.global func_ov27_021786ac
 	arm_func_start func_ov27_021786ac
 func_ov27_021786ac: ; 0x021786ac
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #4
 	mov r6, r0
 	cmp r1, #1
@@ -12958,7 +12958,7 @@ _02178718:
 	cmp r0, #0
 	addeq sp, sp, #4
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	ldrb r0, [r6, #0x489]
 	cmp r0, #0
 	beq _02178760
@@ -12966,7 +12966,7 @@ _02178718:
 	strb r0, [r6, #0x489]
 	add sp, sp, #4
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 _02178760:
 	mov r5, #0
 	ldr r7, _02178868 ; =gItemManager
@@ -12977,10 +12977,10 @@ _02178774:
 	ldr r10, [r7]
 	mov r0, r10
 	blx _ZNK11ItemManager16GetTreasureCountEj
-	mov sb, r0
+	mov r9, r0
 	mov r0, r10
 	blx _ZNK11ItemManager19GetMaxTreasureCountEv
-	cmp sb, r0
+	cmp r9, r0
 	ldrge r0, [sp]
 	orrge r0, r5, r8, lsl r0
 	andge r5, r0, #0xff
@@ -13016,7 +13016,7 @@ _021787f0:
 	strb r0, [r6, #0x489]
 	add sp, sp, #4
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 _02178814:
 	add r0, r6, #0x1d8
 	bl func_ov14_0214610c
@@ -13028,15 +13028,15 @@ _02178814:
 	cmp r0, #0
 	addne sp, sp, #4
 	movne r0, #1
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 _02178840:
 	add sp, sp, #4
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 _0217884c:
 	mov r0, #1
 	add sp, sp, #4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov27_021786ac
 _02178858: .word 0x00001001

--- a/asm/ov27.s
+++ b/asm/ov27.s
@@ -273,7 +273,7 @@ _0216da34: .word data_027e0fe4
 	.global func_ov27_0216da38
 	arm_func_start func_ov27_0216da38
 func_ov27_0216da38: ; 0x0216da38
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #4
 	sub sp, sp, #0x400
 	mov r5, r0
@@ -553,7 +553,7 @@ _0216de58:
 	cmpne r0, #9
 	addeq sp, sp, #4
 	addeq sp, sp, #0x400
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, _0216e92c ; =data_027e0764
 	ldr r2, [r0]
 	ldmib r0, {r1, r3}
@@ -717,7 +717,7 @@ _0216e084:
 	bl func_ov27_0216da38
 	add sp, sp, #4
 	add sp, sp, #0x400
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0216e0d8:
 	mov r1, #0xc
 	mov r2, #0
@@ -948,7 +948,7 @@ _0216e2b8:
 	ldr r8, [sp, #0x1e4]
 	str r7, [sp, #0x264]
 	ldr r7, [sp, #0x1e8]
-	mov fp, #1
+	mov r11, #1
 	str r1, [sp, #0x268]
 	ldr r0, [r0]
 	add r1, sp, #0x1f4
@@ -961,7 +961,7 @@ _0216e2b8:
 	strb ip, [sp, #0x282]
 	strb r3, [sp, #0x283]
 	strb r2, [sp, #0x284]
-	strb fp, [sp, #0x20a]
+	strb r11, [sp, #0x20a]
 	bl func_ov00_02097810
 	str r0, [r5, #0x488]
 	add r0, sp, #0x1f4
@@ -1082,7 +1082,7 @@ _0216e4f4:
 	ldr r0, _0216e928 ; =data_027e0f74
 	ldr r1, [sp, #0xbc]
 	ldr ip, [sp, #0xc4]
-	ldr fp, [sp, #0xc8]
+	ldr r11, [sp, #0xc8]
 	ldr sl, [sp, #0xcc]
 	ldr sb, [sp, #0xd0]
 	mov lr, #1
@@ -1090,7 +1090,7 @@ _0216e4f4:
 	ldr r0, [r0]
 	add r1, sp, #0xdc
 	str ip, [sp, #0x158]
-	str fp, [sp, #0x15c]
+	str r11, [sp, #0x15c]
 	str sl, [sp, #0x160]
 	str sb, [sp, #0x164]
 	strb r8, [sp, #0x168]
@@ -1257,7 +1257,7 @@ _0216e8fc:
 	str r4, [r5, #0x130]
 	add sp, sp, #4
 	add sp, sp, #0x400
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov27_0216da38
 _0216e914: .word 0x00000ccd
@@ -2660,7 +2660,7 @@ _0216fbfc: .word data_027e0764
 	.global func_ov27_0216fc00
 	arm_func_start func_ov27_0216fc00
 func_ov27_0216fc00: ; 0x0216fc00
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x18
 	mov sl, r0
 	ldr r2, [sl, #0x1e8]
@@ -2690,7 +2690,7 @@ _0216fc4c:
 	mov sb, sl
 	add r7, sl, #0x470
 	mov r5, #0
-	add fp, sp, #0xc
+	add r11, sp, #0xc
 _0216fc74:
 	ldr r0, [r4]
 	mov r1, r7
@@ -2699,7 +2699,7 @@ _0216fc74:
 	ldr r3, [r8, #4]
 	ldr r2, [r8, #8]
 	ldr r1, [r8], #0xc
-	mov r0, fp
+	mov r0, r11
 	str r1, [sp, #0xc]
 	str r3, [sp, #0x10]
 	str r2, [sp, #0x14]
@@ -2776,7 +2776,7 @@ _0216fd9c:
 	bl func_0202e58c
 	cmp r0, #0
 	addeq sp, sp, #0x18
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r2, _0216fe40 ; =data_027e0764
 	mov r1, #0
 	ldr r3, [r2]
@@ -2801,12 +2801,12 @@ _0216fd9c:
 	mov r1, #0xe
 	bl func_ov27_0216da38
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0216fe18:
 	mov r1, #4
 	bl func_ov27_0216da38
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov27_0216fc00
 _0216fe28: .word 0x00000bb8
@@ -2893,7 +2893,7 @@ _0216ff34: .word data_027e0764
 	.global func_ov27_0216ff38
 	arm_func_start func_ov27_0216ff38
 func_ov27_0216ff38: ; 0x0216ff38
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x18
 	mov sl, r0
 	ldr r2, [sl, #0x1e8]
@@ -2923,7 +2923,7 @@ _0216ff84:
 	mov sb, sl
 	add r7, sl, #0x470
 	mov r5, #0
-	add fp, sp, #0xc
+	add r11, sp, #0xc
 _0216ffac:
 	ldr r0, [r4]
 	mov r1, r7
@@ -2932,7 +2932,7 @@ _0216ffac:
 	ldr r3, [r8, #4]
 	ldr r2, [r8, #8]
 	ldr r1, [r8], #0xc
-	mov r0, fp
+	mov r0, r11
 	str r1, [sp, #0xc]
 	str r3, [sp, #0x10]
 	str r2, [sp, #0x14]
@@ -3016,7 +3016,7 @@ _021700ec:
 	bl func_0202e58c
 	cmp r0, #0
 	addeq sp, sp, #0x18
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r2, _02170190 ; =data_027e0764
 	mov r1, #0
 	ldr r3, [r2]
@@ -3041,12 +3041,12 @@ _021700ec:
 	mov r1, #0xe
 	bl func_ov27_0216da38
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02170168:
 	mov r1, #4
 	bl func_ov27_0216da38
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov27_0216ff38
 _02170178: .word 0x00000bb8
@@ -4039,7 +4039,7 @@ _02170f84: .word data_027e0e60
 	.global func_ov27_02170f88
 	arm_func_start func_ov27_02170f88
 func_ov27_02170f88: ; 0x02170f88
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x44
 	mov sl, r0
 	ldr r0, _02171374 ; =data_027e0f94
@@ -4072,7 +4072,7 @@ func_ov27_02170f88: ; 0x02170f88
 	mov r0, #0x4000
 	rsb r0, r0, #0
 	str r0, [sp, #4]
-	add fp, sp, #8
+	add r11, sp, #8
 _02171010:
 	add r0, sl, #0x48
 	mov r1, r5
@@ -4216,18 +4216,18 @@ _02171154:
 	b _02171244
 _02171228:
 	ldr r1, [sp, #4]
-	mov r0, fp
+	mov r0, r11
 	bl func_ov00_020a61ac
 	b _02171244
 _02171238:
-	mov r0, fp
+	mov r0, r11
 	mov r1, #0x4000
 	bl func_ov00_020a61ac
 _02171244:
 	ldr r0, _02171388 ; =0x00000266
 	add r2, sl, #0x48
 	sub r0, r0, r6
-	mov r1, fp
+	mov r1, r11
 	mov r3, r2
 	bl func_01ff9e64
 	mov r0, sl
@@ -4267,13 +4267,13 @@ _02171288:
 	ldr r0, [r0, #0x420]
 	cmp r0, #4
 	addne sp, sp, #0x44
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	mov r0, sl
 	mov r1, #3
 	mov r2, #1
 	bl func_ov27_0217164c
 	add sp, sp, #0x44
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02171308:
 	ldr r0, [r0, #0x420]
 	cmp r0, #3
@@ -4302,7 +4302,7 @@ _02171324:
 	ldr r1, [sl, #0x1e8]
 	str r0, [r1, #0x10]
 	add sp, sp, #0x44
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov27_02170f88
 _02171374: .word data_027e0f94
@@ -7983,7 +7983,7 @@ _02174450: .word data_027e0e60
 	.global func_ov27_02174454
 	arm_func_start func_ov27_02174454
 func_ov27_02174454: ; 0x02174454
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x124
 	ldr r1, _021746e4 ; =data_027e0f94
 	mov r4, r0
@@ -8121,7 +8121,7 @@ func_ov27_02174454: ; 0x02174454
 	ldr r1, [sp, #0x60]
 	str r6, [sp, #0xf0]
 	ldr r6, [sp, #0x68]
-	mov fp, #1
+	mov r11, #1
 	str r1, [sp, #0xf4]
 	ldr r0, [r0]
 	add r1, sp, #0x74
@@ -8139,14 +8139,14 @@ func_ov27_02174454: ; 0x02174454
 	strb ip, [sp, #0x102]
 	strb r3, [sp, #0x103]
 	strb r2, [sp, #0x104]
-	strb fp, [sp, #0x88]
+	strb r11, [sp, #0x88]
 	strb r7, [sp, #0x8a]
 	bl func_ov00_02097810
 	str r0, [r4, #0x1b4]
 	add r0, sp, #0x74
 	bl func_ov00_0209a508
 	add sp, sp, #0x124
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov27_02174454
 _021746e4: .word data_027e0f94
@@ -10852,7 +10852,7 @@ _02176aa8: .word data_027e0dbc
 	.global func_ov27_02176aac
 	arm_func_start func_ov27_02176aac
 func_ov27_02176aac: ; 0x02176aac
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x44
 	mov sl, r0
 	ldr r0, _02176e74 ; =data_027e0f94
@@ -10877,7 +10877,7 @@ func_ov27_02176aac: ; 0x02176aac
 	ldr r0, _02176e78 ; =data_ov27_02179bc4
 	add r4, sp, #0x2c
 	ldr r0, [r0, #0x158]
-	add fp, sp, #8
+	add r11, sp, #8
 	str r0, [sp]
 	mov r0, #0x4000
 	rsb r0, r0, #0
@@ -11027,18 +11027,18 @@ _02176c68:
 	b _02176d5c
 _02176d40:
 	ldr r1, [sp, #4]
-	mov r0, fp
+	mov r0, r11
 	bl func_ov00_020a61ac
 	b _02176d5c
 _02176d50:
-	mov r0, fp
+	mov r0, r11
 	mov r1, #0x4000
 	bl func_ov00_020a61ac
 _02176d5c:
 	ldr r0, _02176e84 ; =0x0000019a
 	add r2, sl, #0x48
 	sub r0, r0, r6
-	mov r1, fp
+	mov r1, r11
 	mov r3, r2
 	bl func_01ff9e64
 	mov r0, sl
@@ -11078,7 +11078,7 @@ _02176da0:
 	ldr r0, [r0, #0x420]
 	cmp r0, #0
 	addeq sp, sp, #0x44
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r0, sl, #0x1d8
 	mov r1, #0
 	bl func_ov14_02145f0c
@@ -11086,7 +11086,7 @@ _02176da0:
 	mov r1, #0
 	str r1, [r0, #0x20]
 	add sp, sp, #0x44
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02176e28:
 	ldr r0, [r0, #0x420]
 	cmp r0, #3
@@ -11107,7 +11107,7 @@ _02176e54:
 	subeq r1, r1, #0x2000
 	str r1, [r0, #0x10]
 	add sp, sp, #0x44
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov27_02176aac
 _02176e74: .word data_027e0f94
@@ -11900,7 +11900,7 @@ _02177938:
 	.global func_ov27_02177940
 	arm_func_start func_ov27_02177940
 func_ov27_02177940: ; 0x02177940
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x28
 	mov sl, r0
 	mov r4, r1
@@ -11909,22 +11909,22 @@ func_ov27_02177940: ; 0x02177940
 	bl func_0203d7e0
 	cmp r0, #0
 	addeq sp, sp, #0x28
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, _02177bb0 ; =data_027e0618
 	ldrb r0, [r0, #0x101]
 	cmp r0, #0
 	addne sp, sp, #0x28
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldrh r0, [r4]
 	tst r0, #2
 	addeq sp, sp, #0x28
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, _02177bb4 ; =data_027e0f90
 	ldr r0, [r0]
 	ldrb r0, [r0, #0x12]
 	cmp r0, #0
 	addeq sp, sp, #0x28
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r0, sp, #8
 	bl func_01ffbe34
 	ldr r0, _02177bb8 ; =data_027e0c38
@@ -11938,7 +11938,7 @@ func_ov27_02177940: ; 0x02177940
 	mov sb, #0
 	add r5, sl, #0xec
 	add r4, sl, #0x500
-	mov fp, sb
+	mov r11, sb
 	mov r7, #1
 	add r6, sp, #8
 _021779e4:
@@ -11953,7 +11953,7 @@ _021779e4:
 	ldreq r1, [sl, #0x550]
 	cmpeq r2, r1
 	moveq r1, r7
-	movne r1, fp
+	movne r1, r11
 	cmp r1, #0
 	cmpne r0, #0
 	mov r0, #0
@@ -12060,7 +12060,7 @@ _02177a9c:
 	mov r2, #7
 	bl func_020349cc
 	add sp, sp, #0x28
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov27_02177940
 _02177bac: .word data_027e0cbc

--- a/asm/ov28.s
+++ b/asm/ov28.s
@@ -5435,28 +5435,28 @@ _02171d0c: .word data_027e0f6c
 	.global func_ov28_02171d10
 	arm_func_start func_ov28_02171d10
 func_ov28_02171d10: ; 0x02171d10
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #0x70
-	mov sb, r0
-	ldr r1, [sb, #0x18]
+	mov r9, r0
+	ldr r1, [r9, #0x18]
 	add r0, sp, #0x64
 	add r1, r1, #0x3fc
 	add r1, r1, #0x400
-	str r1, [sb, #0x18]
+	str r1, [r9, #0x18]
 	str r1, [sp, #0x64]
-	ldr r2, [sb, #0x1c]
+	ldr r2, [r9, #0x1c]
 	add r1, sp, #0x4c
 	str r2, [sp, #0x68]
-	ldr r3, [sb, #0x20]
+	ldr r3, [r9, #0x20]
 	mov r2, r0
 	str r3, [sp, #0x6c]
-	ldr r3, [sb, #0x18]
+	ldr r3, [r9, #0x18]
 	mov r5, #0x800
 	str r3, [sp, #0x58]
-	ldr r3, [sb, #0x1c]
+	ldr r3, [r9, #0x1c]
 	mov r4, #0
 	str r3, [sp, #0x5c]
-	ldr r6, [sb, #0x20]
+	ldr r6, [r9, #0x20]
 	mov r3, #0x400
 	str r6, [sp, #0x60]
 	str r5, [sp, #0x4c]
@@ -5473,16 +5473,16 @@ func_ov28_02171d10: ; 0x02171d10
 	str r3, [sp, #0x48]
 	bl func_01ff9bc4
 	mov r1, #0
-	ldr r2, [sb, #4]
+	ldr r2, [r9, #4]
 	bic r0, r1, #0x1f
 	orr r2, r2, #4
 	orr r0, r0, #6
 	bic r0, r0, #0x80000000
 	orr r4, r0, #0x80000000
-	str r2, [sb, #4]
+	str r2, [r9, #4]
 	mov r2, #1
 	add r0, sp, #0x64
-	strb r2, [sb, #0x12]
+	strb r2, [r9, #0x12]
 	str r1, [sp, #8]
 	add r3, sp, #0x28
 	ldmia r0, {r0, r1, r2}
@@ -5491,20 +5491,20 @@ func_ov28_02171d10: ; 0x02171d10
 	add r3, sp, #0x34
 	ldmia r0, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
-	mov r0, sb
+	mov r0, r9
 	str r4, [sp, #0xc]
 	bl func_ov00_0208b9cc
 	mov r2, r0
 	mov r0, #0
 	str r0, [sp]
-	add r0, sb, #0x38
+	add r0, r9, #0x38
 	mov r3, r4
 	ldr r4, [r0]
 	add r1, sp, #0x28
 	ldr r4, [r4, #0x14]
 	blx r4
 	ldr r0, [sp, #8]
-	ldrh r1, [sb, #0x24]
+	ldrh r1, [r9, #0x24]
 	bic r0, r0, #0x1f
 	orr r0, r0, #7
 	bic r0, r0, #0x6000
@@ -5522,7 +5522,7 @@ func_ov28_02171d10: ; 0x02171d10
 	stmia r4, {r0, r1, r2}
 	mov r0, #0
 	str r0, [sp]
-	add r0, sb, #0x70
+	add r0, r9, #0x70
 	ldr r4, [r0]
 	orr r1, r6, #0x13800000
 	ldr r2, [sp, #0xc]
@@ -5536,12 +5536,12 @@ func_ov28_02171d10: ; 0x02171d10
 	str r3, [sp, #8]
 	blx r4
 	mov r1, #0
-	strb r1, [sb, #0x74]
+	strb r1, [r9, #0x74]
 	ldr r0, _02171f70 ; =data_027e0f6c
-	add r1, sb, #0x70
+	add r1, r9, #0x70
 	ldr r0, [r0]
 	bl func_ov00_02093a5c
-	ldrb r7, [sb, #0x14]
+	ldrb r7, [r9, #0x14]
 	add r0, r7, #2
 	cmp r7, r0
 	bge _02171f28
@@ -5549,7 +5549,7 @@ func_ov28_02171d10: ; 0x02171d10
 	add r5, sp, #4
 	mov r4, #1
 _02171ed4:
-	ldrb r8, [sb, #0x15]
+	ldrb r8, [r9, #0x15]
 	add r0, r8, #1
 	cmp r8, r0
 	bge _02171f14
@@ -5561,22 +5561,22 @@ _02171ee8:
 	strb r6, [sp, #4]
 	strb r8, [sp, #5]
 	bl func_ov00_02082680
-	ldrb r0, [sb, #0x15]
+	ldrb r0, [r9, #0x15]
 	add r8, r8, #1
 	add r0, r0, #1
 	cmp r8, r0
 	blt _02171ee8
 _02171f14:
-	ldrb r0, [sb, #0x14]
+	ldrb r0, [r9, #0x14]
 	add r7, r7, #1
 	add r0, r0, #2
 	cmp r7, r0
 	blt _02171ed4
 _02171f28:
-	mov r0, sb
+	mov r0, r9
 	bl func_ov28_02172144
 	cmp r0, #0
-	mov r0, sb
+	mov r0, r9
 	ldr r3, [r0]
 	beq _02171f58
 	ldr r3, [r3, #0x80]
@@ -5584,14 +5584,14 @@ _02171f28:
 	mov r2, #0
 	blx r3
 	add sp, sp, #0x70
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _02171f58:
 	mov r1, #0
 	ldr r3, [r3, #0x80]
 	mov r2, r1
 	blx r3
 	add sp, sp, #0x70
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov28_02171d10
 _02171f70: .word data_027e0f6c
@@ -5854,28 +5854,28 @@ func_ov28_02172250: ; 0x02172250
 	.global func_ov28_02172280
 	arm_func_start func_ov28_02172280
 func_ov28_02172280: ; 0x02172280
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #0x54
-	mov sb, r0
-	ldr r1, [sb, #0x18]
+	mov r9, r0
+	ldr r1, [r9, #0x18]
 	add r0, sp, #0x48
 	add r1, r1, #0x3fc
 	add r1, r1, #0x400
-	str r1, [sb, #0x18]
+	str r1, [r9, #0x18]
 	str r1, [sp, #0x48]
-	ldr r1, [sb, #0x1c]
+	ldr r1, [r9, #0x1c]
 	ldr r3, _0217244c ; =0x0000059a
 	str r1, [sp, #0x4c]
-	ldr r2, [sb, #0x20]
+	ldr r2, [r9, #0x20]
 	add r1, sp, #0x30
 	str r2, [sp, #0x50]
-	ldr r4, [sb, #0x18]
+	ldr r4, [r9, #0x18]
 	mov r2, r0
 	str r4, [sp, #0x3c]
-	ldr r4, [sb, #0x1c]
+	ldr r4, [r9, #0x1c]
 	mov r5, #0x1000
 	str r4, [sp, #0x40]
-	ldr r6, [sb, #0x20]
+	ldr r6, [r9, #0x20]
 	mov r4, #0
 	str r6, [sp, #0x44]
 	str r5, [sp, #0x30]
@@ -5891,13 +5891,13 @@ func_ov28_02172280: ; 0x02172280
 	str r4, [sp, #0x28]
 	str r3, [sp, #0x2c]
 	bl func_01ff9bc4
-	ldr r1, [sb, #4]
-	mov r0, sb
+	ldr r1, [r9, #4]
+	mov r0, r9
 	orr r1, r1, #0x14
-	str r1, [sb, #4]
+	str r1, [r9, #4]
 	bl func_ov00_0208c214
 	mov r0, #7
-	strb r0, [sb, #0x12]
+	strb r0, [r9, #0x12]
 	mov r0, #0
 	bic r0, r0, #0x1f
 	orr r0, r0, #6
@@ -5912,18 +5912,18 @@ func_ov28_02172280: ; 0x02172280
 	add r3, sp, #0x18
 	ldmia r4, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
-	mov r0, sb
+	mov r0, r9
 	bl func_ov00_0208b9cc
 	mov r2, r0
 	mov r0, #0
 	str r0, [sp]
-	add r0, sb, #0x38
+	add r0, r9, #0x38
 	ldr r4, [r0]
 	ldr r3, [sp, #8]
 	ldr r4, [r4, #0x14]
 	mov r1, r5
 	blx r4
-	ldrb r7, [sb, #0x14]
+	ldrb r7, [r9, #0x14]
 	add r0, r7, #2
 	cmp r7, r0
 	bge _02172404
@@ -5931,7 +5931,7 @@ func_ov28_02172280: ; 0x02172280
 	add r5, sp, #4
 	mov r4, #1
 _021723b0:
-	ldrb r8, [sb, #0x15]
+	ldrb r8, [r9, #0x15]
 	add r0, r8, #1
 	cmp r8, r0
 	bge _021723f0
@@ -5943,22 +5943,22 @@ _021723c4:
 	strb r6, [sp, #4]
 	strb r8, [sp, #5]
 	bl func_ov00_02082680
-	ldrb r0, [sb, #0x15]
+	ldrb r0, [r9, #0x15]
 	add r8, r8, #1
 	add r0, r0, #1
 	cmp r8, r0
 	blt _021723c4
 _021723f0:
-	ldrb r0, [sb, #0x14]
+	ldrb r0, [r9, #0x14]
 	add r7, r7, #1
 	add r0, r0, #2
 	cmp r7, r0
 	blt _021723b0
 _02172404:
-	mov r0, sb
+	mov r0, r9
 	bl func_ov28_02172658
 	cmp r0, #0
-	mov r0, sb
+	mov r0, r9
 	ldr r3, [r0]
 	beq _02172434
 	ldr r3, [r3, #0x80]
@@ -5966,14 +5966,14 @@ _02172404:
 	mov r2, #0
 	blx r3
 	add sp, sp, #0x54
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 _02172434:
 	mov r1, #0
 	ldr r3, [r3, #0x80]
 	mov r2, r1
 	blx r3
 	add sp, sp, #0x54
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov28_02172280
 _0217244c: .word 0x0000059a
@@ -6291,9 +6291,9 @@ _02172808: .word 0x000001ad
 	.global func_ov28_0217280c
 	arm_func_start func_ov28_0217280c
 func_ov28_0217280c: ; 0x0217280c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	ldr r3, _021728fc ; =gItemManager
-	mov sb, r1
+	mov r9, r1
 	ldr r7, [r3]
 	mov r10, r0
 	ldrb r4, [r7, #0x25]
@@ -6348,7 +6348,7 @@ _021728c8:
 _021728d0:
 	add r3, r10, #0x1f8
 	mov r0, r10
-	mov r1, sb
+	mov r1, r9
 	mov r2, r8
 	str r3, [r8, #0x38]
 	mov r3, #6
@@ -6356,7 +6356,7 @@ _021728d0:
 	bl func_ov14_02144d70
 	mov r0, r10
 	bl func_ov28_02172b40
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov28_0217280c
 _021728fc: .word gItemManager

--- a/asm/ov28.s
+++ b/asm/ov28.s
@@ -5435,7 +5435,7 @@ _02171d0c: .word data_027e0f6c
 	.global func_ov28_02171d10
 	arm_func_start func_ov28_02171d10
 func_ov28_02171d10: ; 0x02171d10
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #0x70
 	mov sb, r0
 	ldr r1, [sb, #0x18]
@@ -5545,7 +5545,7 @@ func_ov28_02171d10: ; 0x02171d10
 	add r0, r7, #2
 	cmp r7, r0
 	bge _02171f28
-	ldr sl, _02171f74 ; =data_027e0e60
+	ldr r10, _02171f74 ; =data_027e0e60
 	add r5, sp, #4
 	mov r4, #1
 _02171ed4:
@@ -5555,7 +5555,7 @@ _02171ed4:
 	bge _02171f14
 	and r6, r7, #0xff
 _02171ee8:
-	ldr r0, [sl]
+	ldr r0, [r10]
 	mov r1, r5
 	mov r2, r4
 	strb r6, [sp, #4]
@@ -5584,14 +5584,14 @@ _02171f28:
 	mov r2, #0
 	blx r3
 	add sp, sp, #0x70
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _02171f58:
 	mov r1, #0
 	ldr r3, [r3, #0x80]
 	mov r2, r1
 	blx r3
 	add sp, sp, #0x70
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov28_02171d10
 _02171f70: .word data_027e0f6c
@@ -5854,7 +5854,7 @@ func_ov28_02172250: ; 0x02172250
 	.global func_ov28_02172280
 	arm_func_start func_ov28_02172280
 func_ov28_02172280: ; 0x02172280
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #0x54
 	mov sb, r0
 	ldr r1, [sb, #0x18]
@@ -5927,7 +5927,7 @@ func_ov28_02172280: ; 0x02172280
 	add r0, r7, #2
 	cmp r7, r0
 	bge _02172404
-	ldr sl, _02172450 ; =data_027e0e60
+	ldr r10, _02172450 ; =data_027e0e60
 	add r5, sp, #4
 	mov r4, #1
 _021723b0:
@@ -5937,7 +5937,7 @@ _021723b0:
 	bge _021723f0
 	and r6, r7, #0xff
 _021723c4:
-	ldr r0, [sl]
+	ldr r0, [r10]
 	mov r1, r5
 	mov r2, r4
 	strb r6, [sp, #4]
@@ -5966,14 +5966,14 @@ _02172404:
 	mov r2, #0
 	blx r3
 	add sp, sp, #0x54
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 _02172434:
 	mov r1, #0
 	ldr r3, [r3, #0x80]
 	mov r2, r1
 	blx r3
 	add sp, sp, #0x54
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov28_02172280
 _0217244c: .word 0x0000059a
@@ -6291,34 +6291,34 @@ _02172808: .word 0x000001ad
 	.global func_ov28_0217280c
 	arm_func_start func_ov28_0217280c
 func_ov28_0217280c: ; 0x0217280c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	ldr r3, _021728fc ; =gItemManager
 	mov sb, r1
 	ldr r7, [r3]
-	mov sl, r0
+	mov r10, r0
 	ldrb r4, [r7, #0x25]
 	ldrb r5, [r7, #0x26]
 	ldrb r6, [r7, #0x24]
 	mov r3, #0
 	mov r0, r7
-	str r4, [sl, #0x1f8]
-	str r5, [sl, #0x1fc]
-	str r6, [sl, #0x200]
-	str r3, [sl, #0x204]
-	str r3, [sl, #0x208]
+	str r4, [r10, #0x1f8]
+	str r5, [r10, #0x1fc]
+	str r6, [r10, #0x200]
+	str r3, [r10, #0x204]
+	str r3, [r10, #0x208]
 	mov r1, #1
 	mov r8, r2
-	str r3, [sl, #0x20c]
+	str r3, [r10, #0x20c]
 	bl _ZNK11ItemManager13GetFairyLevelEi
 	cmp r0, #0
 	beq _02172870
 	cmp r0, #1
 	rsbeq r0, r4, #0x14
-	streq r0, [sl, #0x204]
+	streq r0, [r10, #0x204]
 	b _02172878
 _02172870:
 	rsb r0, r4, #0xa
-	str r0, [sl, #0x204]
+	str r0, [r10, #0x204]
 _02172878:
 	mov r0, r7
 	mov r1, #2
@@ -6327,11 +6327,11 @@ _02172878:
 	beq _0217289c
 	cmp r0, #1
 	rsbeq r0, r5, #0x14
-	streq r0, [sl, #0x208]
+	streq r0, [r10, #0x208]
 	b _021728a4
 _0217289c:
 	rsb r0, r5, #0xa
-	str r0, [sl, #0x208]
+	str r0, [r10, #0x208]
 _021728a4:
 	mov r0, r7
 	mov r1, #0
@@ -6340,23 +6340,23 @@ _021728a4:
 	beq _021728c8
 	cmp r0, #1
 	rsbeq r0, r6, #0x14
-	streq r0, [sl, #0x20c]
+	streq r0, [r10, #0x20c]
 	b _021728d0
 _021728c8:
 	rsb r0, r6, #0xa
-	str r0, [sl, #0x20c]
+	str r0, [r10, #0x20c]
 _021728d0:
-	add r3, sl, #0x1f8
-	mov r0, sl
+	add r3, r10, #0x1f8
+	mov r0, r10
 	mov r1, sb
 	mov r2, r8
 	str r3, [r8, #0x38]
 	mov r3, #6
 	strh r3, [r8, #0x3c]
 	bl func_ov14_02144d70
-	mov r0, sl
+	mov r0, r10
 	bl func_ov28_02172b40
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov28_0217280c
 _021728fc: .word gItemManager

--- a/asm/ov29.s
+++ b/asm/ov29.s
@@ -280,7 +280,7 @@ _0216d9ac: .word func_02017d30
 	.global func_ov29_0216d9b0
 	arm_func_start func_ov29_0216d9b0
 func_ov29_0216d9b0: ; 0x0216d9b0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	ldr r3, [r1, #0x2c]
 	ldr r4, [r1, #0x38]
 	mov r3, r3, lsl #0x10
@@ -342,19 +342,19 @@ _0216da94:
 	add r2, r2, #1
 	add r4, r4, #2
 	mov r0, r3, asr #0x5
-	mov sl, r3, asr #0xa
+	mov r10, r3, asr #0xa
 	and r3, r3, #0x1f
 	and r0, r0, #0x1f
-	and sl, sl, #0x1f
+	and r10, r10, #0x1f
 	add r0, r3, r0
-	add sl, sl, r0
-	mul r0, sl, r7
+	add r10, r10, r0
+	mul r0, r10, r7
 	add r0, r0, #0x3000
 	mov r3, r0, asr #0xc
-	mul r0, sl, r8
+	mul r0, r10, r8
 	add r0, r0, #0x3000
 	mov ip, r0, asr #0xc
-	mul r0, sl, lr
+	mul r0, r10, lr
 	add r0, r0, #0x3000
 	cmp r3, #0x1f
 	movgt r3, r1
@@ -372,7 +372,7 @@ _0216db0c:
 	ldr r0, [sb, #4]
 	ldr r1, [sb, #0xc]
 	bl func_0200e2a4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov29_0216d9b0
 _0216db1c: .word 0x00000554
@@ -1764,7 +1764,7 @@ _0216ed7c: .word 0x000004cd
 	.global func_ov29_0216ed80
 	arm_func_start func_ov29_0216ed80
 func_ov29_0216ed80: ; 0x0216ed80
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x38
 	ldr r6, _0216f124 ; =data_027e0764
 	mov r7, #0
@@ -1777,24 +1777,24 @@ func_ov29_0216ed80: ; 0x0216ed80
 	mla r8, r4, r3, r8
 	adds sb, r2, r5
 	ldr r5, [r6, #0x14]
-	umull r3, sl, r11, sb
+	umull r3, r10, r11, sb
 	adc r8, r5, r8
-	mla sl, r11, r8, sl
+	mla r10, r11, r8, r10
 	mov r1, #0xb5
 	adds r2, r2, r3
 	umull r11, r3, r8, r1
-	mla sl, r4, sb, sl
+	mla r10, r4, sb, r10
 	str sb, [r6]
 	stmia r6, {r2, r8}
-	adc sl, r5, sl
-	umull r4, r5, sl, r1
+	adc r10, r5, r10
+	umull r4, r5, r10, r1
 	mla r3, r8, r7, r3
 	mov r2, r7
 	mla r3, r2, r1, r3
-	mla r5, sl, r7, r5
+	mla r5, r10, r7, r5
 	mla r5, r2, r1, r5
 	sub r3, r3, #0x5a
-	str sl, [r6, #4]
+	str r10, [r6, #4]
 	add r1, r3, #0x96
 	str r1, [r0, #0x4e4]
 	ldr r1, _0216f128 ; =data_027e0d38
@@ -1803,7 +1803,7 @@ func_ov29_0216ed80: ; 0x0216ed80
 	ldr r1, [r1, #0x14]
 	cmp r1, #1
 	addeq sp, sp, #0x38
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r1, _0216f12c ; =data_ov29_021798e8
 	ldr r8, [r0, #0x50]
 	ldr r2, [r1]
@@ -1817,15 +1817,15 @@ func_ov29_0216ed80: ; 0x0216ed80
 	ble _0216ee98
 	ldr r11, [r6]
 	ldmib r6, {r7, r8}
-	umull sl, sb, r8, r11
+	umull r10, sb, r8, r11
 	mla sb, r8, r7, sb
 	ldr r7, [r6, #0x10]
 	ldr r8, [r6, #0x14]
-	adds sl, r7, sl
+	adds r10, r7, r10
 	ldr r7, [r6, #0xc]
 	mla sb, r7, r11, sb
 	adc r7, r8, sb
-	str sl, [r6]
+	str r10, [r6]
 	str r7, [r6, #4]
 	cmp lr, #0
 	beq _0216ee98
@@ -1849,12 +1849,12 @@ _0216ee98:
 	ble _0216ef18
 	ldr r8, _0216f124 ; =data_027e0764
 	ldr sb, [r8]
-	ldmib r8, {r4, sl}
-	umull r2, r1, sl, sb
-	mla r1, sl, r4, r1
-	ldr sl, [r8, #0xc]
+	ldmib r8, {r4, r10}
+	umull r2, r1, r10, sb
+	mla r1, r10, r4, r1
+	ldr r10, [r8, #0xc]
 	ldr r4, [r8, #0x10]
-	mla r1, sl, sb, r1
+	mla r1, r10, sb, r1
 	ldr sb, [r8, #0x14]
 	adds r2, r4, r2
 	adc r1, sb, r1
@@ -1920,13 +1920,13 @@ _0216efa0:
 	ldr r6, _0216f124 ; =data_027e0764
 	ldr r7, [r6]
 	ldmib r6, {r5, r8}
-	umull sl, sb, r8, r7
+	umull r10, sb, r8, r7
 	mla sb, r8, r5, sb
 	ldr r5, [r6, #0xc]
 	ldr r8, [r6, #0x10]
 	mla sb, r5, r7, sb
 	ldr r5, [r6, #0x14]
-	adds r7, r8, sl
+	adds r7, r8, r10
 	adc r5, r5, sb
 	str r7, [r6]
 	str r5, [r6, #4]
@@ -1977,7 +1977,7 @@ _0216f074:
 	mov r3, #2
 	bl func_ov00_0207c1b0
 	add sp, sp, #0x38
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0216f0c4:
 	cmp ip, #0
 	strgt r2, [sp, #0x14]
@@ -2002,7 +2002,7 @@ _0216f0c4:
 	mov r3, #2
 	bl func_ov00_0207c1b0
 	add sp, sp, #0x38
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov29_0216ed80
 _0216f124: .word data_027e0764
@@ -3127,7 +3127,7 @@ _0216ffe4: .word 0x474f3154
 	.global func_ov29_0216ffe8
 	arm_func_start func_ov29_0216ffe8
 func_ov29_0216ffe8: ; 0x0216ffe8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0xb8
 	ldr r0, _02170130 ; =data_027e0fec
 	ldr r0, [r0]
@@ -3156,7 +3156,7 @@ _02170040:
 	ldr r11, [r1, r0, lsl #2]
 	ldr r1, _0217013c ; =data_ov29_02179ad0
 	cmp r11, #0
-	ldr sl, [r1, r0, lsl #2]
+	ldr r10, [r1, r0, lsl #2]
 	ldr r1, _02170140 ; =data_ov29_02179ac8
 	ldr r0, [r1, r0, lsl #2]
 	str r0, [sp]
@@ -3191,13 +3191,13 @@ _02170070:
 	mov r1, r6
 	bl func_ov00_020a97e0
 	mov r0, r5
-	mov r1, sl
+	mov r1, r10
 	bl func_ov00_020a9960
 	mov r0, r5
 	bl func_ov00_020a9968
 	add r8, r8, #1
 	add sb, sb, #0x1000
-	add sl, sl, #0x58
+	add r10, r10, #0x58
 	cmp r8, r11
 	blt _02170070
 _02170104:
@@ -3211,7 +3211,7 @@ _02170104:
 	add r0, sp, #0x5c
 	blx func_ov00_020a95a4
 	add sp, sp, #0xb8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov29_0216ffe8
 _02170130: .word data_027e0fec
@@ -3395,7 +3395,7 @@ _02170368: .word data_ov29_021793a0
 	.global func_ov29_0217036c
 	arm_func_start func_ov29_0217036c
 func_ov29_0217036c: ; 0x0217036c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	mov r3, #0
 	str r3, [r0, #0x130]
 	ldr r2, [r1]
@@ -3419,13 +3419,13 @@ func_ov29_0217036c: ; 0x0217036c
 	str r3, [r0, #0x24c]
 	ldr r2, [r6]
 	ldmib r6, {r1, r7}
-	umull sl, sb, r7, r2
+	umull r10, sb, r7, r2
 	mla sb, r7, r1, sb
 	ldr r1, [r6, #0xc]
 	ldr r7, [r6, #0x10]
 	mla sb, r1, r2, sb
 	ldr r1, [r6, #0x14]
-	adds r2, r7, sl
+	adds r2, r7, r10
 	adc sb, r1, sb
 	umull r7, r1, sb, ip
 	mla r1, sb, r3, r1
@@ -3454,7 +3454,7 @@ func_ov29_0217036c: ; 0x0217036c
 	ldr r1, [r5, #0x14]
 	str r2, [r0, #0x158]
 	str r1, [r0, #0x15c]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov29_0217036c
 _0217045c: .word data_027e0764
@@ -3738,7 +3738,7 @@ _0217084c: .word 0x00000433
 	.global func_ov29_02170850
 	arm_func_start func_ov29_02170850
 func_ov29_02170850: ; 0x02170850
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	mov r4, #2
 	str r4, [r0, #0x130]
 	add r8, r0, #0x200
@@ -3787,20 +3787,20 @@ func_ov29_02170850: ; 0x02170850
 	ldr r2, [r0, #0x50]
 	str r2, [r0, #0x23c]
 	str r3, [r0, #0x24c]
-	ldr sl, [r5]
+	ldr r10, [r5]
 	ldmib r5, {sb, r11}
-	umull r8, r2, r11, sl
+	umull r8, r2, r11, r10
 	mla r2, r11, sb, r2
 	ldr sb, [r5, #0xc]
 	ldr r11, [r5, #0x10]
-	mla r2, sb, sl, r2
+	mla r2, sb, r10, r2
 	ldr sb, [r5, #0x14]
 	adds r8, r11, r8
-	adc sl, sb, r2
-	umull sb, r2, sl, r1
-	mla r2, sl, r3, r2
+	adc r10, sb, r2
+	umull sb, r2, r10, r1
+	mla r2, r10, r3, r2
 	mla r2, r7, r1, r2
-	stmia r5, {r8, sl}
+	stmia r5, {r8, r10}
 	umull r5, r1, r2, ip
 	adds r5, r5, #0x800
 	mla r1, r2, r3, r1
@@ -3826,7 +3826,7 @@ func_ov29_02170850: ; 0x02170850
 	ldr r1, [r4, #0x24]
 	str r2, [r0, #0x158]
 	str r1, [r0, #0x15c]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov29_02170850
 _021709b4: .word data_027e0764
@@ -7393,7 +7393,7 @@ _021739d0: .word data_ov29_02179db0
 	.global func_ov29_021739d4
 	arm_func_start func_ov29_021739d4
 func_ov29_021739d4: ; 0x021739d4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x2c
 	mov r4, r0
 	ldr r0, [r4, #0x288]
@@ -7724,7 +7724,7 @@ _02173e68:
 	ldrsh r1, [r6, #2]
 	add r5, r5, r5, lsr #31
 	smull r7, sb, r0, r3
-	adds sl, r7, #0x800
+	adds r10, r7, #0x800
 	mov r5, r5, lsl #0xf
 	mov r5, r5, lsr #0x10
 	mov r5, r5, asr #0x4
@@ -7735,8 +7735,8 @@ _02173e68:
 	smull r11, r7, r1, r2
 	adc ip, sb, #0
 	adds r11, r11, #0x800
-	mov sb, sl, lsr #0xc
-	ldrsh sl, [r6, r5]
+	mov sb, r10, lsr #0xc
+	ldrsh r10, [r6, r5]
 	orr sb, sb, ip, lsl #20
 	ldrsh r8, [r6, r8]
 	adc r5, r7, #0
@@ -7744,7 +7744,7 @@ _02173e68:
 	orr r7, r7, r5, lsl #20
 	smull r6, r5, r7, r8
 	adds r6, r6, #0x800
-	smull lr, ip, sb, sl
+	smull lr, ip, sb, r10
 	smull r3, r11, r1, r3
 	smull r2, r1, r0, r2
 	adc r0, r5, #0
@@ -7764,14 +7764,14 @@ _02173e68:
 	adc r0, r1, #0
 	mov r1, r3, lsr #0xc
 	orr r1, r1, r0, lsl #20
-	smull r3, r0, r1, sl
+	smull r3, r0, r1, r10
 	adds r5, r3, #0x800
 	adc r3, r0, #0
 	mov r0, r5, lsr #0xc
 	orr r0, r0, r3, lsl #20
 	smull r6, r5, r1, r8
-	smull r3, r1, r7, sl
-	smull sl, r7, r2, sl
+	smull r3, r1, r7, r10
+	smull r10, r7, r2, r10
 	smull ip, r11, r2, r8
 	smull r8, r2, sb, r8
 	adds ip, ip, #0x800
@@ -7780,7 +7780,7 @@ _02173e68:
 	orr r11, r11, sb, lsl #20
 	add r0, r0, r11
 	str r0, [r4, #0x214]
-	adds sb, sl, #0x800
+	adds sb, r10, #0x800
 	adc r0, r7, #0
 	mov r7, sb, lsr #0xc
 	orr r7, r7, r0, lsl #20
@@ -7804,7 +7804,7 @@ _02173e68:
 	add r1, r4, #0x244
 	bl func_ov38_021854e4
 	add sp, sp, #0x2c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov29_021739d4
 _02173ffc: .word 0xfffff555
@@ -8015,7 +8015,7 @@ _021742dc: .word 0x00000e39
 	.global func_ov29_021742e0
 	arm_func_start func_ov29_021742e0
 func_ov29_021742e0: ; 0x021742e0
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x24
 	mov r4, r0
 	ldr r0, [r4, #0x288]
@@ -8209,7 +8209,7 @@ _02174578:
 	ldrsh r1, [r6, #2]
 	add r5, r5, r5, lsr #31
 	smull r7, sb, r0, r3
-	adds sl, r7, #0x800
+	adds r10, r7, #0x800
 	mov r5, r5, lsl #0xf
 	mov r5, r5, lsr #0x10
 	mov r5, r5, asr #0x4
@@ -8220,8 +8220,8 @@ _02174578:
 	smull r11, r7, r1, r2
 	adc ip, sb, #0
 	adds r11, r11, #0x800
-	mov sb, sl, lsr #0xc
-	ldrsh sl, [r6, r5]
+	mov sb, r10, lsr #0xc
+	ldrsh r10, [r6, r5]
 	orr sb, sb, ip, lsl #20
 	ldrsh r8, [r6, r8]
 	adc r5, r7, #0
@@ -8229,7 +8229,7 @@ _02174578:
 	orr r7, r7, r5, lsl #20
 	smull r6, r5, r7, r8
 	adds r6, r6, #0x800
-	smull lr, ip, sb, sl
+	smull lr, ip, sb, r10
 	smull r3, r11, r1, r3
 	smull r2, r1, r0, r2
 	adc r0, r5, #0
@@ -8249,14 +8249,14 @@ _02174578:
 	adc r0, r1, #0
 	mov r1, r3, lsr #0xc
 	orr r1, r1, r0, lsl #20
-	smull r3, r0, r1, sl
+	smull r3, r0, r1, r10
 	adds r5, r3, #0x800
 	adc r3, r0, #0
 	mov r0, r5, lsr #0xc
 	orr r0, r0, r3, lsl #20
 	smull r6, r5, r1, r8
-	smull r3, r1, r7, sl
-	smull sl, r7, r2, sl
+	smull r3, r1, r7, r10
+	smull r10, r7, r2, r10
 	smull ip, r11, r2, r8
 	smull r8, r2, sb, r8
 	adds ip, ip, #0x800
@@ -8265,7 +8265,7 @@ _02174578:
 	orr r11, r11, sb, lsl #20
 	add r0, r0, r11
 	str r0, [sp, #0xc]
-	adds sb, sl, #0x800
+	adds sb, r10, #0x800
 	adc r0, r7, #0
 	mov r7, sb, lsr #0xc
 	orr r7, r7, r0, lsl #20
@@ -8295,7 +8295,7 @@ _02174578:
 	add r1, r4, #0x244
 	bl func_ov38_021854e4
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov29_021742e0
 _0217471c: .word 0x000038e4
@@ -8463,7 +8463,7 @@ _0217494c: .word data_02050f54
 	.global func_ov29_02174950
 	arm_func_start func_ov29_02174950
 func_ov29_02174950: ; 0x02174950
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x10
 	mov r4, r0
 	add r0, r4, #0x244
@@ -8518,14 +8518,14 @@ func_ov29_02174950: ; 0x02174950
 	mov sb, sb, lsr #0xc
 	adds r7, r7, #0x800
 	orr sb, sb, r8, lsl #20
-	ldrsh sl, [r5, #2]
+	ldrsh r10, [r5, #2]
 	ldrsh r8, [r5]
 	smull r3, r11, r1, r3
 	adc r5, r6, #0
 	mov r7, r7, lsr #0xc
 	orr r7, r7, r5, lsl #20
 	smull r6, r5, r7, r8
-	smull lr, ip, sb, sl
+	smull lr, ip, sb, r10
 	smull r2, r1, r0, r2
 	adds r6, r6, #0x800
 	adc r0, r5, #0
@@ -8545,22 +8545,22 @@ func_ov29_02174950: ; 0x02174950
 	adc r0, r1, #0
 	mov r1, r3, lsr #0xc
 	orr r1, r1, r0, lsl #20
-	smull r3, r0, r1, sl
+	smull r3, r0, r1, r10
 	adds r5, r3, #0x800
 	adc r3, r0, #0
 	mov r0, r5, lsr #0xc
 	smull ip, r11, r2, r8
 	orr r0, r0, r3, lsl #20
 	smull r6, r5, r1, r8
-	smull r3, r1, r7, sl
-	smull sl, r7, r2, sl
+	smull r3, r1, r7, r10
+	smull r10, r7, r2, r10
 	adds ip, ip, #0x800
 	smull r8, r2, sb, r8
 	adc sb, r11, #0
 	mov r11, ip, lsr #0xc
 	orr r11, r11, sb, lsl #20
 	add r0, r0, r11
-	adds sb, sl, #0x800
+	adds sb, r10, #0x800
 	str r0, [sp, #4]
 	adc r0, r7, #0
 	mov r7, sb, lsr #0xc
@@ -8606,13 +8606,13 @@ _02174b2c:
 	adc r8, r8, #0
 	mov r11, sb, lsr #0xc
 	adds r7, r7, #0x800
-	ldrsh sl, [r5, #0x1c]
+	ldrsh r10, [r5, #0x1c]
 	ldrsh ip, [r5, #0x1e]
 	smull r3, lr, r1, r3
 	adc r5, r6, #0
 	mov sb, r7, lsr #0xc
 	orr sb, sb, r5, lsl #20
-	smull r5, r7, sb, sl
+	smull r5, r7, sb, r10
 	orr r11, r11, r8, lsl #20
 	adds r8, r5, #0x800
 	smull r2, r1, r0, r2
@@ -8639,11 +8639,11 @@ _02174b2c:
 	adc r3, r0, #0
 	mov r0, r5, lsr #0xc
 	orr r0, r0, r3, lsl #20
-	smull r6, r5, r1, sl
+	smull r6, r5, r1, r10
 	smull r3, r1, sb, ip
 	smull r8, r7, r2, ip
-	smull ip, sb, r2, sl
-	smull sl, r2, r11, sl
+	smull ip, sb, r2, r10
+	smull r10, r2, r11, r10
 	adds r11, ip, #0x800
 	adc sb, sb, #0
 	mov r11, r11, lsr #0xc
@@ -8663,7 +8663,7 @@ _02174b2c:
 	str r0, [sp, #8]
 	adc r0, r1, #0
 	mov r3, r3, lsr #0xc
-	adds r1, sl, #0x800
+	adds r1, r10, #0x800
 	orr r3, r3, r0, lsl #20
 	adc r0, r2, #0
 	mov r1, r1, lsr #0xc
@@ -8681,7 +8681,7 @@ _02174c88:
 	add r1, r4, #0x244
 	bl func_ov38_021854e4
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov29_02174950
 _02174cb4: .word data_02050f54
@@ -9249,7 +9249,7 @@ _021753a8: .word data_ov29_02179f4c
 	.global func_ov29_021753ac
 	arm_func_start func_ov29_021753ac
 func_ov29_021753ac: ; 0x021753ac
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x68
 	ldr r3, _0217558c ; =data_027e0d0c
 	mov r4, r0
@@ -9320,7 +9320,7 @@ func_ov29_021753ac: ; 0x021753ac
 	mla r6, r5, r3, r6
 	ldr r0, [r0]
 	ldr sb, [r2, #0x10]
-	ldrsh sl, [r0, #0x78]
+	ldrsh r10, [r0, #0x78]
 	mla r6, lr, ip, r6
 	ldr r8, [r2, #0x14]
 	adds r3, sb, r7
@@ -9334,7 +9334,7 @@ func_ov29_021753ac: ; 0x021753ac
 	ldr r0, _021755a8 ; =0xfffffc72
 	add r1, r4, #0x200
 	add r0, r3, r0
-	add r0, sl, r0
+	add r0, r10, r0
 	strh r0, [r1, #0xbe]
 	ldr r0, _021755ac ; =0xffffe38e
 	strh r0, [r1, #0xbc]
@@ -9368,7 +9368,7 @@ func_ov29_021753ac: ; 0x021753ac
 	bl func_ov29_02175724
 	mov r0, #1
 	add sp, sp, #0x68
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov29_021753ac
 _0217558c: .word data_027e0d0c
@@ -10590,10 +10590,10 @@ _021765ec: .word data_027e0fe4
 	.global func_ov29_021765f0
 	arm_func_start func_ov29_021765f0
 func_ov29_021765f0: ; 0x021765f0
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0xc
-	mov sl, r0
-	ldrb r7, [sl, #0x14]
+	mov r10, r0
+	ldrb r7, [r10, #0x14]
 	mov sb, r1
 	add r0, r7, #2
 	cmp r7, r0
@@ -10602,7 +10602,7 @@ func_ov29_021765f0: ; 0x021765f0
 	add r5, sp, #2
 	mov r11, #1
 _0217661c:
-	ldrb r8, [sl, #0x15]
+	ldrb r8, [r10, #0x15]
 	add r0, r8, #2
 	cmp r8, r0
 	bge _021766a4
@@ -10634,24 +10634,24 @@ _02176668:
 	mov r3, #0x35
 	bl func_ov00_02084d24
 _02176690:
-	ldrb r0, [sl, #0x15]
+	ldrb r0, [r10, #0x15]
 	add r8, r8, #1
 	add r0, r0, #2
 	cmp r8, r0
 	blt _02176630
 _021766a4:
-	ldrb r0, [sl, #0x14]
+	ldrb r0, [r10, #0x14]
 	add r7, r7, #1
 	add r0, r0, #2
 	cmp r7, r0
 	blt _0217661c
 _021766b8:
-	ldrh r4, [sl, #0x2a]
+	ldrh r4, [r10, #0x2a]
 	ldr r1, _02176788 ; =data_027e0f6c
 	add r0, sp, #8
 	ldr r1, [r1]
 	mov r2, r4
-	ldrh r5, [sl, #0x28]
+	ldrh r5, [r10, #0x28]
 	bl func_ov00_02093a4c
 	ldr r1, _02176788 ; =data_027e0f6c
 	add r0, sp, #4
@@ -10678,7 +10678,7 @@ _021766b8:
 	str r3, [sp, #4]
 	bl func_ov00_02093a3c
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0217673c:
 	ldr r0, _02176788 ; =data_027e0f6c
 	ldr r1, [sp, #8]
@@ -10697,7 +10697,7 @@ _0217673c:
 	str r3, [sp, #4]
 	bl func_ov00_02093a3c
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov29_021765f0
 _02176784: .word data_027e0e60
@@ -13773,14 +13773,14 @@ _02179000: .word data_ov29_0217bd70
 	.global func_ov29_02179004
 	arm_func_start func_ov29_02179004
 func_ov29_02179004: ; 0x02179004
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #0x24
 	ldr r1, _021791f4 ; =data_ov29_0217bd50
 	mov r4, r0
 	ldr r0, [r1, #0xc]
 	cmp r0, #0
 	addeq sp, sp, #0x24
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	ldrsh r0, [r4, #0x56]
 	mov r1, #0x100
 	mov r0, r0, lsl #0xd
@@ -13807,7 +13807,7 @@ func_ov29_02179004: ; 0x02179004
 	str r1, [sp, #4]
 	movs r0, #0x14
 	addeq sp, sp, #0x24
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	ldr r0, [sp, #0x18]
 	str r6, [sp, #0x20]
 	mov r0, r0, asr #0x1f
@@ -13836,32 +13836,32 @@ _021790ac:
 	smull r2, r1, r0, r1
 	ldr r0, [sp, #0x20]
 	mov r3, sb, asr #0x1f
-	sub sl, r6, r0
-	mov r0, sl, asr #0x1
-	add r0, sl, r0, lsr #30
-	mov sl, r0, asr #0x2
+	sub r10, r6, r0
+	mov r0, r10, asr #0x1
+	add r0, r10, r0, lsr #30
+	mov r10, r0, asr #0x2
 	ldr r0, _02179200 ; =data_ov29_0217949c
-	ldr r0, [r0, sl, lsl #2]
-	ldr sl, [sp, #0x18]
-	umull lr, ip, sl, sb
-	mla ip, sl, r3, ip
+	ldr r0, [r0, r10, lsl #2]
+	ldr r10, [sp, #0x18]
+	umull lr, ip, r10, sb
+	mla ip, r10, r3, ip
 	ldr r3, [sp, #0x1c]
-	adds sl, lr, #0x800
+	adds r10, lr, #0x800
 	mla ip, r3, sb, ip
 	adc sb, ip, #0
-	mov r3, sl, lsr #0xc
+	mov r3, r10, lsr #0xc
 	orr r3, r3, sb, lsl #20
 	adds sb, r2, #0x800
 	adc r1, r1, #0
 	mov r2, sb, lsr #0xc
 	orr r2, r2, r1, lsl #20
 	sub r3, r3, r2
-	umull sl, sb, r7, r3
-	adds r1, sl, #0x80000000
+	umull r10, sb, r7, r3
+	adds r1, r10, #0x80000000
 	mov r2, r3, asr #0x1f
 	mla sb, r7, r2, sb
 	ldr r1, [sp, #0xc]
-	ldr sl, [sp, #0x10]
+	ldr r10, [sp, #0x10]
 	mla sb, r1, r3, sb
 	adc r1, sb, #0
 	str r1, [r4, #4]
@@ -13870,22 +13870,22 @@ _021790ac:
 	rsb ip, r1, #0
 	smull r2, r1, r3, r1
 	mov r3, ip, asr #0x1f
-	umull sb, lr, sl, ip
-	mla lr, sl, r3, lr
+	umull sb, lr, r10, ip
+	mla lr, r10, r3, lr
 	ldr r3, [sp, #0x14]
-	adds sl, sb, #0x800
+	adds r10, sb, #0x800
 	mla lr, r3, ip, lr
 	adc sb, lr, #0
-	mov r3, sl, lsr #0xc
+	mov r3, r10, lsr #0xc
 	orr r3, r3, sb, lsl #20
 	adds sb, r2, #0x800
 	adc r1, r1, #0
 	mov r2, sb, lsr #0xc
 	orr r2, r2, r1, lsl #20
 	sub r3, r3, r2
-	umull sl, sb, r8, r3
+	umull r10, sb, r8, r3
 	mov r2, r3, asr #0x1f
-	adds r1, sl, #0x80000000
+	adds r1, r10, #0x80000000
 	mla sb, r8, r2, sb
 	ldr r1, [sp, #4]
 	mla sb, r1, r3, sb
@@ -13898,7 +13898,7 @@ _021791dc:
 	cmp r6, r0
 	bne _021790ac
 	add sp, sp, #0x24
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov29_02179004
 _021791f4: .word data_ov29_0217bd50

--- a/asm/ov29.s
+++ b/asm/ov29.s
@@ -280,7 +280,7 @@ _0216d9ac: .word func_02017d30
 	.global func_ov29_0216d9b0
 	arm_func_start func_ov29_0216d9b0
 func_ov29_0216d9b0: ; 0x0216d9b0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	ldr r3, [r1, #0x2c]
 	ldr r4, [r1, #0x38]
 	mov r3, r3, lsl #0x10
@@ -336,7 +336,7 @@ func_ov29_0216d9b0: ; 0x0216d9b0
 	mov lr, r0, asr #0xc
 	ble _0216db0c
 	mov r1, #0x1f
-	mov fp, r1
+	mov r11, r1
 _0216da94:
 	ldrh r3, [r4]
 	add r2, r2, #1
@@ -359,7 +359,7 @@ _0216da94:
 	cmp r3, #0x1f
 	movgt r3, r1
 	cmp ip, #0x1f
-	movgt ip, fp
+	movgt ip, r11
 	mov r0, r0, asr #0xc
 	cmp r0, #0x1f
 	movgt r0, #0x1f
@@ -372,7 +372,7 @@ _0216db0c:
 	ldr r0, [sb, #4]
 	ldr r1, [sb, #0xc]
 	bl func_0200e2a4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov29_0216d9b0
 _0216db1c: .word 0x00000554
@@ -1764,25 +1764,25 @@ _0216ed7c: .word 0x000004cd
 	.global func_ov29_0216ed80
 	arm_func_start func_ov29_0216ed80
 func_ov29_0216ed80: ; 0x0216ed80
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x38
 	ldr r6, _0216f124 ; =data_027e0764
 	mov r7, #0
 	ldr r3, [r6]
-	ldmib r6, {r1, fp}
-	umull r5, r8, fp, r3
-	mla r8, fp, r1, r8
+	ldmib r6, {r1, r11}
+	umull r5, r8, r11, r3
+	mla r8, r11, r1, r8
 	ldr r4, [r6, #0xc]
 	ldr r2, [r6, #0x10]
 	mla r8, r4, r3, r8
 	adds sb, r2, r5
 	ldr r5, [r6, #0x14]
-	umull r3, sl, fp, sb
+	umull r3, sl, r11, sb
 	adc r8, r5, r8
-	mla sl, fp, r8, sl
+	mla sl, r11, r8, sl
 	mov r1, #0xb5
 	adds r2, r2, r3
-	umull fp, r3, r8, r1
+	umull r11, r3, r8, r1
 	mla sl, r4, sb, sl
 	str sb, [r6]
 	stmia r6, {r2, r8}
@@ -1803,7 +1803,7 @@ func_ov29_0216ed80: ; 0x0216ed80
 	ldr r1, [r1, #0x14]
 	cmp r1, #1
 	addeq sp, sp, #0x38
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r1, _0216f12c ; =data_ov29_021798e8
 	ldr r8, [r0, #0x50]
 	ldr r2, [r1]
@@ -1815,15 +1815,15 @@ func_ov29_0216ed80: ; 0x0216ed80
 	add r2, r8, r4
 	ldr r1, [r0, #0x4c]
 	ble _0216ee98
-	ldr fp, [r6]
+	ldr r11, [r6]
 	ldmib r6, {r7, r8}
-	umull sl, sb, r8, fp
+	umull sl, sb, r8, r11
 	mla sb, r8, r7, sb
 	ldr r7, [r6, #0x10]
 	ldr r8, [r6, #0x14]
 	adds sl, r7, sl
 	ldr r7, [r6, #0xc]
-	mla sb, r7, fp, sb
+	mla sb, r7, r11, sb
 	adc r7, r8, sb
 	str sl, [r6]
 	str r7, [r6, #4]
@@ -1977,7 +1977,7 @@ _0216f074:
 	mov r3, #2
 	bl func_ov00_0207c1b0
 	add sp, sp, #0x38
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0216f0c4:
 	cmp ip, #0
 	strgt r2, [sp, #0x14]
@@ -2002,7 +2002,7 @@ _0216f0c4:
 	mov r3, #2
 	bl func_ov00_0207c1b0
 	add sp, sp, #0x38
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov29_0216ed80
 _0216f124: .word data_027e0764
@@ -3127,7 +3127,7 @@ _0216ffe4: .word 0x474f3154
 	.global func_ov29_0216ffe8
 	arm_func_start func_ov29_0216ffe8
 func_ov29_0216ffe8: ; 0x0216ffe8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0xb8
 	ldr r0, _02170130 ; =data_027e0fec
 	ldr r0, [r0]
@@ -3153,9 +3153,9 @@ _02170040:
 	ldr r1, _02170138 ; =data_ov29_02179398
 	ldr r0, [sp, #4]
 	mov r8, #0
-	ldr fp, [r1, r0, lsl #2]
+	ldr r11, [r1, r0, lsl #2]
 	ldr r1, _0217013c ; =data_ov29_02179ad0
-	cmp fp, #0
+	cmp r11, #0
 	ldr sl, [r1, r0, lsl #2]
 	ldr r1, _02170140 ; =data_ov29_02179ac8
 	ldr r0, [r1, r0, lsl #2]
@@ -3198,7 +3198,7 @@ _02170070:
 	add r8, r8, #1
 	add sb, sb, #0x1000
 	add sl, sl, #0x58
-	cmp r8, fp
+	cmp r8, r11
 	blt _02170070
 _02170104:
 	ldr r0, [sp, #4]
@@ -3211,7 +3211,7 @@ _02170104:
 	add r0, sp, #0x5c
 	blx func_ov00_020a95a4
 	add sp, sp, #0xb8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov29_0216ffe8
 _02170130: .word data_027e0fec
@@ -3738,7 +3738,7 @@ _0217084c: .word 0x00000433
 	.global func_ov29_02170850
 	arm_func_start func_ov29_02170850
 func_ov29_02170850: ; 0x02170850
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	mov r4, #2
 	str r4, [r0, #0x130]
 	add r8, r0, #0x200
@@ -3788,14 +3788,14 @@ func_ov29_02170850: ; 0x02170850
 	str r2, [r0, #0x23c]
 	str r3, [r0, #0x24c]
 	ldr sl, [r5]
-	ldmib r5, {sb, fp}
-	umull r8, r2, fp, sl
-	mla r2, fp, sb, r2
+	ldmib r5, {sb, r11}
+	umull r8, r2, r11, sl
+	mla r2, r11, sb, r2
 	ldr sb, [r5, #0xc]
-	ldr fp, [r5, #0x10]
+	ldr r11, [r5, #0x10]
 	mla r2, sb, sl, r2
 	ldr sb, [r5, #0x14]
-	adds r8, fp, r8
+	adds r8, r11, r8
 	adc sl, sb, r2
 	umull sb, r2, sl, r1
 	mla r2, sl, r3, r2
@@ -3826,7 +3826,7 @@ func_ov29_02170850: ; 0x02170850
 	ldr r1, [r4, #0x24]
 	str r2, [r0, #0x158]
 	str r1, [r0, #0x15c]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov29_02170850
 _021709b4: .word data_027e0764
@@ -7393,7 +7393,7 @@ _021739d0: .word data_ov29_02179db0
 	.global func_ov29_021739d4
 	arm_func_start func_ov29_021739d4
 func_ov29_021739d4: ; 0x021739d4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x2c
 	mov r4, r0
 	ldr r0, [r4, #0x288]
@@ -7732,20 +7732,20 @@ _02173e68:
 	add r5, r7, #1
 	mov r5, r5, lsl #0x1
 	mov r8, r7, lsl #0x1
-	smull fp, r7, r1, r2
+	smull r11, r7, r1, r2
 	adc ip, sb, #0
-	adds fp, fp, #0x800
+	adds r11, r11, #0x800
 	mov sb, sl, lsr #0xc
 	ldrsh sl, [r6, r5]
 	orr sb, sb, ip, lsl #20
 	ldrsh r8, [r6, r8]
 	adc r5, r7, #0
-	mov r7, fp, lsr #0xc
+	mov r7, r11, lsr #0xc
 	orr r7, r7, r5, lsl #20
 	smull r6, r5, r7, r8
 	adds r6, r6, #0x800
 	smull lr, ip, sb, sl
-	smull r3, fp, r1, r3
+	smull r3, r11, r1, r3
 	smull r2, r1, r0, r2
 	adc r0, r5, #0
 	mov r5, r6, lsr #0xc
@@ -7757,7 +7757,7 @@ _02173e68:
 	sub r0, r5, r6
 	str r0, [r4, #0x210]
 	adds r5, r3, #0x800
-	adc r0, fp, #0
+	adc r0, r11, #0
 	adds r3, r2, #0x800
 	mov r2, r5, lsr #0xc
 	orr r2, r2, r0, lsl #20
@@ -7772,13 +7772,13 @@ _02173e68:
 	smull r6, r5, r1, r8
 	smull r3, r1, r7, sl
 	smull sl, r7, r2, sl
-	smull ip, fp, r2, r8
+	smull ip, r11, r2, r8
 	smull r8, r2, sb, r8
 	adds ip, ip, #0x800
-	adc sb, fp, #0
-	mov fp, ip, lsr #0xc
-	orr fp, fp, sb, lsl #20
-	add r0, r0, fp
+	adc sb, r11, #0
+	mov r11, ip, lsr #0xc
+	orr r11, r11, sb, lsl #20
+	add r0, r0, r11
 	str r0, [r4, #0x214]
 	adds sb, sl, #0x800
 	adc r0, r7, #0
@@ -7804,7 +7804,7 @@ _02173e68:
 	add r1, r4, #0x244
 	bl func_ov38_021854e4
 	add sp, sp, #0x2c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov29_021739d4
 _02173ffc: .word 0xfffff555
@@ -8015,7 +8015,7 @@ _021742dc: .word 0x00000e39
 	.global func_ov29_021742e0
 	arm_func_start func_ov29_021742e0
 func_ov29_021742e0: ; 0x021742e0
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x24
 	mov r4, r0
 	ldr r0, [r4, #0x288]
@@ -8217,20 +8217,20 @@ _02174578:
 	add r5, r7, #1
 	mov r5, r5, lsl #0x1
 	mov r8, r7, lsl #0x1
-	smull fp, r7, r1, r2
+	smull r11, r7, r1, r2
 	adc ip, sb, #0
-	adds fp, fp, #0x800
+	adds r11, r11, #0x800
 	mov sb, sl, lsr #0xc
 	ldrsh sl, [r6, r5]
 	orr sb, sb, ip, lsl #20
 	ldrsh r8, [r6, r8]
 	adc r5, r7, #0
-	mov r7, fp, lsr #0xc
+	mov r7, r11, lsr #0xc
 	orr r7, r7, r5, lsl #20
 	smull r6, r5, r7, r8
 	adds r6, r6, #0x800
 	smull lr, ip, sb, sl
-	smull r3, fp, r1, r3
+	smull r3, r11, r1, r3
 	smull r2, r1, r0, r2
 	adc r0, r5, #0
 	mov r5, r6, lsr #0xc
@@ -8242,7 +8242,7 @@ _02174578:
 	sub r0, r5, r6
 	str r0, [sp, #8]
 	adds r5, r3, #0x800
-	adc r0, fp, #0
+	adc r0, r11, #0
 	adds r3, r2, #0x800
 	mov r2, r5, lsr #0xc
 	orr r2, r2, r0, lsl #20
@@ -8257,13 +8257,13 @@ _02174578:
 	smull r6, r5, r1, r8
 	smull r3, r1, r7, sl
 	smull sl, r7, r2, sl
-	smull ip, fp, r2, r8
+	smull ip, r11, r2, r8
 	smull r8, r2, sb, r8
 	adds ip, ip, #0x800
-	adc sb, fp, #0
-	mov fp, ip, lsr #0xc
-	orr fp, fp, sb, lsl #20
-	add r0, r0, fp
+	adc sb, r11, #0
+	mov r11, ip, lsr #0xc
+	orr r11, r11, sb, lsl #20
+	add r0, r0, r11
 	str r0, [sp, #0xc]
 	adds sb, sl, #0x800
 	adc r0, r7, #0
@@ -8295,7 +8295,7 @@ _02174578:
 	add r1, r4, #0x244
 	bl func_ov38_021854e4
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov29_021742e0
 _0217471c: .word 0x000038e4
@@ -8463,7 +8463,7 @@ _0217494c: .word data_02050f54
 	.global func_ov29_02174950
 	arm_func_start func_ov29_02174950
 func_ov29_02174950: ; 0x02174950
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x10
 	mov r4, r0
 	add r0, r4, #0x244
@@ -8520,7 +8520,7 @@ func_ov29_02174950: ; 0x02174950
 	orr sb, sb, r8, lsl #20
 	ldrsh sl, [r5, #2]
 	ldrsh r8, [r5]
-	smull r3, fp, r1, r3
+	smull r3, r11, r1, r3
 	adc r5, r6, #0
 	mov r7, r7, lsr #0xc
 	orr r7, r7, r5, lsl #20
@@ -8538,7 +8538,7 @@ func_ov29_02174950: ; 0x02174950
 	sub r0, r5, r6
 	adds r5, r3, #0x800
 	str r0, [sp]
-	adc r0, fp, #0
+	adc r0, r11, #0
 	adds r3, r2, #0x800
 	mov r2, r5, lsr #0xc
 	orr r2, r2, r0, lsl #20
@@ -8549,17 +8549,17 @@ func_ov29_02174950: ; 0x02174950
 	adds r5, r3, #0x800
 	adc r3, r0, #0
 	mov r0, r5, lsr #0xc
-	smull ip, fp, r2, r8
+	smull ip, r11, r2, r8
 	orr r0, r0, r3, lsl #20
 	smull r6, r5, r1, r8
 	smull r3, r1, r7, sl
 	smull sl, r7, r2, sl
 	adds ip, ip, #0x800
 	smull r8, r2, sb, r8
-	adc sb, fp, #0
-	mov fp, ip, lsr #0xc
-	orr fp, fp, sb, lsl #20
-	add r0, r0, fp
+	adc sb, r11, #0
+	mov r11, ip, lsr #0xc
+	orr r11, r11, sb, lsl #20
+	add r0, r0, r11
 	adds sb, sl, #0x800
 	str r0, [sp, #4]
 	adc r0, r7, #0
@@ -8604,7 +8604,7 @@ _02174b2c:
 	ldr r5, _02174cc4 ; =data_02054e54
 	smull r7, r6, r1, r2
 	adc r8, r8, #0
-	mov fp, sb, lsr #0xc
+	mov r11, sb, lsr #0xc
 	adds r7, r7, #0x800
 	ldrsh sl, [r5, #0x1c]
 	ldrsh ip, [r5, #0x1e]
@@ -8613,11 +8613,11 @@ _02174b2c:
 	mov sb, r7, lsr #0xc
 	orr sb, sb, r5, lsl #20
 	smull r5, r7, sb, sl
-	orr fp, fp, r8, lsl #20
+	orr r11, r11, r8, lsl #20
 	adds r8, r5, #0x800
 	smull r2, r1, r0, r2
 	adc r0, r7, #0
-	smull r6, r5, fp, ip
+	smull r6, r5, r11, ip
 	mov r7, r8, lsr #0xc
 	adds r6, r6, #0x800
 	orr r7, r7, r0, lsl #20
@@ -8643,12 +8643,12 @@ _02174b2c:
 	smull r3, r1, sb, ip
 	smull r8, r7, r2, ip
 	smull ip, sb, r2, sl
-	smull sl, r2, fp, sl
-	adds fp, ip, #0x800
+	smull sl, r2, r11, sl
+	adds r11, ip, #0x800
 	adc sb, sb, #0
-	mov fp, fp, lsr #0xc
-	orr fp, fp, sb, lsl #20
-	add r0, r0, fp
+	mov r11, r11, lsr #0xc
+	orr r11, r11, sb, lsl #20
+	add r0, r0, r11
 	adds r8, r8, #0x800
 	str r0, [sp, #4]
 	adc r0, r7, #0
@@ -8681,7 +8681,7 @@ _02174c88:
 	add r1, r4, #0x244
 	bl func_ov38_021854e4
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov29_02174950
 _02174cb4: .word data_02050f54
@@ -9249,7 +9249,7 @@ _021753a8: .word data_ov29_02179f4c
 	.global func_ov29_021753ac
 	arm_func_start func_ov29_021753ac
 func_ov29_021753ac: ; 0x021753ac
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x68
 	ldr r3, _0217558c ; =data_027e0d0c
 	mov r4, r0
@@ -9307,9 +9307,9 @@ func_ov29_021753ac: ; 0x021753ac
 	add r1, r4, #0x200
 	ldr r2, [r2, #0x24]
 	blx r2
-	mov fp, #0
-	str fp, [r4, #0x26c]
-	str fp, [r4, #0x270]
+	mov r11, #0
+	str r11, [r4, #0x26c]
+	str r11, [r4, #0x270]
 	mov r0, #0x1000
 	str r0, [r4, #0x274]
 	ldr r2, _0217559c ; =data_027e0764
@@ -9328,8 +9328,8 @@ func_ov29_021753ac: ; 0x021753ac
 	ldr r0, _021755a4 ; =0x0000071d
 	stmia r2, {r3, r5}
 	umull r2, r3, r5, r0
-	mla r3, r5, fp, r3
-	mov r2, fp
+	mla r3, r5, r11, r3
+	mov r2, r11
 	mla r3, r2, r0, r3
 	ldr r0, _021755a8 ; =0xfffffc72
 	add r1, r4, #0x200
@@ -9368,7 +9368,7 @@ func_ov29_021753ac: ; 0x021753ac
 	bl func_ov29_02175724
 	mov r0, #1
 	add sp, sp, #0x68
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov29_021753ac
 _0217558c: .word data_027e0d0c
@@ -10590,7 +10590,7 @@ _021765ec: .word data_027e0fe4
 	.global func_ov29_021765f0
 	arm_func_start func_ov29_021765f0
 func_ov29_021765f0: ; 0x021765f0
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0xc
 	mov sl, r0
 	ldrb r7, [sl, #0x14]
@@ -10600,7 +10600,7 @@ func_ov29_021765f0: ; 0x021765f0
 	bge _021766b8
 	ldr r4, _02176784 ; =data_027e0e60
 	add r5, sp, #2
-	mov fp, #1
+	mov r11, #1
 _0217661c:
 	ldrb r8, [sl, #0x15]
 	add r0, r8, #2
@@ -10612,7 +10612,7 @@ _02176630:
 	ldr r0, [r4]
 	beq _02176668
 	mov r1, r5
-	mov r2, fp
+	mov r2, r11
 	strb r6, [sp, #2]
 	strb r8, [sp, #3]
 	bl func_ov00_02082680
@@ -10678,7 +10678,7 @@ _021766b8:
 	str r3, [sp, #4]
 	bl func_ov00_02093a3c
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0217673c:
 	ldr r0, _02176788 ; =data_027e0f6c
 	ldr r1, [sp, #8]
@@ -10697,7 +10697,7 @@ _0217673c:
 	str r3, [sp, #4]
 	bl func_ov00_02093a3c
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov29_021765f0
 _02176784: .word data_027e0e60

--- a/asm/ov29.s
+++ b/asm/ov29.s
@@ -280,39 +280,39 @@ _0216d9ac: .word func_02017d30
 	.global func_ov29_0216d9b0
 	arm_func_start func_ov29_0216d9b0
 func_ov29_0216d9b0: ; 0x0216d9b0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	ldr r3, [r1, #0x2c]
 	ldr r4, [r1, #0x38]
 	mov r3, r3, lsl #0x10
-	mov sb, r0
+	mov r9, r0
 	mov r0, r3, lsr #0xd
-	str r0, [sb, #8]
+	str r0, [r9, #8]
 	ldrh r0, [r1, #0x30]
 	mov r5, r2
 	add r4, r1, r4
 	mov r0, r0, lsl #0x3
 	mov r1, r5
-	str r0, [sb, #0xc]
+	str r0, [r9, #0xc]
 	mov r2, #4
 	bl func_0202e9f4
-	str r0, [sb]
-	ldr r0, [sb, #0xc]
+	str r0, [r9]
+	ldr r0, [r9, #0xc]
 	mov r1, r5
 	mov r2, #4
 	bl func_0202e9f4
-	str r0, [sb, #4]
-	ldr r1, [sb]
-	ldr r2, [sb, #0xc]
+	str r0, [r9, #4]
+	ldr r1, [r9]
+	ldr r2, [r9, #0xc]
 	mov r0, r4
 	bl func_02007984
-	ldr r0, [sb]
-	ldr r1, [sb, #0xc]
+	ldr r0, [r9]
+	ldr r1, [r9, #0xc]
 	bl func_0200e2a4
-	ldr r1, [sb, #0xc]
+	ldr r1, [r9, #0xc]
 	mov r0, #0x1f000
 	mov r6, r1, lsr #0x1
 	mov r1, #0x22000
-	ldr r5, [sb, #4]
+	ldr r5, [r9, #4]
 	bl Divide
 	ldr r2, _0216db1c ; =0x00000554
 	mov r1, #0x22000
@@ -369,10 +369,10 @@ _0216da94:
 	strh r0, [r5], #2
 	blt _0216da94
 _0216db0c:
-	ldr r0, [sb, #4]
-	ldr r1, [sb, #0xc]
+	ldr r0, [r9, #4]
+	ldr r1, [r9, #0xc]
 	bl func_0200e2a4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov29_0216d9b0
 _0216db1c: .word 0x00000554
@@ -1764,7 +1764,7 @@ _0216ed7c: .word 0x000004cd
 	.global func_ov29_0216ed80
 	arm_func_start func_ov29_0216ed80
 func_ov29_0216ed80: ; 0x0216ed80
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x38
 	ldr r6, _0216f124 ; =data_027e0764
 	mov r7, #0
@@ -1775,16 +1775,16 @@ func_ov29_0216ed80: ; 0x0216ed80
 	ldr r4, [r6, #0xc]
 	ldr r2, [r6, #0x10]
 	mla r8, r4, r3, r8
-	adds sb, r2, r5
+	adds r9, r2, r5
 	ldr r5, [r6, #0x14]
-	umull r3, r10, r11, sb
+	umull r3, r10, r11, r9
 	adc r8, r5, r8
 	mla r10, r11, r8, r10
 	mov r1, #0xb5
 	adds r2, r2, r3
 	umull r11, r3, r8, r1
-	mla r10, r4, sb, r10
-	str sb, [r6]
+	mla r10, r4, r9, r10
+	str r9, [r6]
 	stmia r6, {r2, r8}
 	adc r10, r5, r10
 	umull r4, r5, r10, r1
@@ -1803,7 +1803,7 @@ func_ov29_0216ed80: ; 0x0216ed80
 	ldr r1, [r1, #0x14]
 	cmp r1, #1
 	addeq sp, sp, #0x38
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r1, _0216f12c ; =data_ov29_021798e8
 	ldr r8, [r0, #0x50]
 	ldr r2, [r1]
@@ -1817,14 +1817,14 @@ func_ov29_0216ed80: ; 0x0216ed80
 	ble _0216ee98
 	ldr r11, [r6]
 	ldmib r6, {r7, r8}
-	umull r10, sb, r8, r11
-	mla sb, r8, r7, sb
+	umull r10, r9, r8, r11
+	mla r9, r8, r7, r9
 	ldr r7, [r6, #0x10]
 	ldr r8, [r6, #0x14]
 	adds r10, r7, r10
 	ldr r7, [r6, #0xc]
-	mla sb, r7, r11, sb
-	adc r7, r8, sb
+	mla r9, r7, r11, r9
+	adc r7, r8, r9
 	str r10, [r6]
 	str r7, [r6, #4]
 	cmp lr, #0
@@ -1848,16 +1848,16 @@ _0216ee98:
 	movle r1, #0
 	ble _0216ef18
 	ldr r8, _0216f124 ; =data_027e0764
-	ldr sb, [r8]
+	ldr r9, [r8]
 	ldmib r8, {r4, r10}
-	umull r2, r1, r10, sb
+	umull r2, r1, r10, r9
 	mla r1, r10, r4, r1
 	ldr r10, [r8, #0xc]
 	ldr r4, [r8, #0x10]
-	mla r1, r10, sb, r1
-	ldr sb, [r8, #0x14]
+	mla r1, r10, r9, r1
+	ldr r9, [r8, #0x14]
 	adds r2, r4, r2
-	adc r1, sb, r1
+	adc r1, r9, r1
 	str r2, [r8]
 	str r1, [r8, #4]
 	cmp lr, #0
@@ -1885,13 +1885,13 @@ _0216ef18:
 	ldr r2, _0216f124 ; =data_027e0764
 	ldr r6, [r2]
 	ldmib r2, {r5, r7}
-	umull sb, r8, r7, r6
+	umull r9, r8, r7, r6
 	mla r8, r7, r5, r8
 	ldr r5, [r2, #0xc]
 	ldr r7, [r2, #0x10]
 	mla r8, r5, r6, r8
 	ldr r5, [r2, #0x14]
-	adds r6, r7, sb
+	adds r6, r7, r9
 	adc r5, r5, r8
 	str r6, [r2]
 	str r5, [r2, #4]
@@ -1920,14 +1920,14 @@ _0216efa0:
 	ldr r6, _0216f124 ; =data_027e0764
 	ldr r7, [r6]
 	ldmib r6, {r5, r8}
-	umull r10, sb, r8, r7
-	mla sb, r8, r5, sb
+	umull r10, r9, r8, r7
+	mla r9, r8, r5, r9
 	ldr r5, [r6, #0xc]
 	ldr r8, [r6, #0x10]
-	mla sb, r5, r7, sb
+	mla r9, r5, r7, r9
 	ldr r5, [r6, #0x14]
 	adds r7, r8, r10
-	adc r5, r5, sb
+	adc r5, r5, r9
 	str r7, [r6]
 	str r5, [r6, #4]
 	cmp r4, #0
@@ -1977,7 +1977,7 @@ _0216f074:
 	mov r3, #2
 	bl func_ov00_0207c1b0
 	add sp, sp, #0x38
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0216f0c4:
 	cmp ip, #0
 	strgt r2, [sp, #0x14]
@@ -2002,7 +2002,7 @@ _0216f0c4:
 	mov r3, #2
 	bl func_ov00_0207c1b0
 	add sp, sp, #0x38
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov29_0216ed80
 _0216f124: .word data_027e0764
@@ -2990,7 +2990,7 @@ func_ov29_0216fe04: ; 0x0216fe04
 	.global func_ov29_0216fe28
 	arm_func_start func_ov29_0216fe28
 func_ov29_0216fe28: ; 0x0216fe28
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x38
 	mov r5, r0
 	ldr r1, [r5, #0x50]
@@ -2999,7 +2999,7 @@ func_ov29_0216fe28: ; 0x0216fe28
 	sub r4, r1, #0xd000
 	sub ip, r0, #0x2000
 	add r7, r0, #0x2000
-	sub sb, r1, #0xc000
+	sub r9, r1, #0xc000
 	add r8, lr, #0x2000
 	mov r0, #0
 	bic r1, r0, #0x1f
@@ -3013,7 +3013,7 @@ func_ov29_0216fe28: ; 0x0216fe28
 	str r4, [sp, #0x10]
 	str r7, [sp, #0x14]
 	str r8, [sp, #0x18]
-	str sb, [sp, #0x1c]
+	str r9, [sp, #0x1c]
 	str r0, [sp]
 	add r0, r5, #0x344
 	ldr r6, [r0]
@@ -3026,7 +3026,7 @@ func_ov29_0216fe28: ; 0x0216fe28
 	str r4, [sp, #0x34]
 	str r7, [sp, #0x20]
 	str r8, [sp, #0x24]
-	str sb, [sp, #0x28]
+	str r9, [sp, #0x28]
 	blx r6
 	ldr r3, [r5, #0x50]
 	ldr r2, [r5, #0x4c]
@@ -3066,7 +3066,7 @@ func_ov29_0216fe28: ; 0x0216fe28
 	ldr r0, [r0]
 	bl func_ov00_02093a5c
 	add sp, sp, #0x38
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov29_0216fe28
 _0216ff5c: .word data_027e0f6c
@@ -3127,7 +3127,7 @@ _0216ffe4: .word 0x474f3154
 	.global func_ov29_0216ffe8
 	arm_func_start func_ov29_0216ffe8
 func_ov29_0216ffe8: ; 0x0216ffe8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0xb8
 	ldr r0, _02170130 ; =data_027e0fec
 	ldr r0, [r0]
@@ -3161,7 +3161,7 @@ _02170040:
 	ldr r0, [r1, r0, lsl #2]
 	str r0, [sp]
 	ble _02170104
-	mov sb, r8
+	mov r9, r8
 _02170070:
 	ldr r0, _02170130 ; =data_027e0fec
 	mov r2, #0x10
@@ -3184,7 +3184,7 @@ _02170070:
 	bl func_ov00_020c0cc8
 	mov r0, r6
 	bl func_ov00_020c0d4c
-	str sb, [r0]
+	str r9, [r0]
 	mov r0, r5
 	bl func_ov00_020a9864
 	mov r0, r5
@@ -3196,7 +3196,7 @@ _02170070:
 	mov r0, r5
 	bl func_ov00_020a9968
 	add r8, r8, #1
-	add sb, sb, #0x1000
+	add r9, r9, #0x1000
 	add r10, r10, #0x58
 	cmp r8, r11
 	blt _02170070
@@ -3211,7 +3211,7 @@ _02170104:
 	add r0, sp, #0x5c
 	blx func_ov00_020a95a4
 	add sp, sp, #0xb8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov29_0216ffe8
 _02170130: .word data_027e0fec
@@ -3395,7 +3395,7 @@ _02170368: .word data_ov29_021793a0
 	.global func_ov29_0217036c
 	arm_func_start func_ov29_0217036c
 func_ov29_0217036c: ; 0x0217036c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	mov r3, #0
 	str r3, [r0, #0x130]
 	ldr r2, [r1]
@@ -3419,19 +3419,19 @@ func_ov29_0217036c: ; 0x0217036c
 	str r3, [r0, #0x24c]
 	ldr r2, [r6]
 	ldmib r6, {r1, r7}
-	umull r10, sb, r7, r2
-	mla sb, r7, r1, sb
+	umull r10, r9, r7, r2
+	mla r9, r7, r1, r9
 	ldr r1, [r6, #0xc]
 	ldr r7, [r6, #0x10]
-	mla sb, r1, r2, sb
+	mla r9, r1, r2, r9
 	ldr r1, [r6, #0x14]
 	adds r2, r7, r10
-	adc sb, r1, sb
-	umull r7, r1, sb, ip
-	mla r1, sb, r3, r1
+	adc r9, r1, r9
+	umull r7, r1, r9, ip
+	mla r1, r9, r3, r1
 	mla r1, r8, ip, r1
 	umull r7, ip, r1, lr
-	stmia r6, {r2, sb}
+	stmia r6, {r2, r9}
 	adds r6, r7, #0x800
 	mla ip, r1, r3, ip
 	mov r8, r1, asr #0x1f
@@ -3454,7 +3454,7 @@ func_ov29_0217036c: ; 0x0217036c
 	ldr r1, [r5, #0x14]
 	str r2, [r0, #0x158]
 	str r1, [r0, #0x15c]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov29_0217036c
 _0217045c: .word data_027e0764
@@ -3738,7 +3738,7 @@ _0217084c: .word 0x00000433
 	.global func_ov29_02170850
 	arm_func_start func_ov29_02170850
 func_ov29_02170850: ; 0x02170850
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	mov r4, #2
 	str r4, [r0, #0x130]
 	add r8, r0, #0x200
@@ -3768,12 +3768,12 @@ func_ov29_02170850: ; 0x02170850
 	add r4, r4, #0x800
 	mov r4, r4, asr #0xc
 	str r4, [r0, #0x230]
-	ldrsh sb, [r2]
+	ldrsh r9, [r2]
 	mov r6, #0x78
 	ldr r4, _021709bc ; =data_ov29_02179ac8
-	strh sb, [r8, #0x18]
-	ldrsh sb, [r2, #2]
-	strh sb, [r8, #0x1a]
+	strh r9, [r8, #0x18]
+	ldrsh r9, [r2, #2]
+	strh r9, [r8, #0x1a]
 	ldr r8, [r2, #4]
 	str r8, [r0, #0x21c]
 	ldr r8, [r2, #8]
@@ -3788,16 +3788,16 @@ func_ov29_02170850: ; 0x02170850
 	str r2, [r0, #0x23c]
 	str r3, [r0, #0x24c]
 	ldr r10, [r5]
-	ldmib r5, {sb, r11}
+	ldmib r5, {r9, r11}
 	umull r8, r2, r11, r10
-	mla r2, r11, sb, r2
-	ldr sb, [r5, #0xc]
+	mla r2, r11, r9, r2
+	ldr r9, [r5, #0xc]
 	ldr r11, [r5, #0x10]
-	mla r2, sb, r10, r2
-	ldr sb, [r5, #0x14]
+	mla r2, r9, r10, r2
+	ldr r9, [r5, #0x14]
 	adds r8, r11, r8
-	adc r10, sb, r2
-	umull sb, r2, r10, r1
+	adc r10, r9, r2
+	umull r9, r2, r10, r1
 	mla r2, r10, r3, r2
 	mla r2, r7, r1, r2
 	stmia r5, {r8, r10}
@@ -3826,7 +3826,7 @@ func_ov29_02170850: ; 0x02170850
 	ldr r1, [r4, #0x24]
 	str r2, [r0, #0x158]
 	str r1, [r0, #0x15c]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov29_02170850
 _021709b4: .word data_027e0764
@@ -6632,7 +6632,7 @@ func_ov29_02172f0c: ; 0x02172f0c
 	.global func_ov29_02172f10
 	arm_func_start func_ov29_02172f10
 func_ov29_02172f10: ; 0x02172f10
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	mov r4, r0
 	ldr r0, [r4, #0x160]
 	mov r5, r1
@@ -6677,35 +6677,35 @@ _02172f4c:
 	mov r7, #0
 	adc lr, r3, r6
 	mov r6, #0x64
-	umull r0, sb, lr, r6
-	mla sb, lr, r7, sb
+	umull r0, r9, lr, r6
+	mla r9, lr, r7, r9
 	mov r0, r7
-	mla sb, r0, r6, sb
-	cmp sb, #0x32
-	umull sb, r6, r2, r5
+	mla r9, r0, r6, r9
+	cmp r9, #0x32
+	umull r9, r6, r2, r5
 	mla r6, r2, lr, r6
 	stmia r8, {r5, lr}
 	ble _0217300c
 	mla r6, r1, r5, r6
-	adds sb, ip, sb
+	adds r9, ip, r9
 	adc r5, r3, r6
 	mov r1, #0xb
 	umull r2, r3, r5, r1
 	mla r3, r5, r7, r3
 	mla r3, r0, r1, r3
-	str sb, [r8]
+	str r9, [r8]
 	str r5, [r8, #4]
 	add r0, r3, #0xa
 	b _02173034
 _0217300c:
 	mla r6, r1, r5, r6
-	adds sb, ip, sb
+	adds r9, ip, r9
 	adc r5, r3, r6
 	mov r1, #0xb
 	umull r2, r3, r5, r1
 	mla r3, r5, r7, r3
 	mla r3, r0, r1, r3
-	str sb, [r8]
+	str r9, [r8]
 	str r5, [r8, #4]
 	add r0, r3, #0x1e
 _02173034:
@@ -6729,7 +6729,7 @@ _02173034:
 	ldr r0, [r0, #4]
 	str r1, [r4, #0x160]
 	str r0, [r4, #0x164]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov29_02172f10
 _02173088: .word data_027e0764
@@ -7393,7 +7393,7 @@ _021739d0: .word data_ov29_02179db0
 	.global func_ov29_021739d4
 	arm_func_start func_ov29_021739d4
 func_ov29_021739d4: ; 0x021739d4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x2c
 	mov r4, r0
 	ldr r0, [r4, #0x288]
@@ -7723,7 +7723,7 @@ _02173e68:
 	ldrsh r2, [r6, r1]
 	ldrsh r1, [r6, #2]
 	add r5, r5, r5, lsr #31
-	smull r7, sb, r0, r3
+	smull r7, r9, r0, r3
 	adds r10, r7, #0x800
 	mov r5, r5, lsl #0xf
 	mov r5, r5, lsr #0x10
@@ -7733,18 +7733,18 @@ _02173e68:
 	mov r5, r5, lsl #0x1
 	mov r8, r7, lsl #0x1
 	smull r11, r7, r1, r2
-	adc ip, sb, #0
+	adc ip, r9, #0
 	adds r11, r11, #0x800
-	mov sb, r10, lsr #0xc
+	mov r9, r10, lsr #0xc
 	ldrsh r10, [r6, r5]
-	orr sb, sb, ip, lsl #20
+	orr r9, r9, ip, lsl #20
 	ldrsh r8, [r6, r8]
 	adc r5, r7, #0
 	mov r7, r11, lsr #0xc
 	orr r7, r7, r5, lsl #20
 	smull r6, r5, r7, r8
 	adds r6, r6, #0x800
-	smull lr, ip, sb, r10
+	smull lr, ip, r9, r10
 	smull r3, r11, r1, r3
 	smull r2, r1, r0, r2
 	adc r0, r5, #0
@@ -7773,16 +7773,16 @@ _02173e68:
 	smull r3, r1, r7, r10
 	smull r10, r7, r2, r10
 	smull ip, r11, r2, r8
-	smull r8, r2, sb, r8
+	smull r8, r2, r9, r8
 	adds ip, ip, #0x800
-	adc sb, r11, #0
+	adc r9, r11, #0
 	mov r11, ip, lsr #0xc
-	orr r11, r11, sb, lsl #20
+	orr r11, r11, r9, lsl #20
 	add r0, r0, r11
 	str r0, [r4, #0x214]
-	adds sb, r10, #0x800
+	adds r9, r10, #0x800
 	adc r0, r7, #0
-	mov r7, sb, lsr #0xc
+	mov r7, r9, lsr #0xc
 	orr r7, r7, r0, lsl #20
 	adds r6, r6, #0x800
 	adc r0, r5, #0
@@ -7804,7 +7804,7 @@ _02173e68:
 	add r1, r4, #0x244
 	bl func_ov38_021854e4
 	add sp, sp, #0x2c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov29_021739d4
 _02173ffc: .word 0xfffff555
@@ -8015,7 +8015,7 @@ _021742dc: .word 0x00000e39
 	.global func_ov29_021742e0
 	arm_func_start func_ov29_021742e0
 func_ov29_021742e0: ; 0x021742e0
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x24
 	mov r4, r0
 	ldr r0, [r4, #0x288]
@@ -8208,7 +8208,7 @@ _02174578:
 	ldrsh r2, [r6, r1]
 	ldrsh r1, [r6, #2]
 	add r5, r5, r5, lsr #31
-	smull r7, sb, r0, r3
+	smull r7, r9, r0, r3
 	adds r10, r7, #0x800
 	mov r5, r5, lsl #0xf
 	mov r5, r5, lsr #0x10
@@ -8218,18 +8218,18 @@ _02174578:
 	mov r5, r5, lsl #0x1
 	mov r8, r7, lsl #0x1
 	smull r11, r7, r1, r2
-	adc ip, sb, #0
+	adc ip, r9, #0
 	adds r11, r11, #0x800
-	mov sb, r10, lsr #0xc
+	mov r9, r10, lsr #0xc
 	ldrsh r10, [r6, r5]
-	orr sb, sb, ip, lsl #20
+	orr r9, r9, ip, lsl #20
 	ldrsh r8, [r6, r8]
 	adc r5, r7, #0
 	mov r7, r11, lsr #0xc
 	orr r7, r7, r5, lsl #20
 	smull r6, r5, r7, r8
 	adds r6, r6, #0x800
-	smull lr, ip, sb, r10
+	smull lr, ip, r9, r10
 	smull r3, r11, r1, r3
 	smull r2, r1, r0, r2
 	adc r0, r5, #0
@@ -8258,16 +8258,16 @@ _02174578:
 	smull r3, r1, r7, r10
 	smull r10, r7, r2, r10
 	smull ip, r11, r2, r8
-	smull r8, r2, sb, r8
+	smull r8, r2, r9, r8
 	adds ip, ip, #0x800
-	adc sb, r11, #0
+	adc r9, r11, #0
 	mov r11, ip, lsr #0xc
-	orr r11, r11, sb, lsl #20
+	orr r11, r11, r9, lsl #20
 	add r0, r0, r11
 	str r0, [sp, #0xc]
-	adds sb, r10, #0x800
+	adds r9, r10, #0x800
 	adc r0, r7, #0
-	mov r7, sb, lsr #0xc
+	mov r7, r9, lsr #0xc
 	orr r7, r7, r0, lsl #20
 	adds r6, r6, #0x800
 	adc r0, r5, #0
@@ -8295,7 +8295,7 @@ _02174578:
 	add r1, r4, #0x244
 	bl func_ov38_021854e4
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov29_021742e0
 _0217471c: .word 0x000038e4
@@ -8463,7 +8463,7 @@ _0217494c: .word data_02050f54
 	.global func_ov29_02174950
 	arm_func_start func_ov29_02174950
 func_ov29_02174950: ; 0x02174950
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x10
 	mov r4, r0
 	add r0, r4, #0x244
@@ -8511,13 +8511,13 @@ func_ov29_02174950: ; 0x02174950
 	ldrsh r2, [r6, #2]
 	ldrsh r1, [r6, r1]
 	smull r6, r8, r0, r3
-	adds sb, r6, #0x800
+	adds r9, r6, #0x800
 	ldr r5, _02174cbc ; =data_02054b54
 	smull r7, r6, r1, r2
 	adc r8, r8, #0
-	mov sb, sb, lsr #0xc
+	mov r9, r9, lsr #0xc
 	adds r7, r7, #0x800
-	orr sb, sb, r8, lsl #20
+	orr r9, r9, r8, lsl #20
 	ldrsh r10, [r5, #2]
 	ldrsh r8, [r5]
 	smull r3, r11, r1, r3
@@ -8525,7 +8525,7 @@ func_ov29_02174950: ; 0x02174950
 	mov r7, r7, lsr #0xc
 	orr r7, r7, r5, lsl #20
 	smull r6, r5, r7, r8
-	smull lr, ip, sb, r10
+	smull lr, ip, r9, r10
 	smull r2, r1, r0, r2
 	adds r6, r6, #0x800
 	adc r0, r5, #0
@@ -8555,15 +8555,15 @@ func_ov29_02174950: ; 0x02174950
 	smull r3, r1, r7, r10
 	smull r10, r7, r2, r10
 	adds ip, ip, #0x800
-	smull r8, r2, sb, r8
-	adc sb, r11, #0
+	smull r8, r2, r9, r8
+	adc r9, r11, #0
 	mov r11, ip, lsr #0xc
-	orr r11, r11, sb, lsl #20
+	orr r11, r11, r9, lsl #20
 	add r0, r0, r11
-	adds sb, r10, #0x800
+	adds r9, r10, #0x800
 	str r0, [sp, #4]
 	adc r0, r7, #0
-	mov r7, sb, lsr #0xc
+	mov r7, r9, lsr #0xc
 	adds r6, r6, #0x800
 	orr r7, r7, r0, lsl #20
 	adc r0, r5, #0
@@ -8600,19 +8600,19 @@ _02174b2c:
 	ldrsh r2, [r6, #2]
 	ldrsh r1, [r6, r1]
 	smull r6, r8, r0, r3
-	adds sb, r6, #0x800
+	adds r9, r6, #0x800
 	ldr r5, _02174cc4 ; =data_02054e54
 	smull r7, r6, r1, r2
 	adc r8, r8, #0
-	mov r11, sb, lsr #0xc
+	mov r11, r9, lsr #0xc
 	adds r7, r7, #0x800
 	ldrsh r10, [r5, #0x1c]
 	ldrsh ip, [r5, #0x1e]
 	smull r3, lr, r1, r3
 	adc r5, r6, #0
-	mov sb, r7, lsr #0xc
-	orr sb, sb, r5, lsl #20
-	smull r5, r7, sb, r10
+	mov r9, r7, lsr #0xc
+	orr r9, r9, r5, lsl #20
+	smull r5, r7, r9, r10
 	orr r11, r11, r8, lsl #20
 	adds r8, r5, #0x800
 	smull r2, r1, r0, r2
@@ -8640,14 +8640,14 @@ _02174b2c:
 	mov r0, r5, lsr #0xc
 	orr r0, r0, r3, lsl #20
 	smull r6, r5, r1, r10
-	smull r3, r1, sb, ip
+	smull r3, r1, r9, ip
 	smull r8, r7, r2, ip
-	smull ip, sb, r2, r10
+	smull ip, r9, r2, r10
 	smull r10, r2, r11, r10
 	adds r11, ip, #0x800
-	adc sb, sb, #0
+	adc r9, r9, #0
 	mov r11, r11, lsr #0xc
-	orr r11, r11, sb, lsl #20
+	orr r11, r11, r9, lsl #20
 	add r0, r0, r11
 	adds r8, r8, #0x800
 	str r0, [sp, #4]
@@ -8681,7 +8681,7 @@ _02174c88:
 	add r1, r4, #0x244
 	bl func_ov38_021854e4
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov29_02174950
 _02174cb4: .word data_02050f54
@@ -9249,7 +9249,7 @@ _021753a8: .word data_ov29_02179f4c
 	.global func_ov29_021753ac
 	arm_func_start func_ov29_021753ac
 func_ov29_021753ac: ; 0x021753ac
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x68
 	ldr r3, _0217558c ; =data_027e0d0c
 	mov r4, r0
@@ -9319,11 +9319,11 @@ func_ov29_021753ac: ; 0x021753ac
 	umull r7, r6, r5, ip
 	mla r6, r5, r3, r6
 	ldr r0, [r0]
-	ldr sb, [r2, #0x10]
+	ldr r9, [r2, #0x10]
 	ldrsh r10, [r0, #0x78]
 	mla r6, lr, ip, r6
 	ldr r8, [r2, #0x14]
-	adds r3, sb, r7
+	adds r3, r9, r7
 	adc r5, r8, r6
 	ldr r0, _021755a4 ; =0x0000071d
 	stmia r2, {r3, r5}
@@ -9368,7 +9368,7 @@ func_ov29_021753ac: ; 0x021753ac
 	bl func_ov29_02175724
 	mov r0, #1
 	add sp, sp, #0x68
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov29_021753ac
 _0217558c: .word data_027e0d0c
@@ -10590,11 +10590,11 @@ _021765ec: .word data_027e0fe4
 	.global func_ov29_021765f0
 	arm_func_start func_ov29_021765f0
 func_ov29_021765f0: ; 0x021765f0
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0xc
 	mov r10, r0
 	ldrb r7, [r10, #0x14]
-	mov sb, r1
+	mov r9, r1
 	add r0, r7, #2
 	cmp r7, r0
 	bge _021766b8
@@ -10608,7 +10608,7 @@ _0217661c:
 	bge _021766a4
 	and r6, r7, #0xff
 _02176630:
-	cmp sb, #0
+	cmp r9, #0
 	ldr r0, [r4]
 	beq _02176668
 	mov r1, r5
@@ -10658,7 +10658,7 @@ _021766b8:
 	ldr r1, [r1]
 	mov r2, r5
 	bl func_ov00_02093a4c
-	cmp sb, #0
+	cmp r9, #0
 	add r2, sp, #8
 	beq _0217673c
 	ldr r1, [sp, #8]
@@ -10678,7 +10678,7 @@ _021766b8:
 	str r3, [sp, #4]
 	bl func_ov00_02093a3c
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0217673c:
 	ldr r0, _02176788 ; =data_027e0f6c
 	ldr r1, [sp, #8]
@@ -10697,7 +10697,7 @@ _0217673c:
 	str r3, [sp, #4]
 	bl func_ov00_02093a3c
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov29_021765f0
 _02176784: .word data_027e0e60
@@ -13773,14 +13773,14 @@ _02179000: .word data_ov29_0217bd70
 	.global func_ov29_02179004
 	arm_func_start func_ov29_02179004
 func_ov29_02179004: ; 0x02179004
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #0x24
 	ldr r1, _021791f4 ; =data_ov29_0217bd50
 	mov r4, r0
 	ldr r0, [r1, #0xc]
 	cmp r0, #0
 	addeq sp, sp, #0x24
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	ldrsh r0, [r4, #0x56]
 	mov r1, #0x100
 	mov r0, r0, lsl #0xd
@@ -13807,7 +13807,7 @@ func_ov29_02179004: ; 0x02179004
 	str r1, [sp, #4]
 	movs r0, #0x14
 	addeq sp, sp, #0x24
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	ldr r0, [sp, #0x18]
 	str r6, [sp, #0x20]
 	mov r0, r0, asr #0x1f
@@ -13832,10 +13832,10 @@ _021790ac:
 	bl func_01ff9bc4
 	ldr r1, [r4, #0xc]
 	ldr r0, [r5, #0xac]
-	rsb sb, r1, #0
+	rsb r9, r1, #0
 	smull r2, r1, r0, r1
 	ldr r0, [sp, #0x20]
-	mov r3, sb, asr #0x1f
+	mov r3, r9, asr #0x1f
 	sub r10, r6, r0
 	mov r0, r10, asr #0x1
 	add r0, r10, r0, lsr #30
@@ -13843,53 +13843,53 @@ _021790ac:
 	ldr r0, _02179200 ; =data_ov29_0217949c
 	ldr r0, [r0, r10, lsl #2]
 	ldr r10, [sp, #0x18]
-	umull lr, ip, r10, sb
+	umull lr, ip, r10, r9
 	mla ip, r10, r3, ip
 	ldr r3, [sp, #0x1c]
 	adds r10, lr, #0x800
-	mla ip, r3, sb, ip
-	adc sb, ip, #0
+	mla ip, r3, r9, ip
+	adc r9, ip, #0
 	mov r3, r10, lsr #0xc
-	orr r3, r3, sb, lsl #20
-	adds sb, r2, #0x800
+	orr r3, r3, r9, lsl #20
+	adds r9, r2, #0x800
 	adc r1, r1, #0
-	mov r2, sb, lsr #0xc
+	mov r2, r9, lsr #0xc
 	orr r2, r2, r1, lsl #20
 	sub r3, r3, r2
-	umull r10, sb, r7, r3
+	umull r10, r9, r7, r3
 	adds r1, r10, #0x80000000
 	mov r2, r3, asr #0x1f
-	mla sb, r7, r2, sb
+	mla r9, r7, r2, r9
 	ldr r1, [sp, #0xc]
 	ldr r10, [sp, #0x10]
-	mla sb, r1, r3, sb
-	adc r1, sb, #0
+	mla r9, r1, r3, r9
+	adc r1, r9, #0
 	str r1, [r4, #4]
 	ldr r1, [r4, #0xc]
 	ldr r3, [r5, #0xb0]
 	rsb ip, r1, #0
 	smull r2, r1, r3, r1
 	mov r3, ip, asr #0x1f
-	umull sb, lr, r10, ip
+	umull r9, lr, r10, ip
 	mla lr, r10, r3, lr
 	ldr r3, [sp, #0x14]
-	adds r10, sb, #0x800
+	adds r10, r9, #0x800
 	mla lr, r3, ip, lr
-	adc sb, lr, #0
+	adc r9, lr, #0
 	mov r3, r10, lsr #0xc
-	orr r3, r3, sb, lsl #20
-	adds sb, r2, #0x800
+	orr r3, r3, r9, lsl #20
+	adds r9, r2, #0x800
 	adc r1, r1, #0
-	mov r2, sb, lsr #0xc
+	mov r2, r9, lsr #0xc
 	orr r2, r2, r1, lsl #20
 	sub r3, r3, r2
-	umull r10, sb, r8, r3
+	umull r10, r9, r8, r3
 	mov r2, r3, asr #0x1f
 	adds r1, r10, #0x80000000
-	mla sb, r8, r2, sb
+	mla r9, r8, r2, r9
 	ldr r1, [sp, #4]
-	mla sb, r1, r3, sb
-	adc r1, sb, #0
+	mla r9, r1, r3, r9
+	adc r1, r9, #0
 	add r0, r1, r0
 	str r0, [r4, #8]
 _021791dc:
@@ -13898,7 +13898,7 @@ _021791dc:
 	cmp r6, r0
 	bne _021790ac
 	add sp, sp, #0x24
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov29_02179004
 _021791f4: .word data_ov29_0217bd50

--- a/asm/ov30.s
+++ b/asm/ov30.s
@@ -190,7 +190,7 @@ func_ov30_0217bfe0: ; 0x0217bfe0
 	.global func_ov30_0217c020
 	arm_func_start func_ov30_0217c020
 func_ov30_0217c020: ; 0x0217c020
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x3c
 	mov sb, r0
 	ldr r0, [sb, #0x200]
@@ -200,7 +200,7 @@ func_ov30_0217c020: ; 0x0217c020
 	mov r7, r2
 	mov r6, r3
 	addmi sp, sp, #0x3c
-	ldmmiia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmmiia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	add r11, sp, #0x24
 _0217c050:
 	mov r0, sb
@@ -211,8 +211,8 @@ _0217c050:
 	beq _0217c0f4
 	ldr r0, [sp, #0x34]
 	ldr lr, [sp, #0x30]
-	add sl, r0, r7
-	str sl, [sp, #0x34]
+	add r10, r0, r7
+	str r10, [sp, #0x34]
 	ldmia r8, {r0, r1, r2}
 	stmia r11, {r0, r1, r2}
 	ldr ip, [sp, #0x38]
@@ -222,9 +222,9 @@ _0217c050:
 	str r0, [sp, #0x14]
 	str lr, [sp, #0x18]
 	str ip, [sp, #0x20]
-	str sl, [sp, #0x28]
-	str sl, [sp, #0x1c]
-	str sl, [sp, #0x10]
+	str r10, [sp, #0x28]
+	str r10, [sp, #0x1c]
+	str r10, [sp, #0x10]
 	mov r0, #6
 	stmia sp, {r0, r6}
 	mov r0, #0
@@ -237,7 +237,7 @@ _0217c050:
 	bl func_01ffe1cc
 	cmp r0, #0
 	addne sp, sp, #0x3c
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, [sp, #0x30]
 	str r0, [r5]
 	ldr r0, [sp, #0x34]
@@ -248,7 +248,7 @@ _0217c0f4:
 	subs r4, r4, #1
 	bpl _0217c050
 	add sp, sp, #0x3c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov30_0217c020
 _0217c104: .word data_027e0e60
@@ -2051,14 +2051,14 @@ _0217d7d4: .word 0x00000333
 	.global func_ov30_0217d7d8
 	arm_func_start func_ov30_0217d7d8
 func_ov30_0217d7d8: ; 0x0217d7d8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x30
 	ldr r3, _0217d988 ; =data_027e0f94
 	mov r11, #0
 	ldr r5, [r3]
 	ldr r4, [r3, #4]
 	ldr r2, _0217d98c ; =data_027e0e60
-	mov sl, r0
+	mov r10, r0
 	ldr r0, [r2]
 	str r1, [sp]
 	strh r11, [sp, #0x14]
@@ -2115,9 +2115,9 @@ _0217d874:
 	mov r1, r6
 	add r2, sp, #0x24
 	bl func_ov00_0208439c
-	ldr r1, [sl, #8]
+	ldr r1, [r10, #8]
 	ldr r0, [sp, #0x2c]
-	ldr r3, [sl]
+	ldr r3, [r10]
 	sub r2, r1, r0
 	smull r1, r0, r2, r2
 	ldr r2, [sp, #0x24]
@@ -2162,7 +2162,7 @@ _0217d934:
 _0217d97c:
 	mov r0, r11
 	add sp, sp, #0x30
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov30_0217d7d8
 _0217d988: .word data_027e0f94
@@ -3070,7 +3070,7 @@ _0217e5a0: .word data_027e0764
 	.global func_ov30_0217e5a4
 	arm_func_start func_ov30_0217e5a4
 func_ov30_0217e5a4: ; 0x0217e5a4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #0x30
 	mov r6, r0
 	bl func_ov00_020c5118
@@ -3081,7 +3081,7 @@ func_ov30_0217e5a4: ; 0x0217e5a4
 	cmp r1, #1
 	beq _0217e72c
 	add sp, sp, #0x30
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _0217e5d4:
 	bl func_ov30_02182dc0
 	mov r0, r6
@@ -3089,7 +3089,7 @@ _0217e5d4:
 	ldrsh r1, [r6, #0xc]
 	cmp r0, r1
 	addle sp, sp, #0x30
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	ldrsh r0, [r5, #0x78]
 	bl func_0202bbbc
 	bl func_0202bba8
@@ -3098,7 +3098,7 @@ _0217e5d4:
 	cmp r0, #2
 	bne _0217e690
 	ldr r4, _0217e760 ; =data_02050f54
-	mov sl, #0
+	mov r10, #0
 	mov sb, #0x3000
 	add r8, sp, #0x24
 	add r7, sp, #0x18
@@ -3117,7 +3117,7 @@ _0217e620:
 	add lr, r4, lr, lsl #1
 	ldrsh ip, [r4, ip]
 	ldrsh lr, [lr, #2]
-	str sl, [sp, #0x28]
+	str r10, [sp, #0x28]
 	str ip, [sp, #0x24]
 	str lr, [sp, #0x2c]
 	bl func_01ff9e64
@@ -3130,12 +3130,12 @@ _0217e620:
 	mov r1, #1
 	bl func_ov30_0217e4b0
 	add sp, sp, #0x30
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _0217e690:
 	cmp r0, #3
 	bne _0217e71c
 	ldr r4, _0217e760 ; =data_02050f54
-	mov sl, #0
+	mov r10, #0
 	mov sb, #0x3000
 	add r8, sp, #0xc
 	add r7, sp, #0
@@ -3154,7 +3154,7 @@ _0217e6ac:
 	add lr, r4, lr, lsl #1
 	ldrsh ip, [r4, ip]
 	ldrsh lr, [lr, #2]
-	str sl, [sp, #0x10]
+	str r10, [sp, #0x10]
 	str ip, [sp, #0xc]
 	str lr, [sp, #0x14]
 	bl func_01ff9e64
@@ -3167,12 +3167,12 @@ _0217e6ac:
 	mov r1, #1
 	bl func_ov30_0217e4b0
 	add sp, sp, #0x30
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _0217e71c:
 	mov r0, r6
 	bl func_ov00_020c50fc
 	add sp, sp, #0x30
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _0217e72c:
 	ldrsh r1, [r6, #0xe]
 	bl func_ov30_02182e34
@@ -3181,12 +3181,12 @@ _0217e72c:
 	bl func_ov30_02182e50
 	cmp r0, #0
 	addeq sp, sp, #0x30
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	mov r0, r6
 	mov r1, #0
 	bl func_ov30_0217e4b0
 	add sp, sp, #0x30
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov30_0217e5a4
 _0217e760: .word data_02050f54
@@ -3974,7 +3974,7 @@ func_ov30_0217f1a0: ; 0x0217f1a0
 	.global func_ov30_0217f1c4
 	arm_func_start func_ov30_0217f1c4
 func_ov30_0217f1c4: ; 0x0217f1c4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #0x68
 	mov r7, r0
 	bl func_ov00_020c5118
@@ -4005,13 +4005,13 @@ _0217f1f8:
 	mov r2, #0
 	bl func_ov00_020c50d4
 	add sp, sp, #0x68
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _0217f23c:
 	mov r0, r7
 	mov r1, #1
 	bl func_ov30_0217f130
 	add sp, sp, #0x68
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _0217f250:
 	bl func_ov30_02182dc0
 	mov r0, r5
@@ -4022,7 +4022,7 @@ _0217f250:
 	bl func_0202e58c
 	cmp r0, #0
 	addeq sp, sp, #0x68
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	mov r0, r5
 	mov r1, #0
 	bl func_ov30_02183e50
@@ -4053,13 +4053,13 @@ _0217f250:
 	mov r1, #2
 	bl func_ov30_0217f130
 	add sp, sp, #0x68
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _0217f2f4:
 	mov r0, r7
 	bl func_ov00_020c50f0
 	cmp r0, #0xa
 	addle sp, sp, #0x68
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	ldr r3, _0217f550 ; =data_ov00_020e8398
 	mvn r2, #0
 	mov r6, #1
@@ -4113,7 +4113,7 @@ _0217f3b8:
 	ble _0217f43c
 	ldr sb, _0217f55c ; =data_027e10b4
 	ldr r8, _0217f560 ; =data_027e0fe4
-	add sl, sp, #0x50
+	add r10, sp, #0x50
 	add r4, sp, #0
 _0217f3e0:
 	ldr r0, [sb]
@@ -4128,12 +4128,12 @@ _0217f3e0:
 	bl _ZN12ActorManager8GetActorEP8ActorRef
 	movs r1, r0
 	beq _0217f428
-	mov r0, sl
+	mov r0, r10
 	add r1, r1, #0x48
 	bl func_ov00_020ce2f0
 	cmp r0, #0x2000
 	addlt sp, sp, #0x68
-	ldmltia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmltia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _0217f428:
 	ldr r0, [sb]
 	add r6, r6, #1
@@ -4153,7 +4153,7 @@ _0217f43c:
 	strh r2, [r5, #0x78]
 	bl func_ov30_0217f130
 	add sp, sp, #0x68
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _0217f470:
 	bl func_ov30_02182dc0
 	mov r0, r7
@@ -4168,7 +4168,7 @@ _0217f470:
 	mov r3, #0
 	bl func_ov00_020ceacc
 	add sp, sp, #0x68
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _0217f4a8:
 	cmp r0, #0x33
 	bne _0217f4f8
@@ -4189,10 +4189,10 @@ _0217f4a8:
 	ldr r0, [r0]
 	bl func_ov30_021840b0
 	add sp, sp, #0x68
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _0217f4f8:
 	addle sp, sp, #0x68
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	mov r0, r5
 	mov r1, #0
 	bl func_ov00_020cb160
@@ -4201,7 +4201,7 @@ _0217f4f8:
 	bl func_0202e58c
 	cmp r0, #0
 	addeq sp, sp, #0x68
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	mov r0, r5
 	bl func_ov30_02183e90
 	mov r0, r7
@@ -4210,7 +4210,7 @@ _0217f4f8:
 	bl func_ov00_020c50d4
 _0217f53c:
 	add sp, sp, #0x68
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov30_0217f1c4
 _0217f544: .word data_027e0f74
@@ -7318,7 +7318,7 @@ _021818b4: .word 0x0000018f
 	.global func_ov30_021818b8
 	arm_func_start func_ov30_021818b8
 func_ov30_021818b8: ; 0x021818b8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x54
 	mov r5, r0
 	ldr r1, [r5, #0x2a0]
@@ -7326,7 +7326,7 @@ func_ov30_021818b8: ; 0x021818b8
 	cmpne r1, #1
 	cmpne r1, #0xc
 	addeq sp, sp, #0x54
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	add r1, sp, #0x44
 	bl _ZN5Actor9GetHitboxEP8Cylinder
 	ldr r1, _021819e0 ; =data_027e0fe4
@@ -7356,7 +7356,7 @@ func_ov30_021818b8: ; 0x021818b8
 _02181944:
 	ldr r7, _021819e0 ; =data_027e0fe4
 	mov r4, #0
-	add sl, sp, #0
+	add r10, sp, #0
 	add r8, sp, #0x10
 	add r11, sp, #0x44
 	mvn r6, #0
@@ -7370,14 +7370,14 @@ _0218195c:
 	ldr r1, [r7]
 	str sb, [lr]
 	ldr r2, [ip, r4, lsl #2]
-	mov r0, sl
+	mov r0, r10
 	add r3, r5, #0x48
 	bl _ZN12ActorManager22FindNearestActorOfTypeEP8ActorRefPS_jP5Vec3p
 	ldr r0, [sp]
 	cmp r0, r6
 	beq _021819cc
 	ldr r0, [r7]
-	mov r1, sl
+	mov r1, r10
 	bl _ZN12ActorManager8GetActorEP8ActorRef
 	mov r1, r8
 	mov sb, r0
@@ -7394,7 +7394,7 @@ _021819cc:
 	cmp r4, #5
 	blt _0218195c
 	add sp, sp, #0x54
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov30_021818b8
 _021819e0: .word data_027e0fe4
@@ -9953,7 +9953,7 @@ _02183b8c: .word 0x00002aaa
 	.global func_ov30_02183b90
 	arm_func_start func_ov30_02183b90
 func_ov30_02183b90: ; 0x02183b90
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #0xa8
 	ldr r3, _02183c9c ; =data_ov30_02188b08
 	mov r2, #0
@@ -10000,11 +10000,11 @@ _02183c34:
 	ldr r0, [r7]
 	add r1, r1, r5
 	bl _ZN12ActorManager8GetActorEP8ActorRef
-	add sl, r0, #0x48
+	add r10, r0, #0x48
 	bl func_ov30_02182454
 	cmp r0, #0
 	beq _02183c7c
-	str sl, [sp]
+	str r10, [sp]
 	ldrsh r1, [r6, #0x78]
 	mov r2, sb
 	mov r3, r8
@@ -10013,7 +10013,7 @@ _02183c34:
 	cmp r0, #0
 	addne sp, sp, #0xa8
 	movne r0, #1
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _02183c7c:
 	ldr r0, [sp, #0x24]
 	add r4, r4, #1
@@ -10023,7 +10023,7 @@ _02183c7c:
 _02183c90:
 	mov r0, #0
 	add sp, sp, #0xa8
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov30_02183b90
 _02183c9c: .word data_ov30_02188b08
@@ -10450,20 +10450,20 @@ func_ov30_021840ec: ; 0x021840ec
 	.global func_ov30_0218411c
 	arm_func_start func_ov30_0218411c
 func_ov30_0218411c: ; 0x0218411c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #8
 	ldr r1, _021842fc ; =data_027e0fc8
-	mov sl, r0
+	mov r10, r0
 	ldr r0, [r1]
 	bl func_ov00_020bbb64
 	cmp r0, #0
 	addne sp, sp, #8
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	mov r8, #0
 	sub r0, r8, #1
-	str r0, [sl, #0x8c]
-	str r0, [sl, #0x90]
-	ldrsh r0, [sl, #4]
+	str r0, [r10, #0x8c]
+	str r0, [r10, #0x90]
+	ldrsh r0, [r10, #4]
 	mov r6, r8
 	sub r7, r8, #0x80000001
 	cmp r0, #0
@@ -10472,7 +10472,7 @@ func_ov30_0218411c: ; 0x0218411c
 	mov sb, r8
 	add r11, sp, #0
 _02184170:
-	ldr r2, [sl]
+	ldr r2, [r10]
 	ldr r0, [r4]
 	ldr r1, [r2, sb]
 	add r2, r2, sb
@@ -10494,10 +10494,10 @@ _02184170:
 	ldr r2, [sp, #4]
 	ldr r1, [sp]
 	mov r7, r0
-	str r1, [sl, #0x8c]
-	str r2, [sl, #0x90]
+	str r1, [r10, #0x8c]
+	str r2, [r10, #0x90]
 _021841d0:
-	ldrsh r1, [sl, #4]
+	ldrsh r1, [r10, #4]
 	add r0, r6, #1
 	mov r0, r0, lsl #0x10
 	cmp r1, r0, asr #16
@@ -10508,7 +10508,7 @@ _021841ec:
 	ldr r0, _02184304 ; =data_ov00_020eec68
 	cmp r8, #0
 	str r7, [r0, #0x28]
-	str r8, [sl, #0x88]
+	str r8, [r10, #0x88]
 	bne _0218424c
 	bl func_ov00_020d7424
 	cmp r0, #0xa7
@@ -10530,7 +10530,7 @@ _021841ec:
 	bl func_ov00_02084924
 	b _02184298
 _0218424c:
-	ldr r0, [sl, #0x88]
+	ldr r0, [r10, #0x88]
 	cmp r0, #0
 	ble _02184298
 	ldr r0, _02184304 ; =data_ov00_020eec68
@@ -10550,32 +10550,32 @@ _0218424c:
 	ldr r0, [r0]
 	bl func_ov00_02084924
 _02184298:
-	ldr r0, [sl, #0x94]
+	ldr r0, [r10, #0x94]
 	cmp r0, #0
 	ble _021842d4
 	sub r0, r0, #1
-	str r0, [sl, #0x94]
-	ldr r0, [sl, #0x98]
+	str r0, [r10, #0x94]
+	ldr r0, [r10, #0x98]
 	sub r0, r0, #1
-	str r0, [sl, #0x98]
+	str r0, [r10, #0x98]
 	cmp r0, #0
 	bgt _021842d4
 	ldr r0, _0218430c ; =data_ov00_020eec9c
 	mov r2, #0x10
 	mov r1, #0x1c0
-	str r2, [sl, #0x98]
+	str r2, [r10, #0x98]
 	bl func_ov00_020d77e4
 _021842d4:
-	ldr r0, [sl, #0x9c]
+	ldr r0, [r10, #0x9c]
 	cmp r0, #0
 	subgt r0, r0, #1
-	strgt r0, [sl, #0x9c]
-	ldrsh r0, [sl, #0xa0]
+	strgt r0, [r10, #0x9c]
+	ldrsh r0, [r10, #0xa0]
 	cmp r0, #0
 	subgt r0, r0, #1
-	strgth r0, [sl, #0xa0]
+	strgth r0, [r10, #0xa0]
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov30_0218411c
 _021842fc: .word data_027e0fc8
@@ -11285,7 +11285,7 @@ func_ov30_02184850: ; 0x02184850
 	.global func_ov30_02184868
 	arm_func_start func_ov30_02184868
 func_ov30_02184868: ; 0x02184868
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x1bc
 	sub sp, sp, #0x400
 	mov r4, r0
@@ -11293,7 +11293,7 @@ func_ov30_02184868: ; 0x02184868
 	cmp r0, #0
 	addeq sp, sp, #0x1bc
 	addeq sp, sp, #0x400
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	mov r0, r4
 	bl _ZN5Actor20IncreaseActiveFramesEv
 	ldr r0, [r4, #0x130]
@@ -11337,7 +11337,7 @@ _021848f4:
 	mov r6, #0
 	str r6, [sp, #0x18]
 	cmp r0, #0
-	ldrh sl, [r4, #0x20]
+	ldrh r10, [r4, #0x20]
 	ble _021849cc
 	ldr sb, [sp, #0x18]
 	ldr r11, _02185254 ; =data_027e0e60
@@ -11350,14 +11350,14 @@ _02184940:
 	movs r7, r0
 	beq _021849b8
 	mov r8, #0
-	cmp sl, #0
+	cmp r10, #0
 	moveq r8, #1
 	beq _02184998
 	ldr r1, [r7, #0x48]
 	ldr r0, [r11]
 	str r1, [sp, #0x74]
 	ldr r2, [r7, #0x4c]
-	mov r1, sl
+	mov r1, r10
 	str r2, [sp, #0x78]
 	ldr r3, [r7, #0x50]
 	add r2, sp, #0x74
@@ -11390,13 +11390,13 @@ _021849cc:
 	bl _ZN5Actor18func_ov00_020c1c20Eiii
 	add sp, sp, #0x1bc
 	add sp, sp, #0x400
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _021849f4:
 	mov r2, r1
 	bl _ZN5Actor18func_ov00_020c1c20Eiii
 	add sp, sp, #0x1bc
 	add sp, sp, #0x400
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02184a08:
 	ldr r2, _0218524c ; =data_ov30_02188b08
 	mov r1, #0
@@ -11425,7 +11425,7 @@ _02184a34:
 	mov r6, #0
 	str r6, [sp, #0x14]
 	cmp r0, #0
-	ldrh sl, [r4, #0x20]
+	ldrh r10, [r4, #0x20]
 	ble _02184b10
 	ldr sb, [sp, #0x14]
 	ldr r11, _02185254 ; =data_027e0e60
@@ -11438,14 +11438,14 @@ _02184a84:
 	movs r7, r0
 	beq _02184afc
 	mov r8, #0
-	cmp sl, #0
+	cmp r10, #0
 	moveq r8, #1
 	beq _02184adc
 	ldr r1, [r7, #0x48]
 	ldr r0, [r11]
 	str r1, [sp, #0x68]
 	ldr r2, [r7, #0x4c]
-	mov r1, sl
+	mov r1, r10
 	str r2, [sp, #0x6c]
 	ldr r3, [r7, #0x50]
 	add r2, sp, #0x68
@@ -11478,13 +11478,13 @@ _02184b10:
 	bl _ZN5Actor18func_ov00_020c1c20Eiii
 	add sp, sp, #0x1bc
 	add sp, sp, #0x400
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02184b38:
 	mov r2, r1
 	bl _ZN5Actor18func_ov00_020c1c20Eiii
 	add sp, sp, #0x1bc
 	add sp, sp, #0x400
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02184b4c:
 	ldr r6, _02185258 ; =_ZTV11FilterActor
 	mov r2, #0
@@ -11525,7 +11525,7 @@ _02184ba8:
 	mov r6, #0
 	str r6, [sp, #0x10]
 	cmp r0, #0
-	ldrh sl, [r4, #0x20]
+	ldrh r10, [r4, #0x20]
 	ble _02184c84
 	ldr sb, [sp, #0x10]
 	ldr r11, _02185254 ; =data_027e0e60
@@ -11538,14 +11538,14 @@ _02184bf8:
 	movs r7, r0
 	beq _02184c70
 	mov r8, #0
-	cmp sl, #0
+	cmp r10, #0
 	moveq r8, #1
 	beq _02184c50
 	ldr r1, [r7, #0x48]
 	ldr r0, [r11]
 	str r1, [sp, #0x5c]
 	ldr r2, [r7, #0x4c]
-	mov r1, sl
+	mov r1, r10
 	str r2, [sp, #0x60]
 	ldr r3, [r7, #0x50]
 	add r2, sp, #0x5c
@@ -11578,13 +11578,13 @@ _02184c84:
 	bl _ZN5Actor18func_ov00_020c1c20Eiii
 	add sp, sp, #0x1bc
 	add sp, sp, #0x400
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02184cac:
 	mov r2, r1
 	bl _ZN5Actor18func_ov00_020c1c20Eiii
 	add sp, sp, #0x1bc
 	add sp, sp, #0x400
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02184cc0:
 	ldr r6, _02185258 ; =_ZTV11FilterActor
 	mov r2, #0
@@ -11623,7 +11623,7 @@ _02184d18:
 	mov r6, #0
 	str r6, [sp, #0xc]
 	cmp r0, #0
-	ldrh sl, [r4, #0x20]
+	ldrh r10, [r4, #0x20]
 	ble _02184df0
 	ldr sb, [sp, #0xc]
 	ldr r11, _02185254 ; =data_027e0e60
@@ -11636,14 +11636,14 @@ _02184d64:
 	movs r7, r0
 	beq _02184ddc
 	mov r8, #0
-	cmp sl, #0
+	cmp r10, #0
 	moveq r8, #1
 	beq _02184dbc
 	ldr r1, [r7, #0x48]
 	ldr r0, [r11]
 	str r1, [sp, #0x50]
 	ldr r2, [r7, #0x4c]
-	mov r1, sl
+	mov r1, r10
 	str r2, [sp, #0x54]
 	ldr r3, [r7, #0x50]
 	add r2, sp, #0x50
@@ -11676,13 +11676,13 @@ _02184df0:
 	bl _ZN5Actor18func_ov00_020c1c20Eiii
 	add sp, sp, #0x1bc
 	add sp, sp, #0x400
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02184e18:
 	mov r2, r1
 	bl _ZN5Actor18func_ov00_020c1c20Eiii
 	add sp, sp, #0x1bc
 	add sp, sp, #0x400
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02184e2c:
 	ldr r6, _02185258 ; =_ZTV11FilterActor
 	mov r2, #0
@@ -11721,7 +11721,7 @@ _02184e84:
 	mov r7, #0
 	str r7, [sp, #8]
 	cmp r0, #0
-	ldrh sl, [r4, #0x20]
+	ldrh r10, [r4, #0x20]
 	ble _02184f50
 	ldr sb, [sp, #8]
 	ldr r5, _02185254 ; =data_027e0e60
@@ -11735,11 +11735,11 @@ _02184ed4:
 	cmp r0, #0
 	beq _02184f3c
 	mov r8, r11
-	cmp sl, #0
+	cmp r10, #0
 	moveq r8, #1
 	beq _02184f2c
 	ldr r2, [r0, #0x48]
-	mov r1, sl
+	mov r1, r10
 	str r2, [sp, #0x44]
 	ldr r3, [r0, #0x4c]
 	add r2, sp, #0x44
@@ -11771,13 +11771,13 @@ _02184f50:
 	bl _ZN5Actor18func_ov00_020c1c20Eiii
 	add sp, sp, #0x1bc
 	add sp, sp, #0x400
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02184f78:
 	mov r2, r1
 	bl _ZN5Actor18func_ov00_020c1c20Eiii
 	add sp, sp, #0x1bc
 	add sp, sp, #0x400
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02184f8c:
 	ldr r6, _02185258 ; =_ZTV11FilterActor
 	mov r2, #0
@@ -11816,7 +11816,7 @@ _02184fe4:
 	mov r7, #0
 	str r7, [sp, #4]
 	cmp r0, #0
-	ldrh sl, [r4, #0x20]
+	ldrh r10, [r4, #0x20]
 	ble _021850b0
 	ldr sb, [sp, #4]
 	ldr r5, _02185254 ; =data_027e0e60
@@ -11830,11 +11830,11 @@ _02185034:
 	cmp r0, #0
 	beq _0218509c
 	mov r8, r11
-	cmp sl, #0
+	cmp r10, #0
 	moveq r8, #1
 	beq _0218508c
 	ldr r2, [r0, #0x48]
-	mov r1, sl
+	mov r1, r10
 	str r2, [sp, #0x38]
 	ldr r3, [r0, #0x4c]
 	add r2, sp, #0x38
@@ -11866,13 +11866,13 @@ _021850b0:
 	bl _ZN5Actor18func_ov00_020c1c20Eiii
 	add sp, sp, #0x1bc
 	add sp, sp, #0x400
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _021850d8:
 	mov r2, r1
 	bl _ZN5Actor18func_ov00_020c1c20Eiii
 	add sp, sp, #0x1bc
 	add sp, sp, #0x400
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _021850ec:
 	ldr r6, _02185258 ; =_ZTV11FilterActor
 	mov r2, #0
@@ -11911,7 +11911,7 @@ _02185144:
 	mov r7, #0
 	str r7, [sp]
 	cmp r0, #0
-	ldrh sl, [r4, #0x20]
+	ldrh r10, [r4, #0x20]
 	ble _02185210
 	ldr sb, [sp]
 	ldr r5, _02185254 ; =data_027e0e60
@@ -11925,11 +11925,11 @@ _02185194:
 	cmp r0, #0
 	beq _021851fc
 	mov r8, r11
-	cmp sl, #0
+	cmp r10, #0
 	moveq r8, #1
 	beq _021851ec
 	ldr r2, [r0, #0x48]
-	mov r1, sl
+	mov r1, r10
 	str r2, [sp, #0x2c]
 	ldr r3, [r0, #0x4c]
 	add r2, sp, #0x2c
@@ -11961,14 +11961,14 @@ _02185210:
 	bl _ZN5Actor18func_ov00_020c1c20Eiii
 	add sp, sp, #0x1bc
 	add sp, sp, #0x400
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02185238:
 	mov r2, r1
 	bl _ZN5Actor18func_ov00_020c1c20Eiii
 _02185240:
 	add sp, sp, #0x1bc
 	add sp, sp, #0x400
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov30_02184868
 _0218524c: .word data_ov30_02188b08
@@ -15170,9 +15170,9 @@ func_ov30_02187dfc: ; 0x02187dfc
 	.global func_ov30_02187e18
 	arm_func_start func_ov30_02187e18
 func_ov30_02187e18: ; 0x02187e18
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x3c
-	mov sl, r0
+	mov r10, r0
 	mov sb, r1
 	mov r8, r2
 	mov r7, r3
@@ -15182,17 +15182,17 @@ func_ov30_02187e18: ; 0x02187e18
 	add r5, sp, #0x24
 	mov r4, #6
 _02187e44:
-	mov r0, sl
+	mov r0, r10
 	bl func_ov30_02187ef0
 	cmp r0, #0
 	addne sp, sp, #0x3c
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
-	mov r0, sl
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	mov r0, r10
 	add r1, sp, #0x30
 	bl func_ov30_02187dac
 	cmp r0, #0
 	addeq sp, sp, #0x3c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, [sp, #0x34]
 	ldr r3, [sp, #0x30]
 	add ip, r0, r8
@@ -15218,8 +15218,8 @@ _02187e44:
 	bl func_01ffe1cc
 	cmp r0, #0
 	addne sp, sp, #0x3c
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
-	mov r0, sl
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	mov r0, r10
 	bl func_ov30_02187dfc
 	b _02187e44
 	arm_func_end func_ov30_02187e18
@@ -15228,7 +15228,7 @@ _02187e44:
 	arm_func_start func_ov30_02187ee4
 func_ov30_02187ee4: ; 0x02187ee4
 	add sp, sp, #0x3c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov30_02187ee4
 _02187eec: .word data_027e0e60
@@ -15273,7 +15273,7 @@ _02187f2c:
 	.global func_ov30_02187f58
 	arm_func_start func_ov30_02187f58
 func_ov30_02187f58: ; 0x02187f58
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0xc
 	str r0, [sp]
 	add r0, r0, #0x1000
@@ -15285,7 +15285,7 @@ func_ov30_02187f58: ; 0x02187f58
 	ldr r0, [r2, #4]
 	cmp r0, #0
 	addle sp, sp, #0xc
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02187f8c:
 	ldr r8, [r2]
 	and r7, sb, #0xff
@@ -15297,7 +15297,7 @@ _02187f8c:
 	cmp r0, r1
 	bne _02188054
 	ldrb r0, [r2, #1]
-	mov sl, #0
+	mov r10, #0
 	cmp r0, #0
 	ble _02188054
 	ldr r0, [sp]
@@ -15308,7 +15308,7 @@ _02187f8c:
 _02187fd4:
 	ldr r0, [r11]
 	strb sb, [sp, #0xa]
-	strb sl, [sp, #0xb]
+	strb r10, [sp, #0xb]
 	add r1, sp, #0xa
 	bl func_ov00_020c47cc
 	ldrsb r0, [r0, #0x16]
@@ -15333,10 +15333,10 @@ _02187fd4:
 	str r0, [r5]
 _02188038:
 	ldr r1, [r8, r7, lsl #3]
-	add r0, sl, #1
+	add r0, r10, #1
 	mov r0, r0, lsl #0x18
 	ldrb r1, [r1, #1]
-	mov sl, r0, asr #0x18
+	mov r10, r0, asr #0x18
 	cmp r1, r0, asr #24
 	bgt _02187fd4
 _02188054:
@@ -15349,7 +15349,7 @@ _02188054:
 	cmp r1, r0, asr #24
 	bgt _02187f8c
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov30_02187f58
 _0218807c: .word data_027e0ff0
@@ -15452,10 +15452,10 @@ _021881b4:
 	.global func_ov30_021881bc
 	arm_func_start func_ov30_021881bc
 func_ov30_021881bc: ; 0x021881bc
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x2c
-	mov sl, r0
-	ldr r3, [sl]
+	mov r10, r0
+	ldr r3, [r10]
 	mov r7, #0
 	cmp r3, #0
 	sub r2, r7, #0x80000001
@@ -15471,13 +15471,13 @@ _021881dc:
 	cmp r3, #0
 	bne _021881dc
 _02188200:
-	mov r0, sl
+	mov r0, r10
 	mov r1, r7
 	bl func_ov30_0218727c
 	mov r1, r7
-	add r0, sl, #8
+	add r0, r10, #8
 	bl func_ov30_02187234
-	add r0, sl, #0x1000
+	add r0, r10, #0x1000
 	ldr r3, [r0, #0x18]
 	ldr r0, _02188394 ; =data_027e0ff0
 	ldrsb r2, [r3, #0x1c]
@@ -15502,7 +15502,7 @@ _02188200:
 	mov r6, r0
 	mov r11, #0
 	add sb, r6, #0x14
-	add r4, sl, #0x1000
+	add r4, r10, #0x1000
 _02188280:
 	ldrsb r0, [sb, #2]
 	sub r0, r0, #1
@@ -15523,14 +15523,14 @@ _02188280:
 	strb r2, [sp, #3]
 	bl func_ov00_020c47cc
 	mov r5, r0
-	mov r0, sl
+	mov r0, r10
 	add r1, sp, #2
 	bl func_ov30_02188168
 	mov r8, r0
 	ldr r0, [r8, #8]
 	cmp r0, #0
 	bne _02188378
-	mov r0, sl
+	mov r0, r10
 	str r7, [r8, #0x14]
 	mov r1, r8
 	bl func_ov30_02187234
@@ -15565,7 +15565,7 @@ _02188280:
 	cmp r8, r0
 	addeq sp, sp, #0x2c
 	moveq r0, #1
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02188378:
 	add r11, r11, #1
 	cmp r11, #4
@@ -15573,7 +15573,7 @@ _02188378:
 	blt _02188280
 	mov r0, #0
 	add sp, sp, #0x2c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov30_021881bc
 _02188394: .word data_027e0ff0

--- a/asm/ov30.s
+++ b/asm/ov30.s
@@ -190,7 +190,7 @@ func_ov30_0217bfe0: ; 0x0217bfe0
 	.global func_ov30_0217c020
 	arm_func_start func_ov30_0217c020
 func_ov30_0217c020: ; 0x0217c020
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x3c
 	mov sb, r0
 	ldr r0, [sb, #0x200]
@@ -200,8 +200,8 @@ func_ov30_0217c020: ; 0x0217c020
 	mov r7, r2
 	mov r6, r3
 	addmi sp, sp, #0x3c
-	ldmmiia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
-	add fp, sp, #0x24
+	ldmmiia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	add r11, sp, #0x24
 _0217c050:
 	mov r0, sb
 	mov r1, r4
@@ -214,7 +214,7 @@ _0217c050:
 	add sl, r0, r7
 	str sl, [sp, #0x34]
 	ldmia r8, {r0, r1, r2}
-	stmia fp, {r0, r1, r2}
+	stmia r11, {r0, r1, r2}
 	ldr ip, [sp, #0x38]
 	ldr r1, [sp, #0x24]
 	ldr r0, [sp, #0x2c]
@@ -237,7 +237,7 @@ _0217c050:
 	bl func_01ffe1cc
 	cmp r0, #0
 	addne sp, sp, #0x3c
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, [sp, #0x30]
 	str r0, [r5]
 	ldr r0, [sp, #0x34]
@@ -248,7 +248,7 @@ _0217c0f4:
 	subs r4, r4, #1
 	bpl _0217c050
 	add sp, sp, #0x3c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov30_0217c020
 _0217c104: .word data_027e0e60
@@ -2051,18 +2051,18 @@ _0217d7d4: .word 0x00000333
 	.global func_ov30_0217d7d8
 	arm_func_start func_ov30_0217d7d8
 func_ov30_0217d7d8: ; 0x0217d7d8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x30
 	ldr r3, _0217d988 ; =data_027e0f94
-	mov fp, #0
+	mov r11, #0
 	ldr r5, [r3]
 	ldr r4, [r3, #4]
 	ldr r2, _0217d98c ; =data_027e0e60
 	mov sl, r0
 	ldr r0, [r2]
 	str r1, [sp]
-	strh fp, [sp, #0x14]
-	strh fp, [sp, #0x16]
+	strh r11, [sp, #0x14]
+	strh r11, [sp, #0x16]
 	str r5, [sp, #0x18]
 	str r4, [sp, #0x1c]
 	ldr r3, [r3, #8]
@@ -2070,7 +2070,7 @@ func_ov30_0217d7d8: ; 0x0217d7d8
 	add r2, sp, #0x14
 	str r3, [sp, #0x20]
 	bl func_ov00_0208433c
-	mov r0, fp
+	mov r0, r11
 	ldrsh r2, [sp, #0x16]
 	ldrsh r1, [sp, #0x14]
 	str r0, [sp, #8]
@@ -2137,7 +2137,7 @@ _0217d874:
 	mov sb, r0
 	ldrsh r1, [sp, #0xc]
 	ldrsh r0, [sp, #0xe]
-	mov fp, #1
+	mov r11, #1
 	strh r1, [sp, #0x10]
 	strh r0, [sp, #0x12]
 _0217d934:
@@ -2152,7 +2152,7 @@ _0217d934:
 	add r0, r0, #1
 	str r0, [sp, #4]
 	blt _0217d85c
-	cmp fp, #0
+	cmp r11, #0
 	beq _0217d97c
 	ldr r0, _0217d98c ; =data_027e0e60
 	ldr r2, [sp]
@@ -2160,9 +2160,9 @@ _0217d934:
 	add r1, sp, #0x10
 	bl func_ov00_0208439c
 _0217d97c:
-	mov r0, fp
+	mov r0, r11
 	add sp, sp, #0x30
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov30_0217d7d8
 _0217d988: .word data_027e0f94
@@ -7318,7 +7318,7 @@ _021818b4: .word 0x0000018f
 	.global func_ov30_021818b8
 	arm_func_start func_ov30_021818b8
 func_ov30_021818b8: ; 0x021818b8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x54
 	mov r5, r0
 	ldr r1, [r5, #0x2a0]
@@ -7326,7 +7326,7 @@ func_ov30_021818b8: ; 0x021818b8
 	cmpne r1, #1
 	cmpne r1, #0xc
 	addeq sp, sp, #0x54
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r1, sp, #0x44
 	bl _ZN5Actor9GetHitboxEP8Cylinder
 	ldr r1, _021819e0 ; =data_027e0fe4
@@ -7358,7 +7358,7 @@ _02181944:
 	mov r4, #0
 	add sl, sp, #0
 	add r8, sp, #0x10
-	add fp, sp, #0x44
+	add r11, sp, #0x44
 	mvn r6, #0
 _0218195c:
 	ldr sb, _021819e8 ; =data_ov30_021887d0
@@ -7382,7 +7382,7 @@ _0218195c:
 	mov r1, r8
 	mov sb, r0
 	bl _ZN5Actor9GetHitboxEP8Cylinder
-	mov r0, fp
+	mov r0, r11
 	mov r1, r8
 	bl func_01ffec34
 	cmp r0, #0
@@ -7394,7 +7394,7 @@ _021819cc:
 	cmp r4, #5
 	blt _0218195c
 	add sp, sp, #0x54
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov30_021818b8
 _021819e0: .word data_027e0fe4
@@ -10450,7 +10450,7 @@ func_ov30_021840ec: ; 0x021840ec
 	.global func_ov30_0218411c
 	arm_func_start func_ov30_0218411c
 func_ov30_0218411c: ; 0x0218411c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #8
 	ldr r1, _021842fc ; =data_027e0fc8
 	mov sl, r0
@@ -10458,7 +10458,7 @@ func_ov30_0218411c: ; 0x0218411c
 	bl func_ov00_020bbb64
 	cmp r0, #0
 	addne sp, sp, #8
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	mov r8, #0
 	sub r0, r8, #1
 	str r0, [sl, #0x8c]
@@ -10470,7 +10470,7 @@ func_ov30_0218411c: ; 0x0218411c
 	ble _021841ec
 	ldr r4, _02184300 ; =data_027e0fe4
 	mov sb, r8
-	add fp, sp, #0
+	add r11, sp, #0
 _02184170:
 	ldr r2, [sl]
 	ldr r0, [r4]
@@ -10478,7 +10478,7 @@ _02184170:
 	add r2, r2, sb
 	str r1, [sp]
 	ldr r2, [r2, #4]
-	mov r1, fp
+	mov r1, r11
 	str r2, [sp, #4]
 	bl _ZN12ActorManager8GetActorEP8ActorRef
 	movs r5, r0
@@ -10575,7 +10575,7 @@ _021842d4:
 	subgt r0, r0, #1
 	strgth r0, [sl, #0xa0]
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov30_0218411c
 _021842fc: .word data_027e0fc8
@@ -11285,7 +11285,7 @@ func_ov30_02184850: ; 0x02184850
 	.global func_ov30_02184868
 	arm_func_start func_ov30_02184868
 func_ov30_02184868: ; 0x02184868
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x1bc
 	sub sp, sp, #0x400
 	mov r4, r0
@@ -11293,7 +11293,7 @@ func_ov30_02184868: ; 0x02184868
 	cmp r0, #0
 	addeq sp, sp, #0x1bc
 	addeq sp, sp, #0x400
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	mov r0, r4
 	bl _ZN5Actor20IncreaseActiveFramesEv
 	ldr r0, [r4, #0x130]
@@ -11340,7 +11340,7 @@ _021848f4:
 	ldrh sl, [r4, #0x20]
 	ble _021849cc
 	ldr sb, [sp, #0x18]
-	ldr fp, _02185254 ; =data_027e0e60
+	ldr r11, _02185254 ; =data_027e0e60
 	ldr r5, _02185250 ; =data_027e0fe4
 _02184940:
 	ldr r1, [sp, #0x530]
@@ -11354,7 +11354,7 @@ _02184940:
 	moveq r8, #1
 	beq _02184998
 	ldr r1, [r7, #0x48]
-	ldr r0, [fp]
+	ldr r0, [r11]
 	str r1, [sp, #0x74]
 	ldr r2, [r7, #0x4c]
 	mov r1, sl
@@ -11390,13 +11390,13 @@ _021849cc:
 	bl _ZN5Actor18func_ov00_020c1c20Eiii
 	add sp, sp, #0x1bc
 	add sp, sp, #0x400
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _021849f4:
 	mov r2, r1
 	bl _ZN5Actor18func_ov00_020c1c20Eiii
 	add sp, sp, #0x1bc
 	add sp, sp, #0x400
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02184a08:
 	ldr r2, _0218524c ; =data_ov30_02188b08
 	mov r1, #0
@@ -11428,7 +11428,7 @@ _02184a34:
 	ldrh sl, [r4, #0x20]
 	ble _02184b10
 	ldr sb, [sp, #0x14]
-	ldr fp, _02185254 ; =data_027e0e60
+	ldr r11, _02185254 ; =data_027e0e60
 	ldr r5, _02185250 ; =data_027e0fe4
 _02184a84:
 	ldr r1, [sp, #0x4a4]
@@ -11442,7 +11442,7 @@ _02184a84:
 	moveq r8, #1
 	beq _02184adc
 	ldr r1, [r7, #0x48]
-	ldr r0, [fp]
+	ldr r0, [r11]
 	str r1, [sp, #0x68]
 	ldr r2, [r7, #0x4c]
 	mov r1, sl
@@ -11478,13 +11478,13 @@ _02184b10:
 	bl _ZN5Actor18func_ov00_020c1c20Eiii
 	add sp, sp, #0x1bc
 	add sp, sp, #0x400
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02184b38:
 	mov r2, r1
 	bl _ZN5Actor18func_ov00_020c1c20Eiii
 	add sp, sp, #0x1bc
 	add sp, sp, #0x400
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02184b4c:
 	ldr r6, _02185258 ; =_ZTV11FilterActor
 	mov r2, #0
@@ -11528,7 +11528,7 @@ _02184ba8:
 	ldrh sl, [r4, #0x20]
 	ble _02184c84
 	ldr sb, [sp, #0x10]
-	ldr fp, _02185254 ; =data_027e0e60
+	ldr r11, _02185254 ; =data_027e0e60
 	ldr r5, _02185250 ; =data_027e0fe4
 _02184bf8:
 	ldr r1, [sp, #0x3d0]
@@ -11542,7 +11542,7 @@ _02184bf8:
 	moveq r8, #1
 	beq _02184c50
 	ldr r1, [r7, #0x48]
-	ldr r0, [fp]
+	ldr r0, [r11]
 	str r1, [sp, #0x5c]
 	ldr r2, [r7, #0x4c]
 	mov r1, sl
@@ -11578,13 +11578,13 @@ _02184c84:
 	bl _ZN5Actor18func_ov00_020c1c20Eiii
 	add sp, sp, #0x1bc
 	add sp, sp, #0x400
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02184cac:
 	mov r2, r1
 	bl _ZN5Actor18func_ov00_020c1c20Eiii
 	add sp, sp, #0x1bc
 	add sp, sp, #0x400
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02184cc0:
 	ldr r6, _02185258 ; =_ZTV11FilterActor
 	mov r2, #0
@@ -11626,7 +11626,7 @@ _02184d18:
 	ldrh sl, [r4, #0x20]
 	ble _02184df0
 	ldr sb, [sp, #0xc]
-	ldr fp, _02185254 ; =data_027e0e60
+	ldr r11, _02185254 ; =data_027e0e60
 	ldr r5, _02185250 ; =data_027e0fe4
 _02184d64:
 	ldr r1, [sp, #0x2fc]
@@ -11640,7 +11640,7 @@ _02184d64:
 	moveq r8, #1
 	beq _02184dbc
 	ldr r1, [r7, #0x48]
-	ldr r0, [fp]
+	ldr r0, [r11]
 	str r1, [sp, #0x50]
 	ldr r2, [r7, #0x4c]
 	mov r1, sl
@@ -11676,13 +11676,13 @@ _02184df0:
 	bl _ZN5Actor18func_ov00_020c1c20Eiii
 	add sp, sp, #0x1bc
 	add sp, sp, #0x400
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02184e18:
 	mov r2, r1
 	bl _ZN5Actor18func_ov00_020c1c20Eiii
 	add sp, sp, #0x1bc
 	add sp, sp, #0x400
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02184e2c:
 	ldr r6, _02185258 ; =_ZTV11FilterActor
 	mov r2, #0
@@ -11726,7 +11726,7 @@ _02184e84:
 	ldr sb, [sp, #8]
 	ldr r5, _02185254 ; =data_027e0e60
 	ldr r6, _02185250 ; =data_027e0fe4
-	mov fp, r7
+	mov r11, r7
 _02184ed4:
 	ldr r1, [sp, #0x228]
 	ldr r0, [r6]
@@ -11734,7 +11734,7 @@ _02184ed4:
 	bl _ZN12ActorManager8GetActorEP8ActorRef
 	cmp r0, #0
 	beq _02184f3c
-	mov r8, fp
+	mov r8, r11
 	cmp sl, #0
 	moveq r8, #1
 	beq _02184f2c
@@ -11771,13 +11771,13 @@ _02184f50:
 	bl _ZN5Actor18func_ov00_020c1c20Eiii
 	add sp, sp, #0x1bc
 	add sp, sp, #0x400
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02184f78:
 	mov r2, r1
 	bl _ZN5Actor18func_ov00_020c1c20Eiii
 	add sp, sp, #0x1bc
 	add sp, sp, #0x400
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02184f8c:
 	ldr r6, _02185258 ; =_ZTV11FilterActor
 	mov r2, #0
@@ -11821,7 +11821,7 @@ _02184fe4:
 	ldr sb, [sp, #4]
 	ldr r5, _02185254 ; =data_027e0e60
 	ldr r6, _02185250 ; =data_027e0fe4
-	mov fp, r7
+	mov r11, r7
 _02185034:
 	ldr r1, [sp, #0x154]
 	ldr r0, [r6]
@@ -11829,7 +11829,7 @@ _02185034:
 	bl _ZN12ActorManager8GetActorEP8ActorRef
 	cmp r0, #0
 	beq _0218509c
-	mov r8, fp
+	mov r8, r11
 	cmp sl, #0
 	moveq r8, #1
 	beq _0218508c
@@ -11866,13 +11866,13 @@ _021850b0:
 	bl _ZN5Actor18func_ov00_020c1c20Eiii
 	add sp, sp, #0x1bc
 	add sp, sp, #0x400
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _021850d8:
 	mov r2, r1
 	bl _ZN5Actor18func_ov00_020c1c20Eiii
 	add sp, sp, #0x1bc
 	add sp, sp, #0x400
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _021850ec:
 	ldr r6, _02185258 ; =_ZTV11FilterActor
 	mov r2, #0
@@ -11916,7 +11916,7 @@ _02185144:
 	ldr sb, [sp]
 	ldr r5, _02185254 ; =data_027e0e60
 	ldr r6, _02185250 ; =data_027e0fe4
-	mov fp, r7
+	mov r11, r7
 _02185194:
 	ldr r1, [sp, #0x80]
 	ldr r0, [r6]
@@ -11924,7 +11924,7 @@ _02185194:
 	bl _ZN12ActorManager8GetActorEP8ActorRef
 	cmp r0, #0
 	beq _021851fc
-	mov r8, fp
+	mov r8, r11
 	cmp sl, #0
 	moveq r8, #1
 	beq _021851ec
@@ -11961,14 +11961,14 @@ _02185210:
 	bl _ZN5Actor18func_ov00_020c1c20Eiii
 	add sp, sp, #0x1bc
 	add sp, sp, #0x400
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02185238:
 	mov r2, r1
 	bl _ZN5Actor18func_ov00_020c1c20Eiii
 _02185240:
 	add sp, sp, #0x1bc
 	add sp, sp, #0x400
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov30_02184868
 _0218524c: .word data_ov30_02188b08
@@ -15170,7 +15170,7 @@ func_ov30_02187dfc: ; 0x02187dfc
 	.global func_ov30_02187e18
 	arm_func_start func_ov30_02187e18
 func_ov30_02187e18: ; 0x02187e18
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x3c
 	mov sl, r0
 	mov sb, r1
@@ -15178,7 +15178,7 @@ func_ov30_02187e18: ; 0x02187e18
 	mov r7, r3
 	ldr r6, [sp, #0x60]
 	bl func_ov30_02187dfc
-	ldr fp, _02187eec ; =data_027e0e60
+	ldr r11, _02187eec ; =data_027e0e60
 	add r5, sp, #0x24
 	mov r4, #6
 _02187e44:
@@ -15186,13 +15186,13 @@ _02187e44:
 	bl func_ov30_02187ef0
 	cmp r0, #0
 	addne sp, sp, #0x3c
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	mov r0, sl
 	add r1, sp, #0x30
 	bl func_ov30_02187dac
 	cmp r0, #0
 	addeq sp, sp, #0x3c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, [sp, #0x34]
 	ldr r3, [sp, #0x30]
 	add ip, r0, r8
@@ -15211,14 +15211,14 @@ _02187e44:
 	str r0, [sp, #0x14]
 	stmia sp, {r4, r7}
 	str r6, [sp, #8]
-	ldr r0, [fp]
+	ldr r0, [r11]
 	add r1, sp, #0x18
 	add r2, sp, #0xc
 	mov r3, r8
 	bl func_01ffe1cc
 	cmp r0, #0
 	addne sp, sp, #0x3c
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	mov r0, sl
 	bl func_ov30_02187dfc
 	b _02187e44
@@ -15228,7 +15228,7 @@ _02187e44:
 	arm_func_start func_ov30_02187ee4
 func_ov30_02187ee4: ; 0x02187ee4
 	add sp, sp, #0x3c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov30_02187ee4
 _02187eec: .word data_027e0e60
@@ -15273,7 +15273,7 @@ _02187f2c:
 	.global func_ov30_02187f58
 	arm_func_start func_ov30_02187f58
 func_ov30_02187f58: ; 0x02187f58
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0xc
 	str r0, [sp]
 	add r0, r0, #0x1000
@@ -15285,7 +15285,7 @@ func_ov30_02187f58: ; 0x02187f58
 	ldr r0, [r2, #4]
 	cmp r0, #0
 	addle sp, sp, #0xc
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02187f8c:
 	ldr r8, [r2]
 	and r7, sb, #0xff
@@ -15301,12 +15301,12 @@ _02187f8c:
 	cmp r0, #0
 	ble _02188054
 	ldr r0, [sp]
-	ldr fp, _0218807c ; =data_027e0ff0
+	ldr r11, _0218807c ; =data_027e0ff0
 	add r6, r0, #0x10
 	add r5, r6, #0x1000
 	add r4, r0, #0x1000
 _02187fd4:
-	ldr r0, [fp]
+	ldr r0, [r11]
 	strb sb, [sp, #0xa]
 	strb sl, [sp, #0xb]
 	add r1, sp, #0xa
@@ -15349,7 +15349,7 @@ _02188054:
 	cmp r1, r0, asr #24
 	bgt _02187f8c
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov30_02187f58
 _0218807c: .word data_027e0ff0
@@ -15452,7 +15452,7 @@ _021881b4:
 	.global func_ov30_021881bc
 	arm_func_start func_ov30_021881bc
 func_ov30_021881bc: ; 0x021881bc
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x2c
 	mov sl, r0
 	ldr r3, [sl]
@@ -15500,7 +15500,7 @@ _02188200:
 	strb r2, [sp, #5]
 	bl func_ov00_020c47cc
 	mov r6, r0
-	mov fp, #0
+	mov r11, #0
 	add sb, r6, #0x14
 	add r4, sl, #0x1000
 _02188280:
@@ -15565,15 +15565,15 @@ _02188280:
 	cmp r8, r0
 	addeq sp, sp, #0x2c
 	moveq r0, #1
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02188378:
-	add fp, fp, #1
-	cmp fp, #4
+	add r11, r11, #1
+	cmp r11, #4
 	add sb, sb, #4
 	blt _02188280
 	mov r0, #0
 	add sp, sp, #0x2c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov30_021881bc
 _02188394: .word data_027e0ff0

--- a/asm/ov30.s
+++ b/asm/ov30.s
@@ -6,7 +6,7 @@
 	.global func_ov30_0217bd80
 	arm_func_start func_ov30_0217bd80
 func_ov30_0217bd80: ; 0x0217bd80
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x2c
 	mov r2, #0
 	mov r7, r0
@@ -22,7 +22,7 @@ func_ov30_0217bd80: ; 0x0217bd80
 	cmp r2, r0
 	addge sp, sp, #0x2c
 	movge r0, #0
-	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmgeia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	ldrh r1, [sp, #0x28]
 	ldrh r0, [sp, #0x2a]
 	ldr r4, [r7, #0x204]
@@ -35,7 +35,7 @@ func_ov30_0217bd80: ; 0x0217bd80
 	add r1, r1, #1
 	mov r0, #1
 	str r1, [r7, #0x200]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _0217bdf8:
 	ldr r0, [r7, #0x200]
 	mov r1, #0
@@ -74,12 +74,12 @@ _0217be38:
 	strh r3, [sp, #0x1e]
 	addeq sp, sp, #0x2c
 	moveq r0, #1
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	sub r5, r0, #1
 	cmp r5, #0
 	mov r6, #0
 	ble _0217bf94
-	add sb, sp, #0x20
+	add r9, sp, #0x20
 	add r8, sp, #0x28
 	mov r4, r6
 _0217bea8:
@@ -113,9 +113,9 @@ _0217bea8:
 	str r0, [r7, #0x200]
 	add sp, sp, #0x2c
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _0217bf24:
-	mov r0, sb
+	mov r0, r9
 	mov r1, r8
 	bl func_ov30_021873bc
 	cmp r0, #0
@@ -126,7 +126,7 @@ _0217bf24:
 	cmp r2, r0
 	addge sp, sp, #0x2c
 	movge r0, #0
-	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmgeia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	ldrh r1, [sp, #0x28]
 	ldrh r0, [sp, #0x2a]
 	ldr r4, [r7, #0x204]
@@ -139,7 +139,7 @@ _0217bf24:
 	add r1, r1, #1
 	mov r0, #1
 	str r1, [r7, #0x200]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _0217bf88:
 	add r6, r6, #1
 	cmp r6, r5
@@ -150,7 +150,7 @@ _0217bf94:
 	cmp r2, r0
 	addge sp, sp, #0x2c
 	movge r0, #0
-	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmgeia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	ldrh r1, [sp, #0x28]
 	ldrh r0, [sp, #0x2a]
 	ldr r4, [r7, #0x204]
@@ -163,7 +163,7 @@ _0217bf94:
 	add r1, r1, #1
 	str r1, [r7, #0x200]
 	add sp, sp, #0x2c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	arm_func_end func_ov30_0217bd80
 
 	.global func_ov30_0217bfe0
@@ -190,20 +190,20 @@ func_ov30_0217bfe0: ; 0x0217bfe0
 	.global func_ov30_0217c020
 	arm_func_start func_ov30_0217c020
 func_ov30_0217c020: ; 0x0217c020
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x3c
-	mov sb, r0
-	ldr r0, [sb, #0x200]
+	mov r9, r0
+	ldr r0, [r9, #0x200]
 	ldr r5, [sp, #0x60]
 	subs r4, r0, #1
 	mov r8, r1
 	mov r7, r2
 	mov r6, r3
 	addmi sp, sp, #0x3c
-	ldmmiia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmmiia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r11, sp, #0x24
 _0217c050:
-	mov r0, sb
+	mov r0, r9
 	mov r1, r4
 	add r2, sp, #0x30
 	bl func_ov30_0217bfe0
@@ -237,7 +237,7 @@ _0217c050:
 	bl func_01ffe1cc
 	cmp r0, #0
 	addne sp, sp, #0x3c
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, [sp, #0x30]
 	str r0, [r5]
 	ldr r0, [sp, #0x34]
@@ -248,7 +248,7 @@ _0217c0f4:
 	subs r4, r4, #1
 	bpl _0217c050
 	add sp, sp, #0x3c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov30_0217c020
 _0217c104: .word data_027e0e60
@@ -2051,7 +2051,7 @@ _0217d7d4: .word 0x00000333
 	.global func_ov30_0217d7d8
 	arm_func_start func_ov30_0217d7d8
 func_ov30_0217d7d8: ; 0x0217d7d8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x30
 	ldr r3, _0217d988 ; =data_027e0f94
 	mov r11, #0
@@ -2080,7 +2080,7 @@ func_ov30_0217d7d8: ; 0x0217d7d8
 	ldr r0, [sp, #8]
 	sub r2, r2, #3
 	strh r0, [sp, #0x12]
-	sub sb, r0, #0x80000001
+	sub r9, r0, #0x80000001
 	mov r0, r1, asr #0x10
 	str r0, [sp, #4]
 	mov r4, r2, lsl #0x10
@@ -2132,9 +2132,9 @@ _0217d874:
 	orr r2, r2, ip, lsl #20
 	orr r1, r1, r0, lsl #20
 	add r0, r2, r1
-	cmp sb, r0
+	cmp r9, r0
 	ble _0217d934
-	mov sb, r0
+	mov r9, r0
 	ldrsh r1, [sp, #0xc]
 	ldrsh r0, [sp, #0xe]
 	mov r11, #1
@@ -2162,7 +2162,7 @@ _0217d934:
 _0217d97c:
 	mov r0, r11
 	add sp, sp, #0x30
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov30_0217d7d8
 _0217d988: .word data_027e0f94
@@ -3070,7 +3070,7 @@ _0217e5a0: .word data_027e0764
 	.global func_ov30_0217e5a4
 	arm_func_start func_ov30_0217e5a4
 func_ov30_0217e5a4: ; 0x0217e5a4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #0x30
 	mov r6, r0
 	bl func_ov00_020c5118
@@ -3081,7 +3081,7 @@ func_ov30_0217e5a4: ; 0x0217e5a4
 	cmp r1, #1
 	beq _0217e72c
 	add sp, sp, #0x30
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _0217e5d4:
 	bl func_ov30_02182dc0
 	mov r0, r6
@@ -3089,7 +3089,7 @@ _0217e5d4:
 	ldrsh r1, [r6, #0xc]
 	cmp r0, r1
 	addle sp, sp, #0x30
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	ldrsh r0, [r5, #0x78]
 	bl func_0202bbbc
 	bl func_0202bba8
@@ -3099,12 +3099,12 @@ _0217e5d4:
 	bne _0217e690
 	ldr r4, _0217e760 ; =data_02050f54
 	mov r10, #0
-	mov sb, #0x3000
+	mov r9, #0x3000
 	add r8, sp, #0x24
 	add r7, sp, #0x18
 _0217e620:
 	ldrsh r2, [r6, #0xe]
-	mov r0, sb
+	mov r0, r9
 	mov r1, r8
 	add r2, r2, #0x4000
 	strh r2, [r6, #0xe]
@@ -3130,18 +3130,18 @@ _0217e620:
 	mov r1, #1
 	bl func_ov30_0217e4b0
 	add sp, sp, #0x30
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _0217e690:
 	cmp r0, #3
 	bne _0217e71c
 	ldr r4, _0217e760 ; =data_02050f54
 	mov r10, #0
-	mov sb, #0x3000
+	mov r9, #0x3000
 	add r8, sp, #0xc
 	add r7, sp, #0
 _0217e6ac:
 	ldrsh r2, [r6, #0xe]
-	mov r0, sb
+	mov r0, r9
 	mov r1, r8
 	sub r2, r2, #0x4000
 	strh r2, [r6, #0xe]
@@ -3167,12 +3167,12 @@ _0217e6ac:
 	mov r1, #1
 	bl func_ov30_0217e4b0
 	add sp, sp, #0x30
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _0217e71c:
 	mov r0, r6
 	bl func_ov00_020c50fc
 	add sp, sp, #0x30
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _0217e72c:
 	ldrsh r1, [r6, #0xe]
 	bl func_ov30_02182e34
@@ -3181,12 +3181,12 @@ _0217e72c:
 	bl func_ov30_02182e50
 	cmp r0, #0
 	addeq sp, sp, #0x30
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	mov r0, r6
 	mov r1, #0
 	bl func_ov30_0217e4b0
 	add sp, sp, #0x30
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov30_0217e5a4
 _0217e760: .word data_02050f54
@@ -3974,7 +3974,7 @@ func_ov30_0217f1a0: ; 0x0217f1a0
 	.global func_ov30_0217f1c4
 	arm_func_start func_ov30_0217f1c4
 func_ov30_0217f1c4: ; 0x0217f1c4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #0x68
 	mov r7, r0
 	bl func_ov00_020c5118
@@ -4005,13 +4005,13 @@ _0217f1f8:
 	mov r2, #0
 	bl func_ov00_020c50d4
 	add sp, sp, #0x68
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _0217f23c:
 	mov r0, r7
 	mov r1, #1
 	bl func_ov30_0217f130
 	add sp, sp, #0x68
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _0217f250:
 	bl func_ov30_02182dc0
 	mov r0, r5
@@ -4022,7 +4022,7 @@ _0217f250:
 	bl func_0202e58c
 	cmp r0, #0
 	addeq sp, sp, #0x68
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	mov r0, r5
 	mov r1, #0
 	bl func_ov30_02183e50
@@ -4053,13 +4053,13 @@ _0217f250:
 	mov r1, #2
 	bl func_ov30_0217f130
 	add sp, sp, #0x68
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _0217f2f4:
 	mov r0, r7
 	bl func_ov00_020c50f0
 	cmp r0, #0xa
 	addle sp, sp, #0x68
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	ldr r3, _0217f550 ; =data_ov00_020e8398
 	mvn r2, #0
 	mov r6, #1
@@ -4111,12 +4111,12 @@ _0217f3b8:
 	bl func_ov30_021840e4
 	cmp r0, #0
 	ble _0217f43c
-	ldr sb, _0217f55c ; =data_027e10b4
+	ldr r9, _0217f55c ; =data_027e10b4
 	ldr r8, _0217f560 ; =data_027e0fe4
 	add r10, sp, #0x50
 	add r4, sp, #0
 _0217f3e0:
-	ldr r0, [sb]
+	ldr r0, [r9]
 	mov r1, r6
 	bl func_ov30_021840ec
 	ldr r2, [r0]
@@ -4133,9 +4133,9 @@ _0217f3e0:
 	bl func_ov00_020ce2f0
 	cmp r0, #0x2000
 	addlt sp, sp, #0x68
-	ldmltia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmltia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _0217f428:
-	ldr r0, [sb]
+	ldr r0, [r9]
 	add r6, r6, #1
 	bl func_ov30_021840e4
 	cmp r6, r0
@@ -4153,7 +4153,7 @@ _0217f43c:
 	strh r2, [r5, #0x78]
 	bl func_ov30_0217f130
 	add sp, sp, #0x68
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _0217f470:
 	bl func_ov30_02182dc0
 	mov r0, r7
@@ -4168,7 +4168,7 @@ _0217f470:
 	mov r3, #0
 	bl func_ov00_020ceacc
 	add sp, sp, #0x68
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _0217f4a8:
 	cmp r0, #0x33
 	bne _0217f4f8
@@ -4189,10 +4189,10 @@ _0217f4a8:
 	ldr r0, [r0]
 	bl func_ov30_021840b0
 	add sp, sp, #0x68
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _0217f4f8:
 	addle sp, sp, #0x68
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	mov r0, r5
 	mov r1, #0
 	bl func_ov00_020cb160
@@ -4201,7 +4201,7 @@ _0217f4f8:
 	bl func_0202e58c
 	cmp r0, #0
 	addeq sp, sp, #0x68
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	mov r0, r5
 	bl func_ov30_02183e90
 	mov r0, r7
@@ -4210,7 +4210,7 @@ _0217f4f8:
 	bl func_ov00_020c50d4
 _0217f53c:
 	add sp, sp, #0x68
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov30_0217f1c4
 _0217f544: .word data_027e0f74
@@ -4225,10 +4225,10 @@ _0217f560: .word data_027e0fe4
 	.global func_ov30_0217f564
 	arm_func_start func_ov30_0217f564
 func_ov30_0217f564: ; 0x0217f564
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x54
 	mov r8, r1
-	mov sb, r0
+	mov r9, r0
 	bl func_ov00_020c5118
 	mov r4, r0
 	cmp r8, #7
@@ -4350,11 +4350,11 @@ _0217f724:
 _0217f72c:
 	bl func_ov30_02182da8
 _0217f730:
-	mov r0, sb
-	str r8, [sb, #8]
+	mov r0, r9
+	str r8, [r9, #8]
 	bl func_ov00_020c50fc
 	add sp, sp, #0x54
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov30_0217f564
 _0217f744: .word data_ov00_020e8398
@@ -7318,7 +7318,7 @@ _021818b4: .word 0x0000018f
 	.global func_ov30_021818b8
 	arm_func_start func_ov30_021818b8
 func_ov30_021818b8: ; 0x021818b8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x54
 	mov r5, r0
 	ldr r1, [r5, #0x2a0]
@@ -7326,7 +7326,7 @@ func_ov30_021818b8: ; 0x021818b8
 	cmpne r1, #1
 	cmpne r1, #0xc
 	addeq sp, sp, #0x54
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r1, sp, #0x44
 	bl _ZN5Actor9GetHitboxEP8Cylinder
 	ldr r1, _021819e0 ; =data_027e0fe4
@@ -7361,14 +7361,14 @@ _02181944:
 	add r11, sp, #0x44
 	mvn r6, #0
 _0218195c:
-	ldr sb, _021819e8 ; =data_ov30_021887d0
+	ldr r9, _021819e8 ; =data_ov30_021887d0
 	add lr, sp, #0x20
 	ldmia sb!, {r0, r1, r2, r3}
 	mov ip, lr
 	stmia lr!, {r0, r1, r2, r3}
-	ldr sb, [sb]
+	ldr r9, [r9]
 	ldr r1, [r7]
-	str sb, [lr]
+	str r9, [lr]
 	ldr r2, [ip, r4, lsl #2]
 	mov r0, r10
 	add r3, r5, #0x48
@@ -7380,21 +7380,21 @@ _0218195c:
 	mov r1, r10
 	bl _ZN12ActorManager8GetActorEP8ActorRef
 	mov r1, r8
-	mov sb, r0
+	mov r9, r0
 	bl _ZN5Actor9GetHitboxEP8Cylinder
 	mov r0, r11
 	mov r1, r8
 	bl func_01ffec34
 	cmp r0, #0
 	beq _021819cc
-	mov r0, sb
+	mov r0, r9
 	bl func_ov14_02135474
 _021819cc:
 	add r4, r4, #1
 	cmp r4, #5
 	blt _0218195c
 	add sp, sp, #0x54
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov30_021818b8
 _021819e0: .word data_027e0fe4
@@ -8322,7 +8322,7 @@ _02182630: .word 0x424f4d42
 	.global func_ov30_02182634
 	arm_func_start func_ov30_02182634
 func_ov30_02182634: ; 0x02182634
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x19c
 	mov r4, r0
 	bl func_ov30_02182b4c
@@ -8410,18 +8410,18 @@ _02182778:
 	add r1, r1, r6
 	bl _ZN12ActorManager8GetActorEP8ActorRef
 	mov r1, r8
-	mov sb, r0
+	mov r9, r0
 	bl _ZN5Actor9GetHitboxEP8Cylinder
 	mov r1, r8
 	add r0, r4, #0x860
 	bl func_01ffec34
 	cmp r0, #0
 	beq _021827c0
-	mov r0, sb
+	mov r0, r9
 	bl func_ov14_02122eb8
 	cmp r0, #0
 	beq _021827c0
-	mov r0, sb
+	mov r0, r9
 	bl func_ov14_02122e98
 _021827c0:
 	ldr r0, [sp, #0x70]
@@ -8457,7 +8457,7 @@ _021827d4:
 	cmp r0, #0
 	addeq sp, sp, #0x19c
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	ldr r0, _02182ad0 ; =data_ov30_021887e4
 	add r3, sp, #0x34
 	ldmia r0, {r0, r1, r2}
@@ -8478,23 +8478,23 @@ _021827d4:
 	smull r1, r3, r2, r5
 	adds lr, r1, #0x800
 	ldr r8, [sp, #0x34]
-	ldr sb, [sp, #0x38]
+	ldr r9, [sp, #0x38]
 	smull r1, r7, r2, r6
-	add r2, ip, sb
+	add r2, ip, r9
 	str ip, [sp, #0x44]
-	adc sb, r3, #0
+	adc r9, r3, #0
 	ldr r3, [r4, #0x50]
 	adds ip, r1, #0x800
 	mov r1, lr, lsr #0xc
-	orr r1, r1, sb, lsl #20
+	orr r1, r1, r9, lsl #20
 	add r1, r0, r1
 	str r2, [sp, #0x44]
 	smull r4, r6, r8, r6
-	adc sb, r7, #0
+	adc r9, r7, #0
 	adds r7, r4, #0x800
 	rsb r5, r5, #0
 	mov r0, ip, lsr #0xc
-	orr r0, r0, sb, lsl #20
+	orr r0, r0, r9, lsl #20
 	add r0, r3, r0
 	smull r5, r4, r8, r5
 	adc r6, r6, #0
@@ -8528,7 +8528,7 @@ _021827d4:
 	bl func_ov00_0207c1b0
 	add sp, sp, #0x19c
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _02182960:
 	mov r0, #0x1e
 	str r0, [sp]
@@ -8539,7 +8539,7 @@ _02182960:
 	cmp r0, #0
 	addeq sp, sp, #0x19c
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	ldr r0, _02182ae0 ; =data_ov30_021887f0
 	add r3, sp, #0x1c
 	ldmia r0, {r0, r1, r2}
@@ -8564,20 +8564,20 @@ _02182960:
 	smull r2, r7, r8, r5
 	orr lr, lr, r6, lsl #20
 	str r1, [sp, #0x28]
-	ldr sb, [r4, #0x4c]
+	ldr r9, [r4, #0x4c]
 	ldr r0, [sp, #0x20]
 	smull r5, r6, ip, r5
 	adds r8, r2, #0x800
 	add r1, r1, lr
 	adc lr, r7, #0
 	adds r7, r5, #0x800
-	str sb, [sp, #0x2c]
+	str r9, [sp, #0x2c]
 	smull r5, r3, ip, r3
 	adc r6, r6, #0
 	mov r7, r7, lsr #0xc
 	orr r7, r7, r6, lsl #20
 	ldr r2, [r4, #0x50]
-	add r0, sb, r0
+	add r0, r9, r0
 	str r0, [sp, #0x2c]
 	mov r0, r8, lsr #0xc
 	orr r0, r0, lr, lsl #20
@@ -8614,7 +8614,7 @@ _02182960:
 	bl func_ov00_020c51d0
 	mov r0, #1
 	add sp, sp, #0x19c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov30_02182634
 _02182ab4: .word 0x0000ffff
@@ -9390,7 +9390,7 @@ _021833e8: .word 0x43525953
 	.global func_ov30_021833ec
 	arm_func_start func_ov30_021833ec
 func_ov30_021833ec: ; 0x021833ec
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x2bc
 	mov r4, r0
 	ldr r1, [r4, #4]
@@ -9398,12 +9398,12 @@ func_ov30_021833ec: ; 0x021833ec
 	cmp r1, r0
 	addeq sp, sp, #0x2bc
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	add r0, r0, #0x1e
 	cmp r1, r0
 	addeq sp, sp, #0x2bc
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	ldr r0, [r4, #0x880]
 	cmp r0, #0
 	beq _02183448
@@ -9412,7 +9412,7 @@ func_ov30_021833ec: ; 0x021833ec
 	str r0, [r4, #0x888]
 	add sp, sp, #0x2bc
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _02183448:
 	ldr r3, _02183804 ; =_ZTV11FilterActor
 	mvn r5, #0
@@ -9467,12 +9467,12 @@ _021834e0:
 	mov r7, #0
 	cmp r0, #0
 	ble _0218358c
-	ldr sb, _0218380c ; =data_027e0fe4
+	ldr r9, _0218380c ; =data_027e0fe4
 	mov r8, r7
 	add r5, sp, #0
 _02183524:
 	ldr r1, [sp, #0x1e8]
-	ldr r0, [sb]
+	ldr r0, [r9]
 	add r1, r1, r8
 	bl _ZN12ActorManager8GetActorEP8ActorRef
 	cmp r0, #0
@@ -9536,12 +9536,12 @@ _021835e4:
 	mov r7, #0
 	cmp r0, #0
 	ble _02183690
-	ldr sb, _0218380c ; =data_027e0fe4
+	ldr r9, _0218380c ; =data_027e0fe4
 	mov r8, r7
 	add r5, sp, #0
 _02183628:
 	ldr r1, [sp, #0x114]
-	ldr r0, [sb]
+	ldr r0, [r9]
 	add r1, r1, r8
 	bl _ZN12ActorManager8GetActorEP8ActorRef
 	cmp r0, #0
@@ -9605,12 +9605,12 @@ _021836e8:
 	mov r7, #0
 	cmp r0, #0
 	ble _02183788
-	ldr sb, _0218380c ; =data_027e0fe4
+	ldr r9, _0218380c ; =data_027e0fe4
 	mov r8, r7
 	add r5, sp, #0
 _0218372c:
 	ldr r1, [sp, #0x40]
-	ldr r0, [sb]
+	ldr r0, [r9]
 	add r1, r1, r8
 	bl _ZN12ActorManager8GetActorEP8ActorRef
 	cmp r0, #0
@@ -9657,7 +9657,7 @@ _0218379c:
 	add sp, sp, #0x2bc
 	mov r0, #1
 	str r1, [r4, #0x888]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _021837e4:
 	add r5, r5, #1
 	cmp r5, r6
@@ -9666,7 +9666,7 @@ _021837e4:
 _021837f4:
 	mov r0, #0
 	add sp, sp, #0x2bc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov30_021833ec
 _02183800: .word 0x43485334
@@ -9873,7 +9873,7 @@ _02183a74: .word 0x0000019a
 	.global func_ov30_02183a78
 	arm_func_start func_ov30_02183a78
 func_ov30_02183a78: ; 0x02183a78
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0xa8
 	ldr r3, _02183b84 ; =data_ov30_02188b08
 	mov r2, #0
@@ -9914,7 +9914,7 @@ _02183ab0:
 	ldr r8, _02183b8c ; =0x00002aaa
 	ldr r7, _02183b88 ; =data_027e0fe4
 	mov r5, r4
-	mov sb, #0x2800
+	mov r9, #0x2800
 _02183b1c:
 	ldr r1, [sp, #0x1c]
 	ldr r0, [r7]
@@ -9926,14 +9926,14 @@ _02183b1c:
 	beq _02183b64
 	str r0, [sp]
 	ldrsh r1, [r6, #0x78]
-	mov r2, sb
+	mov r2, r9
 	mov r3, r8
 	add r0, r6, #0x48
 	bl func_ov00_020c54a0
 	cmp r0, #0
 	addne sp, sp, #0xa8
 	movne r0, #1
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _02183b64:
 	ldr r0, [sp, #0x24]
 	add r4, r4, #1
@@ -9943,7 +9943,7 @@ _02183b64:
 _02183b78:
 	mov r0, #0
 	add sp, sp, #0xa8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov30_02183a78
 _02183b84: .word data_ov30_02188b08
@@ -9953,7 +9953,7 @@ _02183b8c: .word 0x00002aaa
 	.global func_ov30_02183b90
 	arm_func_start func_ov30_02183b90
 func_ov30_02183b90: ; 0x02183b90
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #0xa8
 	ldr r3, _02183c9c ; =data_ov30_02188b08
 	mov r2, #0
@@ -9994,7 +9994,7 @@ _02183bc8:
 	ldr r8, _02183ca4 ; =0x00002aaa
 	ldr r7, _02183ca0 ; =data_027e0fe4
 	mov r5, r4
-	mov sb, #0x2800
+	mov r9, #0x2800
 _02183c34:
 	ldr r1, [sp, #0x1c]
 	ldr r0, [r7]
@@ -10006,14 +10006,14 @@ _02183c34:
 	beq _02183c7c
 	str r10, [sp]
 	ldrsh r1, [r6, #0x78]
-	mov r2, sb
+	mov r2, r9
 	mov r3, r8
 	add r0, r6, #0x48
 	bl func_ov00_020c54a0
 	cmp r0, #0
 	addne sp, sp, #0xa8
 	movne r0, #1
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _02183c7c:
 	ldr r0, [sp, #0x24]
 	add r4, r4, #1
@@ -10023,7 +10023,7 @@ _02183c7c:
 _02183c90:
 	mov r0, #0
 	add sp, sp, #0xa8
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov30_02183b90
 _02183c9c: .word data_ov30_02188b08
@@ -10450,7 +10450,7 @@ func_ov30_021840ec: ; 0x021840ec
 	.global func_ov30_0218411c
 	arm_func_start func_ov30_0218411c
 func_ov30_0218411c: ; 0x0218411c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #8
 	ldr r1, _021842fc ; =data_027e0fc8
 	mov r10, r0
@@ -10458,7 +10458,7 @@ func_ov30_0218411c: ; 0x0218411c
 	bl func_ov00_020bbb64
 	cmp r0, #0
 	addne sp, sp, #8
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	mov r8, #0
 	sub r0, r8, #1
 	str r0, [r10, #0x8c]
@@ -10469,13 +10469,13 @@ func_ov30_0218411c: ; 0x0218411c
 	cmp r0, #0
 	ble _021841ec
 	ldr r4, _02184300 ; =data_027e0fe4
-	mov sb, r8
+	mov r9, r8
 	add r11, sp, #0
 _02184170:
 	ldr r2, [r10]
 	ldr r0, [r4]
-	ldr r1, [r2, sb]
-	add r2, r2, sb
+	ldr r1, [r2, r9]
+	add r2, r2, r9
 	str r1, [sp]
 	ldr r2, [r2, #4]
 	mov r1, r11
@@ -10501,7 +10501,7 @@ _021841d0:
 	add r0, r6, #1
 	mov r0, r0, lsl #0x10
 	cmp r1, r0, asr #16
-	add sb, sb, #8
+	add r9, r9, #8
 	mov r6, r0, asr #0x10
 	bgt _02184170
 _021841ec:
@@ -10575,7 +10575,7 @@ _021842d4:
 	subgt r0, r0, #1
 	strgth r0, [r10, #0xa0]
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov30_0218411c
 _021842fc: .word data_027e0fc8
@@ -11285,7 +11285,7 @@ func_ov30_02184850: ; 0x02184850
 	.global func_ov30_02184868
 	arm_func_start func_ov30_02184868
 func_ov30_02184868: ; 0x02184868
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x1bc
 	sub sp, sp, #0x400
 	mov r4, r0
@@ -11293,7 +11293,7 @@ func_ov30_02184868: ; 0x02184868
 	cmp r0, #0
 	addeq sp, sp, #0x1bc
 	addeq sp, sp, #0x400
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	mov r0, r4
 	bl _ZN5Actor20IncreaseActiveFramesEv
 	ldr r0, [r4, #0x130]
@@ -11339,13 +11339,13 @@ _021848f4:
 	cmp r0, #0
 	ldrh r10, [r4, #0x20]
 	ble _021849cc
-	ldr sb, [sp, #0x18]
+	ldr r9, [sp, #0x18]
 	ldr r11, _02185254 ; =data_027e0e60
 	ldr r5, _02185250 ; =data_027e0fe4
 _02184940:
 	ldr r1, [sp, #0x530]
 	ldr r0, [r5]
-	add r1, r1, sb
+	add r1, r1, r9
 	bl _ZN12ActorManager8GetActorEP8ActorRef
 	movs r7, r0
 	beq _021849b8
@@ -11378,7 +11378,7 @@ _021849b8:
 	ldr r0, [sp, #0x534]
 	add r6, r6, #1
 	cmp r6, r0
-	add sb, sb, #8
+	add r9, r9, #8
 	blt _02184940
 _021849cc:
 	ldr r0, [sp, #0x18]
@@ -11390,13 +11390,13 @@ _021849cc:
 	bl _ZN5Actor18func_ov00_020c1c20Eiii
 	add sp, sp, #0x1bc
 	add sp, sp, #0x400
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _021849f4:
 	mov r2, r1
 	bl _ZN5Actor18func_ov00_020c1c20Eiii
 	add sp, sp, #0x1bc
 	add sp, sp, #0x400
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02184a08:
 	ldr r2, _0218524c ; =data_ov30_02188b08
 	mov r1, #0
@@ -11427,13 +11427,13 @@ _02184a34:
 	cmp r0, #0
 	ldrh r10, [r4, #0x20]
 	ble _02184b10
-	ldr sb, [sp, #0x14]
+	ldr r9, [sp, #0x14]
 	ldr r11, _02185254 ; =data_027e0e60
 	ldr r5, _02185250 ; =data_027e0fe4
 _02184a84:
 	ldr r1, [sp, #0x4a4]
 	ldr r0, [r5]
-	add r1, r1, sb
+	add r1, r1, r9
 	bl _ZN12ActorManager8GetActorEP8ActorRef
 	movs r7, r0
 	beq _02184afc
@@ -11466,7 +11466,7 @@ _02184afc:
 	ldr r0, [sp, #0x4a8]
 	add r6, r6, #1
 	cmp r6, r0
-	add sb, sb, #8
+	add r9, r9, #8
 	blt _02184a84
 _02184b10:
 	ldr r0, [sp, #0x14]
@@ -11478,13 +11478,13 @@ _02184b10:
 	bl _ZN5Actor18func_ov00_020c1c20Eiii
 	add sp, sp, #0x1bc
 	add sp, sp, #0x400
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02184b38:
 	mov r2, r1
 	bl _ZN5Actor18func_ov00_020c1c20Eiii
 	add sp, sp, #0x1bc
 	add sp, sp, #0x400
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02184b4c:
 	ldr r6, _02185258 ; =_ZTV11FilterActor
 	mov r2, #0
@@ -11527,13 +11527,13 @@ _02184ba8:
 	cmp r0, #0
 	ldrh r10, [r4, #0x20]
 	ble _02184c84
-	ldr sb, [sp, #0x10]
+	ldr r9, [sp, #0x10]
 	ldr r11, _02185254 ; =data_027e0e60
 	ldr r5, _02185250 ; =data_027e0fe4
 _02184bf8:
 	ldr r1, [sp, #0x3d0]
 	ldr r0, [r5]
-	add r1, r1, sb
+	add r1, r1, r9
 	bl _ZN12ActorManager8GetActorEP8ActorRef
 	movs r7, r0
 	beq _02184c70
@@ -11566,7 +11566,7 @@ _02184c70:
 	ldr r0, [sp, #0x3d4]
 	add r6, r6, #1
 	cmp r6, r0
-	add sb, sb, #8
+	add r9, r9, #8
 	blt _02184bf8
 _02184c84:
 	ldr r0, [sp, #0x10]
@@ -11578,13 +11578,13 @@ _02184c84:
 	bl _ZN5Actor18func_ov00_020c1c20Eiii
 	add sp, sp, #0x1bc
 	add sp, sp, #0x400
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02184cac:
 	mov r2, r1
 	bl _ZN5Actor18func_ov00_020c1c20Eiii
 	add sp, sp, #0x1bc
 	add sp, sp, #0x400
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02184cc0:
 	ldr r6, _02185258 ; =_ZTV11FilterActor
 	mov r2, #0
@@ -11625,13 +11625,13 @@ _02184d18:
 	cmp r0, #0
 	ldrh r10, [r4, #0x20]
 	ble _02184df0
-	ldr sb, [sp, #0xc]
+	ldr r9, [sp, #0xc]
 	ldr r11, _02185254 ; =data_027e0e60
 	ldr r5, _02185250 ; =data_027e0fe4
 _02184d64:
 	ldr r1, [sp, #0x2fc]
 	ldr r0, [r5]
-	add r1, r1, sb
+	add r1, r1, r9
 	bl _ZN12ActorManager8GetActorEP8ActorRef
 	movs r7, r0
 	beq _02184ddc
@@ -11664,7 +11664,7 @@ _02184ddc:
 	ldr r0, [sp, #0x300]
 	add r6, r6, #1
 	cmp r6, r0
-	add sb, sb, #8
+	add r9, r9, #8
 	blt _02184d64
 _02184df0:
 	ldr r0, [sp, #0xc]
@@ -11676,13 +11676,13 @@ _02184df0:
 	bl _ZN5Actor18func_ov00_020c1c20Eiii
 	add sp, sp, #0x1bc
 	add sp, sp, #0x400
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02184e18:
 	mov r2, r1
 	bl _ZN5Actor18func_ov00_020c1c20Eiii
 	add sp, sp, #0x1bc
 	add sp, sp, #0x400
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02184e2c:
 	ldr r6, _02185258 ; =_ZTV11FilterActor
 	mov r2, #0
@@ -11723,14 +11723,14 @@ _02184e84:
 	cmp r0, #0
 	ldrh r10, [r4, #0x20]
 	ble _02184f50
-	ldr sb, [sp, #8]
+	ldr r9, [sp, #8]
 	ldr r5, _02185254 ; =data_027e0e60
 	ldr r6, _02185250 ; =data_027e0fe4
 	mov r11, r7
 _02184ed4:
 	ldr r1, [sp, #0x228]
 	ldr r0, [r6]
-	add r1, r1, sb
+	add r1, r1, r9
 	bl _ZN12ActorManager8GetActorEP8ActorRef
 	cmp r0, #0
 	beq _02184f3c
@@ -11759,7 +11759,7 @@ _02184f3c:
 	ldr r0, [sp, #0x22c]
 	add r7, r7, #1
 	cmp r7, r0
-	add sb, sb, #8
+	add r9, r9, #8
 	blt _02184ed4
 _02184f50:
 	ldr r0, [sp, #8]
@@ -11771,13 +11771,13 @@ _02184f50:
 	bl _ZN5Actor18func_ov00_020c1c20Eiii
 	add sp, sp, #0x1bc
 	add sp, sp, #0x400
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02184f78:
 	mov r2, r1
 	bl _ZN5Actor18func_ov00_020c1c20Eiii
 	add sp, sp, #0x1bc
 	add sp, sp, #0x400
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02184f8c:
 	ldr r6, _02185258 ; =_ZTV11FilterActor
 	mov r2, #0
@@ -11818,14 +11818,14 @@ _02184fe4:
 	cmp r0, #0
 	ldrh r10, [r4, #0x20]
 	ble _021850b0
-	ldr sb, [sp, #4]
+	ldr r9, [sp, #4]
 	ldr r5, _02185254 ; =data_027e0e60
 	ldr r6, _02185250 ; =data_027e0fe4
 	mov r11, r7
 _02185034:
 	ldr r1, [sp, #0x154]
 	ldr r0, [r6]
-	add r1, r1, sb
+	add r1, r1, r9
 	bl _ZN12ActorManager8GetActorEP8ActorRef
 	cmp r0, #0
 	beq _0218509c
@@ -11854,7 +11854,7 @@ _0218509c:
 	ldr r0, [sp, #0x158]
 	add r7, r7, #1
 	cmp r7, r0
-	add sb, sb, #8
+	add r9, r9, #8
 	blt _02185034
 _021850b0:
 	ldr r0, [sp, #4]
@@ -11866,13 +11866,13 @@ _021850b0:
 	bl _ZN5Actor18func_ov00_020c1c20Eiii
 	add sp, sp, #0x1bc
 	add sp, sp, #0x400
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _021850d8:
 	mov r2, r1
 	bl _ZN5Actor18func_ov00_020c1c20Eiii
 	add sp, sp, #0x1bc
 	add sp, sp, #0x400
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _021850ec:
 	ldr r6, _02185258 ; =_ZTV11FilterActor
 	mov r2, #0
@@ -11913,14 +11913,14 @@ _02185144:
 	cmp r0, #0
 	ldrh r10, [r4, #0x20]
 	ble _02185210
-	ldr sb, [sp]
+	ldr r9, [sp]
 	ldr r5, _02185254 ; =data_027e0e60
 	ldr r6, _02185250 ; =data_027e0fe4
 	mov r11, r7
 _02185194:
 	ldr r1, [sp, #0x80]
 	ldr r0, [r6]
-	add r1, r1, sb
+	add r1, r1, r9
 	bl _ZN12ActorManager8GetActorEP8ActorRef
 	cmp r0, #0
 	beq _021851fc
@@ -11949,7 +11949,7 @@ _021851fc:
 	ldr r0, [sp, #0x84]
 	add r7, r7, #1
 	cmp r7, r0
-	add sb, sb, #8
+	add r9, r9, #8
 	blt _02185194
 _02185210:
 	ldr r0, [sp]
@@ -11961,14 +11961,14 @@ _02185210:
 	bl _ZN5Actor18func_ov00_020c1c20Eiii
 	add sp, sp, #0x1bc
 	add sp, sp, #0x400
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02185238:
 	mov r2, r1
 	bl _ZN5Actor18func_ov00_020c1c20Eiii
 _02185240:
 	add sp, sp, #0x1bc
 	add sp, sp, #0x400
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov30_02184868
 _0218524c: .word data_ov30_02188b08
@@ -13338,7 +13338,7 @@ _02186574:
 	.global func_ov30_02186584
 	arm_func_start func_ov30_02186584
 func_ov30_02186584: ; 0x02186584
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x40
 	mov r7, r0
 	bl func_ov00_020c5118
@@ -13382,7 +13382,7 @@ _021865c8:
 	bl func_ov00_020c4c00
 	cmp r0, #0
 	addeq sp, sp, #0x40
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	ldr r1, [sp, #0x14]
 	mov r0, r6
 	str r1, [r7, #0x10]
@@ -13405,7 +13405,7 @@ _021865c8:
 	mov r1, r8
 	bl func_ov30_021863e4
 	add sp, sp, #0x40
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _0218668c:
 	add r1, r7, #0x10
 	bl func_ov30_02182c84
@@ -13430,21 +13430,21 @@ _021866ac:
 	mov r1, #0xf
 	bl func_ov00_020c50d4
 	add sp, sp, #0x40
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _021866e8:
 	mov r1, #3
 	bl func_ov00_020c50d4
 	add sp, sp, #0x40
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _021866f8:
 	cmp r5, #0
 	addeq sp, sp, #0x40
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	mov r0, r7
 	mov r1, #2
 	bl func_ov30_021863e4
 	add sp, sp, #0x40
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _02186718:
 	add r1, sp, #4
 	mov r0, r6
@@ -13486,13 +13486,13 @@ _0218678c:
 	ldr ip, [r2, #0x10]
 	mla lr, r0, r3, lr
 	ldr r0, [r2, #0x14]
-	adds sb, ip, r8
+	adds r9, ip, r8
 	adc r8, r0, lr
 	mov r0, #0x64
 	umull r3, ip, r8, r0
 	mla ip, r8, r1, ip
 	mla ip, r1, r0, ip
-	str sb, [r2]
+	str r9, [r2]
 	cmp ip, #0x32
 	str r8, [r2, #4]
 	movlt r5, #1
@@ -13505,7 +13505,7 @@ _021867dc:
 	mov r1, #5
 	bl func_ov30_021863e4
 	add sp, sp, #0x40
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _02186800:
 	mov r0, r4
 	bl func_ov30_021824cc
@@ -13515,7 +13515,7 @@ _02186800:
 	mov r1, #3
 	bl func_ov30_021863e4
 	add sp, sp, #0x40
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _02186824:
 	bl func_ov00_020c50f0
 	cmp r0, #0x1e
@@ -13538,18 +13538,18 @@ _02186860:
 	bl func_ov30_02183fa0
 	cmp r0, #0
 	addeq sp, sp, #0x40
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	mov r0, r7
 	bl func_ov00_020c510c
 	cmp r0, #0x1e
 	addle sp, sp, #0x40
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	mov r0, r7
 	mov r1, #6
 	mov r2, #0
 	bl func_ov00_020c50d4
 	add sp, sp, #0x40
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _021868a4:
 	bl func_ov30_02182dc0
 	mov r0, r4
@@ -13560,24 +13560,24 @@ _021868a4:
 	bl func_0202e58c
 	cmp r0, #0
 	addeq sp, sp, #0x40
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	mov r0, r7
 	mov r1, #2
 	bl func_ov30_021863e4
 	add sp, sp, #0x40
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _021868e0:
 	bl func_ov30_02182dc0
 	mov r0, r7
 	bl func_ov00_020c50f0
 	cmp r0, #0xf
 	addle sp, sp, #0x40
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	mov r0, r7
 	mov r1, #2
 	bl func_ov30_021863e4
 	add sp, sp, #0x40
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _0218690c:
 	bl func_ov30_02182dc0
 	mov r0, r4
@@ -13588,13 +13588,13 @@ _0218690c:
 	bl func_0202e58c
 	cmp r0, #0
 	addeq sp, sp, #0x40
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	mov r0, r7
 	mov r1, #2
 	bl func_ov30_021863e4
 _02186940:
 	add sp, sp, #0x40
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov30_02186584
 _02186948: .word data_ov00_020e8398
@@ -14656,11 +14656,11 @@ func_ov30_02187768: ; 0x02187768
 	.global func_ov30_02187790
 	arm_func_start func_ov30_02187790
 func_ov30_02187790: ; 0x02187790
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x1c
 	mov r4, r0
-	ldmia r4, {r0, sb}
-	mul r1, r0, sb
+	ldmia r4, {r0, r9}
+	mul r1, r0, r9
 	ldrsh r8, [r4, #0x38]
 	ldrsh r0, [r4, #0x3a]
 	cmp r8, r1
@@ -14672,18 +14672,18 @@ _021877c0:
 	cmp r8, r6, asr #16
 	addge sp, sp, #0x1c
 	movge r0, #1
-	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmgeia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	mov r0, r8
-	mov r1, sb
+	mov r1, r9
 	bl func_02002c14
 	mov r5, r0, lsl #0x10
 	mov r0, r8
-	mov r1, sb
+	mov r1, r9
 	mov r8, r5, asr #0x10
 	bl func_02002c14
 	ldrsh r0, [r4, #0x34]
 	mov r2, r1, lsl #0x10
-	mul r1, r8, sb
+	mul r1, r8, r9
 	ldr r3, [r4, #0x1c]
 	add r1, r1, r2, asr #16
 	add r8, r3, r1, lsl #5
@@ -14705,11 +14705,11 @@ _021877c0:
 	rsbmi r0, r0, #0
 	cmp r0, #0x800
 	bge _021878b0
-	ldrh sb, [r8, #0x1c]
+	ldrh r9, [r8, #0x1c]
 	ldrh r3, [r4, #0x2c]
 	ldrh r5, [r8, #0x1e]
 	ldrh r2, [r4, #0x2e]
-	strh sb, [sp]
+	strh r9, [sp]
 	strh r3, [sp, #4]
 	ldrsh r1, [sp, #4]
 	ldrsh r0, [sp]
@@ -14718,7 +14718,7 @@ _021877c0:
 	cmp r1, r0
 	ldreqsh r1, [sp, #6]
 	ldreqsh r0, [sp, #2]
-	strh sb, [sp, #8]
+	strh r9, [sp, #8]
 	strh r5, [sp, #0xa]
 	strh r3, [sp, #0xc]
 	strh r2, [sp, #0xe]
@@ -14737,15 +14737,15 @@ _021878bc:
 	ldrsh r0, [r4, #0x38]
 	add r0, r0, #1
 	strh r0, [r4, #0x38]
-	ldmia r4, {r0, sb}
-	mul r1, r0, sb
+	ldmia r4, {r0, r9}
+	mul r1, r0, r9
 	ldrsh r8, [r4, #0x38]
 	cmp r8, r1
 	blt _021877c0
 _021878dc:
 	mov r0, #0
 	add sp, sp, #0x1c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	arm_func_end func_ov30_02187790
 
 	.global func_ov30_021878e8
@@ -15170,10 +15170,10 @@ func_ov30_02187dfc: ; 0x02187dfc
 	.global func_ov30_02187e18
 	arm_func_start func_ov30_02187e18
 func_ov30_02187e18: ; 0x02187e18
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x3c
 	mov r10, r0
-	mov sb, r1
+	mov r9, r1
 	mov r8, r2
 	mov r7, r3
 	ldr r6, [sp, #0x60]
@@ -15186,18 +15186,18 @@ _02187e44:
 	bl func_ov30_02187ef0
 	cmp r0, #0
 	addne sp, sp, #0x3c
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	mov r0, r10
 	add r1, sp, #0x30
 	bl func_ov30_02187dac
 	cmp r0, #0
 	addeq sp, sp, #0x3c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, [sp, #0x34]
 	ldr r3, [sp, #0x30]
 	add ip, r0, r8
 	str ip, [sp, #0x34]
-	ldmia sb, {r0, r1, r2}
+	ldmia r9, {r0, r1, r2}
 	stmia r5, {r0, r1, r2}
 	ldr r0, [sp, #0x24]
 	ldr r1, [sp, #0x38]
@@ -15218,7 +15218,7 @@ _02187e44:
 	bl func_01ffe1cc
 	cmp r0, #0
 	addne sp, sp, #0x3c
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	mov r0, r10
 	bl func_ov30_02187dfc
 	b _02187e44
@@ -15228,7 +15228,7 @@ _02187e44:
 	arm_func_start func_ov30_02187ee4
 func_ov30_02187ee4: ; 0x02187ee4
 	add sp, sp, #0x3c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov30_02187ee4
 _02187eec: .word data_027e0e60
@@ -15273,22 +15273,22 @@ _02187f2c:
 	.global func_ov30_02187f58
 	arm_func_start func_ov30_02187f58
 func_ov30_02187f58: ; 0x02187f58
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0xc
 	str r0, [sp]
 	add r0, r0, #0x1000
-	mov sb, #0
+	mov r9, #0
 	ldr r2, _0218807c ; =data_027e0ff0
-	str sb, [r0, #0x10]
+	str r9, [r0, #0x10]
 	ldr r2, [r2]
 	str r1, [sp, #4]
 	ldr r0, [r2, #4]
 	cmp r0, #0
 	addle sp, sp, #0xc
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02187f8c:
 	ldr r8, [r2]
-	and r7, sb, #0xff
+	and r7, r9, #0xff
 	ldr r2, [r8, r7, lsl #3]
 	cmp r2, #0
 	beq _02188054
@@ -15307,7 +15307,7 @@ _02187f8c:
 	add r4, r0, #0x1000
 _02187fd4:
 	ldr r0, [r11]
-	strb sb, [sp, #0xa]
+	strb r9, [sp, #0xa]
 	strb r10, [sp, #0xb]
 	add r1, sp, #0xa
 	bl func_ov00_020c47cc
@@ -15341,15 +15341,15 @@ _02188038:
 	bgt _02187fd4
 _02188054:
 	ldr r0, _0218807c ; =data_027e0ff0
-	add r1, sb, #1
+	add r1, r9, #1
 	ldr r2, [r0]
 	mov r0, r1, lsl #0x18
 	ldr r1, [r2, #4]
-	mov sb, r0, asr #0x18
+	mov r9, r0, asr #0x18
 	cmp r1, r0, asr #24
 	bgt _02187f8c
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov30_02187f58
 _0218807c: .word data_027e0ff0
@@ -15452,7 +15452,7 @@ _021881b4:
 	.global func_ov30_021881bc
 	arm_func_start func_ov30_021881bc
 func_ov30_021881bc: ; 0x021881bc
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x2c
 	mov r10, r0
 	ldr r3, [r10]
@@ -15501,24 +15501,24 @@ _02188200:
 	bl func_ov00_020c47cc
 	mov r6, r0
 	mov r11, #0
-	add sb, r6, #0x14
+	add r9, r6, #0x14
 	add r4, r10, #0x1000
 _02188280:
-	ldrsb r0, [sb, #2]
+	ldrsb r0, [r9, #2]
 	sub r0, r0, #1
 	mov r0, r0, lsl #0x18
 	mov r0, r0, asr #0x18
 	and r0, r0, #0xff
 	cmp r0, #2
 	bhi _02188378
-	ldrsb r0, [sb, #3]
+	ldrsb r0, [r9, #3]
 	cmp r0, #0
 	bne _02188378
-	ldrsb r2, [sb]
+	ldrsb r2, [r9]
 	ldr r0, _02188394 ; =data_027e0ff0
 	add r1, sp, #2
 	strb r2, [sp, #2]
-	ldrsb r2, [sb, #1]
+	ldrsb r2, [r9, #1]
 	ldr r0, [r0]
 	strb r2, [sp, #3]
 	bl func_ov00_020c47cc
@@ -15565,15 +15565,15 @@ _02188280:
 	cmp r8, r0
 	addeq sp, sp, #0x2c
 	moveq r0, #1
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02188378:
 	add r11, r11, #1
 	cmp r11, #4
-	add sb, sb, #4
+	add r9, r9, #4
 	blt _02188280
 	mov r0, #0
 	add sp, sp, #0x2c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov30_021881bc
 _02188394: .word data_027e0ff0

--- a/asm/ov31.s
+++ b/asm/ov31.s
@@ -1464,10 +1464,10 @@ _0217cfd0: .word data_ov31_02183e84
 	.global func_ov31_0217cfd4
 	arm_func_start func_ov31_0217cfd4
 func_ov31_0217cfd4: ; 0x0217cfd4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x5c
-	mov sl, r0
-	add r0, sl, #0x1d8
+	mov r10, r0
+	add r0, r10, #0x1d8
 	mov r1, #0x3800
 	str r1, [r0, #0x7c]
 	mov r1, #0x4000
@@ -1477,11 +1477,11 @@ func_ov31_0217cfd4: ; 0x0217cfd4
 	str r2, [r0, #0x80]
 	strh r1, [r0, #0x86]
 	mov r1, #0
-	strb r1, [sl, #0x285]
+	strb r1, [r10, #0x285]
 	bl func_ov14_02145e48
-	ldr r1, [sl, #0x1e8]
+	ldr r1, [r10, #0x1e8]
 	mov r2, #0x1000
-	mov r0, sl
+	mov r0, r10
 	str r2, [r1, #0x10]
 	bl func_ov31_0217d588
 	add r0, sp, #0x30
@@ -1491,7 +1491,7 @@ func_ov31_0217cfd4: ; 0x0217cfd4
 	str r1, [sp, #0x4c]
 	str r1, [sp, #0x50]
 	bl func_ov00_020c3348
-	add r0, sl, #0x48
+	add r0, r10, #0x48
 	add r3, sp, #0x24
 	ldmia r0, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
@@ -1538,7 +1538,7 @@ func_ov31_0217cfd4: ; 0x0217cfd4
 	add r0, r0, #0xf2
 	str r0, [sp, #4]
 _0217d0f8:
-	mov r0, sl
+	mov r0, r10
 	ldr r2, [r0]
 	mov r1, r7
 	ldr r2, [r2, #0x114]
@@ -1620,7 +1620,7 @@ _0217d1fc:
 	add r5, r5, #1
 	b _0217d25c
 _0217d21c:
-	ldr r0, [sl, #0x470]
+	ldr r0, [r10, #0x470]
 	cmp r0, #2
 	bne _0217d240
 	add r0, r6, #2
@@ -1674,13 +1674,13 @@ _0217d2c8:
 	blt _0217d0f8
 	mov r0, #0
 	str r0, [sp, #0x54]
-	ldr r0, [sl, #0x48]
+	ldr r0, [r10, #0x48]
 	sub r0, r0, #0x1000
 	str r0, [sp, #0x24]
-	ldr r0, [sl, #0x4c]
+	ldr r0, [r10, #0x4c]
 	add r0, r0, #0x800
 	str r0, [sp, #0x28]
-	ldr r0, [sl, #0x50]
+	ldr r0, [r10, #0x50]
 	add r0, r0, #0x2800
 	str r0, [sp, #0x2c]
 	bl func_ov31_0217bdb8
@@ -1692,13 +1692,13 @@ _0217d2c8:
 	add r2, sp, #0x24
 	add r3, sp, #0x30
 	bl func_ov00_020c4048
-	ldr r0, [sl, #0x48]
+	ldr r0, [r10, #0x48]
 	add r0, r0, #0x1000
 	str r0, [sp, #0x24]
-	ldr r0, [sl, #0x4c]
+	ldr r0, [r10, #0x4c]
 	add r0, r0, #0x800
 	str r0, [sp, #0x28]
-	ldr r0, [sl, #0x50]
+	ldr r0, [r10, #0x50]
 	add r0, r0, #0x2800
 	str r0, [sp, #0x2c]
 	bl func_ov31_0217bdb8
@@ -1710,13 +1710,13 @@ _0217d2c8:
 	add r2, sp, #0x24
 	add r3, sp, #0x30
 	bl func_ov00_020c4048
-	ldr r0, [sl, #0x48]
+	ldr r0, [r10, #0x48]
 	add r0, r0, #0x1000
 	str r0, [sp, #0x24]
-	ldr r0, [sl, #0x4c]
+	ldr r0, [r10, #0x4c]
 	add r0, r0, #0x800
 	str r0, [sp, #0x28]
-	ldr r0, [sl, #0x50]
+	ldr r0, [r10, #0x50]
 	add r0, r0, #0x2800
 	str r0, [sp, #0x2c]
 	bl func_ov31_0217bdb8
@@ -1729,17 +1729,17 @@ _0217d2c8:
 	add r3, sp, #0x30
 	bl func_ov00_020c4048
 	mov r0, #0
-	str r0, [sl, #0x478]
+	str r0, [r10, #0x478]
 	ldr r0, _0217d400 ; =data_027e0dbc
 	blx func_ov00_0207ba90
 	ldrb r2, [r0, #0xb]
 	mov r1, #0
-	mov r0, sl
-	str r2, [sl, #0x47c]
-	strb r1, [sl, #0x480]
+	mov r0, r10
+	str r2, [r10, #0x47c]
+	strb r1, [r10, #0x480]
 	bl func_ov14_021450f0
 	add sp, sp, #0x5c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov31_0217cfd4
 _0217d3e8: .word 0x00005555
@@ -2843,29 +2843,29 @@ _0217e03c: .word data_027e0ce0
 	.global func_ov31_0217e040
 	arm_func_start func_ov31_0217e040
 func_ov31_0217e040: ; 0x0217e040
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	ldr r7, _0217e278 ; =data_02057878
 	ldr r6, _0217e27c ; =data_0205785c
 	ldr r5, _0217e280 ; =gItemManager
 	ldr r4, _0217e284 ; =data_ov31_021822b0
 	ldr r11, _0217e288 ; =data_027e0ce0
-	mov sl, #0
+	mov r10, #0
 _0217e05c:
-	cmp sl, #6
+	cmp r10, #6
 	ldreq r0, [r5]
 	ldreqh r0, [r0, #0xb6]
 	cmpeq r0, #1
 	ldreq r8, [r4, #0xb0]
 	ldreq sb, [r4, #0x104]
 	beq _0217e0c0
-	cmp sl, #7
+	cmp r10, #7
 	ldreq r0, [r5]
 	ldreqh r0, [r0, #0xb4]
 	cmpeq r0, #1
 	ldreq r8, [r4, #0xb4]
 	ldreq sb, [r4, #0x108]
 	beq _0217e0c0
-	cmp sl, #8
+	cmp r10, #8
 	ldreq r0, [r5]
 	ldreqh r0, [r0, #0xb8]
 	cmpeq r0, #1
@@ -2873,9 +2873,9 @@ _0217e05c:
 	ldreq sb, [r4, #0x10c]
 	beq _0217e0c0
 	ldr r0, _0217e28c ; =data_ov31_02182318
-	ldr r8, [r0, sl, lsl #2]
+	ldr r8, [r0, r10, lsl #2]
 	ldr r0, _0217e290 ; =data_ov31_0218236c
-	ldr sb, [r0, sl, lsl #2]
+	ldr sb, [r0, r10, lsl #2]
 _0217e0c0:
 	ldr r1, [r11, #4]
 	mov r0, #0x14
@@ -2892,7 +2892,7 @@ _0217e0c0:
 _0217e0f0:
 	ldr r1, _0217e294 ; =data_ov31_021840a8
 	mov r2, #4
-	str r0, [r1, sl, lsl #2]
+	str r0, [r1, r10, lsl #2]
 	ldr r1, [r11, #4]
 	mov r0, #0x14
 	bl _ZN9SysObjectnwEmPjj
@@ -2906,9 +2906,9 @@ _0217e0f0:
 	strb r1, [r0, #0x10]
 _0217e128:
 	ldr r1, _0217e298 ; =data_ov31_021840f0
-	str r0, [r1, sl, lsl #2]
-	add sl, sl, #1
-	cmp sl, #0x12
+	str r0, [r1, r10, lsl #2]
+	add r10, r10, #1
+	cmp r10, #0x12
 	blt _0217e05c
 	ldr r1, _0217e288 ; =data_027e0ce0
 	mov r0, #0x14
@@ -2992,7 +2992,7 @@ _0217e254:
 	bl func_ov31_0217dfec
 	ldr r1, _0217e2a0 ; =data_ov31_02183e88
 	str r0, [r1, #0x2c0]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov31_0217e040
 _0217e278: .word data_02057878
@@ -7584,7 +7584,7 @@ func_ov31_021815e0: ; 0x021815e0
 	.global func_ov31_02181610
 	arm_func_start func_ov31_02181610
 func_ov31_02181610: ; 0x02181610
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0xc
 	ldr r4, [r1, #0x38]
 	str r0, [sp]
@@ -7595,7 +7595,7 @@ func_ov31_02181610: ; 0x02181610
 	mov r0, r0, lsl #0x10
 	mov r2, r0, lsr #0xd
 	ldr r0, [sp]
-	ldrh sl, [sp, #0x34]
+	ldrh r10, [sp, #0x34]
 	str r2, [r0, #0x18]
 	ldrh r1, [r1, #0x30]
 	ldr r2, [r0, #0x14]
@@ -7605,17 +7605,17 @@ func_ov31_02181610: ; 0x02181610
 	cmp r2, r1, lsl #3
 	strlo r2, [sp, #8]
 	ldr r0, [sp, #8]
-	and r3, sl, #0x3e0
+	and r3, r10, #0x3e0
 	cmp r0, r2
 	movlo r1, r0
 	ldrlo r0, [sp]
-	and r2, sl, #0x7c00
+	and r2, r10, #0x7c00
 	strlo r1, [r0, #0x14]
 	ldr r1, [sp, #8]
 	mov r5, r2, asr #0xa
 	ldr r2, [sp]
 	mov sb, r1, lsr #0x1
-	and r1, sl, #0x1f
+	and r1, r10, #0x1f
 	add r1, r1, #0x1f
 	mov r0, #0x1f000
 	mov r1, r1, lsl #0xc
@@ -7639,7 +7639,7 @@ func_ov31_02181610: ; 0x02181610
 	mov r1, r1, lsl #0xc
 	bl Divide
 	ldr r3, [sp, #0x30]
-	mov r1, sl, lsl #0x1b
+	mov r1, r10, lsl #0x1b
 	mul r0, r3, r0
 	add r0, r0, #0x800
 	cmp sb, #0
@@ -7647,23 +7647,23 @@ func_ov31_02181610: ; 0x02181610
 	mov lr, r0, asr #0xc
 	ble _02181780
 _02181708:
-	ldrh sl, [r7]
+	ldrh r10, [r7]
 	add r2, r2, #1
 	add r7, r7, #2
-	mov r0, sl, asr #0xa
+	mov r0, r10, asr #0xa
 	and r3, r0, #0x1f
-	and r0, sl, #0x1f
-	mov sl, sl, asr #0x5
-	and sl, sl, #0x1f
-	add r0, r0, sl
-	add sl, r3, r0
-	mul r0, sl, r11
+	and r0, r10, #0x1f
+	mov r10, r10, asr #0x5
+	and r10, r10, #0x1f
+	add r0, r0, r10
+	add r10, r3, r0
+	mul r0, r10, r11
 	add r0, r0, r1, lsr #15
 	mov r3, r0, asr #0xc
-	mul r0, sl, r6
+	mul r0, r10, r6
 	add r0, r0, r4, lsl #12
 	mov ip, r0, asr #0xc
-	mul r0, sl, lr
+	mul r0, r10, lr
 	add r0, r0, r5, lsl #12
 	cmp r3, #0x1f
 	movgt r3, #0x1f
@@ -7683,18 +7683,18 @@ _02181780:
 	ldr r0, [r0, #0xc]
 	bl func_0200e2a4
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	arm_func_end func_ov31_02181610
 
 	.global func_ov31_02181798
 	arm_func_start func_ov31_02181798
 func_ov31_02181798: ; 0x02181798
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	mov r4, r0
 	ldr r1, [r4]
 	ldr r0, [r4, #4]
 	cmp r1, r0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	str r1, [r4, #4]
 	ldr r0, [r4, #0x14]
 	ldr ip, [r4, #8]
@@ -7715,18 +7715,18 @@ _021817d4:
 	and sb, r7, #0x1f
 	mul r7, r0, r2
 	and r8, r3, #0x3e0
-	and sl, r3, #0x7c00
+	and r10, r3, #0x7c00
 	mul r0, r1, r2
 	add r6, r6, #1
-	mov r1, sl, asr #0xa
-	and sl, r3, #0x1f
+	mov r1, r10, asr #0xa
+	and r10, r3, #0x1f
 	mul r3, sb, r2
 	rsb r2, r2, #0x1000
 	mla r0, r1, r2, r0
 	mov r1, r8, asr #0x5
 	mla r7, r1, r2, r7
 	mov r1, r7, asr #0xc
-	mla r2, sl, r2, r3
+	mla r2, r10, r2, r3
 	mov r1, r1, lsl #0x5
 	mov r3, r0, asr #0xc
 	orr r0, r1, r2, asr #12
@@ -7743,7 +7743,7 @@ _02181848:
 	ldr r3, [r4, #0x14]
 	mov r0, #1
 	bl func_02017d30
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	arm_func_end func_ov31_02181798
 
 	.global func_ov31_0218186c

--- a/asm/ov31.s
+++ b/asm/ov31.s
@@ -57,7 +57,7 @@ _0217bdc4: .word data_ov31_02183e80
 	.global func_ov31_0217bdc8
 	arm_func_start func_ov31_0217bdc8
 func_ov31_0217bdc8: ; 0x0217bdc8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	mov r7, r0
 	mov r2, #0
 	str r2, [r7]
@@ -140,9 +140,9 @@ _0217becc:
 	add r0, r7, r6, lsl #2
 	ldr r0, [r0, #0x2c]
 	mov r1, r4
-	and sb, r2, #0xf
+	and r9, r2, #0xf
 	blx func_ov09_0211c9a0
-	add r1, sb, #3
+	add r1, r9, #3
 	mul r2, r1, r0
 	add r1, r7, r6, lsl #2
 	add r6, r6, #1
@@ -155,7 +155,7 @@ _0217becc:
 	mov r0, r7
 	bl func_ov31_0217bdb4
 	mov r0, r7
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov31_0217bdc8
 _0217bf48: .word 0x0000ffff
@@ -1464,7 +1464,7 @@ _0217cfd0: .word data_ov31_02183e84
 	.global func_ov31_0217cfd4
 	arm_func_start func_ov31_0217cfd4
 func_ov31_0217cfd4: ; 0x0217cfd4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x5c
 	mov r10, r0
 	add r0, r10, #0x1d8
@@ -1527,7 +1527,7 @@ func_ov31_0217cfd4: ; 0x0217cfd4
 	sub r0, r0, #0x100
 	str r0, [sp, #0x10]
 	ldr r0, _0217d3ec ; =0x49544150
-	mov sb, r5
+	mov r9, r5
 	add r0, r0, #0x1200
 	str r0, [sp, #0x14]
 	ldr r0, _0217d3f8 ; =0x49545452
@@ -1641,7 +1641,7 @@ _0217d250:
 _0217d25c:
 	bl func_ov31_0217bdb8
 	add r0, r0, #0x70
-	add r0, r0, sb
+	add r0, r0, r9
 	str r0, [sp]
 	ldr r0, _0217d404 ; =data_027e0fe8
 	mov r1, r8
@@ -1668,7 +1668,7 @@ _0217d2b8:
 	sub r0, r0, #0xc00
 	str r0, [sp, #0x2c]
 _0217d2c8:
-	add sb, sb, #8
+	add r9, r9, #8
 	add r7, r7, #1
 	cmp r7, #5
 	blt _0217d0f8
@@ -1739,7 +1739,7 @@ _0217d2c8:
 	strb r1, [r10, #0x480]
 	bl func_ov14_021450f0
 	add sp, sp, #0x5c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov31_0217cfd4
 _0217d3e8: .word 0x00005555
@@ -2843,7 +2843,7 @@ _0217e03c: .word data_027e0ce0
 	.global func_ov31_0217e040
 	arm_func_start func_ov31_0217e040
 func_ov31_0217e040: ; 0x0217e040
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	ldr r7, _0217e278 ; =data_02057878
 	ldr r6, _0217e27c ; =data_0205785c
 	ldr r5, _0217e280 ; =gItemManager
@@ -2856,26 +2856,26 @@ _0217e05c:
 	ldreqh r0, [r0, #0xb6]
 	cmpeq r0, #1
 	ldreq r8, [r4, #0xb0]
-	ldreq sb, [r4, #0x104]
+	ldreq r9, [r4, #0x104]
 	beq _0217e0c0
 	cmp r10, #7
 	ldreq r0, [r5]
 	ldreqh r0, [r0, #0xb4]
 	cmpeq r0, #1
 	ldreq r8, [r4, #0xb4]
-	ldreq sb, [r4, #0x108]
+	ldreq r9, [r4, #0x108]
 	beq _0217e0c0
 	cmp r10, #8
 	ldreq r0, [r5]
 	ldreqh r0, [r0, #0xb8]
 	cmpeq r0, #1
 	ldreq r8, [r4, #0xb8]
-	ldreq sb, [r4, #0x10c]
+	ldreq r9, [r4, #0x10c]
 	beq _0217e0c0
 	ldr r0, _0217e28c ; =data_ov31_02182318
 	ldr r8, [r0, r10, lsl #2]
 	ldr r0, _0217e290 ; =data_ov31_0218236c
-	ldr sb, [r0, r10, lsl #2]
+	ldr r9, [r0, r10, lsl #2]
 _0217e0c0:
 	ldr r1, [r11, #4]
 	mov r0, #0x14
@@ -2898,7 +2898,7 @@ _0217e0f0:
 	bl _ZN9SysObjectnwEmPjj
 	cmp r0, #0
 	beq _0217e128
-	stmia r0, {r7, sb}
+	stmia r0, {r7, r9}
 	mov r1, #0
 	str r1, [r0, #8]
 	str r1, [r0, #0xc]
@@ -2992,7 +2992,7 @@ _0217e254:
 	bl func_ov31_0217dfec
 	ldr r1, _0217e2a0 ; =data_ov31_02183e88
 	str r0, [r1, #0x2c0]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov31_0217e040
 _0217e278: .word data_02057878
@@ -4059,7 +4059,7 @@ _0217ee70: .word data_027e0d78
 	.global func_ov31_0217ee74
 	arm_func_start func_ov31_0217ee74
 func_ov31_0217ee74: ; 0x0217ee74
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x30
 	mov r5, r0
 	mov r4, r1
@@ -4083,14 +4083,14 @@ func_ov31_0217ee74: ; 0x0217ee74
 	ldr ip, [r3, #0x270]
 	ldr r3, [r3, #0x274]
 	add r1, r6, r1
-	add sb, sp, #0
+	add r9, sp, #0
 	str r8, [sp, #0x24]
 	str r0, [sp, #0x28]
 	str r1, [sp, #0x2c]
 	ldmia r2, {r0, r1, r2}
-	stmia sb, {r0, r1, r2}
-	mov r0, sb
-	mov r2, sb
+	stmia r9, {r0, r1, r2}
+	mov r0, r9
+	mov r2, r9
 	add r1, r5, #0x14
 	str r8, [sp, #0x18]
 	str r7, [sp, #0x1c]
@@ -4099,17 +4099,17 @@ func_ov31_0217ee74: ; 0x0217ee74
 	str ip, [sp, #0x10]
 	str r3, [sp, #0x14]
 	bl func_01ff9bf8
-	mov r0, sb
+	mov r0, r9
 	mov r1, r0
 	bl func_01ff9d4c
 	ldrb r0, [r5, #0x174]
 	mov r1, #0x400
 	cmp r0, #1
-	mov r0, sb
+	mov r0, r9
 	bne _0217ef70
 	bl func_01fffbec
 	add r0, r5, #0x48
-	mov r1, sb
+	mov r1, r9
 	mov r2, r0
 	bl func_01ff9bc4
 	ldr r2, [sp, #0x28]
@@ -4126,7 +4126,7 @@ _0217ef70:
 	rsb r1, r1, #0
 	bl func_01fffbec
 	add r0, r5, #0x48
-	mov r1, sb
+	mov r1, r9
 	mov r2, r0
 	bl func_01ff9bc4
 	ldr r2, [r5, #0x18]
@@ -4143,7 +4143,7 @@ _0217efac:
 	mov r1, r4
 	bl func_ov31_0217eddc
 	add sp, sp, #0x30
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov31_0217ee74
 _0217efc0: .word data_027e0f64
@@ -7584,7 +7584,7 @@ func_ov31_021815e0: ; 0x021815e0
 	.global func_ov31_02181610
 	arm_func_start func_ov31_02181610
 func_ov31_02181610: ; 0x02181610
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0xc
 	ldr r4, [r1, #0x38]
 	str r0, [sp]
@@ -7614,7 +7614,7 @@ func_ov31_02181610: ; 0x02181610
 	ldr r1, [sp, #8]
 	mov r5, r2, asr #0xa
 	ldr r2, [sp]
-	mov sb, r1, lsr #0x1
+	mov r9, r1, lsr #0x1
 	and r1, r10, #0x1f
 	add r1, r1, #0x1f
 	mov r0, #0x1f000
@@ -7642,7 +7642,7 @@ func_ov31_02181610: ; 0x02181610
 	mov r1, r10, lsl #0x1b
 	mul r0, r3, r0
 	add r0, r0, #0x800
-	cmp sb, #0
+	cmp r9, #0
 	mov r2, #0
 	mov lr, r0, asr #0xc
 	ble _02181780
@@ -7675,7 +7675,7 @@ _02181708:
 	orr r3, r3, ip, lsl #5
 	orr r0, r3, r0, lsl #10
 	strh r0, [r8], #2
-	cmp r2, sb
+	cmp r2, r9
 	blt _02181708
 _02181780:
 	ldr r0, [sp]
@@ -7683,18 +7683,18 @@ _02181780:
 	ldr r0, [r0, #0xc]
 	bl func_0200e2a4
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	arm_func_end func_ov31_02181610
 
 	.global func_ov31_02181798
 	arm_func_start func_ov31_02181798
 func_ov31_02181798: ; 0x02181798
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	mov r4, r0
 	ldr r1, [r4]
 	ldr r0, [r4, #4]
 	cmp r1, r0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	str r1, [r4, #4]
 	ldr r0, [r4, #0x14]
 	ldr ip, [r4, #8]
@@ -7712,7 +7712,7 @@ _021817d4:
 	mov r0, r0, asr #0x5
 	and r1, r7, #0x7c00
 	mov r1, r1, asr #0xa
-	and sb, r7, #0x1f
+	and r9, r7, #0x1f
 	mul r7, r0, r2
 	and r8, r3, #0x3e0
 	and r10, r3, #0x7c00
@@ -7720,7 +7720,7 @@ _021817d4:
 	add r6, r6, #1
 	mov r1, r10, asr #0xa
 	and r10, r3, #0x1f
-	mul r3, sb, r2
+	mul r3, r9, r2
 	rsb r2, r2, #0x1000
 	mla r0, r1, r2, r0
 	mov r1, r8, asr #0x5
@@ -7743,7 +7743,7 @@ _02181848:
 	ldr r3, [r4, #0x14]
 	mov r0, #1
 	bl func_02017d30
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	arm_func_end func_ov31_02181798
 
 	.global func_ov31_0218186c

--- a/asm/ov31.s
+++ b/asm/ov31.s
@@ -1464,7 +1464,7 @@ _0217cfd0: .word data_ov31_02183e84
 	.global func_ov31_0217cfd4
 	arm_func_start func_ov31_0217cfd4
 func_ov31_0217cfd4: ; 0x0217cfd4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x5c
 	mov sl, r0
 	add r0, sl, #0x1d8
@@ -1515,7 +1515,7 @@ func_ov31_0217cfd4: ; 0x0217cfd4
 	add r0, r0, #0xe2
 	str r0, [sp, #0xc]
 	ldr r0, _0217d3ec ; =0x49544150
-	ldr fp, _0217d3f4 ; =gItemManager
+	ldr r11, _0217d3f4 ; =gItemManager
 	add r0, r0, #0x1200
 	str r0, [sp, #0x18]
 	ldr r0, _0217d3f8 ; =0x49545452
@@ -1590,21 +1590,21 @@ _0217d1a4:
 	beq _0217d21c
 	b _0217d25c
 _0217d1b4:
-	ldr r0, [fp]
+	ldr r0, [r11]
 	mov r1, #4
 	bl _ZNK11ItemManager7HasItemEi
 	cmp r0, #0
 	moveq r8, r4
 	b _0217d25c
 _0217d1cc:
-	ldr r0, [fp]
+	ldr r0, [r11]
 	mov r1, #5
 	bl _ZNK11ItemManager7HasItemEi
 	cmp r0, #0
 	moveq r8, r4
 	b _0217d25c
 _0217d1e4:
-	ldr r0, [fp]
+	ldr r0, [r11]
 	mov r1, #7
 	bl _ZNK11ItemManager7HasItemEi
 	cmp r0, #0
@@ -1739,7 +1739,7 @@ _0217d2c8:
 	strb r1, [sl, #0x480]
 	bl func_ov14_021450f0
 	add sp, sp, #0x5c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov31_0217cfd4
 _0217d3e8: .word 0x00005555
@@ -2843,12 +2843,12 @@ _0217e03c: .word data_027e0ce0
 	.global func_ov31_0217e040
 	arm_func_start func_ov31_0217e040
 func_ov31_0217e040: ; 0x0217e040
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	ldr r7, _0217e278 ; =data_02057878
 	ldr r6, _0217e27c ; =data_0205785c
 	ldr r5, _0217e280 ; =gItemManager
 	ldr r4, _0217e284 ; =data_ov31_021822b0
-	ldr fp, _0217e288 ; =data_027e0ce0
+	ldr r11, _0217e288 ; =data_027e0ce0
 	mov sl, #0
 _0217e05c:
 	cmp sl, #6
@@ -2877,7 +2877,7 @@ _0217e05c:
 	ldr r0, _0217e290 ; =data_ov31_0218236c
 	ldr sb, [r0, sl, lsl #2]
 _0217e0c0:
-	ldr r1, [fp, #4]
+	ldr r1, [r11, #4]
 	mov r0, #0x14
 	mov r2, #4
 	bl _ZN9SysObjectnwEmPjj
@@ -2893,7 +2893,7 @@ _0217e0f0:
 	ldr r1, _0217e294 ; =data_ov31_021840a8
 	mov r2, #4
 	str r0, [r1, sl, lsl #2]
-	ldr r1, [fp, #4]
+	ldr r1, [r11, #4]
 	mov r0, #0x14
 	bl _ZN9SysObjectnwEmPjj
 	cmp r0, #0
@@ -2992,7 +2992,7 @@ _0217e254:
 	bl func_ov31_0217dfec
 	ldr r1, _0217e2a0 ; =data_ov31_02183e88
 	str r0, [r1, #0x2c0]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov31_0217e040
 _0217e278: .word data_02057878
@@ -7584,7 +7584,7 @@ func_ov31_021815e0: ; 0x021815e0
 	.global func_ov31_02181610
 	arm_func_start func_ov31_02181610
 func_ov31_02181610: ; 0x02181610
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0xc
 	ldr r4, [r1, #0x38]
 	str r0, [sp]
@@ -7626,7 +7626,7 @@ func_ov31_02181610: ; 0x02181610
 	mul r1, r6, r0
 	add r1, r1, #0x800
 	add r0, r4, #0x1f
-	mov fp, r1, asr #0xc
+	mov r11, r1, asr #0xc
 	mov r1, r0, lsl #0xc
 	mov r0, #0x1f000
 	bl Divide
@@ -7657,7 +7657,7 @@ _02181708:
 	and sl, sl, #0x1f
 	add r0, r0, sl
 	add sl, r3, r0
-	mul r0, sl, fp
+	mul r0, sl, r11
 	add r0, r0, r1, lsr #15
 	mov r3, r0, asr #0xc
 	mul r0, sl, r6
@@ -7683,23 +7683,23 @@ _02181780:
 	ldr r0, [r0, #0xc]
 	bl func_0200e2a4
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	arm_func_end func_ov31_02181610
 
 	.global func_ov31_02181798
 	arm_func_start func_ov31_02181798
 func_ov31_02181798: ; 0x02181798
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	mov r4, r0
 	ldr r1, [r4]
 	ldr r0, [r4, #4]
 	cmp r1, r0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	str r1, [r4, #4]
 	ldr r0, [r4, #0x14]
 	ldr ip, [r4, #8]
-	mov fp, r0, lsr #0x1
-	cmp fp, #0
+	mov r11, r0, lsr #0x1
+	cmp r11, #0
 	ldr lr, [r4, #0xc]
 	ldr r5, [r4, #0x10]
 	mov r6, #0
@@ -7731,7 +7731,7 @@ _021817d4:
 	mov r3, r0, asr #0xc
 	orr r0, r1, r2, asr #12
 	orr r0, r0, r3, lsl #10
-	cmp r6, fp
+	cmp r6, r11
 	strh r0, [r5], #2
 	blt _021817d4
 _02181848:
@@ -7743,7 +7743,7 @@ _02181848:
 	ldr r3, [r4, #0x14]
 	mov r0, #1
 	bl func_02017d30
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	arm_func_end func_ov31_02181798
 
 	.global func_ov31_0218186c

--- a/asm/ov32.s
+++ b/asm/ov32.s
@@ -3311,7 +3311,7 @@ func_ov32_0217e700: ; 0x0217e700
 	.global func_ov32_0217e730
 	arm_func_start func_ov32_0217e730
 func_ov32_0217e730: ; 0x0217e730
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x78
 	mov r4, r1
 	ldrb r2, [r4]
@@ -3339,7 +3339,7 @@ func_ov32_0217e730: ; 0x0217e730
 	ldr r1, [r5, #0x4f4]
 	cmp r1, #0
 	addne sp, sp, #0x78
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0217e7a4:
 	add r0, r5, #0x21c
 	mov r1, #1
@@ -3348,7 +3348,7 @@ _0217e7a4:
 _0217e7b4:
 	add sp, sp, #0x78
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0217e7c0:
 	ldr r2, [r5, #0x4f4]
 	cmp r2, #0
@@ -3372,7 +3372,7 @@ _0217e7dc: ; jump table
 _0217e808:
 	cmp r2, #0
 	addne sp, sp, #0x78
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0217e814:
 	ldrsh r1, [r5, #0x78]
 	ldr r0, [r4, #0x14]
@@ -3380,7 +3380,7 @@ _0217e814:
 	bl func_ov14_02120ac4
 	add sp, sp, #0x78
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0217e830:
 	cmp r1, #9
 	bne _0217e85c
@@ -3448,7 +3448,7 @@ _0217e85c:
 _0217e928:
 	add sp, sp, #0x78
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0217e934:
 	add r0, r5, #0x100
 	ldrsb r1, [r0, #0xa0]
@@ -3476,7 +3476,7 @@ _0217e934:
 	ldrsb r6, [r0, #0xaa]
 	ldrsb r7, [r0, #0xab]
 	ldrsb r8, [r0, #0xac]
-	ldrsh sb, [r0, #0xae]
+	ldrsh r9, [r0, #0xae]
 	ldrh r10, [r0, #0xb0]
 	ldmia r1, {r0, r1, r2}
 	stmia ip, {r0, r1, r2}
@@ -3537,12 +3537,12 @@ _0217ea20:
 	strb r7, [r5, #0x1ab]
 	strb r8, [r5, #0x1ac]
 	add r0, r5, #0x100
-	strh sb, [r0, #0xae]
+	strh r9, [r0, #0xae]
 	strh r10, [r0, #0xb0]
 	ldmia r1, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0217eaa0:
 	mov r2, #1
 	mov r0, r5
@@ -3599,11 +3599,11 @@ _0217eb64:
 	bl func_ov00_020cadb0
 	add sp, sp, #0x78
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0217eb7c:
 	mov r0, #0
 	add sp, sp, #0x78
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov32_0217e730
 _0217eb88: .word data_027e0e58
@@ -3792,14 +3792,14 @@ _0217edd8: .word func_01fffcec
 	.global func_ov32_0217eddc
 	arm_func_start func_ov32_0217eddc
 func_ov32_0217eddc: ; 0x0217eddc
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x2c
 	mov r7, r0
 	add r0, r7, #0x500
 	ldrsb r1, [r0, #2]
 	cmp r1, #0
 	addle sp, sp, #0x2c
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	mov r2, #0x2b8
 	str r2, [sp, #0x28]
 	ldrsb r1, [r0, #2]
@@ -3836,7 +3836,7 @@ _0217ee34:
 	adc r11, ip, #0
 	str r0, [sp, #0x20]
 	mov r3, r3, lsr #0xc
-	ldr sb, [r7, #0x50]
+	ldr r9, [r7, #0x50]
 	mov r0, r2, asr #0x1f
 	orr r3, r3, r11, lsl #20
 	str r0, [sp, #8]
@@ -3854,8 +3854,8 @@ _0217ee34:
 	mov r3, r3, lsr #0xc
 	orr r3, r3, r2, lsl #20
 	ldr r0, [r0]
-	str sb, [sp, #0x24]
-	add r3, sb, r3
+	str r9, [sp, #0x24]
+	add r3, r9, r3
 	mov r2, r1
 	str r3, [r2, #8]
 	bl _ZN10PlayerBase18func_ov00_020a7c1cEP8Cylinder
@@ -3896,10 +3896,10 @@ _0217ef50:
 	mov r2, #0
 	str r2, [sp, #0x14]
 	mov r2, r3, lsl #0x1
-	ldrsh sb, [r8, r2]
+	ldrsh r9, [r8, r2]
 	add r2, r8, r3, lsl #1
 	ldrsh r3, [r2, #2]
-	str sb, [sp, #0x10]
+	str r9, [sp, #0x10]
 	add r2, sp, #0x10
 	str r3, [sp, #0x18]
 	mov r3, #1
@@ -3917,7 +3917,7 @@ _0217ef94:
 	sub r0, r0, #1
 	strb r0, [r7, #0x502]
 	add sp, sp, #0x2c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov32_0217eddc
 _0217efc4: .word 0x00007fff
@@ -5331,7 +5331,7 @@ _021800dc: .word 0x0000071c
 	.global func_ov32_021800e0
 	arm_func_start func_ov32_021800e0
 func_ov32_021800e0: ; 0x021800e0
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0xc
 	ldr r1, _0218027c ; =0x000005ed
 	mov r7, r0
@@ -5356,20 +5356,20 @@ _02180108:
 	ldrsh lr, [r4, r1]
 	ldr r3, [sp, #8]
 	mov r0, r7
-	umull sb, r8, lr, r2
+	umull r9, r8, lr, r2
 	mov r2, #0
 	mla r8, lr, r2, r8
 	mov ip, lr, asr #0x1f
 	mov r2, #0x1800
 	mla r8, ip, r2, r8
-	adds sb, sb, #0x800
+	adds r9, r9, #0x800
 	adc r2, r8, #0
-	mov r8, sb, lsr #0xc
+	mov r8, r9, lsr #0xc
 	orr r8, r8, r2, lsl #20
 	add r2, r10, r8
 	str r2, [sp]
 	ldrsh r2, [r7, #0x78]
-	mov sb, #0
+	mov r9, #0
 	add r1, sp, #0
 	sub r2, r2, #0x8000
 	mov r2, r2, lsl #0x10
@@ -5378,12 +5378,12 @@ _02180108:
 	add r2, r4, r2, lsl #2
 	ldrsh ip, [r2, #2]
 	umull r8, r2, ip, r11
-	mla r2, ip, sb, r2
+	mla r2, ip, r9, r2
 	mov r10, ip, asr #0x1f
-	adds sb, r8, #0x800
+	adds r9, r8, #0x800
 	mla r2, r10, r11, r2
 	adc r2, r2, #0
-	mov r8, sb, lsr #0xc
+	mov r8, r9, lsr #0xc
 	orr r8, r8, r2, lsl #20
 	add r2, r3, r8
 	str r2, [sp, #8]
@@ -5435,7 +5435,7 @@ _021801e0:
 	orr r1, r1, r0, lsl #20
 	str r1, [r7, #0x68]
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov32_021800e0
 _0218027c: .word 0x000005ed
@@ -5597,7 +5597,7 @@ _021804a0: .word data_027e0764
 	.global func_ov32_021804a4
 	arm_func_start func_ov32_021804a4
 func_ov32_021804a4: ; 0x021804a4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x24
 	mov r10, r0
 	add r0, r10, #0x300
@@ -5657,8 +5657,8 @@ func_ov32_021804a4: ; 0x021804a4
 	mov r2, r2, lsr #0xc
 	adc r3, r3, #0
 	orr r2, r2, r3, lsl #20
-	add sb, r7, r2
-	str sb, [sp, #0x20]
+	add r9, r7, r2
+	str r9, [sp, #0x20]
 	add r1, r10, #0x400
 	ldrsh r2, [r1, #2]
 	mov r1, r6, asr #0x1f
@@ -5719,7 +5719,7 @@ func_ov32_021804a4: ; 0x021804a4
 	adc r3, r6, #0
 	mov r4, r4, lsr #0xc
 	orr r4, r4, r3, lsl #20
-	add r3, sb, r4
+	add r3, r9, r4
 	str r3, [sp, #0x20]
 	bl func_01ff9bc4
 	add r0, sp, #0x18
@@ -5748,14 +5748,14 @@ _021806d4:
 	cmp r7, #0
 	ble _021807b4
 	cmp r7, #0
-	add sb, r10, #0xb8
+	add r9, r10, #0xb8
 	ble _021807b4
 	ldr r6, _02180864 ; =data_027e0f6c
 	ldr r5, _02180854 ; =data_027e0f94
 	ldr r4, _02180868 ; =0x0000ffff
 	add r11, sp, #0x14
 _02180710:
-	add r0, sb, r8, lsl #1
+	add r0, r9, r8, lsl #1
 	ldrh r2, [r0, #0x2e]
 	cmp r2, r4
 	beq _021807a0
@@ -5838,7 +5838,7 @@ _0218081c:
 _02180840:
 	mov r0, #1
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov32_021804a4
 _0218084c: .word 0x0000071c
@@ -5854,7 +5854,7 @@ _0218086c: .word 0x00000a66
 	.global func_ov32_02180870
 	arm_func_start func_ov32_02180870
 func_ov32_02180870: ; 0x02180870
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x1c
 	mov r7, r0
 	mov r2, #2
@@ -5894,31 +5894,31 @@ _021808dc:
 	ldrsh lr, [r1, #2]
 	ldr r3, [sp, #0x18]
 	mov r0, r7
-	umull sb, r8, lr, r2
+	umull r9, r8, lr, r2
 	mov r2, #0
 	mla r8, lr, r2, r8
 	mov ip, lr, asr #0x1f
 	mov r2, #0x1800
 	mla r8, ip, r2, r8
-	adds sb, sb, #0x800
+	adds r9, r9, #0x800
 	adc r2, r8, #0
-	mov r8, sb, lsr #0xc
+	mov r8, r9, lsr #0xc
 	orr r8, r8, r2, lsl #20
 	add r2, r10, r8
 	str r2, [sp, #0x10]
 	ldrh r2, [r7, #0x78]
-	mov sb, #0
+	mov r9, #0
 	add r1, sp, #0x10
 	mov r2, r2, asr #0x4
 	mov r2, r2, lsl #0x2
 	ldrsh ip, [r4, r2]
 	umull r8, r2, ip, r11
-	mla r2, ip, sb, r2
+	mla r2, ip, r9, r2
 	mov r10, ip, asr #0x1f
-	adds sb, r8, #0x800
+	adds r9, r8, #0x800
 	mla r2, r10, r11, r2
 	adc r2, r2, #0
-	mov r8, sb, lsr #0xc
+	mov r8, r9, lsr #0xc
 	orr r8, r8, r2, lsl #20
 	add r2, r3, r8
 	str r2, [sp, #0x18]
@@ -5969,7 +5969,7 @@ _0218099c:
 	ldr r0, [sp, #8]
 	str r0, [r7, #0x64]
 	add sp, sp, #0x1c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov32_02180870
 _02180a34: .word data_027e0f94
@@ -8075,18 +8075,18 @@ _021826ec: .word data_027e0e60
 	.global func_ov32_021826f0
 	arm_func_start func_ov32_021826f0
 func_ov32_021826f0: ; 0x021826f0
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x1c
 	mov r10, r0
 	ldr r2, [r10, #4]
-	mov sb, r1
+	mov r9, r1
 	tst r2, #0x10
 	addeq sp, sp, #0x1c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldrb r1, [r10, #0x68]
 	cmp r1, #0
 	beq _021827ec
-	str sb, [sp]
+	str r9, [sp]
 	mvn r1, #0
 	str r1, [sp, #4]
 	mov r2, #1
@@ -8129,7 +8129,7 @@ _02182790:
 	mov r2, r11
 	rsb r1, r1, #0x4000
 	mov r1, r1, lsl #0x10
-	mov r3, sb
+	mov r3, r9
 	mov r1, r1, asr #0x10
 	bl func_ov00_0208c0dc
 	ldr r1, [sp, #0x10]
@@ -8140,26 +8140,26 @@ _02182790:
 	add r7, r7, r0
 	blt _02182790
 _021827ec:
-	ldrh r0, [sb]
+	ldrh r0, [r9]
 	tst r0, #1
 	bne _02182804
 	tst r0, #2
 	addeq sp, sp, #0x1c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02182804:
 	ldr r0, [r10, #8]
 	cmp r0, #0xc
 	addne sp, sp, #0x1c
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, _02182864 ; =data_027e0618
 	ldrb r0, [r0, #0x101]
 	cmp r0, #0
 	addne sp, sp, #0x1c
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldrb r0, [r10, #0x6a]
 	cmp r0, #0
 	addeq sp, sp, #0x1c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	mov r2, #0
 	str r2, [sp]
 	ldrsh r1, [r10, #0x6c]
@@ -8169,7 +8169,7 @@ _02182804:
 	mov r0, #0x44
 	bl func_0203493c
 	add sp, sp, #0x1c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov32_021826f0
 _02182860: .word data_027e080c
@@ -8925,7 +8925,7 @@ _02183188: .word 0x0000ffff
 	.global func_ov32_0218318c
 	arm_func_start func_ov32_0218318c
 func_ov32_0218318c: ; 0x0218318c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0xc
 	ldr ip, _02183330 ; =data_027e0764
 	mov r8, #0x800
@@ -8938,17 +8938,17 @@ func_ov32_0218318c: ; 0x0218318c
 	mla r4, r7, r2, r4
 	adds r5, r3, r5
 	ldr r2, [ip, #0x14]
-	umull r6, sb, r10, r5
+	umull r6, r9, r10, r5
 	adc r4, r2, r4
-	mla sb, r10, r4, sb
+	mla r9, r10, r4, r9
 	str r5, [ip]
 	ldr r1, _02183334 ; =0x00000e39
 	adds r6, r3, r6
-	mla sb, r7, r5, sb
+	mla r9, r7, r5, r9
 	umull r3, r7, r4, r1
 	add r3, r8, #1
 	mov r8, #0
-	adc r5, r2, sb
+	adc r5, r2, r9
 	mla r7, r4, r8, r7
 	str r4, [ip, #4]
 	mov r4, r0
@@ -8978,11 +8978,11 @@ func_ov32_0218318c: ; 0x0218318c
 	ldrsh r7, [r6, r7]
 	mov r1, r1, lsl #0x1
 	ldrsh r6, [r6, r1]
-	smull sb, r8, r2, r7
+	smull r9, r8, r2, r7
 	smull r7, r6, r2, r6
-	adds sb, sb, #0x800
+	adds r9, r9, #0x800
 	adc r2, r8, #0
-	mov r8, sb, lsr #0xc
+	mov r8, r9, lsr #0xc
 	orr r8, r8, r2, lsl #20
 	ldr r0, [r4, #0x48]
 	adds r2, r7, #0x800
@@ -9011,9 +9011,9 @@ func_ov32_0218318c: ; 0x0218318c
 	mla r7, r6, r11, r7
 	mla r7, r5, lr, r7
 	ldr r10, [ip, #0x10]
-	ldr sb, [ip, #0x14]
+	ldr r9, [ip, #0x14]
 	adds r5, r10, r8
-	adc r7, sb, r7
+	adc r7, r9, r7
 	stmia ip, {r5, r7}
 	umull r5, r6, r7, r3
 	mov r5, #0
@@ -9029,7 +9029,7 @@ func_ov32_0218318c: ; 0x0218318c
 	str r0, [r4, #0x64]
 	str r0, [r4, #0x68]
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov32_0218318c
 _02183330: .word data_027e0764
@@ -9042,7 +9042,7 @@ _02183344: .word data_027e0e60
 	.global func_ov32_02183348
 	arm_func_start func_ov32_02183348
 func_ov32_02183348: ; 0x02183348
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x18
 	ldr lr, _02183534 ; =data_027e0764
 	ldr r2, _02183538 ; =0x00002001
@@ -9105,12 +9105,12 @@ _02183414:
 	str r6, [sp, #0x14]
 	ldr r7, [lr, #8]
 	ldr r6, [lr, #0xc]
-	umull sb, r8, r7, r5
+	umull r9, r8, r7, r5
 	mla r8, r7, r0, r8
 	ldr r7, [lr, #0x10]
 	mla r8, r6, r5, r8
 	ldr r0, [lr, #0x14]
-	adds r7, r7, sb
+	adds r7, r7, r9
 	adc r6, r0, r8
 	sub r0, r2, #0x1800
 	umull r2, r5, r6, r0
@@ -9139,12 +9139,12 @@ _02183498:
 	str r6, [sp, #8]
 	ldr r7, [lr, #8]
 	ldr r6, [lr, #0xc]
-	umull sb, r8, r7, r5
+	umull r9, r8, r7, r5
 	mla r8, r7, r0, r8
 	ldr r7, [lr, #0x10]
 	mla r8, r6, r5, r8
 	ldr r0, [lr, #0x14]
-	adds r7, r7, sb
+	adds r7, r7, r9
 	adc r6, r0, r8
 	sub r0, r2, #0x1800
 	umull r2, r5, r6, r0
@@ -9167,7 +9167,7 @@ _02183518:
 	mov r1, #0x3000
 	bl func_ov00_020ce340
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov32_02183348
 _02183534: .word data_027e0764
@@ -9207,7 +9207,7 @@ _0218359c: .word 0x00000333
 	.global func_ov32_021835a0
 	arm_func_start func_ov32_021835a0
 func_ov32_021835a0: ; 0x021835a0
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	ldr lr, _021836ec ; =data_027e0764
 	mov r3, #0
 	ldr r2, [lr]
@@ -9280,16 +9280,16 @@ func_ov32_021835a0: ; 0x021835a0
 	ldr r5, [lr, #0xc]
 	ldr r10, [lr, #0x10]
 	mla r7, r5, r4, r7
-	ldr sb, [lr, #0x14]
+	ldr r9, [lr, #0x14]
 	adds r1, r10, r8
-	adc r4, sb, r7
+	adc r4, r9, r7
 	stmia lr, {r1, r4}
 	umull r1, lr, r4, ip
 	mla lr, r4, r2, lr
 	mla lr, r3, ip, lr
 	add r1, lr, #0x800
 	str r1, [r0, #0x234]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov32_021835a0
 _021836ec: .word data_027e0764
@@ -9299,7 +9299,7 @@ _021836f4: .word 0x00000b34
 	.global func_ov32_021836f8
 	arm_func_start func_ov32_021836f8
 func_ov32_021836f8: ; 0x021836f8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	mov r4, r0
 	bl _ZN5Actor14GetAngleToLinkEv
 	mov r0, r0, lsl #0x10
@@ -9358,16 +9358,16 @@ func_ov32_021836f8: ; 0x021836f8
 	ldr r5, [ip, #0xc]
 	ldr r10, [ip, #0x10]
 	mla r7, r5, lr, r7
-	ldr sb, [ip, #0x14]
+	ldr r9, [ip, #0x14]
 	adds r1, r10, r8
-	adc r5, sb, r7
+	adc r5, r9, r7
 	stmia ip, {r1, r5}
 	umull r1, ip, r5, r3
 	mla ip, r5, r2, ip
 	mla ip, r0, r3, ip
 	add r0, ip, #0x800
 	str r0, [r4, #0x234]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov32_021836f8
 _0218380c: .word data_02050f54
@@ -10248,7 +10248,7 @@ _02184398: .word data_ov00_020e9370
 	.global func_ov32_0218439c
 	arm_func_start func_ov32_0218439c
 func_ov32_0218439c: ; 0x0218439c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x84
 	ldr r1, _0218453c ; =data_027e0fe4
 	mov r2, #0
@@ -10274,7 +10274,7 @@ func_ov32_0218439c: ; 0x0218439c
 	cmp r0, #0x18
 	addgt sp, sp, #0x84
 	movgt r0, #0
-	ldmgtia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmgtia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r1, [r4, #8]
 	ldr r0, _0218453c ; =data_027e0fe4
 	str r1, [sp, #0x44]
@@ -10287,7 +10287,7 @@ func_ov32_0218439c: ; 0x0218439c
 	cmp r0, #8
 	addgt sp, sp, #0x84
 	movgt r0, #0
-	ldmgtia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmgtia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r0, sp, #0x10
 	bl func_ov00_020c1500
 	mov r1, r5
@@ -10320,9 +10320,9 @@ func_ov32_0218439c: ; 0x0218439c
 	ldrsh r4, [r3, r0]
 	ldr r0, _0218454c ; =0x0000019a
 	mov r6, r7, asr #0x1f
-	umull sb, r8, r7, r0
+	umull r9, r8, r7, r0
 	mla r8, r7, ip, r8
-	adds r7, sb, #0x800
+	adds r7, r9, #0x800
 	mla r8, r6, r0, r8
 	ldr r10, [sp, #4]
 	adc r6, r8, #0
@@ -10351,7 +10351,7 @@ func_ov32_0218439c: ; 0x0218439c
 	movge r0, #1
 	movlt r0, #0
 	add sp, sp, #0x84
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov32_0218439c
 _0218453c: .word data_027e0fe4

--- a/asm/ov32.s
+++ b/asm/ov32.s
@@ -3311,7 +3311,7 @@ func_ov32_0217e700: ; 0x0217e700
 	.global func_ov32_0217e730
 	arm_func_start func_ov32_0217e730
 func_ov32_0217e730: ; 0x0217e730
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x78
 	mov r4, r1
 	ldrb r2, [r4]
@@ -3339,7 +3339,7 @@ func_ov32_0217e730: ; 0x0217e730
 	ldr r1, [r5, #0x4f4]
 	cmp r1, #0
 	addne sp, sp, #0x78
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0217e7a4:
 	add r0, r5, #0x21c
 	mov r1, #1
@@ -3348,7 +3348,7 @@ _0217e7a4:
 _0217e7b4:
 	add sp, sp, #0x78
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0217e7c0:
 	ldr r2, [r5, #0x4f4]
 	cmp r2, #0
@@ -3372,7 +3372,7 @@ _0217e7dc: ; jump table
 _0217e808:
 	cmp r2, #0
 	addne sp, sp, #0x78
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0217e814:
 	ldrsh r1, [r5, #0x78]
 	ldr r0, [r4, #0x14]
@@ -3380,7 +3380,7 @@ _0217e814:
 	bl func_ov14_02120ac4
 	add sp, sp, #0x78
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0217e830:
 	cmp r1, #9
 	bne _0217e85c
@@ -3448,7 +3448,7 @@ _0217e85c:
 _0217e928:
 	add sp, sp, #0x78
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0217e934:
 	add r0, r5, #0x100
 	ldrsb r1, [r0, #0xa0]
@@ -3477,7 +3477,7 @@ _0217e934:
 	ldrsb r7, [r0, #0xab]
 	ldrsb r8, [r0, #0xac]
 	ldrsh sb, [r0, #0xae]
-	ldrh sl, [r0, #0xb0]
+	ldrh r10, [r0, #0xb0]
 	ldmia r1, {r0, r1, r2}
 	stmia ip, {r0, r1, r2}
 	strb r3, [r5, #0x1a0]
@@ -3538,11 +3538,11 @@ _0217ea20:
 	strb r8, [r5, #0x1ac]
 	add r0, r5, #0x100
 	strh sb, [r0, #0xae]
-	strh sl, [r0, #0xb0]
+	strh r10, [r0, #0xb0]
 	ldmia r1, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0217eaa0:
 	mov r2, #1
 	mov r0, r5
@@ -3599,11 +3599,11 @@ _0217eb64:
 	bl func_ov00_020cadb0
 	add sp, sp, #0x78
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0217eb7c:
 	mov r0, #0
 	add sp, sp, #0x78
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov32_0217e730
 _0217eb88: .word data_027e0e58
@@ -3792,14 +3792,14 @@ _0217edd8: .word func_01fffcec
 	.global func_ov32_0217eddc
 	arm_func_start func_ov32_0217eddc
 func_ov32_0217eddc: ; 0x0217eddc
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x2c
 	mov r7, r0
 	add r0, r7, #0x500
 	ldrsb r1, [r0, #2]
 	cmp r1, #0
 	addle sp, sp, #0x2c
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	mov r2, #0x2b8
 	str r2, [sp, #0x28]
 	ldrsb r1, [r0, #2]
@@ -3824,13 +3824,13 @@ _0217ee34:
 	mov r0, r1, lsl #0x1
 	ldrsh r3, [r8, r0]
 	add r0, r8, r1, lsl #1
-	ldr sl, [r7, #0x48]
+	ldr r10, [r7, #0x48]
 	mov r11, r3, asr #0x1f
 	umull lr, ip, r6, r3
 	mla ip, r6, r11, ip
 	mla ip, r5, r3, ip
 	adds r3, lr, #0x800
-	str sl, [sp, #0x1c]
+	str r10, [sp, #0x1c]
 	ldrsh r2, [r0, #2]
 	ldr r0, [r7, #0x4c]
 	adc r11, ip, #0
@@ -3842,15 +3842,15 @@ _0217ee34:
 	str r0, [sp, #8]
 	ldr r0, _0217efcc ; =data_027e0f90
 	add r1, sp, #0x1c
-	add sl, sl, r3
+	add r10, r10, r3
 	mov r3, r1
-	str sl, [r3]
+	str r10, [r3]
 	ldr r3, [sp, #8]
-	umull r11, sl, r6, r2
-	mla sl, r6, r3, sl
+	umull r11, r10, r6, r2
+	mla r10, r6, r3, r10
 	adds r3, r11, #0x800
-	mla sl, r5, r2, sl
-	adc r2, sl, #0
+	mla r10, r5, r2, r10
+	adc r2, r10, #0
 	mov r3, r3, lsr #0xc
 	orr r3, r3, r2, lsl #20
 	ldr r0, [r0]
@@ -3917,7 +3917,7 @@ _0217ef94:
 	sub r0, r0, #1
 	strb r0, [r7, #0x502]
 	add sp, sp, #0x2c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov32_0217eddc
 _0217efc4: .word 0x00007fff
@@ -5331,7 +5331,7 @@ _021800dc: .word 0x0000071c
 	.global func_ov32_021800e0
 	arm_func_start func_ov32_021800e0
 func_ov32_021800e0: ; 0x021800e0
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0xc
 	ldr r1, _0218027c ; =0x000005ed
 	mov r7, r0
@@ -5347,7 +5347,7 @@ _02180108:
 	stmia r3, {r0, r1, r2}
 	ldrsh r1, [r7, #0x78]
 	mov r2, #0x1800
-	ldr sl, [sp]
+	ldr r10, [sp]
 	sub r1, r1, #0x8000
 	mov r1, r1, lsl #0x10
 	mov r1, r1, lsr #0x10
@@ -5366,7 +5366,7 @@ _02180108:
 	adc r2, r8, #0
 	mov r8, sb, lsr #0xc
 	orr r8, r8, r2, lsl #20
-	add r2, sl, r8
+	add r2, r10, r8
 	str r2, [sp]
 	ldrsh r2, [r7, #0x78]
 	mov sb, #0
@@ -5379,9 +5379,9 @@ _02180108:
 	ldrsh ip, [r2, #2]
 	umull r8, r2, ip, r11
 	mla r2, ip, sb, r2
-	mov sl, ip, asr #0x1f
+	mov r10, ip, asr #0x1f
 	adds sb, r8, #0x800
-	mla r2, sl, r11, r2
+	mla r2, r10, r11, r2
 	adc r2, r2, #0
 	mov r8, sb, lsr #0xc
 	orr r8, r8, r2, lsl #20
@@ -5435,7 +5435,7 @@ _021801e0:
 	orr r1, r1, r0, lsl #20
 	str r1, [r7, #0x68]
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov32_021800e0
 _0218027c: .word 0x000005ed
@@ -5597,22 +5597,22 @@ _021804a0: .word data_027e0764
 	.global func_ov32_021804a4
 	arm_func_start func_ov32_021804a4
 func_ov32_021804a4: ; 0x021804a4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x24
-	mov sl, r0
-	add r0, sl, #0x300
+	mov r10, r0
+	add r0, r10, #0x300
 	ldrsh r1, [r0, #0xfc]
-	ldrsh r2, [sl, #0x78]
+	ldrsh r2, [r10, #0x78]
 	ldr r0, _0218084c ; =0x0000071c
 	ldr r3, _02180850 ; =data_027e0fac
 	smlabb r1, r1, r0, r2
-	strh r1, [sl, #0x78]
+	strh r1, [r10, #0x78]
 	ldr r0, _02180854 ; =data_027e0f94
 	ldrsh r4, [r3]
 	add r8, sp, #0x18
 	ldmia r0, {r0, r1, r2}
 	stmia r8, {r0, r1, r2}
-	ldrsh r1, [sl, #0x78]
+	ldrsh r1, [r10, #0x78]
 	ldr r0, _02180858 ; =data_02050f54
 	mov r3, r4, lsl #0x10
 	sub r1, r1, r4
@@ -5636,7 +5636,7 @@ func_ov32_021804a4: ; 0x021804a4
 	orr r6, r6, r5, lsl #20
 	add r11, r1, r6
 	str r11, [sp, #0x18]
-	ldrsh r5, [sl, #0x78]
+	ldrsh r5, [r10, #0x78]
 	mov r3, r3, lsl #0x1
 	ldr r7, [sp, #0x20]
 	sub r4, r5, r4
@@ -5659,12 +5659,12 @@ func_ov32_021804a4: ; 0x021804a4
 	orr r2, r2, r3, lsl #20
 	add sb, r7, r2
 	str sb, [sp, #0x20]
-	add r1, sl, #0x400
+	add r1, r10, #0x400
 	ldrsh r2, [r1, #2]
 	mov r1, r6, asr #0x1f
 	str r1, [sp, #4]
 	ldr r1, _0218085c ; =0x00000333
-	ldrsh r4, [sl, #0x78]
+	ldrsh r4, [r10, #0x78]
 	mov r3, r1, lsr #0x1
 	ldr lr, [sp, #0x1c]
 	add r1, r4, r2
@@ -5726,29 +5726,29 @@ func_ov32_021804a4: ; 0x021804a4
 	bl func_ov00_020c5288
 	cmp r0, #0
 	beq _021806bc
-	add r0, sl, #0x21c
+	add r0, r10, #0x21c
 	mov r1, #3
 	mov r2, #0
 	bl func_ov00_020c515c
 	b _021806d4
 _021806bc:
 	ldr r0, [sp, #0x18]
-	str r0, [sl, #0x48]
+	str r0, [r10, #0x48]
 	ldr r0, [sp, #0x1c]
-	str r0, [sl, #0x4c]
+	str r0, [r10, #0x4c]
 	ldr r0, [sp, #0x20]
-	str r0, [sl, #0x50]
+	str r0, [r10, #0x50]
 _021806d4:
-	mov r0, sl
+	mov r0, r10
 	ldr r1, [r0]
 	ldr r1, [r1, #0x104]
 	blx r1
-	ldrh r7, [sl, #0xe4]
+	ldrh r7, [r10, #0xe4]
 	mov r8, #0
 	cmp r7, #0
 	ble _021807b4
 	cmp r7, #0
-	add sb, sl, #0xb8
+	add sb, r10, #0xb8
 	ble _021807b4
 	ldr r6, _02180864 ; =data_027e0f6c
 	ldr r5, _02180854 ; =data_027e0f94
@@ -5768,13 +5768,13 @@ _02180710:
 	bne _02180764
 	ldr r0, [r5]
 	mov r1, #3
-	str r0, [sl, #0x48]
+	str r0, [r10, #0x48]
 	ldr r2, [r5, #4]
-	add r0, sl, #0x21c
-	str r2, [sl, #0x4c]
+	add r0, r10, #0x21c
+	str r2, [r10, #0x4c]
 	ldr r3, [r5, #8]
 	mov r2, #0
-	str r3, [sl, #0x50]
+	str r3, [r10, #0x50]
 	bl func_ov00_020c515c
 _02180764:
 	ldr r0, [sp, #0x14]
@@ -5784,13 +5784,13 @@ _02180764:
 	bne _021807a0
 	ldr r0, [r5]
 	mov r1, #3
-	str r0, [sl, #0x48]
+	str r0, [r10, #0x48]
 	ldr r2, [r5, #4]
-	add r0, sl, #0x21c
-	str r2, [sl, #0x4c]
+	add r0, r10, #0x21c
+	str r2, [r10, #0x4c]
 	ldr r3, [r5, #8]
 	mov r2, #0
-	str r3, [sl, #0x50]
+	str r3, [r10, #0x50]
 	bl func_ov00_020c515c
 _021807a0:
 	add r0, r8, #1
@@ -5799,7 +5799,7 @@ _021807a0:
 	mov r8, r0, lsr #0x10
 	bgt _02180710
 _021807b4:
-	ldrh r1, [sl, #0xe2]
+	ldrh r1, [r10, #0xe2]
 	ldr r0, _02180868 ; =0x0000ffff
 	cmp r1, r0
 	beq _0218081c
@@ -5815,30 +5815,30 @@ _021807b4:
 	cmp r0, #1
 	bne _0218081c
 	ldr r3, _02180854 ; =data_027e0f94
-	add r0, sl, #0x21c
+	add r0, r10, #0x21c
 	ldr r2, [r3]
 	mov r1, #3
-	str r2, [sl, #0x48]
+	str r2, [r10, #0x48]
 	ldr r4, [r3, #4]
 	mov r2, #0
-	str r4, [sl, #0x4c]
+	str r4, [r10, #0x4c]
 	ldr r3, [r3, #8]
-	str r3, [sl, #0x50]
+	str r3, [r10, #0x50]
 	bl func_ov00_020c515c
 _0218081c:
-	mov r0, sl
+	mov r0, r10
 	bl _ZN5Actor14DistanceToLinkEv
 	ldr r1, _0218086c ; =0x00000a66
 	cmp r0, r1
 	ble _02180840
-	add r0, sl, #0x21c
+	add r0, r10, #0x21c
 	mov r1, #3
 	mov r2, #0
 	bl func_ov00_020c515c
 _02180840:
 	mov r0, #1
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov32_021804a4
 _0218084c: .word 0x0000071c
@@ -5854,7 +5854,7 @@ _0218086c: .word 0x00000a66
 	.global func_ov32_02180870
 	arm_func_start func_ov32_02180870
 func_ov32_02180870: ; 0x02180870
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x1c
 	mov r7, r0
 	mov r2, #2
@@ -5888,7 +5888,7 @@ _021808dc:
 	stmia r3, {r0, r1, r2}
 	ldrh r1, [r7, #0x78]
 	mov r2, #0x1800
-	ldr sl, [sp, #0x10]
+	ldr r10, [sp, #0x10]
 	mov r1, r1, asr #0x4
 	add r1, r4, r1, lsl #2
 	ldrsh lr, [r1, #2]
@@ -5904,7 +5904,7 @@ _021808dc:
 	adc r2, r8, #0
 	mov r8, sb, lsr #0xc
 	orr r8, r8, r2, lsl #20
-	add r2, sl, r8
+	add r2, r10, r8
 	str r2, [sp, #0x10]
 	ldrh r2, [r7, #0x78]
 	mov sb, #0
@@ -5914,9 +5914,9 @@ _021808dc:
 	ldrsh ip, [r4, r2]
 	umull r8, r2, ip, r11
 	mla r2, ip, sb, r2
-	mov sl, ip, asr #0x1f
+	mov r10, ip, asr #0x1f
 	adds sb, r8, #0x800
-	mla r2, sl, r11, r2
+	mla r2, r10, r11, r2
 	adc r2, r2, #0
 	mov r8, sb, lsr #0xc
 	orr r8, r8, r2, lsl #20
@@ -5969,7 +5969,7 @@ _0218099c:
 	ldr r0, [sp, #8]
 	str r0, [r7, #0x64]
 	add sp, sp, #0x1c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov32_02180870
 _02180a34: .word data_027e0f94
@@ -8075,15 +8075,15 @@ _021826ec: .word data_027e0e60
 	.global func_ov32_021826f0
 	arm_func_start func_ov32_021826f0
 func_ov32_021826f0: ; 0x021826f0
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x1c
-	mov sl, r0
-	ldr r2, [sl, #4]
+	mov r10, r0
+	ldr r2, [r10, #4]
 	mov sb, r1
 	tst r2, #0x10
 	addeq sp, sp, #0x1c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
-	ldrb r1, [sl, #0x68]
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldrb r1, [r10, #0x68]
 	cmp r1, #0
 	beq _021827ec
 	str sb, [sp]
@@ -8104,7 +8104,7 @@ func_ov32_021826f0: ; 0x021826f0
 	str r0, [sp, #0x18]
 	str r1, [sp, #0x10]
 	str r1, [sp, #0x14]
-	ldrsh r1, [sl, #0xc]
+	ldrsh r1, [r10, #0xc]
 	add r0, sp, #0x10
 	bl func_ov00_020a61ac
 	ldr r1, [sp, #0x10]
@@ -8124,8 +8124,8 @@ _02182790:
 	str r1, [sp, #8]
 	mov r0, r0, asr #0xc
 	str r0, [sp, #0xc]
-	ldrsh r1, [sl, #0xc]
-	mov r0, sl
+	ldrsh r1, [r10, #0xc]
+	mov r0, r10
 	mov r2, r11
 	rsb r1, r1, #0x4000
 	mov r1, r1, lsl #0x10
@@ -8145,31 +8145,31 @@ _021827ec:
 	bne _02182804
 	tst r0, #2
 	addeq sp, sp, #0x1c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02182804:
-	ldr r0, [sl, #8]
+	ldr r0, [r10, #8]
 	cmp r0, #0xc
 	addne sp, sp, #0x1c
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, _02182864 ; =data_027e0618
 	ldrb r0, [r0, #0x101]
 	cmp r0, #0
 	addne sp, sp, #0x1c
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
-	ldrb r0, [sl, #0x6a]
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldrb r0, [r10, #0x6a]
 	cmp r0, #0
 	addeq sp, sp, #0x1c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	mov r2, #0
 	str r2, [sp]
-	ldrsh r1, [sl, #0x6c]
+	ldrsh r1, [r10, #0x6c]
 	ldr r0, _02182868 ; =data_ov32_02184cc0
 	mov r3, r2
 	ldr r1, [r0, r1, lsl #2]
 	mov r0, #0x44
 	bl func_0203493c
 	add sp, sp, #0x1c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov32_021826f0
 _02182860: .word data_027e080c
@@ -8925,22 +8925,22 @@ _02183188: .word 0x0000ffff
 	.global func_ov32_0218318c
 	arm_func_start func_ov32_0218318c
 func_ov32_0218318c: ; 0x0218318c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0xc
 	ldr ip, _02183330 ; =data_027e0764
 	mov r8, #0x800
 	ldr r2, [ip]
-	ldmib ip, {r1, sl}
-	umull r5, r4, sl, r2
-	mla r4, sl, r1, r4
+	ldmib ip, {r1, r10}
+	umull r5, r4, r10, r2
+	mla r4, r10, r1, r4
 	ldr r7, [ip, #0xc]
 	ldr r3, [ip, #0x10]
 	mla r4, r7, r2, r4
 	adds r5, r3, r5
 	ldr r2, [ip, #0x14]
-	umull r6, sb, sl, r5
+	umull r6, sb, r10, r5
 	adc r4, r2, r4
-	mla sb, sl, r4, sb
+	mla sb, r10, r4, sb
 	str r5, [ip]
 	ldr r1, _02183334 ; =0x00000e39
 	adds r6, r3, r6
@@ -9010,9 +9010,9 @@ func_ov32_0218318c: ; 0x0218318c
 	umull r8, r7, r6, lr
 	mla r7, r6, r11, r7
 	mla r7, r5, lr, r7
-	ldr sl, [ip, #0x10]
+	ldr r10, [ip, #0x10]
 	ldr sb, [ip, #0x14]
-	adds r5, sl, r8
+	adds r5, r10, r8
 	adc r7, sb, r7
 	stmia ip, {r5, r7}
 	umull r5, r6, r7, r3
@@ -9029,7 +9029,7 @@ func_ov32_0218318c: ; 0x0218318c
 	str r0, [r4, #0x64]
 	str r0, [r4, #0x68]
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov32_0218318c
 _02183330: .word data_027e0764
@@ -9207,7 +9207,7 @@ _0218359c: .word 0x00000333
 	.global func_ov32_021835a0
 	arm_func_start func_ov32_021835a0
 func_ov32_021835a0: ; 0x021835a0
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	ldr lr, _021836ec ; =data_027e0764
 	mov r3, #0
 	ldr r2, [lr]
@@ -9278,10 +9278,10 @@ func_ov32_021835a0: ; 0x021835a0
 	umull r8, r7, r6, r4
 	mla r7, r6, r1, r7
 	ldr r5, [lr, #0xc]
-	ldr sl, [lr, #0x10]
+	ldr r10, [lr, #0x10]
 	mla r7, r5, r4, r7
 	ldr sb, [lr, #0x14]
-	adds r1, sl, r8
+	adds r1, r10, r8
 	adc r4, sb, r7
 	stmia lr, {r1, r4}
 	umull r1, lr, r4, ip
@@ -9289,7 +9289,7 @@ func_ov32_021835a0: ; 0x021835a0
 	mla lr, r3, ip, lr
 	add r1, lr, #0x800
 	str r1, [r0, #0x234]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov32_021835a0
 _021836ec: .word data_027e0764
@@ -9299,7 +9299,7 @@ _021836f4: .word 0x00000b34
 	.global func_ov32_021836f8
 	arm_func_start func_ov32_021836f8
 func_ov32_021836f8: ; 0x021836f8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	mov r4, r0
 	bl _ZN5Actor14GetAngleToLinkEv
 	mov r0, r0, lsl #0x10
@@ -9356,10 +9356,10 @@ func_ov32_021836f8: ; 0x021836f8
 	umull r8, r7, r6, lr
 	mla r7, r6, r1, r7
 	ldr r5, [ip, #0xc]
-	ldr sl, [ip, #0x10]
+	ldr r10, [ip, #0x10]
 	mla r7, r5, lr, r7
 	ldr sb, [ip, #0x14]
-	adds r1, sl, r8
+	adds r1, r10, r8
 	adc r5, sb, r7
 	stmia ip, {r1, r5}
 	umull r1, ip, r5, r3
@@ -9367,7 +9367,7 @@ func_ov32_021836f8: ; 0x021836f8
 	mla ip, r0, r3, ip
 	add r0, ip, #0x800
 	str r0, [r4, #0x234]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov32_021836f8
 _0218380c: .word data_02050f54
@@ -10248,7 +10248,7 @@ _02184398: .word data_ov00_020e9370
 	.global func_ov32_0218439c
 	arm_func_start func_ov32_0218439c
 func_ov32_0218439c: ; 0x0218439c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x84
 	ldr r1, _0218453c ; =data_027e0fe4
 	mov r2, #0
@@ -10274,7 +10274,7 @@ func_ov32_0218439c: ; 0x0218439c
 	cmp r0, #0x18
 	addgt sp, sp, #0x84
 	movgt r0, #0
-	ldmgtia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmgtia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r1, [r4, #8]
 	ldr r0, _0218453c ; =data_027e0fe4
 	str r1, [sp, #0x44]
@@ -10287,7 +10287,7 @@ func_ov32_0218439c: ; 0x0218439c
 	cmp r0, #8
 	addgt sp, sp, #0x84
 	movgt r0, #0
-	ldmgtia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmgtia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	add r0, sp, #0x10
 	bl func_ov00_020c1500
 	mov r1, r5
@@ -10324,11 +10324,11 @@ func_ov32_0218439c: ; 0x0218439c
 	mla r8, r7, ip, r8
 	adds r7, sb, #0x800
 	mla r8, r6, r0, r8
-	ldr sl, [sp, #4]
+	ldr r10, [sp, #4]
 	adc r6, r8, #0
 	mov r7, r7, lsr #0xc
 	orr r7, r7, r6, lsl #20
-	add r6, sl, r7
+	add r6, r10, r7
 	str r6, [sp, #4]
 	umull r7, r6, r4, r0
 	mla r6, r4, ip, r6
@@ -10351,7 +10351,7 @@ func_ov32_0218439c: ; 0x0218439c
 	movge r0, #1
 	movlt r0, #0
 	add sp, sp, #0x84
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov32_0218439c
 _0218453c: .word data_027e0fe4

--- a/asm/ov32.s
+++ b/asm/ov32.s
@@ -3311,7 +3311,7 @@ func_ov32_0217e700: ; 0x0217e700
 	.global func_ov32_0217e730
 	arm_func_start func_ov32_0217e730
 func_ov32_0217e730: ; 0x0217e730
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x78
 	mov r4, r1
 	ldrb r2, [r4]
@@ -3339,7 +3339,7 @@ func_ov32_0217e730: ; 0x0217e730
 	ldr r1, [r5, #0x4f4]
 	cmp r1, #0
 	addne sp, sp, #0x78
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0217e7a4:
 	add r0, r5, #0x21c
 	mov r1, #1
@@ -3348,7 +3348,7 @@ _0217e7a4:
 _0217e7b4:
 	add sp, sp, #0x78
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0217e7c0:
 	ldr r2, [r5, #0x4f4]
 	cmp r2, #0
@@ -3372,7 +3372,7 @@ _0217e7dc: ; jump table
 _0217e808:
 	cmp r2, #0
 	addne sp, sp, #0x78
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0217e814:
 	ldrsh r1, [r5, #0x78]
 	ldr r0, [r4, #0x14]
@@ -3380,7 +3380,7 @@ _0217e814:
 	bl func_ov14_02120ac4
 	add sp, sp, #0x78
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0217e830:
 	cmp r1, #9
 	bne _0217e85c
@@ -3448,7 +3448,7 @@ _0217e85c:
 _0217e928:
 	add sp, sp, #0x78
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0217e934:
 	add r0, r5, #0x100
 	ldrsb r1, [r0, #0xa0]
@@ -3472,7 +3472,7 @@ _0217e934:
 	str r2, [sp, #0xc]
 	ldrsb r2, [r0, #0xa8]
 	str r2, [sp, #8]
-	ldrsb fp, [r0, #0xa9]
+	ldrsb r11, [r0, #0xa9]
 	ldrsb r6, [r0, #0xaa]
 	ldrsb r7, [r0, #0xab]
 	ldrsb r8, [r0, #0xac]
@@ -3532,7 +3532,7 @@ _0217ea20:
 	ldr r0, [sp, #8]
 	add sp, sp, #0x78
 	strb r0, [r5, #0x1a8]
-	strb fp, [r5, #0x1a9]
+	strb r11, [r5, #0x1a9]
 	strb r6, [r5, #0x1aa]
 	strb r7, [r5, #0x1ab]
 	strb r8, [r5, #0x1ac]
@@ -3542,7 +3542,7 @@ _0217ea20:
 	ldmia r1, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0217eaa0:
 	mov r2, #1
 	mov r0, r5
@@ -3599,11 +3599,11 @@ _0217eb64:
 	bl func_ov00_020cadb0
 	add sp, sp, #0x78
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0217eb7c:
 	mov r0, #0
 	add sp, sp, #0x78
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov32_0217e730
 _0217eb88: .word data_027e0e58
@@ -3792,14 +3792,14 @@ _0217edd8: .word func_01fffcec
 	.global func_ov32_0217eddc
 	arm_func_start func_ov32_0217eddc
 func_ov32_0217eddc: ; 0x0217eddc
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x2c
 	mov r7, r0
 	add r0, r7, #0x500
 	ldrsb r1, [r0, #2]
 	cmp r1, #0
 	addle sp, sp, #0x2c
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	mov r2, #0x2b8
 	str r2, [sp, #0x28]
 	ldrsb r1, [r0, #2]
@@ -3825,20 +3825,20 @@ _0217ee34:
 	ldrsh r3, [r8, r0]
 	add r0, r8, r1, lsl #1
 	ldr sl, [r7, #0x48]
-	mov fp, r3, asr #0x1f
+	mov r11, r3, asr #0x1f
 	umull lr, ip, r6, r3
-	mla ip, r6, fp, ip
+	mla ip, r6, r11, ip
 	mla ip, r5, r3, ip
 	adds r3, lr, #0x800
 	str sl, [sp, #0x1c]
 	ldrsh r2, [r0, #2]
 	ldr r0, [r7, #0x4c]
-	adc fp, ip, #0
+	adc r11, ip, #0
 	str r0, [sp, #0x20]
 	mov r3, r3, lsr #0xc
 	ldr sb, [r7, #0x50]
 	mov r0, r2, asr #0x1f
-	orr r3, r3, fp, lsl #20
+	orr r3, r3, r11, lsl #20
 	str r0, [sp, #8]
 	ldr r0, _0217efcc ; =data_027e0f90
 	add r1, sp, #0x1c
@@ -3846,9 +3846,9 @@ _0217ee34:
 	mov r3, r1
 	str sl, [r3]
 	ldr r3, [sp, #8]
-	umull fp, sl, r6, r2
+	umull r11, sl, r6, r2
 	mla sl, r6, r3, sl
-	adds r3, fp, #0x800
+	adds r3, r11, #0x800
 	mla sl, r5, r2, sl
 	adc r2, sl, #0
 	mov r3, r3, lsr #0xc
@@ -3917,7 +3917,7 @@ _0217ef94:
 	sub r0, r0, #1
 	strb r0, [r7, #0x502]
 	add sp, sp, #0x2c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov32_0217eddc
 _0217efc4: .word 0x00007fff
@@ -5331,7 +5331,7 @@ _021800dc: .word 0x0000071c
 	.global func_ov32_021800e0
 	arm_func_start func_ov32_021800e0
 func_ov32_021800e0: ; 0x021800e0
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0xc
 	ldr r1, _0218027c ; =0x000005ed
 	mov r7, r0
@@ -5340,7 +5340,7 @@ func_ov32_021800e0: ; 0x021800e0
 	ldr r4, _02180280 ; =data_02050f54
 	str r6, [r7, #0x12c]
 	add r5, r7, #0x48
-	mov fp, #0x1800
+	mov r11, #0x1800
 _02180108:
 	add r3, sp, #0
 	ldmia r5, {r0, r1, r2}
@@ -5377,11 +5377,11 @@ _02180108:
 	mov r2, r2, asr #0x4
 	add r2, r4, r2, lsl #2
 	ldrsh ip, [r2, #2]
-	umull r8, r2, ip, fp
+	umull r8, r2, ip, r11
 	mla r2, ip, sb, r2
 	mov sl, ip, asr #0x1f
 	adds sb, r8, #0x800
-	mla r2, sl, fp, r2
+	mla r2, sl, r11, r2
 	adc r2, r2, #0
 	mov r8, sb, lsr #0xc
 	orr r8, r8, r2, lsl #20
@@ -5435,7 +5435,7 @@ _021801e0:
 	orr r1, r1, r0, lsl #20
 	str r1, [r7, #0x68]
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov32_021800e0
 _0218027c: .word 0x000005ed
@@ -5597,7 +5597,7 @@ _021804a0: .word data_027e0764
 	.global func_ov32_021804a4
 	arm_func_start func_ov32_021804a4
 func_ov32_021804a4: ; 0x021804a4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x24
 	mov sl, r0
 	add r0, sl, #0x300
@@ -5634,8 +5634,8 @@ func_ov32_021804a4: ; 0x021804a4
 	adc r5, r5, #0
 	mov r6, r6, lsr #0xc
 	orr r6, r6, r5, lsl #20
-	add fp, r1, r6
-	str fp, [sp, #0x18]
+	add r11, r1, r6
+	str r11, [sp, #0x18]
 	ldrsh r5, [sl, #0x78]
 	mov r3, r3, lsl #0x1
 	ldr r7, [sp, #0x20]
@@ -5708,7 +5708,7 @@ func_ov32_021804a4: ; 0x021804a4
 	adc r3, r7, #0
 	mov r6, r6, lsr #0xc
 	orr r6, r6, r3, lsl #20
-	add r3, fp, r6
+	add r3, r11, r6
 	str r3, [sp, #0x18]
 	mov r3, ip
 	umull r7, r6, r5, r4
@@ -5753,14 +5753,14 @@ _021806d4:
 	ldr r6, _02180864 ; =data_027e0f6c
 	ldr r5, _02180854 ; =data_027e0f94
 	ldr r4, _02180868 ; =0x0000ffff
-	add fp, sp, #0x14
+	add r11, sp, #0x14
 _02180710:
 	add r0, sb, r8, lsl #1
 	ldrh r2, [r0, #0x2e]
 	cmp r2, r4
 	beq _021807a0
 	ldr r1, [r6]
-	mov r0, fp
+	mov r0, r11
 	bl func_ov00_02093a1c
 	ldr r0, [sp, #0x14]
 	and r0, r0, #0x1f
@@ -5838,7 +5838,7 @@ _0218081c:
 _02180840:
 	mov r0, #1
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov32_021804a4
 _0218084c: .word 0x0000071c
@@ -5854,7 +5854,7 @@ _0218086c: .word 0x00000a66
 	.global func_ov32_02180870
 	arm_func_start func_ov32_02180870
 func_ov32_02180870: ; 0x02180870
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x1c
 	mov r7, r0
 	mov r2, #2
@@ -5881,7 +5881,7 @@ _021808c4:
 	strh r0, [r7, #0x78]
 	mov r6, #0
 	add r5, r7, #0x48
-	mov fp, #0x1800
+	mov r11, #0x1800
 _021808dc:
 	add r3, sp, #0x10
 	ldmia r5, {r0, r1, r2}
@@ -5912,11 +5912,11 @@ _021808dc:
 	mov r2, r2, asr #0x4
 	mov r2, r2, lsl #0x2
 	ldrsh ip, [r4, r2]
-	umull r8, r2, ip, fp
+	umull r8, r2, ip, r11
 	mla r2, ip, sb, r2
 	mov sl, ip, asr #0x1f
 	adds sb, r8, #0x800
-	mla r2, sl, fp, r2
+	mla r2, sl, r11, r2
 	adc r2, r2, #0
 	mov r8, sb, lsr #0xc
 	orr r8, r8, r2, lsl #20
@@ -5969,7 +5969,7 @@ _0218099c:
 	ldr r0, [sp, #8]
 	str r0, [r7, #0x64]
 	add sp, sp, #0x1c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov32_02180870
 _02180a34: .word data_027e0f94
@@ -8075,14 +8075,14 @@ _021826ec: .word data_027e0e60
 	.global func_ov32_021826f0
 	arm_func_start func_ov32_021826f0
 func_ov32_021826f0: ; 0x021826f0
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x1c
 	mov sl, r0
 	ldr r2, [sl, #4]
 	mov sb, r1
 	tst r2, #0x10
 	addeq sp, sp, #0x1c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldrb r1, [sl, #0x68]
 	cmp r1, #0
 	beq _021827ec
@@ -8114,7 +8114,7 @@ func_ov32_021826f0: ; 0x021826f0
 	mov r7, r0, asr #0x1
 	mvn r5, #0
 	mov r4, r8
-	mov fp, #0x2e
+	mov r11, #0x2e
 _02182790:
 	str r5, [sp]
 	add r1, r6, #0x800
@@ -8126,7 +8126,7 @@ _02182790:
 	str r0, [sp, #0xc]
 	ldrsh r1, [sl, #0xc]
 	mov r0, sl
-	mov r2, fp
+	mov r2, r11
 	rsb r1, r1, #0x4000
 	mov r1, r1, lsl #0x10
 	mov r3, sb
@@ -8145,21 +8145,21 @@ _021827ec:
 	bne _02182804
 	tst r0, #2
 	addeq sp, sp, #0x1c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02182804:
 	ldr r0, [sl, #8]
 	cmp r0, #0xc
 	addne sp, sp, #0x1c
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, _02182864 ; =data_027e0618
 	ldrb r0, [r0, #0x101]
 	cmp r0, #0
 	addne sp, sp, #0x1c
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldrb r0, [sl, #0x6a]
 	cmp r0, #0
 	addeq sp, sp, #0x1c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	mov r2, #0
 	str r2, [sp]
 	ldrsh r1, [sl, #0x6c]
@@ -8169,7 +8169,7 @@ _02182804:
 	mov r0, #0x44
 	bl func_0203493c
 	add sp, sp, #0x1c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov32_021826f0
 _02182860: .word data_027e080c
@@ -8925,7 +8925,7 @@ _02183188: .word 0x0000ffff
 	.global func_ov32_0218318c
 	arm_func_start func_ov32_0218318c
 func_ov32_0218318c: ; 0x0218318c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0xc
 	ldr ip, _02183330 ; =data_027e0764
 	mov r8, #0x800
@@ -9000,7 +9000,7 @@ func_ov32_0218318c: ; 0x0218318c
 	ldr lr, [ip]
 	str r5, [sp]
 	ldr r5, [r4, #0x4c]
-	ldr fp, [ip, #4]
+	ldr r11, [ip, #4]
 	str r5, [sp, #4]
 	ldr r5, [r4, #0x50]
 	add r1, sp, #0
@@ -9008,7 +9008,7 @@ func_ov32_0218318c: ; 0x0218318c
 	ldr r6, [ip, #8]
 	ldr r5, [ip, #0xc]
 	umull r8, r7, r6, lr
-	mla r7, r6, fp, r7
+	mla r7, r6, r11, r7
 	mla r7, r5, lr, r7
 	ldr sl, [ip, #0x10]
 	ldr sb, [ip, #0x14]
@@ -9029,7 +9029,7 @@ func_ov32_0218318c: ; 0x0218318c
 	str r0, [r4, #0x64]
 	str r0, [r4, #0x68]
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov32_0218318c
 _02183330: .word data_027e0764
@@ -10248,7 +10248,7 @@ _02184398: .word data_ov00_020e9370
 	.global func_ov32_0218439c
 	arm_func_start func_ov32_0218439c
 func_ov32_0218439c: ; 0x0218439c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x84
 	ldr r1, _0218453c ; =data_027e0fe4
 	mov r2, #0
@@ -10274,7 +10274,7 @@ func_ov32_0218439c: ; 0x0218439c
 	cmp r0, #0x18
 	addgt sp, sp, #0x84
 	movgt r0, #0
-	ldmgtia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmgtia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r1, [r4, #8]
 	ldr r0, _0218453c ; =data_027e0fe4
 	str r1, [sp, #0x44]
@@ -10287,7 +10287,7 @@ func_ov32_0218439c: ; 0x0218439c
 	cmp r0, #8
 	addgt sp, sp, #0x84
 	movgt r0, #0
-	ldmgtia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmgtia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r0, sp, #0x10
 	bl func_ov00_020c1500
 	mov r1, r5
@@ -10341,17 +10341,17 @@ func_ov32_0218439c: ; 0x0218439c
 	orr r4, r4, r0, lsl #20
 	add r0, r5, r4
 	str r0, [sp, #0xc]
-	ldr fp, _02184550 ; =data_027e0fe8
+	ldr r11, _02184550 ; =data_027e0fe8
 	str ip, [sp]
 	ldr r1, _02184544 ; =0x42454530
-	ldr r0, [fp]
+	ldr r0, [r11]
 	add r3, sp, #0x10
 	bl func_ov00_020c4048
 	cmp r0, #0
 	movge r0, #1
 	movlt r0, #0
 	add sp, sp, #0x84
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov32_0218439c
 _0218453c: .word data_027e0fe4

--- a/asm/ov33.s
+++ b/asm/ov33.s
@@ -733,7 +733,7 @@ func_ov33_0217c658: ; 0x0217c658
 	.global func_ov33_0217c66c
 	arm_func_start func_ov33_0217c66c
 func_ov33_0217c66c: ; 0x0217c66c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	mov r4, r0
 	ldr r0, [r4, #0x138]
 	mov r1, #0x1e
@@ -777,13 +777,13 @@ func_ov33_0217c66c: ; 0x0217c66c
 	str r2, [r4, #0x48]
 	ldr r5, [r7]
 	ldmib r7, {r2, sb}
-	umull fp, sl, sb, r5
+	umull r11, sl, sb, r5
 	mla sl, sb, r2, sl
 	ldr r8, [r7, #0xc]
 	ldr lr, [r7, #0x10]
 	mla sl, r8, r5, sl
 	ldr ip, [r7, #0x14]
-	adds r2, lr, fp
+	adds r2, lr, r11
 	adc sb, ip, sl
 	umull r5, r8, sb, r6
 	mla r8, sb, r1, r8
@@ -808,10 +808,10 @@ func_ov33_0217c66c: ; 0x0217c66c
 	umull sb, r8, lr, r5
 	mla r8, lr, r2, r8
 	ldr ip, [r7, #0xc]
-	ldr fp, [r7, #0x10]
+	ldr r11, [r7, #0x10]
 	mla r8, ip, r5, r8
 	ldr sl, [r7, #0x14]
-	adds r2, fp, sb
+	adds r2, r11, sb
 	adc r8, sl, r8
 	stmia r7, {r2, r8}
 	umull r5, r7, r8, r6
@@ -832,7 +832,7 @@ func_ov33_0217c66c: ; 0x0217c66c
 	add r0, r2, r3
 	str r0, [r4, #0x50]
 	mov r0, r1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov33_0217c66c
 _0217c7fc: .word 0x000002aa
@@ -4468,7 +4468,7 @@ func_ov33_0217f70c: ; 0x0217f70c
 	.global func_ov33_0217f744
 	arm_func_start func_ov33_0217f744
 func_ov33_0217f744: ; 0x0217f744
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0xc
 	ldr r3, _0217f88c ; =0x00000666
 	mov r4, r0
@@ -4497,7 +4497,7 @@ func_ov33_0217f744: ; 0x0217f744
 	mov r1, r5
 	bl func_ov33_0217dec4
 	ldr r0, _0217f890 ; =data_027e0764
-	ldr fp, _0217f894 ; =data_02050f54
+	ldr r11, _0217f894 ; =data_02050f54
 	ldr r6, [r0, #8]
 	ldr lr, [r0]
 	ldr ip, [r0, #4]
@@ -4524,10 +4524,10 @@ func_ov33_0217f744: ; 0x0217f744
 	mov r5, r5, asr #0x4
 	mov r7, r5, lsl #0x1
 	mov r5, r7, lsl #0x1
-	ldrsh r6, [fp, r5]
+	ldrsh r6, [r11, r5]
 	add r5, r7, #1
 	mov r5, r5, lsl #0x1
-	ldrsh r5, [fp, r5]
+	ldrsh r5, [r11, r5]
 	ldr r2, _0217f898 ; =data_027e0f94
 	mov r0, #0x7000
 	add r1, sp, #0
@@ -4549,7 +4549,7 @@ func_ov33_0217f744: ; 0x0217f744
 	bl func_ov33_0217f954
 	mov r0, #1
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov33_0217f744
 _0217f88c: .word 0x00000666

--- a/asm/ov33.s
+++ b/asm/ov33.s
@@ -733,7 +733,7 @@ func_ov33_0217c658: ; 0x0217c658
 	.global func_ov33_0217c66c
 	arm_func_start func_ov33_0217c66c
 func_ov33_0217c66c: ; 0x0217c66c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	mov r4, r0
 	ldr r0, [r4, #0x138]
 	mov r1, #0x1e
@@ -777,14 +777,14 @@ func_ov33_0217c66c: ; 0x0217c66c
 	str r2, [r4, #0x48]
 	ldr r5, [r7]
 	ldmib r7, {r2, sb}
-	umull r11, sl, sb, r5
-	mla sl, sb, r2, sl
+	umull r11, r10, sb, r5
+	mla r10, sb, r2, r10
 	ldr r8, [r7, #0xc]
 	ldr lr, [r7, #0x10]
-	mla sl, r8, r5, sl
+	mla r10, r8, r5, r10
 	ldr ip, [r7, #0x14]
 	adds r2, lr, r11
-	adc sb, ip, sl
+	adc sb, ip, r10
 	umull r5, r8, sb, r6
 	mla r8, sb, r1, r8
 	mla r8, r3, r6, r8
@@ -810,9 +810,9 @@ func_ov33_0217c66c: ; 0x0217c66c
 	ldr ip, [r7, #0xc]
 	ldr r11, [r7, #0x10]
 	mla r8, ip, r5, r8
-	ldr sl, [r7, #0x14]
+	ldr r10, [r7, #0x14]
 	adds r2, r11, sb
-	adc r8, sl, r8
+	adc r8, r10, r8
 	stmia r7, {r2, r8}
 	umull r5, r7, r8, r6
 	mla r7, r8, r1, r7
@@ -832,7 +832,7 @@ func_ov33_0217c66c: ; 0x0217c66c
 	add r0, r2, r3
 	str r0, [r4, #0x50]
 	mov r0, r1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov33_0217c66c
 _0217c7fc: .word 0x000002aa
@@ -4468,7 +4468,7 @@ func_ov33_0217f70c: ; 0x0217f70c
 	.global func_ov33_0217f744
 	arm_func_start func_ov33_0217f744
 func_ov33_0217f744: ; 0x0217f744
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0xc
 	ldr r3, _0217f88c ; =0x00000666
 	mov r4, r0
@@ -4502,12 +4502,12 @@ func_ov33_0217f744: ; 0x0217f744
 	ldr lr, [r0]
 	ldr ip, [r0, #4]
 	umull r8, r7, r6, lr
-	ldr sl, [r0, #0x10]
+	ldr r10, [r0, #0x10]
 	mla r7, r6, ip, r7
 	ldr r5, [r0, #0xc]
 	ldr sb, [r0, #0x14]
 	mla r7, r5, lr, r7
-	adds r8, sl, r8
+	adds r8, r10, r8
 	ldr r5, _0217f890 ; =data_027e0764
 	mov r0, #0
 	str r0, [sp, #4]
@@ -4549,7 +4549,7 @@ func_ov33_0217f744: ; 0x0217f744
 	bl func_ov33_0217f954
 	mov r0, #1
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov33_0217f744
 _0217f88c: .word 0x00000666

--- a/asm/ov33.s
+++ b/asm/ov33.s
@@ -733,7 +733,7 @@ func_ov33_0217c658: ; 0x0217c658
 	.global func_ov33_0217c66c
 	arm_func_start func_ov33_0217c66c
 func_ov33_0217c66c: ; 0x0217c66c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	mov r4, r0
 	ldr r0, [r4, #0x138]
 	mov r1, #0x1e
@@ -754,11 +754,11 @@ func_ov33_0217c66c: ; 0x0217c66c
 	mla r6, r2, r3, r6
 	ldr r2, [r7, #0x14]
 	adds r5, r5, r8
-	adc sb, r2, r6
-	stmia r7, {r5, sb}
+	adc r9, r2, r6
+	stmia r7, {r5, r9}
 	mov r6, #0xc9
-	umull r5, r8, sb, r6
-	mla r8, sb, r1, r8
+	umull r5, r8, r9, r6
+	mla r8, r9, r1, r8
 	mov r3, r1
 	mla r8, r3, r6, r8
 	sub r5, r8, #0x64
@@ -767,8 +767,8 @@ func_ov33_0217c66c: ; 0x0217c66c
 	mov lr, r5, lsr #0x1f
 	smull r5, r8, ip, r5
 	add r8, lr, r8, asr #5
-	smull sb, r5, r8, r0
-	adds r8, sb, #0x800
+	smull r9, r5, r8, r0
+	adds r8, r9, #0x800
 	ldr r2, [r4, #0x48]
 	adc r5, r5, #0
 	mov r8, r8, lsr #0xc
@@ -776,26 +776,26 @@ func_ov33_0217c66c: ; 0x0217c66c
 	add r2, r2, r8
 	str r2, [r4, #0x48]
 	ldr r5, [r7]
-	ldmib r7, {r2, sb}
-	umull r11, r10, sb, r5
-	mla r10, sb, r2, r10
+	ldmib r7, {r2, r9}
+	umull r11, r10, r9, r5
+	mla r10, r9, r2, r10
 	ldr r8, [r7, #0xc]
 	ldr lr, [r7, #0x10]
 	mla r10, r8, r5, r10
 	ldr ip, [r7, #0x14]
 	adds r2, lr, r11
-	adc sb, ip, r10
-	umull r5, r8, sb, r6
-	mla r8, sb, r1, r8
+	adc r9, ip, r10
+	umull r5, r8, r9, r6
+	mla r8, r9, r1, r8
 	mla r8, r3, r6, r8
 	sub r5, r8, #0x64
-	stmia r7, {r2, sb}
+	stmia r7, {r2, r9}
 	ldr ip, _0217c804 ; =0x51eb851f
 	mov r8, r5, lsl #0xc
-	smull r5, sb, ip, r8
+	smull r5, r9, ip, r8
 	mov r5, r8, lsr #0x1f
-	add sb, r5, sb, asr #5
-	smull r8, r5, sb, r0
+	add r9, r5, r9, asr #5
+	smull r8, r5, r9, r0
 	adds r8, r8, #0x800
 	ldr r2, [r4, #0x4c]
 	adc r5, r5, #0
@@ -805,13 +805,13 @@ func_ov33_0217c66c: ; 0x0217c66c
 	str r2, [r4, #0x4c]
 	ldr r5, [r7]
 	ldmib r7, {r2, lr}
-	umull sb, r8, lr, r5
+	umull r9, r8, lr, r5
 	mla r8, lr, r2, r8
 	ldr ip, [r7, #0xc]
 	ldr r11, [r7, #0x10]
 	mla r8, ip, r5, r8
 	ldr r10, [r7, #0x14]
-	adds r2, r11, sb
+	adds r2, r11, r9
 	adc r8, r10, r8
 	stmia r7, {r2, r8}
 	umull r5, r7, r8, r6
@@ -832,7 +832,7 @@ func_ov33_0217c66c: ; 0x0217c66c
 	add r0, r2, r3
 	str r0, [r4, #0x50]
 	mov r0, r1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov33_0217c66c
 _0217c7fc: .word 0x000002aa
@@ -2203,18 +2203,18 @@ _0217d984: .word func_ov33_0217d988
 	.global func_ov33_0217d988
 	arm_func_start func_ov33_0217d988
 func_ov33_0217d988: ; 0x0217d988
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	mov r4, r0
 	ldr r0, [r4, #4]
 	cmp r0, #2
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	mov r6, #0
 	mov r8, r4
-	add sb, r4, #8
+	add r9, r4, #8
 	mov r5, r6
 _0217d9b0:
-	mov r0, sb
+	mov r0, r9
 	ldr ip, [r0]
 	ldrh r7, [r8, #0x12]
 	ldr ip, [ip]
@@ -2228,14 +2228,14 @@ _0217d9b0:
 	bl func_ov33_0217da08
 	cmp r0, #0
 	movne r0, #1
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	add r6, r6, #1
 	cmp r6, #3
 	add r8, r8, #0x18
-	add sb, sb, #0x18
+	add r9, r9, #0x18
 	blt _0217d9b0
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	arm_func_end func_ov33_0217d988
 
 	.global func_ov33_0217da08
@@ -3671,7 +3671,7 @@ _0217ecb0: .word 0x0000023d
 	.global func_ov33_0217ecb4
 	arm_func_start func_ov33_0217ecb4
 func_ov33_0217ecb4: ; 0x0217ecb4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x1c
 	mov r4, r0
 	ldrb r0, [r4, #0x16c]
@@ -3697,7 +3697,7 @@ _0217ed04:
 	mov r0, #0
 	strh r0, [r1, #0x82]
 	add sp, sp, #0x1c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _0217ed18:
 	mov r0, r4
 	add r1, r4, #0x100
@@ -4046,7 +4046,7 @@ _0217f1b8:
 	ldr r1, [sp, #0xc]
 	mov r0, r0, lsl #0x1
 	smull r6, r5, r1, r7
-	adds sb, r6, #0x800
+	adds r9, r6, #0x800
 	ldrsh r3, [r3, r0]
 	str r2, [sp, #0x10]
 	ldr lr, [r4, #0x4c]
@@ -4055,7 +4055,7 @@ _0217f1b8:
 	adc ip, r5, #0
 	add lr, lr, r8
 	smull r5, r8, r1, r3
-	mov r1, sb, lsr #0xc
+	mov r1, r9, lsr #0xc
 	orr r1, r1, ip, lsl #20
 	add ip, r2, r1
 	adds r2, r5, #0x800
@@ -4164,7 +4164,7 @@ _0217f3ac:
 _0217f3c0:
 	mov r0, #1
 	add sp, sp, #0x1c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov33_0217ecb4
 _0217f3cc: .word data_027e0ffc
@@ -4468,7 +4468,7 @@ func_ov33_0217f70c: ; 0x0217f70c
 	.global func_ov33_0217f744
 	arm_func_start func_ov33_0217f744
 func_ov33_0217f744: ; 0x0217f744
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0xc
 	ldr r3, _0217f88c ; =0x00000666
 	mov r4, r0
@@ -4505,13 +4505,13 @@ func_ov33_0217f744: ; 0x0217f744
 	ldr r10, [r0, #0x10]
 	mla r7, r6, ip, r7
 	ldr r5, [r0, #0xc]
-	ldr sb, [r0, #0x14]
+	ldr r9, [r0, #0x14]
 	mla r7, r5, lr, r7
 	adds r8, r10, r8
 	ldr r5, _0217f890 ; =data_027e0764
 	mov r0, #0
 	str r0, [sp, #4]
-	adc r6, sb, r7
+	adc r6, r9, r7
 	str r8, [r5]
 	str r6, [r5, #4]
 	mov r5, r6, lsr #0x10
@@ -4549,7 +4549,7 @@ func_ov33_0217f744: ; 0x0217f744
 	bl func_ov33_0217f954
 	mov r0, #1
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov33_0217f744
 _0217f88c: .word 0x00000666

--- a/asm/ov34.s
+++ b/asm/ov34.s
@@ -1621,7 +1621,7 @@ _0217d350: .word data_027e0d0c
 	.global func_ov34_0217d354
 	arm_func_start func_ov34_0217d354
 func_ov34_0217d354: ; 0x0217d354
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #8
 	ldr r2, _0217d494 ; =data_ov34_021861a0
 	ldr r0, [r2, #0x190]
@@ -1641,10 +1641,10 @@ func_ov34_0217d354: ; 0x0217d354
 	adds sb, r7, sb
 	mla r8, r4, r6, r8
 	ldr r6, [r1, #0x14]
-	umull fp, r3, r5, sb
+	umull r11, r3, r5, sb
 	adc r8, r6, r8
-	adds ip, r7, fp
-	sub fp, sl, #1
+	adds ip, r7, r11
+	sub r11, sl, #1
 	umull sl, lr, r8, r0
 	mla r3, r5, r8, r3
 	str sl, [sp, #4]
@@ -1683,7 +1683,7 @@ func_ov34_0217d354: ; 0x0217d354
 	add r0, r4, r0
 	str r0, [r2, #0x188]
 	str r3, [r2, #0x190]
-	str fp, [r2, #0x194]
+	str r11, [r2, #0x194]
 	b _0217d470
 _0217d454:
 	ldr r0, _0217d4a4 ; =data_ov00_020eec9c
@@ -1702,7 +1702,7 @@ _0217d470:
 	str r4, [sp]
 	bl func_ov34_0217ceb0
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov34_0217d354
 _0217d494: .word data_ov34_021861a0
@@ -2937,7 +2937,7 @@ _0217e670: .word data_ov34_021861e0
 	.global func_ov34_0217e674
 	arm_func_start func_ov34_0217e674
 func_ov34_0217e674: ; 0x0217e674
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	ldr r2, _0217e8b4 ; =data_027e0764
 	mov ip, #0xa5
 	ldr r3, [r2]
@@ -2958,17 +2958,17 @@ func_ov34_0217e674: ; 0x0217e674
 	adc r4, r8, r1
 	str r3, [r2, #4]
 	umull sl, r1, r3, ip
-	mov fp, #0
-	mov sl, fp
+	mov r11, #0
+	mov sl, r11
 	mla r1, r3, sl, r1
-	mla r1, fp, ip, r1
+	mla r1, r11, ip, r1
 	str r5, [r2]
 	ldr ip, _0217e8b8 ; =0x00001001
 	add sl, r1, #0x29
 	umull r3, r1, r4, ip
-	mov r3, fp
+	mov r3, r11
 	mla r1, r4, r3, r1
-	mla r1, fp, ip, r1
+	mla r1, r11, ip, r1
 	umull ip, r3, r7, r5
 	mla r3, r7, r4, r3
 	mla r3, r6, r5, r3
@@ -2981,10 +2981,10 @@ func_ov34_0217e674: ; 0x0217e674
 	ldr r2, _0217e8bc ; =0x00005557
 	add r1, r0, #0x1000
 	umull r2, r3, r4, r2
-	mov r2, fp
+	mov r2, r11
 	mla r3, r4, r2, r3
 	ldr r2, _0217e8bc ; =0x00005557
-	mla r3, fp, r2, r3
+	mla r3, r11, r2, r3
 	ldr r2, _0217e8c0 ; =0xffffd555
 	add r2, r3, r2
 	mov r2, r2, lsl #0x10
@@ -3082,7 +3082,7 @@ _0217e820:
 	mov r1, #1
 	strh r2, [r4, #0x82]
 	bl func_ov34_02183d14
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov34_0217e674
 _0217e8b4: .word data_027e0764
@@ -3301,7 +3301,7 @@ _0217eb90: .word data_ov34_021861a0
 	.global func_ov34_0217eb94
 	arm_func_start func_ov34_0217eb94
 func_ov34_0217eb94: ; 0x0217eb94
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x48
 	mov r4, r0
 	add r0, r4, #0x1000
@@ -3386,7 +3386,7 @@ _0217eccc:
 	mov r1, #3
 	bl func_ov34_0217be60
 	add sp, sp, #0x48
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0217ece0:
 	add r0, r4, #0x1000
 	ldr r0, [r0, #0xaa0]
@@ -3397,7 +3397,7 @@ _0217ece0:
 	bl func_0202e310
 	cmp r0, #0
 	addeq sp, sp, #0x48
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r1, r4, #0x1000
 	ldr r2, [r1, #0xa78]
 	add r0, sp, #0x10
@@ -3427,7 +3427,7 @@ _0217ece0:
 	strh r4, [sp, #0x10]
 	ldrh r1, [r1, #0x7e]
 	ldr sl, [r2, #0xd04]
-	ldr fp, _0217ee4c ; =data_027e0fe8
+	ldr r11, _0217ee4c ; =data_027e0fe8
 	mov r1, r1, asr #0x4
 	mov r4, r1, lsl #0x1
 	mov r1, r4, lsl #0x1
@@ -3464,7 +3464,7 @@ _0217ece0:
 	str r0, [sp, #0xc]
 	str ip, [sp]
 	ldr r1, _0217ee50 ; =0x47524f42
-	ldr r0, [fp]
+	ldr r0, [r11]
 	add r2, sp, #4
 	add r3, sp, #0x10
 	bl func_ov00_020c4048
@@ -3474,7 +3474,7 @@ _0217ece0:
 	mov r3, #0
 	bl func_ov00_020ceacc
 	add sp, sp, #0x48
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov34_0217eb94
 _0217ee3c: .word data_027e0f94
@@ -8450,7 +8450,7 @@ _02183470: .word data_027e0194
 	.global func_ov34_02183474
 	arm_func_start func_ov34_02183474
 func_ov34_02183474: ; 0x02183474
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0xa8
 	mov sl, r0
 	add r0, sl, #0x1d00
@@ -8474,7 +8474,7 @@ func_ov34_02183474: ; 0x02183474
 	ldrb r0, [r4, #0xd88]
 	cmp r0, #0
 	addeq sp, sp, #0xa8
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r0, sl, #0x304
 	add r2, r0, #0x1800
 	add r0, sl, #0x1b40
@@ -8483,7 +8483,7 @@ func_ov34_02183474: ; 0x02183474
 	str r0, [sp, #4]
 	add r7, r0, #0x40
 	add r0, sl, #0xb90
-	ldr fp, _02183cfc ; =0x000002cb
+	ldr r11, _02183cfc ; =0x000002cb
 	add r6, r2, #0x30
 	add sb, r1, #0x90
 	mov r5, #4
@@ -8569,7 +8569,7 @@ _02183510:
 _02183640:
 	mov r0, r7
 	add r1, sp, #0x80
-	mov r2, fp
+	mov r2, r11
 	bl func_ov00_020d59f0
 	rsb r0, r5, #4
 	rsb r0, r0, r0, lsl #5
@@ -8606,7 +8606,7 @@ _02183690:
 	bl func_ov00_020d5cd8
 	sub r5, r5, #1
 	sub r6, r6, #0xc
-	sub fp, fp, #0x66
+	sub r11, r11, #0x66
 	sub r7, r7, #0x10
 	sub r8, r8, #0x21
 	sub sb, sb, #0x24
@@ -8674,7 +8674,7 @@ _02183710:
 	ldrsh r1, [r4, r1]
 	smull r7, r5, r0, r3
 	mov r6, sb, lsl #0x1
-	ldrsh fp, [r4, r8]
+	ldrsh r11, [r4, r8]
 	ldrsh r8, [r4, r6]
 	adds r7, r7, #0x800
 	smull sb, r4, r1, r2
@@ -8692,7 +8692,7 @@ _02183710:
 	adc r0, r5, #0
 	mov r5, r6, lsr #0xc
 	orr r5, r5, r0, lsl #20
-	mov r0, fp, asr #0x1f
+	mov r0, r11, asr #0x1f
 	str r0, [sp, #0x18]
 	mov r0, sb, asr #0x1f
 	str r0, [sp, #0x1c]
@@ -8700,7 +8700,7 @@ _02183710:
 	str r0, [sp, #0x20]
 	mov r0, r7, asr #0x1f
 	str r0, [sp, #0x24]
-	smull r0, r6, sb, fp
+	smull r0, r6, sb, r11
 	adds r0, r0, #0x800
 	adc r6, r6, #0
 	mov r0, r0, lsr #0xc
@@ -8717,7 +8717,7 @@ _02183710:
 	orr r6, r6, r0, lsl #20
 	mov r0, r6, asr #0x1f
 	str r0, [sp, #0x28]
-	smull r1, r0, r6, fp
+	smull r1, r0, r6, r11
 	adds r2, r1, #0x800
 	adc r1, r0, #0
 	mov r0, r2, lsr #0xc
@@ -8730,12 +8730,12 @@ _02183710:
 	add r0, r0, r2
 	mov lr, r4, asr #0x1f
 	str r0, [sp, #0x84]
-	umull r5, r3, r4, fp
+	umull r5, r3, r4, r11
 	str r5, [sp, #0x34]
 	ldr r5, [sp, #0x18]
 	ldr r2, _02183d0c ; =0x00000333
 	mla r3, r4, r5, r3
-	mla r3, lr, fp, r3
+	mla r3, lr, r11, r3
 	ldr r4, [sp, #0x34]
 	add r0, sl, #0x1b40
 	adds r4, r4, #0x800
@@ -8754,11 +8754,11 @@ _02183710:
 	sub r3, r5, r4
 	str r3, [sp, #0x88]
 	ldr r5, [sp, #0x18]
-	umull r4, r3, r7, fp
+	umull r4, r3, r7, r11
 	mla r3, r7, r5, r3
 	ldr r5, [sp, #0x24]
 	add r1, sp, #0x80
-	mla r3, r5, fp, r3
+	mla r3, r5, r11, r3
 	adds r5, r4, #0x800
 	adc r4, r3, ip
 	mov r3, r5, lsr #0xc
@@ -8799,7 +8799,7 @@ _0218398c:
 	ldrsh r2, [r5, #2]
 	ldrsh r1, [r5, r1]
 	smull r6, r7, r0, r3
-	adds fp, r6, #0x800
+	adds r11, r6, #0x800
 	mov r4, r4, lsl #0xf
 	mov r4, r4, lsr #0x10
 	mov r4, r4, asr #0x4
@@ -8810,16 +8810,16 @@ _0218398c:
 	smull ip, r6, r1, r2
 	adc sb, r7, #0
 	adds r7, ip, #0x800
-	mov fp, fp, lsr #0xc
+	mov r11, r11, lsr #0xc
 	ldrsh ip, [r5, r4]
-	orr fp, fp, sb, lsl #20
+	orr r11, r11, sb, lsl #20
 	ldrsh sb, [r5, r8]
 	adc r4, r6, #0
 	mov r8, r7, lsr #0xc
 	orr r8, r8, r4, lsl #20
 	smull r4, r6, r8, sb
 	adds r7, r4, #0x800
-	smull r5, r4, fp, ip
+	smull r5, r4, r11, ip
 	smull r3, lr, r1, r3
 	smull r2, r1, r0, r2
 	adc r0, r6, #0
@@ -8848,12 +8848,12 @@ _0218398c:
 	smull r3, r1, r8, ip
 	smull r7, r6, r2, ip
 	smull ip, r8, r2, sb
-	smull sb, r2, fp, sb
-	adds fp, ip, #0x800
+	smull sb, r2, r11, sb
+	adds r11, ip, #0x800
 	adc r8, r8, #0
-	mov fp, fp, lsr #0xc
-	orr fp, fp, r8, lsl #20
-	add r0, r0, fp
+	mov r11, r11, lsr #0xc
+	orr r11, r11, r8, lsl #20
+	add r0, r0, r11
 	str r0, [sp, #0x84]
 	adds r7, r7, #0x800
 	adc r0, r6, #0
@@ -9002,7 +9002,7 @@ _02183ca4:
 	add r1, r1, #0x1c00
 	bl func_ov00_020d5cd8
 	add sp, sp, #0xa8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov34_02183474
 _02183cf8: .word data_ov34_0218577c

--- a/asm/ov34.s
+++ b/asm/ov34.s
@@ -1621,7 +1621,7 @@ _0217d350: .word data_027e0d0c
 	.global func_ov34_0217d354
 	arm_func_start func_ov34_0217d354
 func_ov34_0217d354: ; 0x0217d354
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #8
 	ldr r2, _0217d494 ; =data_ov34_021861a0
 	ldr r0, [r2, #0x190]
@@ -1634,14 +1634,14 @@ func_ov34_0217d354: ; 0x0217d354
 	ldr r0, _0217d49c ; =0x00000335
 	ldr r6, [r1]
 	ldmib r1, {r3, r5}
-	umull sb, r8, r5, r6
+	umull r9, r8, r5, r6
 	ldr r7, [r1, #0x10]
 	mla r8, r5, r3, r8
 	ldr r4, [r1, #0xc]
-	adds sb, r7, sb
+	adds r9, r7, r9
 	mla r8, r4, r6, r8
 	ldr r6, [r1, #0x14]
-	umull r11, r3, r5, sb
+	umull r11, r3, r5, r9
 	adc r8, r6, r8
 	adds ip, r7, r11
 	sub r11, r10, #1
@@ -1649,30 +1649,30 @@ func_ov34_0217d354: ; 0x0217d354
 	mla r3, r5, r8, r3
 	str r10, [sp, #4]
 	mov r10, #0
-	str sb, [r1]
-	mla r3, r4, sb, r3
+	str r9, [r1]
+	mla r3, r4, r9, r3
 	mla lr, r8, r10, lr
 	str r8, [r1, #4]
 	adc r8, r6, r3
 	mov r3, r10
 	mla lr, r3, r0, lr
-	umull sb, r3, r8, r0
-	ldr sb, _0217d4a0 ; =0xfffffe66
-	add sb, lr, sb
-	str sb, [r2, #0x180]
-	mov sb, r10
-	mla r3, r8, sb, r3
-	mla r3, sb, r0, r3
-	ldr sb, _0217d4a0 ; =0xfffffe66
+	umull r9, r3, r8, r0
+	ldr r9, _0217d4a0 ; =0xfffffe66
+	add r9, lr, r9
+	str r9, [r2, #0x180]
+	mov r9, r10
+	mla r3, r8, r9, r3
+	mla r3, r9, r0, r3
+	ldr r9, _0217d4a0 ; =0xfffffe66
 	str ip, [r1]
-	add r3, r3, sb
-	umull r10, sb, r5, ip
-	mla sb, r5, r8, sb
-	mla sb, r4, ip, sb
+	add r3, r3, r9
+	umull r10, r9, r5, ip
+	mla r9, r5, r8, r9
+	mla r9, r4, ip, r9
 	str r8, [r1, #4]
 	str r3, [r2, #0x184]
 	adds r4, r7, r10
-	adc r5, r6, sb
+	adc r5, r6, r9
 	stmia r1, {r4, r5}
 	umull r1, r4, r5, r0
 	mov r1, #0
@@ -1702,7 +1702,7 @@ _0217d470:
 	str r4, [sp]
 	bl func_ov34_0217ceb0
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov34_0217d354
 _0217d494: .word data_ov34_021861a0
@@ -2937,7 +2937,7 @@ _0217e670: .word data_ov34_021861e0
 	.global func_ov34_0217e674
 	arm_func_start func_ov34_0217e674
 func_ov34_0217e674: ; 0x0217e674
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	ldr r2, _0217e8b4 ; =data_027e0764
 	mov ip, #0xa5
 	ldr r3, [r2]
@@ -2945,16 +2945,16 @@ func_ov34_0217e674: ; 0x0217e674
 	umull r4, r5, r7, r3
 	mla r5, r7, r1, r5
 	ldr r6, [r2, #0xc]
-	ldr sb, [r2, #0x10]
+	ldr r9, [r2, #0x10]
 	mla r5, r6, r3, r5
-	adds r10, sb, r4
+	adds r10, r9, r4
 	ldr r8, [r2, #0x14]
 	umull r4, r1, r7, r10
 	adc r3, r8, r5
 	mla r1, r7, r3, r1
 	str r10, [r2]
 	mla r1, r6, r10, r1
-	adds r5, sb, r4
+	adds r5, r9, r4
 	adc r4, r8, r1
 	str r3, [r2, #4]
 	umull r10, r1, r3, ip
@@ -2974,7 +2974,7 @@ func_ov34_0217e674: ; 0x0217e674
 	mla r3, r6, r5, r3
 	add lr, r1, #0x1800
 	str r4, [r2, #4]
-	adds r5, sb, ip
+	adds r5, r9, ip
 	adc r4, r8, r3
 	str r5, [r2]
 	str r4, [r2, #4]
@@ -3082,7 +3082,7 @@ _0217e820:
 	mov r1, #1
 	strh r2, [r4, #0x82]
 	bl func_ov34_02183d14
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov34_0217e674
 _0217e8b4: .word data_027e0764
@@ -3301,7 +3301,7 @@ _0217eb90: .word data_ov34_021861a0
 	.global func_ov34_0217eb94
 	arm_func_start func_ov34_0217eb94
 func_ov34_0217eb94: ; 0x0217eb94
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x48
 	mov r4, r0
 	add r0, r4, #0x1000
@@ -3386,7 +3386,7 @@ _0217eccc:
 	mov r1, #3
 	bl func_ov34_0217be60
 	add sp, sp, #0x48
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0217ece0:
 	add r0, r4, #0x1000
 	ldr r0, [r0, #0xaa0]
@@ -3397,7 +3397,7 @@ _0217ece0:
 	bl func_0202e310
 	cmp r0, #0
 	addeq sp, sp, #0x48
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r1, r4, #0x1000
 	ldr r2, [r1, #0xa78]
 	add r0, sp, #0x10
@@ -3440,7 +3440,7 @@ _0217ece0:
 	ldrsh r4, [r3, r1]
 	str r5, [sp, #8]
 	add r1, r5, #0x9a
-	ldr sb, [r2, #0xd0c]
+	ldr r9, [r2, #0xd0c]
 	mla r7, r6, ip, r7
 	mov r5, r6, asr #0x1f
 	adds r6, r8, #0x800
@@ -3460,7 +3460,7 @@ _0217ece0:
 	adc r0, r5, #0
 	mov r4, r4, lsr #0xc
 	orr r4, r4, r0, lsl #20
-	add r0, sb, r4
+	add r0, r9, r4
 	str r0, [sp, #0xc]
 	str ip, [sp]
 	ldr r1, _0217ee50 ; =0x47524f42
@@ -3474,7 +3474,7 @@ _0217ece0:
 	mov r3, #0
 	bl func_ov00_020ceacc
 	add sp, sp, #0x48
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov34_0217eb94
 _0217ee3c: .word data_027e0f94
@@ -3488,14 +3488,14 @@ _0217ee54: .word data_027e0ffc
 	.global func_ov34_0217ee58
 	arm_func_start func_ov34_0217ee58
 func_ov34_0217ee58: ; 0x0217ee58
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #0xc
 	mov r7, r0
 	mvn r5, #0x80000000
 	sub r0, r5, #0x80000000
-	add sb, r7, #0x1000
+	add r9, r7, #0x1000
 	ldr r10, _0217ef80 ; =data_ov34_021861a0
-	str r0, [sb, #0xd74]
+	str r0, [r9, #0xd74]
 	ldr r0, [r10, #0x78]
 	mov r6, #0
 	cmp r0, #0
@@ -3517,7 +3517,7 @@ _0217ee90:
 	bl func_01ff9ec0
 	cmp r0, r5
 	movlt r5, r0
-	strlt r6, [sb, #0xd74]
+	strlt r6, [r9, #0xd74]
 _0217eecc:
 	ldr r0, [r10, #0x78]
 	add r6, r6, #1
@@ -3554,7 +3554,7 @@ _0217eedc:
 	ldr r0, [r1, #0x54]
 	cmp r0, r2
 	addne sp, sp, #0xc
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	cmp r2, #0
 	moveq r2, #1
 	ldr r0, _0217ef84 ; =data_ov34_021861e0
@@ -3564,7 +3564,7 @@ _0217eedc:
 	add r0, r0, #0x21c
 	bl func_ov34_0217be60
 	add sp, sp, #0xc
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov34_0217ee58
 _0217ef80: .word data_ov34_021861a0
@@ -8450,7 +8450,7 @@ _02183470: .word data_027e0194
 	.global func_ov34_02183474
 	arm_func_start func_ov34_02183474
 func_ov34_02183474: ; 0x02183474
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0xa8
 	mov r10, r0
 	add r0, r10, #0x1d00
@@ -8474,7 +8474,7 @@ func_ov34_02183474: ; 0x02183474
 	ldrb r0, [r4, #0xd88]
 	cmp r0, #0
 	addeq sp, sp, #0xa8
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r0, r10, #0x304
 	add r2, r0, #0x1800
 	add r0, r10, #0x1b40
@@ -8485,7 +8485,7 @@ func_ov34_02183474: ; 0x02183474
 	add r0, r10, #0xb90
 	ldr r11, _02183cfc ; =0x000002cb
 	add r6, r2, #0x30
-	add sb, r1, #0x90
+	add r9, r1, #0x90
 	mov r5, #4
 	mov r8, #0x84
 	str r0, [sp, #0x2c]
@@ -8602,14 +8602,14 @@ _02183690:
 	mov r0, r7
 	bl func_ov00_020d5c54
 	mov r0, r7
-	mov r1, sb
+	mov r1, r9
 	bl func_ov00_020d5cd8
 	sub r5, r5, #1
 	sub r6, r6, #0xc
 	sub r11, r11, #0x66
 	sub r7, r7, #0x10
 	sub r8, r8, #0x21
-	sub sb, sb, #0x24
+	sub r9, r9, #0x24
 	cmp r5, #0
 	bgt _02183510
 	add r0, r10, #0x1000
@@ -8662,8 +8662,8 @@ _02183710:
 	mov r0, r0, lsr #0x10
 	mov r0, r0, asr #0x4
 	mov r1, r0, lsl #0x1
-	mov sb, r6, lsl #0x1
-	add r6, sb, #1
+	mov r9, r6, lsl #0x1
+	add r6, r9, #1
 	mov r8, r6, lsl #0x1
 	add r0, r1, #1
 	mov r2, r1, lsl #0x1
@@ -8673,18 +8673,18 @@ _02183710:
 	ldrsh r2, [r4, #2]
 	ldrsh r1, [r4, r1]
 	smull r7, r5, r0, r3
-	mov r6, sb, lsl #0x1
+	mov r6, r9, lsl #0x1
 	ldrsh r11, [r4, r8]
 	ldrsh r8, [r4, r6]
 	adds r7, r7, #0x800
-	smull sb, r4, r1, r2
+	smull r9, r4, r1, r2
 	adc r6, r5, #0
-	adds r5, sb, #0x800
-	mov sb, r7, lsr #0xc
+	adds r5, r9, #0x800
+	mov r9, r7, lsr #0xc
 	adc r4, r4, #0
 	mov r7, r5, lsr #0xc
 	orr r7, r7, r4, lsl #20
-	orr sb, sb, r6, lsl #20
+	orr r9, r9, r6, lsl #20
 	smull r6, r5, r7, r8
 	smull r4, r3, r1, r3
 	adds r6, r6, #0x800
@@ -8694,13 +8694,13 @@ _02183710:
 	orr r5, r5, r0, lsl #20
 	mov r0, r11, asr #0x1f
 	str r0, [sp, #0x18]
-	mov r0, sb, asr #0x1f
+	mov r0, r9, asr #0x1f
 	str r0, [sp, #0x1c]
 	mov r0, r8, asr #0x1f
 	str r0, [sp, #0x20]
 	mov r0, r7, asr #0x1f
 	str r0, [sp, #0x24]
-	smull r0, r6, sb, r11
+	smull r0, r6, r9, r11
 	adds r0, r0, #0x800
 	adc r6, r6, #0
 	mov r0, r0, lsr #0xc
@@ -8763,10 +8763,10 @@ _02183710:
 	adc r4, r3, ip
 	mov r3, r5, lsr #0xc
 	orr r3, r3, r4, lsl #20
-	umull r6, r5, sb, r8
+	umull r6, r5, r9, r8
 	ldr r4, [sp, #0x20]
 	adds r6, r6, #0x800
-	mla r5, sb, r4, r5
+	mla r5, r9, r4, r5
 	ldr r4, [sp, #0x1c]
 	mla r5, r4, r8, r5
 	adc r4, r5, ip
@@ -8808,16 +8808,16 @@ _0218398c:
 	mov r4, r4, lsl #0x1
 	mov r8, r6, lsl #0x1
 	smull ip, r6, r1, r2
-	adc sb, r7, #0
+	adc r9, r7, #0
 	adds r7, ip, #0x800
 	mov r11, r11, lsr #0xc
 	ldrsh ip, [r5, r4]
-	orr r11, r11, sb, lsl #20
-	ldrsh sb, [r5, r8]
+	orr r11, r11, r9, lsl #20
+	ldrsh r9, [r5, r8]
 	adc r4, r6, #0
 	mov r8, r7, lsr #0xc
 	orr r8, r8, r4, lsl #20
-	smull r4, r6, r8, sb
+	smull r4, r6, r8, r9
 	adds r7, r4, #0x800
 	smull r5, r4, r11, ip
 	smull r3, lr, r1, r3
@@ -8844,11 +8844,11 @@ _0218398c:
 	adc r3, r0, #0
 	mov r0, r4, lsr #0xc
 	orr r0, r0, r3, lsl #20
-	smull r5, r4, r1, sb
+	smull r5, r4, r1, r9
 	smull r3, r1, r8, ip
 	smull r7, r6, r2, ip
-	smull ip, r8, r2, sb
-	smull sb, r2, r11, sb
+	smull ip, r8, r2, r9
+	smull r9, r2, r11, r9
 	adds r11, ip, #0x800
 	adc r8, r8, #0
 	mov r11, r11, lsr #0xc
@@ -8869,7 +8869,7 @@ _0218398c:
 	adc r0, r1, #0
 	mov r3, r3, lsr #0xc
 	orr r3, r3, r0, lsl #20
-	adds r1, sb, #0x800
+	adds r1, r9, #0x800
 	adc r0, r2, #0
 	mov r1, r1, lsr #0xc
 	orr r1, r1, r0, lsl #20
@@ -9002,7 +9002,7 @@ _02183ca4:
 	add r1, r1, #0x1c00
 	bl func_ov00_020d5cd8
 	add sp, sp, #0xa8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov34_02183474
 _02183cf8: .word data_ov34_0218577c

--- a/asm/ov34.s
+++ b/asm/ov34.s
@@ -1621,14 +1621,14 @@ _0217d350: .word data_027e0d0c
 	.global func_ov34_0217d354
 	arm_func_start func_ov34_0217d354
 func_ov34_0217d354: ; 0x0217d354
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #8
 	ldr r2, _0217d494 ; =data_ov34_021861a0
 	ldr r0, [r2, #0x190]
 	cmp r0, #0
 	bne _0217d454
-	ldr sl, [r2, #0x194]
-	cmp sl, #0
+	ldr r10, [r2, #0x194]
+	cmp r10, #0
 	beq _0217d470
 	ldr r1, _0217d498 ; =data_027e0764
 	ldr r0, _0217d49c ; =0x00000335
@@ -1644,34 +1644,34 @@ func_ov34_0217d354: ; 0x0217d354
 	umull r11, r3, r5, sb
 	adc r8, r6, r8
 	adds ip, r7, r11
-	sub r11, sl, #1
-	umull sl, lr, r8, r0
+	sub r11, r10, #1
+	umull r10, lr, r8, r0
 	mla r3, r5, r8, r3
-	str sl, [sp, #4]
-	mov sl, #0
+	str r10, [sp, #4]
+	mov r10, #0
 	str sb, [r1]
 	mla r3, r4, sb, r3
-	mla lr, r8, sl, lr
+	mla lr, r8, r10, lr
 	str r8, [r1, #4]
 	adc r8, r6, r3
-	mov r3, sl
+	mov r3, r10
 	mla lr, r3, r0, lr
 	umull sb, r3, r8, r0
 	ldr sb, _0217d4a0 ; =0xfffffe66
 	add sb, lr, sb
 	str sb, [r2, #0x180]
-	mov sb, sl
+	mov sb, r10
 	mla r3, r8, sb, r3
 	mla r3, sb, r0, r3
 	ldr sb, _0217d4a0 ; =0xfffffe66
 	str ip, [r1]
 	add r3, r3, sb
-	umull sl, sb, r5, ip
+	umull r10, sb, r5, ip
 	mla sb, r5, r8, sb
 	mla sb, r4, ip, sb
 	str r8, [r1, #4]
 	str r3, [r2, #0x184]
-	adds r4, r7, sl
+	adds r4, r7, r10
 	adc r5, r6, sb
 	stmia r1, {r4, r5}
 	umull r1, r4, r5, r0
@@ -1702,7 +1702,7 @@ _0217d470:
 	str r4, [sp]
 	bl func_ov34_0217ceb0
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov34_0217d354
 _0217d494: .word data_ov34_021861a0
@@ -2937,7 +2937,7 @@ _0217e670: .word data_ov34_021861e0
 	.global func_ov34_0217e674
 	arm_func_start func_ov34_0217e674
 func_ov34_0217e674: ; 0x0217e674
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	ldr r2, _0217e8b4 ; =data_027e0764
 	mov ip, #0xa5
 	ldr r3, [r2]
@@ -2947,24 +2947,24 @@ func_ov34_0217e674: ; 0x0217e674
 	ldr r6, [r2, #0xc]
 	ldr sb, [r2, #0x10]
 	mla r5, r6, r3, r5
-	adds sl, sb, r4
+	adds r10, sb, r4
 	ldr r8, [r2, #0x14]
-	umull r4, r1, r7, sl
+	umull r4, r1, r7, r10
 	adc r3, r8, r5
 	mla r1, r7, r3, r1
-	str sl, [r2]
-	mla r1, r6, sl, r1
+	str r10, [r2]
+	mla r1, r6, r10, r1
 	adds r5, sb, r4
 	adc r4, r8, r1
 	str r3, [r2, #4]
-	umull sl, r1, r3, ip
+	umull r10, r1, r3, ip
 	mov r11, #0
-	mov sl, r11
-	mla r1, r3, sl, r1
+	mov r10, r11
+	mla r1, r3, r10, r1
 	mla r1, r11, ip, r1
 	str r5, [r2]
 	ldr ip, _0217e8b8 ; =0x00001001
-	add sl, r1, #0x29
+	add r10, r1, #0x29
 	umull r3, r1, r4, ip
 	mov r3, r11
 	mla r1, r4, r3, r1
@@ -3046,8 +3046,8 @@ _0217e7f4:
 	cmp r5, r4
 	strlt r4, [r1, #0xa70]
 _0217e820:
-	mul r2, sl, r2
-	mul r1, sl, r3
+	mul r2, r10, r2
+	mul r1, r10, r3
 	add r2, r2, #0x800
 	mov r2, r2, asr #0xc
 	add r1, r1, #0x800
@@ -3082,7 +3082,7 @@ _0217e820:
 	mov r1, #1
 	strh r2, [r4, #0x82]
 	bl func_ov34_02183d14
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov34_0217e674
 _0217e8b4: .word data_027e0764
@@ -3301,7 +3301,7 @@ _0217eb90: .word data_ov34_021861a0
 	.global func_ov34_0217eb94
 	arm_func_start func_ov34_0217eb94
 func_ov34_0217eb94: ; 0x0217eb94
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x48
 	mov r4, r0
 	add r0, r4, #0x1000
@@ -3386,7 +3386,7 @@ _0217eccc:
 	mov r1, #3
 	bl func_ov34_0217be60
 	add sp, sp, #0x48
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0217ece0:
 	add r0, r4, #0x1000
 	ldr r0, [r0, #0xaa0]
@@ -3397,7 +3397,7 @@ _0217ece0:
 	bl func_0202e310
 	cmp r0, #0
 	addeq sp, sp, #0x48
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	add r1, r4, #0x1000
 	ldr r2, [r1, #0xa78]
 	add r0, sp, #0x10
@@ -3426,13 +3426,13 @@ _0217ece0:
 	and r4, r4, #0xff
 	strh r4, [sp, #0x10]
 	ldrh r1, [r1, #0x7e]
-	ldr sl, [r2, #0xd04]
+	ldr r10, [r2, #0xd04]
 	ldr r11, _0217ee4c ; =data_027e0fe8
 	mov r1, r1, asr #0x4
 	mov r4, r1, lsl #0x1
 	mov r1, r4, lsl #0x1
 	ldrsh r6, [r3, r1]
-	str sl, [sp, #4]
+	str r10, [sp, #4]
 	ldr r5, [r2, #0xd08]
 	umull r8, r7, r6, r0
 	add r1, r4, #1
@@ -3450,7 +3450,7 @@ _0217ece0:
 	adc r5, r7, #0
 	mov r6, r6, lsr #0xc
 	orr r6, r6, r5, lsl #20
-	add r5, sl, r6
+	add r5, r10, r6
 	str r5, [sp, #4]
 	umull r6, r5, r4, r0
 	mla r5, r4, ip, r5
@@ -3474,7 +3474,7 @@ _0217ece0:
 	mov r3, #0
 	bl func_ov00_020ceacc
 	add sp, sp, #0x48
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov34_0217eb94
 _0217ee3c: .word data_027e0f94
@@ -3488,15 +3488,15 @@ _0217ee54: .word data_027e0ffc
 	.global func_ov34_0217ee58
 	arm_func_start func_ov34_0217ee58
 func_ov34_0217ee58: ; 0x0217ee58
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #0xc
 	mov r7, r0
 	mvn r5, #0x80000000
 	sub r0, r5, #0x80000000
 	add sb, r7, #0x1000
-	ldr sl, _0217ef80 ; =data_ov34_021861a0
+	ldr r10, _0217ef80 ; =data_ov34_021861a0
 	str r0, [sb, #0xd74]
-	ldr r0, [sl, #0x78]
+	ldr r0, [r10, #0x78]
 	mov r6, #0
 	cmp r0, #0
 	ble _0217eedc
@@ -3519,7 +3519,7 @@ _0217ee90:
 	movlt r5, r0
 	strlt r6, [sb, #0xd74]
 _0217eecc:
-	ldr r0, [sl, #0x78]
+	ldr r0, [r10, #0x78]
 	add r6, r6, #1
 	cmp r6, r0
 	blt _0217ee90
@@ -3554,7 +3554,7 @@ _0217eedc:
 	ldr r0, [r1, #0x54]
 	cmp r0, r2
 	addne sp, sp, #0xc
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	cmp r2, #0
 	moveq r2, #1
 	ldr r0, _0217ef84 ; =data_ov34_021861e0
@@ -3564,7 +3564,7 @@ _0217eedc:
 	add r0, r0, #0x21c
 	bl func_ov34_0217be60
 	add sp, sp, #0xc
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov34_0217ee58
 _0217ef80: .word data_ov34_021861a0
@@ -8450,39 +8450,39 @@ _02183470: .word data_027e0194
 	.global func_ov34_02183474
 	arm_func_start func_ov34_02183474
 func_ov34_02183474: ; 0x02183474
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0xa8
-	mov sl, r0
-	add r0, sl, #0x1d00
+	mov r10, r0
+	add r0, r10, #0x1d00
 	ldrsh r1, [r0, #0x80]
-	add r0, sl, #0x7e
+	add r0, r10, #0x7e
 	add r0, r0, #0x1d00
 	mov r2, #0x200
 	bl func_0202b154
-	add r1, sl, #0x1d00
-	add r0, sl, #0x17c
+	add r1, r10, #0x1d00
+	add r0, r10, #0x17c
 	ldrsh r1, [r1, #0x82]
 	add r0, r0, #0x1c00
 	mov r2, #0x200
 	bl func_0202b154
-	add r2, sl, #0x128
+	add r2, r10, #0x128
 	ldr r1, _02183cf8 ; =data_ov34_0218577c
-	add r0, sl, #0x48
+	add r0, r10, #0x48
 	add r2, r2, #0x1c00
 	bl func_01ff9bc4
-	add r4, sl, #0x1000
+	add r4, r10, #0x1000
 	ldrb r0, [r4, #0xd88]
 	cmp r0, #0
 	addeq sp, sp, #0xa8
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
-	add r0, sl, #0x304
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	add r0, r10, #0x304
 	add r2, r0, #0x1800
-	add r0, sl, #0x1b40
-	add r1, sl, #0xba0
+	add r0, r10, #0x1b40
+	add r1, r10, #0xba0
 	add r1, r1, #0x1000
 	str r0, [sp, #4]
 	add r7, r0, #0x40
-	add r0, sl, #0xb90
+	add r0, r10, #0xb90
 	ldr r11, _02183cfc ; =0x000002cb
 	add r6, r2, #0x30
 	add sb, r1, #0x90
@@ -8514,7 +8514,7 @@ _02183510:
 	add r1, sp, #0x90
 	add r2, sp, #0x9c
 	bl func_ov00_020d5f98
-	add r0, sl, r5, lsl #4
+	add r0, r10, r5, lsl #4
 	add r2, r0, #0x1000
 	ldr r1, [r2, #0xb40]
 	str r0, [sp, #8]
@@ -8612,7 +8612,7 @@ _02183690:
 	sub sb, sb, #0x24
 	cmp r5, #0
 	bgt _02183510
-	add r0, sl, #0x1000
+	add r0, r10, #0x1000
 	ldr r1, [r0, #0xd30]
 	ldr r0, [r0, #0xab8]
 	sub r0, r1, r0
@@ -8625,7 +8625,7 @@ _02183710:
 	mov r1, #0xc000
 	bl Divide
 	ldr r1, _02183d04 ; =0x00005555
-	ldr r2, [sl, #0x22c]
+	ldr r2, [r10, #0x22c]
 	mul r3, r0, r1
 	sub r0, r1, #0x8000
 	add r0, r0, r3, asr #12
@@ -8634,7 +8634,7 @@ _02183710:
 	cmp r1, #4
 	mov r0, r0, asr #0x10
 	bhi _0218398c
-	add r2, sl, #0x1d00
+	add r2, r10, #0x1d00
 	ldrsh r1, [r2, #0x86]
 	mov ip, #0
 	add r0, r0, r0, lsr #31
@@ -8737,7 +8737,7 @@ _02183710:
 	mla r3, r4, r5, r3
 	mla r3, lr, r11, r3
 	ldr r4, [sp, #0x34]
-	add r0, sl, #0x1b40
+	add r0, r10, #0x1b40
 	adds r4, r4, #0x800
 	mov r5, r4, lsr #0xc
 	adc r3, r3, ip
@@ -8775,14 +8775,14 @@ _02183710:
 	add r3, r3, r5
 	str r3, [sp, #0x8c]
 	bl func_ov00_020d59f0
-	add r2, sl, #0x1000
+	add r2, r10, #0x1000
 	ldr r2, [r2, #0xd64]
-	add r0, sl, #0x1b40
+	add r0, r10, #0x1b40
 	add r1, sp, #0x60
 	bl func_ov00_020d59f0
 	b _02183b3c
 _0218398c:
-	add r1, sl, #0x1d00
+	add r1, r10, #0x1d00
 	ldrsh r1, [r1, #0x86]
 	ldr r5, _02183d08 ; =data_02050f54
 	add r4, r0, r0, lsr #31
@@ -8877,28 +8877,28 @@ _0218398c:
 	str r0, [sp, #0x8c]
 	ldr r2, _02183d0c ; =0x00000333
 	add r1, sp, #0x80
-	add r0, sl, #0x1b40
+	add r0, r10, #0x1b40
 	bl func_ov00_020d59f0
-	add r0, sl, #0x1000
+	add r0, r10, #0x1000
 	ldr r2, [r0, #0xd64]
 	ldr r1, _02183d00 ; =data_ov34_021861cc
-	add r0, sl, #0x1b40
+	add r0, r10, #0x1b40
 	bl func_ov00_020d59f0
-	add r1, sl, #0x1d00
-	add r0, sl, #0x86
+	add r1, r10, #0x1d00
+	add r0, r10, #0x86
 	ldrsh r1, [r1, #0x7e]
 	add r0, r0, #0x1d00
 	mov r2, #0x100
 	bl func_0202b154
 _02183b3c:
-	add r0, sl, #0x1b40
+	add r0, r10, #0x1b40
 	bl func_ov00_020d5c54
-	add r1, sl, #0xba0
-	add r0, sl, #0x1b40
+	add r1, r10, #0xba0
+	add r0, r10, #0x1b40
 	add r1, r1, #0x1000
 	bl func_ov00_020d5cd8
 	ldr r0, _02183d10 ; =data_ov34_02185740
-	add r3, sl, #0x1000
+	add r3, r10, #0x1000
 	ldr r2, [r0, #0x24]
 	ldr r1, [r0, #0x28]
 	str r2, [sp, #0x9c]
@@ -8915,7 +8915,7 @@ _02183b3c:
 	ldr r3, [r3, #0xd18]
 	str r3, [sp, #0x98]
 	bl func_ov00_020d5f98
-	add r2, sl, #0x1000
+	add r2, r10, #0x1000
 	ldr r1, [r2, #0xb90]
 	add r0, sp, #0x80
 	str r1, [sp, #0x70]
@@ -8932,15 +8932,15 @@ _02183b3c:
 	str r0, [sp, #0xa0]
 	mov r0, #0x1000
 	str r0, [sp, #0xa4]
-	add r0, sl, #0x1d00
+	add r0, r10, #0x1d00
 	ldrsh r1, [r0, #0x7c]
 	add r0, sp, #0x9c
 	bl func_ov00_020a6110
-	add r1, sl, #0x1d00
+	add r1, r10, #0x1d00
 	ldrsh r1, [r1, #0x7e]
 	add r0, sp, #0x9c
 	bl func_ov00_020a61ac
-	add r2, sl, #0x1000
+	add r2, r10, #0x1000
 	ldr r1, [r2, #0xd1c]
 	add r0, sp, #0x50
 	str r1, [sp, #0x90]
@@ -8954,7 +8954,7 @@ _02183b3c:
 	add r0, sp, #0x50
 	add r1, sp, #0x80
 	bl func_ov00_020d5dc4
-	add r0, sl, #0x1000
+	add r0, r10, #0x1000
 	ldr r7, [r0, #0xb9c]
 	ldr r5, [r0, #0xb98]
 	ldr r3, [r0, #0xb90]
@@ -8982,27 +8982,27 @@ _02183b3c:
 	str r1, [sp, #0x54]
 	str r0, [sp, #0x58]
 _02183ca4:
-	add r0, sl, #0xb90
+	add r0, r10, #0xb90
 	add r1, sp, #0x50
 	add r0, r0, #0x1000
 	mov r2, #0xc00
 	bl func_ov00_020d59f0
-	add r1, sl, #0x1000
-	add r0, sl, #0xb90
+	add r1, r10, #0x1000
+	add r0, r10, #0xb90
 	ldr r2, [r1, #0xd64]
 	ldr r1, _02183d00 ; =data_ov34_021861cc
 	add r0, r0, #0x1000
 	bl func_ov00_020d59f0
-	add r0, sl, #0xb90
+	add r0, r10, #0xb90
 	add r0, r0, #0x1000
 	bl func_ov00_020d5c54
-	add r0, sl, #0xb90
-	add r1, sl, #0x54
+	add r0, r10, #0xb90
+	add r1, r10, #0x54
 	add r0, r0, #0x1000
 	add r1, r1, #0x1c00
 	bl func_ov00_020d5cd8
 	add sp, sp, #0xa8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov34_02183474
 _02183cf8: .word data_ov34_0218577c

--- a/asm/ov35.s
+++ b/asm/ov35.s
@@ -338,55 +338,55 @@ _0217c1d0: .word func_ov35_0217bf4c
 	.global func_ov35_0217c1d4
 	arm_func_start func_ov35_0217c1d4
 func_ov35_0217c1d4: ; 0x0217c1d4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x48
 	ldr r1, _0217c498 ; =data_027e0fe4
-	mov sl, r0
+	mov r10, r0
 	ldr r0, [r1]
-	add r1, sl, #0x34
+	add r1, r10, #0x34
 	bl _ZN12ActorManager8GetActorEP8ActorRef
 	cmp r0, #0
-	str r0, [sl, #0x234]
+	str r0, [r10, #0x234]
 	addeq sp, sp, #0x48
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r1, _0217c49c ; =0xfffffe66
 	ldr r0, _0217c4a0 ; =0x000004cd
-	str r1, [sl, #0x7c]
+	str r1, [r10, #0x7c]
 	mov r1, #0xc00
 	rsb r1, r1, #0
-	str r0, [sl, #0x80]
-	str r1, [sl, #0x84]
+	str r0, [r10, #0x80]
+	str r1, [r10, #0x84]
 	rsb r0, r0, #0x2000
-	str r0, [sl, #0x88]
+	str r0, [r10, #0x88]
 	mov r3, r1, asr #0xc
 	ldr r1, _0217c4a4 ; =data_027e0d0c
-	str r3, [sl, #0x98]
+	str r3, [r10, #0x98]
 	ldr r2, [r1]
 	ldr r0, _0217c4a8 ; =data_027e0fec
-	str r2, [sl, #0xa8]
+	str r2, [r10, #0xa8]
 	ldr r2, [r1, #4]
-	str r2, [sl, #0xac]
+	str r2, [r10, #0xac]
 	ldr r1, [r1, #8]
-	str r1, [sl, #0xb0]
-	str r3, [sl, #0xb4]
+	str r1, [r10, #0xb0]
+	str r3, [r10, #0xb4]
 	ldr r0, [r0]
 	add r0, r0, #0x530
 	add r0, r0, #0x2000
 	bl func_ov00_020c4588
 	mov r1, r0
-	add r0, sl, #0x294
+	add r0, r10, #0x294
 	ldr r2, [r0]
 	ldr r2, [r2, #0xc]
 	blx r2
-	add r0, sl, #4
+	add r0, r10, #4
 	ldr r11, _0217c4a8 ; =data_027e0fec
-	mov r8, sl
-	add r7, sl, #0x2f0
+	mov r8, r10
+	add r7, r10, #0x2f0
 	add sb, r0, #0x400
 	mov r5, #0
 _0217c290:
-	add r1, sl, r5
+	add r1, r10, r5
 	mov r0, #0
 	strb r0, [r1, #0x551]
 	ldr r0, _0217c4ac ; =data_ov35_0218512c
@@ -438,23 +438,23 @@ _0217c290:
 	cmp r5, #3
 	blt _0217c290
 	mov r2, #0
-	strb r2, [sl, #0x556]
-	str r2, [sl, #0x54c]
-	ldr r1, [sl, #0x234]
+	strb r2, [r10, #0x556]
+	str r2, [r10, #0x54c]
+	ldr r1, [r10, #0x234]
 	add r0, sp, #0xc
 	ldrb r1, [r1, #0x125]
-	strb r1, [sl, #0x125]
-	strb r2, [sl, #0x554]
+	strb r1, [r10, #0x125]
+	strb r2, [r10, #0x554]
 	bl func_ov00_020c1500
 	mvn r1, #0
 	add r0, sp, #0xc
 	str r1, [sp, #0x28]
 	str r1, [sp, #0x2c]
 	bl func_ov00_020c3348
-	ldr r1, [sl, #8]
+	ldr r1, [r10, #8]
 	mvn r0, #0
 	str r1, [sp, #0x28]
-	ldr r1, [sl, #0xc]
+	ldr r1, [r10, #0xc]
 	ldr r5, _0217c4b8 ; =0x52594448
 	ldr r8, _0217c498 ; =data_027e0fe4
 	ldr sb, _0217c4bc ; =data_027e0fe8
@@ -470,30 +470,30 @@ _0217c3c8:
 	ldr r0, [sb]
 	mov r1, r5
 	mov r3, r4
-	add r2, sl, #0x48
+	add r2, r10, #0x48
 	bl func_ov00_020c4048
 	cmp r0, #0
 	addeq sp, sp, #0x48
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, [r8]
 	mov r1, r6
 	bl _ZN12ActorManager8GetActorEP8ActorRef
-	add r2, sl, r7, lsl #2
+	add r2, r10, r7, lsl #2
 	add r1, r7, #1
 	and r7, r1, #0xff
 	str r0, [r2, #0x280]
 	cmp r7, #5
 	blo _0217c3c8
 	mov sb, #0
-	str sb, [sl, #0x218]
-	strb sb, [sl, #0x22f]
+	str sb, [r10, #0x218]
+	strb sb, [r10, #0x22f]
 	mov r0, #2
-	str sb, [sl, #0x228]
+	str sb, [r10, #0x228]
 	ldr r8, _0217c4c0 ; =data_ov35_02185154
 	ldr r5, _0217c4c4 ; =0x0000017b
-	mov r11, sl
-	str r0, [sl, #0x230]
+	mov r11, r10
+	str r0, [r10, #0x230]
 	mov r6, r0
 	mov r4, #0x17c
 	mov r3, sb
@@ -501,8 +501,8 @@ _0217c3c8:
 _0217c44c:
 	mov r0, sb, lsl #0x1
 	ldrsh r7, [r8, r0]
-	add r2, sl, sb, lsl #2
-	add r0, sl, sb
+	add r2, r10, sb, lsl #2
+	add r0, r10, sb
 	str r7, [r11, #0x1f8]
 	str r6, [r11, #0x1fc]
 	str r5, [r11, #0x15c]
@@ -517,7 +517,7 @@ _0217c44c:
 	blt _0217c44c
 	mov r0, #1
 	add sp, sp, #0x48
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov35_0217c1d4
 _0217c498: .word data_027e0fe4
@@ -1528,31 +1528,31 @@ _0217d20c: .word data_ov35_02185146
 	.global func_ov35_0217d210
 	arm_func_start func_ov35_0217d210
 func_ov35_0217d210: ; 0x0217d210
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x64
-	mov sl, r0
-	ldr r0, [sl, #0x218]
+	mov r10, r0
+	ldr r0, [r10, #0x218]
 	mov r5, #0
 	cmp r0, #0
 	beq _0217d374
 	sub r3, r0, #1
 	add r2, sp, #4
-	add r0, sl, #0x4d0
-	add r1, sl, #0x500
-	str r3, [sl, #0x218]
+	add r0, r10, #0x4d0
+	add r1, r10, #0x500
+	str r3, [r10, #0x218]
 	bl func_01ff8e84
 	add r0, sp, #4
 	add r1, sp, #0x34
 	bl func_020079d8
-	ldr r0, [sl, #0x1a4]
+	ldr r0, [r10, #0x1a4]
 	ldr r6, _0217d398 ; =data_ov35_0218515a
 	cmp r0, #0x174
 	moveq r11, #1
-	add r0, sl, #0x48
+	add r0, r10, #0x48
 	ldr r7, _0217d39c ; =data_ov35_02185184
 	ldr sb, _0217d3a0 ; =data_ov35_021851ae
 	movne r11, #0
-	add r8, sl, #0x1a0
+	add r8, r10, #0x1a0
 	str r0, [sp]
 	add r4, sp, #0x58
 _0217d27c:
@@ -1596,7 +1596,7 @@ _0217d2b8:
 	add r1, sp, #0x34
 	mov r2, r4
 	bl func_01ff88b0
-	ldr r3, [sl, #0x1a0]
+	ldr r3, [r10, #0x1a0]
 	ldr r0, [sp, #0x58]
 	ldr r2, [sp, #0x5c]
 	mov r0, r0, lsl #0x10
@@ -1616,12 +1616,12 @@ _0217d2b8:
 	add r7, r7, #6
 	add r8, r8, #0xc
 	add sb, sb, #6
-	add sl, sl, #0xc
+	add r10, r10, #0xc
 	blt _0217d27c
 	add sp, sp, #0x64
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0217d374:
-	add r4, sl, #0x1a0
+	add r4, r10, #0x1a0
 _0217d378:
 	mov r0, r4
 	bl func_ov00_020b7e6c
@@ -1630,7 +1630,7 @@ _0217d378:
 	add r4, r4, #0xc
 	blt _0217d378
 	add sp, sp, #0x64
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov35_0217d210
 _0217d398: .word data_ov35_0218515a
@@ -1641,7 +1641,7 @@ _0217d3a4: .word data_027e0e58
 	.global func_ov35_0217d3a8
 	arm_func_start func_ov35_0217d3a8
 func_ov35_0217d3a8: ; 0x0217d3a8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x78
 	mov r6, r0
 	ldrb r0, [r6, #0x22f]
@@ -1650,7 +1650,7 @@ func_ov35_0217d3a8: ; 0x0217d3a8
 	mov r7, #0
 	add r8, r6, #0x1f4
 	add sb, r6, #0x158
-	add sl, r6, #0x17c
+	add r10, r6, #0x17c
 	mov r5, r7
 	mov r4, #0xff
 _0217d3d8:
@@ -1658,7 +1658,7 @@ _0217d3d8:
 	bl func_ov00_020b7e6c
 	mov r0, sb
 	bl func_ov00_020b7e6c
-	mov r0, sl
+	mov r0, r10
 	bl func_ov00_020b7e6c
 	add r1, r6, r7, lsl #2
 	add r0, r6, r7
@@ -1668,11 +1668,11 @@ _0217d3d8:
 	cmp r7, #3
 	add r8, r8, #0xc
 	add sb, sb, #0xc
-	add sl, sl, #0xc
+	add r10, r10, #0xc
 	blt _0217d3d8
 	add sp, sp, #0x78
 	str r5, [r6, #0x228]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0217d424:
 	add r2, sp, #0x18
 	add r0, r6, #0x4d0
@@ -1796,22 +1796,22 @@ _0217d5d0:
 	adc r3, r8, lr
 	stmia r0, {r1, r3}
 	umull r1, r2, r3, r11
-	mov sl, #0
-	mov r1, sl
+	mov r10, #0
+	mov r1, r10
 	mla r2, r3, r1, r2
 	mla r2, r1, r11, r2
 	strb r2, [r4, #0x22c]
 _0217d614:
-	cmp r5, sl
+	cmp r5, r10
 	beq _0217d630
 	ldrb r2, [r4, #0x22c]
-	add r1, r6, sl
+	add r1, r6, r10
 	ldrb r1, [r1, #0x22c]
 	cmp r2, r1
 	beq _0217d5d0
 _0217d630:
-	add sl, sl, #1
-	cmp sl, #3
+	add r10, r10, #1
+	cmp r10, #3
 	blt _0217d614
 	ldr r1, _0217d760 ; =0x0000017b
 	ldr r0, [sp, #0xc]
@@ -1881,7 +1881,7 @@ _0217d680:
 	subne r0, r0, #1
 	strne r0, [r6, #0x228]
 	add sp, sp, #0x78
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov35_0217d3a8
 _0217d74c: .word data_ov35_021851d8
@@ -3906,7 +3906,7 @@ func_ov35_0217f210: ; 0x0217f210
 	.global func_ov35_0217f234
 	arm_func_start func_ov35_0217f234
 func_ov35_0217f234: ; 0x0217f234
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x520
 	mov r4, r0
 	ldr r2, [r4, #0x168]
@@ -3961,7 +3961,7 @@ _0217f2f8:
 	bl _ZN5Actor18func_ov00_020c198cEv
 	cmp r0, #0
 	addeq sp, sp, #0x520
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r1, [r4, #0x168]
 	mov r2, #0x1000
 	add r0, sp, #0x470
@@ -4062,7 +4062,7 @@ _0217f2f8:
 	ldr r1, [sp, #0x420]
 	ldr ip, [sp, #0x424]
 	ldr r11, [sp, #0x428]
-	ldr sl, [sp, #0x42c]
+	ldr r10, [sp, #0x42c]
 	ldr sb, [sp, #0x430]
 	ldr r8, [sp, #0x434]
 	str r1, [sp, #0x4b4]
@@ -4072,8 +4072,8 @@ _0217f2f8:
 	ldr ip, [sp, #0x43c]
 	str r11, [sp, #0x4bc]
 	ldr r11, [sp, #0x440]
-	str sl, [sp, #0x4c0]
-	ldr sl, [sp, #0x444]
+	str r10, [sp, #0x4c0]
+	ldr r10, [sp, #0x444]
 	str sb, [sp, #0x4c4]
 	ldr sb, [sp, #0x448]
 	str r8, [sp, #0x4c8]
@@ -4089,8 +4089,8 @@ _0217f2f8:
 	ldr ip, [sp, #0x454]
 	str r11, [sp, #0x4d4]
 	ldr r11, [sp, #0x458]
-	str sl, [sp, #0x4d8]
-	ldr sl, [sp, #0x45c]
+	str r10, [sp, #0x4d8]
+	ldr r10, [sp, #0x45c]
 	str sb, [sp, #0x4dc]
 	ldr sb, [sp, #0x460]
 	str r8, [sp, #0x4e0]
@@ -4100,7 +4100,7 @@ _0217f2f8:
 	add r1, sp, #0x470
 	str ip, [sp, #0x4e8]
 	str r11, [sp, #0x4ec]
-	str sl, [sp, #0x4f0]
+	str r10, [sp, #0x4f0]
 	str sb, [sp, #0x4f4]
 	str r8, [sp, #0x4f8]
 	strb r7, [sp, #0x4fc]
@@ -4116,7 +4116,7 @@ _0217f2f8:
 	add r0, sp, #0x470
 	bl func_ov00_0209a508
 	add sp, sp, #0x520
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0217f574:
 	mov r1, #6
 	add r0, r4, #0xe8
@@ -4220,7 +4220,7 @@ _0217f688:
 	blx func_02036140
 	cmp r0, #0
 	addeq sp, sp, #0x520
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0217f6f8:
 	ldr r0, [r4, #0x4e4]
 	mov r1, #1
@@ -4441,7 +4441,7 @@ _0217fa0c:
 	bl func_ov00_020bd3b0
 	cmp r0, #0
 	addeq sp, sp, #0x520
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r2, _021800b8 ; =data_027e0d0c
 	add r0, r4, #0x158
 	ldr r3, [r2]
@@ -4476,23 +4476,23 @@ _0217fa0c:
 	mov r1, r1, asr #0x4
 	mov r7, r1, lsl #0x1
 	mov r1, r7, lsl #0x1
-	ldrsh sl, [r5, r1]
+	ldrsh r10, [r5, r1]
 	add r1, r7, #1
 	mov r1, r1, lsl #0x1
 	ldrsh r8, [r5, r1]
-	umull ip, r11, sl, r2
-	mla r11, sl, r3, r11
-	mov sb, sl, asr #0x1f
-	adds sl, ip, #0x800
+	umull ip, r11, r10, r2
+	mla r11, r10, r3, r11
+	mov sb, r10, asr #0x1f
+	adds r10, ip, #0x800
 	mla r11, sb, r2, r11
 	adc sb, r11, #0
-	mov sl, sl, lsr #0xc
-	orr sl, sl, sb, lsl #20
-	add r0, r0, sl
-	umull sl, sb, r8, r2
+	mov r10, r10, lsr #0xc
+	orr r10, r10, sb, lsl #20
+	add r0, r0, r10
+	umull r10, sb, r8, r2
 	mla sb, r8, r3, sb
 	mov r7, r8, asr #0x1f
-	adds r3, sl, #0x800
+	adds r3, r10, #0x800
 	mla sb, r7, r2, sb
 	str r0, [r4, #0x48]
 	ldr r0, [r4, #0x50]
@@ -4563,16 +4563,16 @@ _0217fc10:
 	bl _ZN5Actor18func_ov00_020c198cEv
 	cmp r0, #0
 	addeq sp, sp, #0x520
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, _021800c0 ; =data_027e0c54
 	ldrb r1, [r0]
 	cmp r1, #0
 	addeq sp, sp, #0x520
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	bl func_0203608c
 	cmp r0, #0
 	addne sp, sp, #0x520
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	mov r0, #0x1f000
 	mov r1, #0x1000
 	bl Divide
@@ -4592,7 +4592,7 @@ _0217fc10:
 	blx func_02036140
 	cmp r0, #0
 	addeq sp, sp, #0x520
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	add r0, sp, #0x358
 	bl func_ov00_0209a4f4
 	add r0, r4, #0x48
@@ -4637,7 +4637,7 @@ _0217fd30:
 	ldr r1, [sp, #0x2f4]
 	ldr ip, [sp, #0x2f8]
 	ldr r11, [sp, #0x2fc]
-	ldr sl, [sp, #0x300]
+	ldr r10, [sp, #0x300]
 	ldr sb, [sp, #0x304]
 	str r2, [sp, #0x384]
 	ldr r2, [sp, #0x308]
@@ -4647,8 +4647,8 @@ _0217fd30:
 	ldr ip, [sp, #0x310]
 	str r11, [sp, #0x390]
 	ldr r11, [sp, #0x314]
-	str sl, [sp, #0x394]
-	ldr sl, [sp, #0x318]
+	str r10, [sp, #0x394]
+	ldr r10, [sp, #0x318]
 	str sb, [sp, #0x398]
 	ldr sb, [sp, #0x31c]
 	str r2, [sp, #0x39c]
@@ -4660,8 +4660,8 @@ _0217fd30:
 	ldr ip, [sp, #0x328]
 	str r11, [sp, #0x3a8]
 	ldr r11, [sp, #0x32c]
-	str sl, [sp, #0x3ac]
-	ldr sl, [sp, #0x330]
+	str r10, [sp, #0x3ac]
+	ldr r10, [sp, #0x330]
 	str sb, [sp, #0x3b0]
 	ldr sb, [sp, #0x334]
 	ldrb r8, [sp, #0x350]
@@ -4677,8 +4677,8 @@ _0217fd30:
 	ldr ip, [sp, #0x340]
 	str r11, [sp, #0x3c0]
 	ldr r11, [sp, #0x344]
-	str sl, [sp, #0x3c4]
-	ldr sl, [sp, #0x348]
+	str r10, [sp, #0x3c4]
+	ldr r10, [sp, #0x348]
 	str sb, [sp, #0x3c8]
 	ldr sb, [sp, #0x34c]
 	str r2, [sp, #0x3cc]
@@ -4688,7 +4688,7 @@ _0217fd30:
 	add r1, sp, #0x358
 	str ip, [sp, #0x3d4]
 	str r11, [sp, #0x3d8]
-	str sl, [sp, #0x3dc]
+	str r10, [sp, #0x3dc]
 	str sb, [sp, #0x3e0]
 	strb r8, [sp, #0x3e4]
 	strb r7, [sp, #0x3e5]
@@ -4704,7 +4704,7 @@ _0217fd30:
 	add r0, sp, #0x358
 	bl func_ov00_0209a508
 	add sp, sp, #0x520
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0217fe50:
 	ldr r2, _021800b8 ; =data_027e0d0c
 	add r0, r4, #0x158
@@ -4746,7 +4746,7 @@ _0217fee0:
 	bl _ZN5Actor18func_ov00_020c198cEv
 	cmp r0, #0
 	addeq sp, sp, #0x520
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	add r0, r4, #0x48
 	add r3, sp, #0x48
 	ldmia r0, {r0, r1, r2}
@@ -4810,7 +4810,7 @@ _0217fee0:
 	add r0, sp, #0x240
 	bl func_ov00_0209a508
 	add sp, sp, #0x520
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0217fff0:
 	ldr r1, [sp, #0x48]
 	add r0, r4, #0x158
@@ -4891,7 +4891,7 @@ _0218010c:
 	bl _ZN5Actor18func_ov00_020c198cEv
 	cmp r0, #0
 	addeq sp, sp, #0x520
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r1, [r4, #0x4e4]
 	mov r2, #0
 	add r0, sp, #0x190
@@ -4907,16 +4907,16 @@ _0218010c:
 	mov r0, r0, asr #0x4
 	mov r3, r0, lsl #0x1
 	mov r0, r3, lsl #0x1
-	ldrsh sl, [r2, r0]
+	ldrsh r10, [r2, r0]
 	add r0, r3, #1
 	mov r0, r0, lsl #0x1
 	ldr r5, _02180108 ; =0x00001b33
 	ldrsh r8, [r2, r0]
-	umull r6, r0, sl, r5
+	umull r6, r0, r10, r5
 	umull r3, r2, r8, r5
 	adds r6, r6, #0x800
-	mla r0, sl, lr, r0
-	mov sb, sl, asr #0x1f
+	mla r0, r10, lr, r0
+	mov sb, r10, asr #0x1f
 	mla r0, sb, r5, r0
 	adc r0, r0, #0
 	mov r6, r6, lsr #0xc
@@ -4944,9 +4944,9 @@ _0218010c:
 	sub r0, r1, #0x2000
 	str r3, [sp, #0x1b4]
 	sub r3, r5, #0x800
-	umull r6, r5, sl, r0
+	umull r6, r5, r10, r0
 	sub r11, lr, #1
-	mla r5, sl, r11, r5
+	mla r5, r10, r11, r5
 	ldr r2, [sp, #0x44]
 	mla r5, sb, r0, r5
 	adds r6, r6, #0x800
@@ -4984,8 +4984,8 @@ _0218010c:
 	adc r1, r0, #0
 	mov r0, r3, lsr #0xc
 	orr r0, r0, r1, lsl #20
-	umull r3, r1, sl, ip
-	mla r1, sl, lr, r1
+	umull r3, r1, r10, ip
+	mla r1, r10, lr, r1
 	adds r3, r3, #0x800
 	mla r1, sb, ip, r1
 	strb r2, [sp, #0x19a]
@@ -5027,7 +5027,7 @@ _0218010c:
 	add r0, sp, #0x190
 	bl func_ov00_0209a508
 	add sp, sp, #0x520
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0218033c:
 	add r0, r4, #0x158
 	mov r1, #5
@@ -5107,7 +5107,7 @@ _02180424:
 	mov r1, #0x19
 	bl func_ov35_0217f234
 	add sp, sp, #0x520
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0218046c:
 	add r0, r4, #0x158
 	mov r1, #0xb
@@ -5198,7 +5198,7 @@ _021805ac:
 	bl _ZN5Actor18func_ov00_020c198cEv
 	cmp r0, #0
 	addeq sp, sp, #0x520
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, _021800ac ; =data_027e0fc8
 	ldr r0, [r0]
 	ldr r1, [r0]
@@ -5292,7 +5292,7 @@ _021805ac:
 	ldr r0, _021800a4 ; =data_027e0f74
 	ldr ip, [sp, #0xb0]
 	ldr r11, [sp, #0xb4]
-	ldr sl, [sp, #0xb8]
+	ldr r10, [sp, #0xb8]
 	str sb, [sp, #0x138]
 	ldr sb, [sp, #0xbc]
 	ldrb r8, [sp, #0xd8]
@@ -5308,8 +5308,8 @@ _021805ac:
 	ldr ip, [sp, #0xc8]
 	str r11, [sp, #0x148]
 	ldr r11, [sp, #0xcc]
-	str sl, [sp, #0x14c]
-	ldr sl, [sp, #0xd0]
+	str r10, [sp, #0x14c]
+	ldr r10, [sp, #0xd0]
 	str sb, [sp, #0x150]
 	ldr sb, [sp, #0xd4]
 	str r2, [sp, #0x154]
@@ -5319,7 +5319,7 @@ _021805ac:
 	add r1, sp, #0xe0
 	str ip, [sp, #0x15c]
 	str r11, [sp, #0x160]
-	str sl, [sp, #0x164]
+	str r10, [sp, #0x164]
 	str sb, [sp, #0x168]
 	strb r8, [sp, #0x16c]
 	strb r7, [sp, #0x16d]
@@ -5335,7 +5335,7 @@ _021805ac:
 	add r0, sp, #0xe0
 	bl func_ov00_0209a508
 	add sp, sp, #0x520
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _021807e0:
 	ldr r0, _021800d8 ; =data_ov00_020eec68
 	mov r2, #0
@@ -5446,7 +5446,7 @@ _02180974:
 	ldr r0, [sp, #8]
 	str r0, [r4, #0x130]
 	add sp, sp, #0x520
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 _0218098c: .word data_027e0764
 _02180990: .word 0x00000223
@@ -7918,7 +7918,7 @@ _02182b18: .word 0x00001ccd
 	.global func_ov35_02182b1c
 	arm_func_start func_ov35_02182b1c
 func_ov35_02182b1c: ; 0x02182b1c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #0x118
 	mov r4, r0
 	ldr r0, [r4, #0x550]
@@ -7926,11 +7926,11 @@ func_ov35_02182b1c: ; 0x02182b1c
 	subgt r0, r0, #1
 	addgt sp, sp, #0x118
 	strgt r0, [r4, #0x550]
-	ldmgtia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmgtia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	ldrb r0, [r4, #0x563]
 	cmp r0, #3
 	addhs sp, sp, #0x118
-	ldmhsia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmhsia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	ldr r0, _02182f88 ; =data_027e0f64
 	ldr r3, _02182f8c ; =data_027e0f94
 	ldr r0, [r0]
@@ -7975,17 +7975,17 @@ _02182be8:
 	ldr r7, [sp, #0xac]
 	sub r8, sb, #0x7000
 	add sb, sb, #0x6000
-	add sl, r7, #0x8000
+	add r10, r7, #0x8000
 	sub sb, sb, r8
 	add r7, sb, #1
 	cmp r7, #0
-	str sl, [sp, #0xac]
+	str r10, [sp, #0xac]
 	movle r3, r0
 	ble _02182c44
-	umull sl, sb, r2, r5
+	umull r10, sb, r2, r5
 	mla sb, r2, lr, sb
 	mla sb, r1, r5, sb
-	adds r2, ip, sl
+	adds r2, ip, r10
 	adc r3, r3, sb
 	stmia r6, {r2, r3}
 	cmp r7, #0
@@ -8003,17 +8003,17 @@ _02182c50:
 	ldr r7, [sp, #0xac]
 	sub r8, sb, #0x7000
 	add sb, sb, #0x6000
-	sub sl, r7, #0x8000
+	sub r10, r7, #0x8000
 	sub sb, sb, r8
 	add r7, sb, #1
 	cmp r7, #0
-	str sl, [sp, #0xac]
+	str r10, [sp, #0xac]
 	movle r3, r0
 	ble _02182cac
-	umull sl, sb, r2, r5
+	umull r10, sb, r2, r5
 	mla sb, r2, lr, sb
 	mla sb, r1, r5, sb
-	adds r2, ip, sl
+	adds r2, ip, r10
 	adc r3, r3, sb
 	stmia r6, {r2, r3}
 	cmp r7, #0
@@ -8035,10 +8035,10 @@ _02182cb8:
 	cmp r7, #0
 	movle r3, r0
 	ble _02182d08
-	umull sl, sb, r2, r5
+	umull r10, sb, r2, r5
 	mla sb, r2, lr, sb
 	mla sb, r1, r5, sb
-	adds r2, ip, sl
+	adds r2, ip, r10
 	adc r3, r3, sb
 	stmia r6, {r2, r3}
 	cmp r7, #0
@@ -8063,10 +8063,10 @@ _02182d20:
 	cmp r7, #0
 	movle r3, r0
 	ble _02182d70
-	umull sl, sb, r2, r5
+	umull r10, sb, r2, r5
 	mla sb, r2, lr, sb
 	mla sb, r1, r5, sb
-	adds r2, ip, sl
+	adds r2, ip, r10
 	adc r3, r3, sb
 	stmia r6, {r2, r3}
 	cmp r7, #0
@@ -8101,7 +8101,7 @@ _02182d84:
 	movne r0, #0
 	cmp r0, #0
 	addne sp, sp, #0x118
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	ldr r0, _02182f88 ; =data_027e0f64
 	ldr r3, [sp, #0xac]
 	ldr r2, [sp, #0xb0]
@@ -8132,7 +8132,7 @@ _02182d84:
 _02182e40:
 	cmp r5, #0
 	addne sp, sp, #0x118
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	ldr r0, _02182f8c ; =data_027e0f94
 	mov r8, #0
 	ldr ip, _02182f98 ; =0x0000ffff
@@ -8185,7 +8185,7 @@ _02182e40:
 	bl func_01ffbe78
 	cmp r0, #0
 	addne sp, sp, #0x118
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	add r0, sp, #0x58
 	bl func_ov00_020c1500
 	mvn r1, #0
@@ -8211,7 +8211,7 @@ _02182e40:
 	mov r0, #0x1e
 	str r0, [r4, #0x550]
 	add sp, sp, #0x118
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov35_02182b1c
 _02182f88: .word data_027e0f64

--- a/asm/ov35.s
+++ b/asm/ov35.s
@@ -170,14 +170,14 @@ func_ov35_0217bf68: ; 0x0217bf68
 	.global func_ov35_0217bf7c
 	arm_func_start func_ov35_0217bf7c
 func_ov35_0217bf7c: ; 0x0217bf7c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	ldr r1, _0217c090 ; =data_ov35_0218598c
 	mov r6, r0
 	mov r4, #0
 	ldr r8, _0217c094 ; =data_027e0fe4
 	str r1, [r6]
 	add r5, r6, #0x238
-	mov sb, r4
+	mov r9, r4
 	mvn r7, #0
 _0217bfa0:
 	add r0, r6, r4, lsl #3
@@ -188,7 +188,7 @@ _0217bfa0:
 	mov r1, r5
 	bl _ZN12ActorManager8GetActorEP8ActorRef
 	cmp r0, #0
-	strneb sb, [r0, #0x118]
+	strneb r9, [r0, #0x118]
 _0217bfc4:
 	add r4, r4, #1
 	cmp r4, #9
@@ -241,7 +241,7 @@ _0217bfdc:
 	mov r0, r6
 	bl _ZN5ActorD2Ev
 	mov r0, r6
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov35_0217bf7c
 _0217c090: .word data_ov35_0218598c
@@ -253,14 +253,14 @@ _0217c0a0: .word func_ov35_0217bf4c
 	.global func_ov35_0217c0a4
 	arm_func_start func_ov35_0217c0a4
 func_ov35_0217c0a4: ; 0x0217c0a4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	ldr r1, _0217c1c0 ; =data_ov35_0218598c
 	mov r6, r0
 	mov r4, #0
 	ldr r8, _0217c1c4 ; =data_027e0fe4
 	str r1, [r6]
 	add r5, r6, #0x238
-	mov sb, r4
+	mov r9, r4
 	mvn r7, #0
 _0217c0c8:
 	add r0, r6, r4, lsl #3
@@ -271,7 +271,7 @@ _0217c0c8:
 	mov r1, r5
 	bl _ZN12ActorManager8GetActorEP8ActorRef
 	cmp r0, #0
-	strneb sb, [r0, #0x118]
+	strneb r9, [r0, #0x118]
 _0217c0ec:
 	add r4, r4, #1
 	cmp r4, #9
@@ -326,7 +326,7 @@ _0217c104:
 	mov r0, r6
 	bl _ZN9SysObjectdlEPv
 	mov r0, r6
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov35_0217c0a4
 _0217c1c0: .word data_ov35_0218598c
@@ -338,7 +338,7 @@ _0217c1d0: .word func_ov35_0217bf4c
 	.global func_ov35_0217c1d4
 	arm_func_start func_ov35_0217c1d4
 func_ov35_0217c1d4: ; 0x0217c1d4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x48
 	ldr r1, _0217c498 ; =data_027e0fe4
 	mov r10, r0
@@ -349,7 +349,7 @@ func_ov35_0217c1d4: ; 0x0217c1d4
 	str r0, [r10, #0x234]
 	addeq sp, sp, #0x48
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r1, _0217c49c ; =0xfffffe66
 	ldr r0, _0217c4a0 ; =0x000004cd
 	str r1, [r10, #0x7c]
@@ -383,7 +383,7 @@ func_ov35_0217c1d4: ; 0x0217c1d4
 	ldr r11, _0217c4a8 ; =data_027e0fec
 	mov r8, r10
 	add r7, r10, #0x2f0
-	add sb, r0, #0x400
+	add r9, r0, #0x400
 	mov r5, #0
 _0217c290:
 	add r1, r10, r5
@@ -423,18 +423,18 @@ _0217c290:
 	bl func_0201e544
 	mov r1, r0
 	mov r2, r6
-	mov r0, sb
+	mov r0, r9
 	mov r3, #0
 	bl func_ov00_020c0cc8
 	mov r0, #0
-	str r0, [sb, #0x10]
-	mov r0, sb
+	str r0, [r9, #0x10]
+	mov r0, r9
 	add r1, r7, #4
 	bl func_ov00_020c0d70
 	add r5, r5, #1
 	add r7, r7, #0x5c
 	add r8, r8, #0x44
-	add sb, sb, #0x44
+	add r9, r9, #0x44
 	cmp r5, #3
 	blt _0217c290
 	mov r2, #0
@@ -457,7 +457,7 @@ _0217c290:
 	ldr r1, [r10, #0xc]
 	ldr r5, _0217c4b8 ; =0x52594448
 	ldr r8, _0217c498 ; =data_027e0fe4
-	ldr sb, _0217c4bc ; =data_027e0fe8
+	ldr r9, _0217c4bc ; =data_027e0fe8
 	mov r7, #0
 	str r1, [sp, #0x2c]
 	str r0, [sp, #4]
@@ -467,7 +467,7 @@ _0217c290:
 _0217c3c8:
 	strh r7, [sp, #0xc]
 	str r6, [sp]
-	ldr r0, [sb]
+	ldr r0, [r9]
 	mov r1, r5
 	mov r3, r4
 	add r2, r10, #0x48
@@ -475,7 +475,7 @@ _0217c3c8:
 	cmp r0, #0
 	addeq sp, sp, #0x48
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, [r8]
 	mov r1, r6
 	bl _ZN12ActorManager8GetActorEP8ActorRef
@@ -485,24 +485,24 @@ _0217c3c8:
 	str r0, [r2, #0x280]
 	cmp r7, #5
 	blo _0217c3c8
-	mov sb, #0
-	str sb, [r10, #0x218]
-	strb sb, [r10, #0x22f]
+	mov r9, #0
+	str r9, [r10, #0x218]
+	strb r9, [r10, #0x22f]
 	mov r0, #2
-	str sb, [r10, #0x228]
+	str r9, [r10, #0x228]
 	ldr r8, _0217c4c0 ; =data_ov35_02185154
 	ldr r5, _0217c4c4 ; =0x0000017b
 	mov r11, r10
 	str r0, [r10, #0x230]
 	mov r6, r0
 	mov r4, #0x17c
-	mov r3, sb
+	mov r3, r9
 	mov r1, #0xff
 _0217c44c:
-	mov r0, sb, lsl #0x1
+	mov r0, r9, lsl #0x1
 	ldrsh r7, [r8, r0]
-	add r2, r10, sb, lsl #2
-	add r0, r10, sb
+	add r2, r10, r9, lsl #2
+	add r0, r10, r9
 	str r7, [r11, #0x1f8]
 	str r6, [r11, #0x1fc]
 	str r5, [r11, #0x15c]
@@ -510,14 +510,14 @@ _0217c44c:
 	str r4, [r11, #0x180]
 	str r6, [r11, #0x184]
 	str r3, [r2, #0x21c]
-	add sb, sb, #1
+	add r9, r9, #1
 	strb r1, [r0, #0x22c]
-	cmp sb, #3
+	cmp r9, #3
 	add r11, r11, #0xc
 	blt _0217c44c
 	mov r0, #1
 	add sp, sp, #0x48
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov35_0217c1d4
 _0217c498: .word data_027e0fe4
@@ -1528,7 +1528,7 @@ _0217d20c: .word data_ov35_02185146
 	.global func_ov35_0217d210
 	arm_func_start func_ov35_0217d210
 func_ov35_0217d210: ; 0x0217d210
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x64
 	mov r10, r0
 	ldr r0, [r10, #0x218]
@@ -1550,7 +1550,7 @@ func_ov35_0217d210: ; 0x0217d210
 	moveq r11, #1
 	add r0, r10, #0x48
 	ldr r7, _0217d39c ; =data_ov35_02185184
-	ldr sb, _0217d3a0 ; =data_ov35_021851ae
+	ldr r9, _0217d3a0 ; =data_ov35_021851ae
 	movne r11, #0
 	add r8, r10, #0x1a0
 	str r0, [sp]
@@ -1586,9 +1586,9 @@ _0217d2b8:
 	ldr r0, [r0]
 	mov r2, r4
 	bl func_ov00_0207c474
-	ldrsh r2, [sb]
-	ldrsh r1, [sb, #2]
-	ldrsh r0, [sb, #4]
+	ldrsh r2, [r9]
+	ldrsh r1, [r9, #2]
+	ldrsh r0, [r9, #4]
 	str r2, [sp, #0x58]
 	str r1, [sp, #0x5c]
 	str r0, [sp, #0x60]
@@ -1615,11 +1615,11 @@ _0217d2b8:
 	add r6, r6, #6
 	add r7, r7, #6
 	add r8, r8, #0xc
-	add sb, sb, #6
+	add r9, r9, #6
 	add r10, r10, #0xc
 	blt _0217d27c
 	add sp, sp, #0x64
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0217d374:
 	add r4, r10, #0x1a0
 _0217d378:
@@ -1630,7 +1630,7 @@ _0217d378:
 	add r4, r4, #0xc
 	blt _0217d378
 	add sp, sp, #0x64
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov35_0217d210
 _0217d398: .word data_ov35_0218515a
@@ -1641,7 +1641,7 @@ _0217d3a4: .word data_027e0e58
 	.global func_ov35_0217d3a8
 	arm_func_start func_ov35_0217d3a8
 func_ov35_0217d3a8: ; 0x0217d3a8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x78
 	mov r6, r0
 	ldrb r0, [r6, #0x22f]
@@ -1649,14 +1649,14 @@ func_ov35_0217d3a8: ; 0x0217d3a8
 	bne _0217d424
 	mov r7, #0
 	add r8, r6, #0x1f4
-	add sb, r6, #0x158
+	add r9, r6, #0x158
 	add r10, r6, #0x17c
 	mov r5, r7
 	mov r4, #0xff
 _0217d3d8:
 	mov r0, r8
 	bl func_ov00_020b7e6c
-	mov r0, sb
+	mov r0, r9
 	bl func_ov00_020b7e6c
 	mov r0, r10
 	bl func_ov00_020b7e6c
@@ -1667,12 +1667,12 @@ _0217d3d8:
 	strb r4, [r0, #0x22c]
 	cmp r7, #3
 	add r8, r8, #0xc
-	add sb, sb, #0xc
+	add r9, r9, #0xc
 	add r10, r10, #0xc
 	blt _0217d3d8
 	add sp, sp, #0x78
 	str r5, [r6, #0x228]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0217d424:
 	add r2, sp, #0x18
 	add r0, r6, #0x4d0
@@ -1789,10 +1789,10 @@ _0217d5d0:
 	umull r7, lr, ip, r2
 	mla lr, ip, r1, lr
 	ldr r3, [r0, #0xc]
-	ldr sb, [r0, #0x10]
+	ldr r9, [r0, #0x10]
 	mla lr, r3, r2, lr
 	ldr r8, [r0, #0x14]
-	adds r1, sb, r7
+	adds r1, r9, r7
 	adc r3, r8, lr
 	stmia r0, {r1, r3}
 	umull r1, r2, r3, r11
@@ -1881,7 +1881,7 @@ _0217d680:
 	subne r0, r0, #1
 	strne r0, [r6, #0x228]
 	add sp, sp, #0x78
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov35_0217d3a8
 _0217d74c: .word data_ov35_021851d8
@@ -3906,7 +3906,7 @@ func_ov35_0217f210: ; 0x0217f210
 	.global func_ov35_0217f234
 	arm_func_start func_ov35_0217f234
 func_ov35_0217f234: ; 0x0217f234
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x520
 	mov r4, r0
 	ldr r2, [r4, #0x168]
@@ -3961,7 +3961,7 @@ _0217f2f8:
 	bl _ZN5Actor18func_ov00_020c198cEv
 	cmp r0, #0
 	addeq sp, sp, #0x520
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r1, [r4, #0x168]
 	mov r2, #0x1000
 	add r0, sp, #0x470
@@ -4063,7 +4063,7 @@ _0217f2f8:
 	ldr ip, [sp, #0x424]
 	ldr r11, [sp, #0x428]
 	ldr r10, [sp, #0x42c]
-	ldr sb, [sp, #0x430]
+	ldr r9, [sp, #0x430]
 	ldr r8, [sp, #0x434]
 	str r1, [sp, #0x4b4]
 	ldr r1, [sp, #0x438]
@@ -4074,8 +4074,8 @@ _0217f2f8:
 	ldr r11, [sp, #0x440]
 	str r10, [sp, #0x4c0]
 	ldr r10, [sp, #0x444]
-	str sb, [sp, #0x4c4]
-	ldr sb, [sp, #0x448]
+	str r9, [sp, #0x4c4]
+	ldr r9, [sp, #0x448]
 	str r8, [sp, #0x4c8]
 	ldr r8, [sp, #0x44c]
 	ldrb r7, [sp, #0x468]
@@ -4091,8 +4091,8 @@ _0217f2f8:
 	ldr r11, [sp, #0x458]
 	str r10, [sp, #0x4d8]
 	ldr r10, [sp, #0x45c]
-	str sb, [sp, #0x4dc]
-	ldr sb, [sp, #0x460]
+	str r9, [sp, #0x4dc]
+	ldr r9, [sp, #0x460]
 	str r8, [sp, #0x4e0]
 	ldr r8, [sp, #0x464]
 	str r1, [sp, #0x4e4]
@@ -4101,7 +4101,7 @@ _0217f2f8:
 	str ip, [sp, #0x4e8]
 	str r11, [sp, #0x4ec]
 	str r10, [sp, #0x4f0]
-	str sb, [sp, #0x4f4]
+	str r9, [sp, #0x4f4]
 	str r8, [sp, #0x4f8]
 	strb r7, [sp, #0x4fc]
 	strb r6, [sp, #0x4fd]
@@ -4116,7 +4116,7 @@ _0217f2f8:
 	add r0, sp, #0x470
 	bl func_ov00_0209a508
 	add sp, sp, #0x520
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0217f574:
 	mov r1, #6
 	add r0, r4, #0xe8
@@ -4220,7 +4220,7 @@ _0217f688:
 	blx func_02036140
 	cmp r0, #0
 	addeq sp, sp, #0x520
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0217f6f8:
 	ldr r0, [r4, #0x4e4]
 	mov r1, #1
@@ -4441,7 +4441,7 @@ _0217fa0c:
 	bl func_ov00_020bd3b0
 	cmp r0, #0
 	addeq sp, sp, #0x520
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r2, _021800b8 ; =data_027e0d0c
 	add r0, r4, #0x158
 	ldr r3, [r2]
@@ -4482,21 +4482,21 @@ _0217fa0c:
 	ldrsh r8, [r5, r1]
 	umull ip, r11, r10, r2
 	mla r11, r10, r3, r11
-	mov sb, r10, asr #0x1f
+	mov r9, r10, asr #0x1f
 	adds r10, ip, #0x800
-	mla r11, sb, r2, r11
-	adc sb, r11, #0
+	mla r11, r9, r2, r11
+	adc r9, r11, #0
 	mov r10, r10, lsr #0xc
-	orr r10, r10, sb, lsl #20
+	orr r10, r10, r9, lsl #20
 	add r0, r0, r10
-	umull r10, sb, r8, r2
-	mla sb, r8, r3, sb
+	umull r10, r9, r8, r2
+	mla r9, r8, r3, r9
 	mov r7, r8, asr #0x1f
 	adds r3, r10, #0x800
-	mla sb, r7, r2, sb
+	mla r9, r7, r2, r9
 	str r0, [r4, #0x48]
 	ldr r0, [r4, #0x50]
-	adc r2, sb, #0
+	adc r2, r9, #0
 	mov r3, r3, lsr #0xc
 	orr r3, r3, r2, lsl #20
 	add r0, r0, r3
@@ -4563,16 +4563,16 @@ _0217fc10:
 	bl _ZN5Actor18func_ov00_020c198cEv
 	cmp r0, #0
 	addeq sp, sp, #0x520
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, _021800c0 ; =data_027e0c54
 	ldrb r1, [r0]
 	cmp r1, #0
 	addeq sp, sp, #0x520
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	bl func_0203608c
 	cmp r0, #0
 	addne sp, sp, #0x520
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	mov r0, #0x1f000
 	mov r1, #0x1000
 	bl Divide
@@ -4592,7 +4592,7 @@ _0217fc10:
 	blx func_02036140
 	cmp r0, #0
 	addeq sp, sp, #0x520
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r0, sp, #0x358
 	bl func_ov00_0209a4f4
 	add r0, r4, #0x48
@@ -4638,7 +4638,7 @@ _0217fd30:
 	ldr ip, [sp, #0x2f8]
 	ldr r11, [sp, #0x2fc]
 	ldr r10, [sp, #0x300]
-	ldr sb, [sp, #0x304]
+	ldr r9, [sp, #0x304]
 	str r2, [sp, #0x384]
 	ldr r2, [sp, #0x308]
 	str r1, [sp, #0x388]
@@ -4649,8 +4649,8 @@ _0217fd30:
 	ldr r11, [sp, #0x314]
 	str r10, [sp, #0x394]
 	ldr r10, [sp, #0x318]
-	str sb, [sp, #0x398]
-	ldr sb, [sp, #0x31c]
+	str r9, [sp, #0x398]
+	ldr r9, [sp, #0x31c]
 	str r2, [sp, #0x39c]
 	ldr r2, [sp, #0x320]
 	str r1, [sp, #0x3a0]
@@ -4662,8 +4662,8 @@ _0217fd30:
 	ldr r11, [sp, #0x32c]
 	str r10, [sp, #0x3ac]
 	ldr r10, [sp, #0x330]
-	str sb, [sp, #0x3b0]
-	ldr sb, [sp, #0x334]
+	str r9, [sp, #0x3b0]
+	ldr r9, [sp, #0x334]
 	ldrb r8, [sp, #0x350]
 	ldrb r7, [sp, #0x351]
 	ldrb r6, [sp, #0x352]
@@ -4679,8 +4679,8 @@ _0217fd30:
 	ldr r11, [sp, #0x344]
 	str r10, [sp, #0x3c4]
 	ldr r10, [sp, #0x348]
-	str sb, [sp, #0x3c8]
-	ldr sb, [sp, #0x34c]
+	str r9, [sp, #0x3c8]
+	ldr r9, [sp, #0x34c]
 	str r2, [sp, #0x3cc]
 	mov r2, #0x5c
 	str r1, [sp, #0x3d0]
@@ -4689,7 +4689,7 @@ _0217fd30:
 	str ip, [sp, #0x3d4]
 	str r11, [sp, #0x3d8]
 	str r10, [sp, #0x3dc]
-	str sb, [sp, #0x3e0]
+	str r9, [sp, #0x3e0]
 	strb r8, [sp, #0x3e4]
 	strb r7, [sp, #0x3e5]
 	strb r6, [sp, #0x3e6]
@@ -4704,7 +4704,7 @@ _0217fd30:
 	add r0, sp, #0x358
 	bl func_ov00_0209a508
 	add sp, sp, #0x520
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0217fe50:
 	ldr r2, _021800b8 ; =data_027e0d0c
 	add r0, r4, #0x158
@@ -4746,7 +4746,7 @@ _0217fee0:
 	bl _ZN5Actor18func_ov00_020c198cEv
 	cmp r0, #0
 	addeq sp, sp, #0x520
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r0, r4, #0x48
 	add r3, sp, #0x48
 	ldmia r0, {r0, r1, r2}
@@ -4810,7 +4810,7 @@ _0217fee0:
 	add r0, sp, #0x240
 	bl func_ov00_0209a508
 	add sp, sp, #0x520
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0217fff0:
 	ldr r1, [sp, #0x48]
 	add r0, r4, #0x158
@@ -4891,7 +4891,7 @@ _0218010c:
 	bl _ZN5Actor18func_ov00_020c198cEv
 	cmp r0, #0
 	addeq sp, sp, #0x520
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r1, [r4, #0x4e4]
 	mov r2, #0
 	add r0, sp, #0x190
@@ -4916,8 +4916,8 @@ _0218010c:
 	umull r3, r2, r8, r5
 	adds r6, r6, #0x800
 	mla r0, r10, lr, r0
-	mov sb, r10, asr #0x1f
-	mla r0, sb, r5, r0
+	mov r9, r10, asr #0x1f
+	mla r0, r9, r5, r0
 	adc r0, r0, #0
 	mov r6, r6, lsr #0xc
 	adds r3, r3, #0x800
@@ -4948,7 +4948,7 @@ _0218010c:
 	sub r11, lr, #1
 	mla r5, r10, r11, r5
 	ldr r2, [sp, #0x44]
-	mla r5, sb, r0, r5
+	mla r5, r9, r0, r5
 	adds r6, r6, #0x800
 	adc r0, r5, #0
 	mov r5, r6, lsr #0xc
@@ -4987,7 +4987,7 @@ _0218010c:
 	umull r3, r1, r10, ip
 	mla r1, r10, lr, r1
 	adds r3, r3, #0x800
-	mla r1, sb, ip, r1
+	mla r1, r9, ip, r1
 	strb r2, [sp, #0x19a]
 	strb r2, [sp, #0x19b]
 	str r6, [sp, #0x3c]
@@ -5027,7 +5027,7 @@ _0218010c:
 	add r0, sp, #0x190
 	bl func_ov00_0209a508
 	add sp, sp, #0x520
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0218033c:
 	add r0, r4, #0x158
 	mov r1, #5
@@ -5054,10 +5054,10 @@ _02180370:
 	umull r8, r7, r6, r5
 	mla r7, r6, r3, r7
 	ldr r3, [r2, #0xc]
-	ldr sb, [r2, #0x10]
+	ldr r9, [r2, #0x10]
 	mla r7, r3, r5, r7
 	ldr r6, [r2, #0x14]
-	adds r8, sb, r8
+	adds r8, r9, r8
 	mov r1, #0x1f
 	adc r6, r6, r7
 	umull r3, r5, r6, r1
@@ -5107,7 +5107,7 @@ _02180424:
 	mov r1, #0x19
 	bl func_ov35_0217f234
 	add sp, sp, #0x520
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0218046c:
 	add r0, r4, #0x158
 	mov r1, #0xb
@@ -5198,7 +5198,7 @@ _021805ac:
 	bl _ZN5Actor18func_ov00_020c198cEv
 	cmp r0, #0
 	addeq sp, sp, #0x520
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, _021800ac ; =data_027e0fc8
 	ldr r0, [r0]
 	ldr r1, [r0]
@@ -5286,15 +5286,15 @@ _021805ac:
 	ldr r0, [sp, #0xa0]
 	str r1, [sp, #0x12c]
 	str r0, [sp, #0x134]
-	ldr sb, [sp, #0xa4]
+	ldr r9, [sp, #0xa4]
 	ldr r2, [sp, #0xa8]
 	ldr r1, [sp, #0xac]
 	ldr r0, _021800a4 ; =data_027e0f74
 	ldr ip, [sp, #0xb0]
 	ldr r11, [sp, #0xb4]
 	ldr r10, [sp, #0xb8]
-	str sb, [sp, #0x138]
-	ldr sb, [sp, #0xbc]
+	str r9, [sp, #0x138]
+	ldr r9, [sp, #0xbc]
 	ldrb r8, [sp, #0xd8]
 	ldrb r7, [sp, #0xd9]
 	ldrb r6, [sp, #0xda]
@@ -5310,8 +5310,8 @@ _021805ac:
 	ldr r11, [sp, #0xcc]
 	str r10, [sp, #0x14c]
 	ldr r10, [sp, #0xd0]
-	str sb, [sp, #0x150]
-	ldr sb, [sp, #0xd4]
+	str r9, [sp, #0x150]
+	ldr r9, [sp, #0xd4]
 	str r2, [sp, #0x154]
 	mov r2, #0x5c
 	str r1, [sp, #0x158]
@@ -5320,7 +5320,7 @@ _021805ac:
 	str ip, [sp, #0x15c]
 	str r11, [sp, #0x160]
 	str r10, [sp, #0x164]
-	str sb, [sp, #0x168]
+	str r9, [sp, #0x168]
 	strb r8, [sp, #0x16c]
 	strb r7, [sp, #0x16d]
 	strb r6, [sp, #0x16e]
@@ -5335,7 +5335,7 @@ _021805ac:
 	add r0, sp, #0xe0
 	bl func_ov00_0209a508
 	add sp, sp, #0x520
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _021807e0:
 	ldr r0, _021800d8 ; =data_ov00_020eec68
 	mov r2, #0
@@ -5446,7 +5446,7 @@ _02180974:
 	ldr r0, [sp, #8]
 	str r0, [r4, #0x130]
 	add sp, sp, #0x520
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 _0218098c: .word data_027e0764
 _02180990: .word 0x00000223
@@ -7918,7 +7918,7 @@ _02182b18: .word 0x00001ccd
 	.global func_ov35_02182b1c
 	arm_func_start func_ov35_02182b1c
 func_ov35_02182b1c: ; 0x02182b1c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #0x118
 	mov r4, r0
 	ldr r0, [r4, #0x550]
@@ -7926,11 +7926,11 @@ func_ov35_02182b1c: ; 0x02182b1c
 	subgt r0, r0, #1
 	addgt sp, sp, #0x118
 	strgt r0, [r4, #0x550]
-	ldmgtia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmgtia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	ldrb r0, [r4, #0x563]
 	cmp r0, #3
 	addhs sp, sp, #0x118
-	ldmhsia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmhsia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	ldr r0, _02182f88 ; =data_027e0f64
 	ldr r3, _02182f8c ; =data_027e0f94
 	ldr r0, [r0]
@@ -7971,22 +7971,22 @@ _02182bd8: ; jump table
 	b _02182cb8 ; case 2
 	b _02182d20 ; case 3
 _02182be8:
-	ldr sb, [sp, #0xb4]
+	ldr r9, [sp, #0xb4]
 	ldr r7, [sp, #0xac]
-	sub r8, sb, #0x7000
-	add sb, sb, #0x6000
+	sub r8, r9, #0x7000
+	add r9, r9, #0x6000
 	add r10, r7, #0x8000
-	sub sb, sb, r8
-	add r7, sb, #1
+	sub r9, r9, r8
+	add r7, r9, #1
 	cmp r7, #0
 	str r10, [sp, #0xac]
 	movle r3, r0
 	ble _02182c44
-	umull r10, sb, r2, r5
-	mla sb, r2, lr, sb
-	mla sb, r1, r5, sb
+	umull r10, r9, r2, r5
+	mla r9, r2, lr, r9
+	mla r9, r1, r5, r9
 	adds r2, ip, r10
-	adc r3, r3, sb
+	adc r3, r3, r9
 	stmia r6, {r2, r3}
 	cmp r7, #0
 	beq _02182c44
@@ -7999,22 +7999,22 @@ _02182c44:
 	str r0, [sp, #0xb4]
 	b _02182d84
 _02182c50:
-	ldr sb, [sp, #0xb4]
+	ldr r9, [sp, #0xb4]
 	ldr r7, [sp, #0xac]
-	sub r8, sb, #0x7000
-	add sb, sb, #0x6000
+	sub r8, r9, #0x7000
+	add r9, r9, #0x6000
 	sub r10, r7, #0x8000
-	sub sb, sb, r8
-	add r7, sb, #1
+	sub r9, r9, r8
+	add r7, r9, #1
 	cmp r7, #0
 	str r10, [sp, #0xac]
 	movle r3, r0
 	ble _02182cac
-	umull r10, sb, r2, r5
-	mla sb, r2, lr, sb
-	mla sb, r1, r5, sb
+	umull r10, r9, r2, r5
+	mla r9, r2, lr, r9
+	mla r9, r1, r5, r9
 	adds r2, ip, r10
-	adc r3, r3, sb
+	adc r3, r3, r9
 	stmia r6, {r2, r3}
 	cmp r7, #0
 	beq _02182cac
@@ -8035,11 +8035,11 @@ _02182cb8:
 	cmp r7, #0
 	movle r3, r0
 	ble _02182d08
-	umull r10, sb, r2, r5
-	mla sb, r2, lr, sb
-	mla sb, r1, r5, sb
+	umull r10, r9, r2, r5
+	mla r9, r2, lr, r9
+	mla r9, r1, r5, r9
 	adds r2, ip, r10
-	adc r3, r3, sb
+	adc r3, r3, r9
 	stmia r6, {r2, r3}
 	cmp r7, #0
 	beq _02182d08
@@ -8063,11 +8063,11 @@ _02182d20:
 	cmp r7, #0
 	movle r3, r0
 	ble _02182d70
-	umull r10, sb, r2, r5
-	mla sb, r2, lr, sb
-	mla sb, r1, r5, sb
+	umull r10, r9, r2, r5
+	mla r9, r2, lr, r9
+	mla r9, r1, r5, r9
 	adds r2, ip, r10
-	adc r3, r3, sb
+	adc r3, r3, r9
 	stmia r6, {r2, r3}
 	cmp r7, #0
 	beq _02182d70
@@ -8101,7 +8101,7 @@ _02182d84:
 	movne r0, #0
 	cmp r0, #0
 	addne sp, sp, #0x118
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	ldr r0, _02182f88 ; =data_027e0f64
 	ldr r3, [sp, #0xac]
 	ldr r2, [sp, #0xb0]
@@ -8132,7 +8132,7 @@ _02182d84:
 _02182e40:
 	cmp r5, #0
 	addne sp, sp, #0x118
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	ldr r0, _02182f8c ; =data_027e0f94
 	mov r8, #0
 	ldr ip, _02182f98 ; =0x0000ffff
@@ -8185,7 +8185,7 @@ _02182e40:
 	bl func_01ffbe78
 	cmp r0, #0
 	addne sp, sp, #0x118
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	add r0, sp, #0x58
 	bl func_ov00_020c1500
 	mvn r1, #0
@@ -8211,7 +8211,7 @@ _02182e40:
 	mov r0, #0x1e
 	str r0, [r4, #0x550]
 	add sp, sp, #0x118
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov35_02182b1c
 _02182f88: .word data_027e0f64
@@ -8867,7 +8867,7 @@ _02183844: .word data_ov35_02185c70
 	.global func_ov35_02183848
 	arm_func_start func_ov35_02183848
 func_ov35_02183848: ; 0x02183848
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x30
 	mov r7, r0
 	movs r4, r1
@@ -8877,12 +8877,12 @@ func_ov35_02183848: ; 0x02183848
 	bne _02183874
 	cmp r4, #0
 	addne sp, sp, #0x30
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _02183874:
 	ldr r0, [r7, #0x130]
 	cmp r0, #0x1f
 	addeq sp, sp, #0x30
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	add r0, r7, #0x168
 	add r0, r0, #0x400
 	bl func_ov17_021687f0
@@ -8908,7 +8908,7 @@ _02183874:
 	mov r0, r7
 	bl func_ov35_02183f0c
 	add sp, sp, #0x30
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _021838ec:
 	ldr r0, [r7, #0x15c]
 	mov r1, r6
@@ -9119,7 +9119,7 @@ _02183ba4:
 	umull r8, r5, r0, r1
 	ldr r2, _02183e78 ; =0x00000d99
 	adds ip, r8, #0x800
-	umull sb, r8, r0, r2
+	umull r9, r8, r0, r2
 	mov ip, ip, lsr #0xc
 	mov lr, r0, asr #0x1f
 	mla r5, r0, r3, r5
@@ -9129,7 +9129,7 @@ _02183ba4:
 	adc r0, r5, #0
 	orr ip, ip, r0, lsl #20
 	add r5, ip, #0x1800
-	adds r1, sb, #0x800
+	adds r1, r9, #0x800
 	adc r0, r8, #0
 	mov r1, r1, lsr #0xc
 	orr r1, r1, r0, lsl #20
@@ -9157,14 +9157,14 @@ _02183c74:
 	mov ip, #0
 	umull r0, lr, r2, r3
 	add r5, r3, #0xcc
-	umull sb, r8, r2, r5
+	umull r9, r8, r2, r5
 	adds r0, r0, #0x800
 	mla lr, r2, ip, lr
 	mov r1, r2, asr #0x1f
 	mla r8, r2, ip, r8
 	mla lr, r1, r3, lr
 	adc ip, lr, #0
-	adds r2, sb, #0x800
+	adds r2, r9, #0x800
 	mla r8, r1, r5, r8
 	mov r5, r0, lsr #0xc
 	orr r5, r5, ip, lsl #20
@@ -9236,9 +9236,9 @@ _02183d8c:
 	ldrsh r1, [r2, r1]
 	mov r0, r0, lsl #0x1
 	ldrsh r8, [r2, r0]
-	smull sb, r0, r1, ip
-	adds r1, sb, #0x800
-	smull ip, sb, r8, ip
+	smull r9, r0, r1, ip
+	adds r1, r9, #0x800
+	smull ip, r9, r8, ip
 	adc r0, r0, #0
 	mov r1, r1, lsr #0xc
 	ldr r2, [sp, #0x24]
@@ -9246,7 +9246,7 @@ _02183d8c:
 	adds r8, ip, #0x800
 	orr r1, r1, r0, lsl #20
 	add ip, r2, r1
-	adc r0, sb, #0
+	adc r0, r9, #0
 	mov r1, r8, lsr #0xc
 	orr r1, r1, r0, lsl #20
 	ldr r2, [sp, #0x2c]
@@ -9276,7 +9276,7 @@ _02183d8c:
 	mov r0, r7
 	bl func_ov35_02183f0c
 	add sp, sp, #0x30
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov35_02183848
 _02183e58: .word data_ov00_020e9c88

--- a/asm/ov35.s
+++ b/asm/ov35.s
@@ -338,7 +338,7 @@ _0217c1d0: .word func_ov35_0217bf4c
 	.global func_ov35_0217c1d4
 	arm_func_start func_ov35_0217c1d4
 func_ov35_0217c1d4: ; 0x0217c1d4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x48
 	ldr r1, _0217c498 ; =data_027e0fe4
 	mov sl, r0
@@ -349,7 +349,7 @@ func_ov35_0217c1d4: ; 0x0217c1d4
 	str r0, [sl, #0x234]
 	addeq sp, sp, #0x48
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r1, _0217c49c ; =0xfffffe66
 	ldr r0, _0217c4a0 ; =0x000004cd
 	str r1, [sl, #0x7c]
@@ -380,7 +380,7 @@ func_ov35_0217c1d4: ; 0x0217c1d4
 	ldr r2, [r2, #0xc]
 	blx r2
 	add r0, sl, #4
-	ldr fp, _0217c4a8 ; =data_027e0fec
+	ldr r11, _0217c4a8 ; =data_027e0fec
 	mov r8, sl
 	add r7, sl, #0x2f0
 	add sb, r0, #0x400
@@ -390,7 +390,7 @@ _0217c290:
 	mov r0, #0
 	strb r0, [r1, #0x551]
 	ldr r0, _0217c4ac ; =data_ov35_0218512c
-	ldr r1, [fp]
+	ldr r1, [r11]
 	ldr r4, [r0, r5, lsl #2]
 	mov r0, #0x38
 	mla r0, r4, r0, r1
@@ -406,7 +406,7 @@ _0217c290:
 	blx r1
 	str r0, [r8, #0x40c]
 	ldr r0, _0217c4b0 ; =data_ov35_0218595c
-	ldr r2, [fp]
+	ldr r2, [r11]
 	mov r1, #0x38
 	mla r1, r4, r1, r2
 	ldr r0, [r0, r5, lsl #2]
@@ -475,7 +475,7 @@ _0217c3c8:
 	cmp r0, #0
 	addeq sp, sp, #0x48
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, [r8]
 	mov r1, r6
 	bl _ZN12ActorManager8GetActorEP8ActorRef
@@ -492,7 +492,7 @@ _0217c3c8:
 	str sb, [sl, #0x228]
 	ldr r8, _0217c4c0 ; =data_ov35_02185154
 	ldr r5, _0217c4c4 ; =0x0000017b
-	mov fp, sl
+	mov r11, sl
 	str r0, [sl, #0x230]
 	mov r6, r0
 	mov r4, #0x17c
@@ -503,21 +503,21 @@ _0217c44c:
 	ldrsh r7, [r8, r0]
 	add r2, sl, sb, lsl #2
 	add r0, sl, sb
-	str r7, [fp, #0x1f8]
-	str r6, [fp, #0x1fc]
-	str r5, [fp, #0x15c]
-	str r6, [fp, #0x160]
-	str r4, [fp, #0x180]
-	str r6, [fp, #0x184]
+	str r7, [r11, #0x1f8]
+	str r6, [r11, #0x1fc]
+	str r5, [r11, #0x15c]
+	str r6, [r11, #0x160]
+	str r4, [r11, #0x180]
+	str r6, [r11, #0x184]
 	str r3, [r2, #0x21c]
 	add sb, sb, #1
 	strb r1, [r0, #0x22c]
 	cmp sb, #3
-	add fp, fp, #0xc
+	add r11, r11, #0xc
 	blt _0217c44c
 	mov r0, #1
 	add sp, sp, #0x48
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov35_0217c1d4
 _0217c498: .word data_027e0fe4
@@ -1528,7 +1528,7 @@ _0217d20c: .word data_ov35_02185146
 	.global func_ov35_0217d210
 	arm_func_start func_ov35_0217d210
 func_ov35_0217d210: ; 0x0217d210
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x64
 	mov sl, r0
 	ldr r0, [sl, #0x218]
@@ -1547,16 +1547,16 @@ func_ov35_0217d210: ; 0x0217d210
 	ldr r0, [sl, #0x1a4]
 	ldr r6, _0217d398 ; =data_ov35_0218515a
 	cmp r0, #0x174
-	moveq fp, #1
+	moveq r11, #1
 	add r0, sl, #0x48
 	ldr r7, _0217d39c ; =data_ov35_02185184
 	ldr sb, _0217d3a0 ; =data_ov35_021851ae
-	movne fp, #0
+	movne r11, #0
 	add r8, sl, #0x1a0
 	str r0, [sp]
 	add r4, sp, #0x58
 _0217d27c:
-	cmp fp, #0
+	cmp r11, #0
 	beq _0217d2a0
 	ldrsh r2, [r6]
 	ldrsh r1, [r6, #2]
@@ -1619,7 +1619,7 @@ _0217d2b8:
 	add sl, sl, #0xc
 	blt _0217d27c
 	add sp, sp, #0x64
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0217d374:
 	add r4, sl, #0x1a0
 _0217d378:
@@ -1630,7 +1630,7 @@ _0217d378:
 	add r4, r4, #0xc
 	blt _0217d378
 	add sp, sp, #0x64
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov35_0217d210
 _0217d398: .word data_ov35_0218515a
@@ -1641,7 +1641,7 @@ _0217d3a4: .word data_027e0e58
 	.global func_ov35_0217d3a8
 	arm_func_start func_ov35_0217d3a8
 func_ov35_0217d3a8: ; 0x0217d3a8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x78
 	mov r6, r0
 	ldrb r0, [r6, #0x22f]
@@ -1672,7 +1672,7 @@ _0217d3d8:
 	blt _0217d3d8
 	add sp, sp, #0x78
 	str r5, [r6, #0x228]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0217d424:
 	add r2, sp, #0x18
 	add r0, r6, #0x4d0
@@ -1782,7 +1782,7 @@ _0217d5a4:
 	mov r0, #0xf
 	str r0, [r6, #0x228]
 	ldr r0, _0217d75c ; =data_027e0764
-	mov fp, #6
+	mov r11, #6
 _0217d5d0:
 	ldr r2, [r0]
 	ldmib r0, {r1, ip}
@@ -1795,11 +1795,11 @@ _0217d5d0:
 	adds r1, sb, r7
 	adc r3, r8, lr
 	stmia r0, {r1, r3}
-	umull r1, r2, r3, fp
+	umull r1, r2, r3, r11
 	mov sl, #0
 	mov r1, sl
 	mla r2, r3, r1, r2
-	mla r2, r1, fp, r2
+	mla r2, r1, r11, r2
 	strb r2, [r4, #0x22c]
 _0217d614:
 	cmp r5, sl
@@ -1881,7 +1881,7 @@ _0217d680:
 	subne r0, r0, #1
 	strne r0, [r6, #0x228]
 	add sp, sp, #0x78
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov35_0217d3a8
 _0217d74c: .word data_ov35_021851d8
@@ -3906,7 +3906,7 @@ func_ov35_0217f210: ; 0x0217f210
 	.global func_ov35_0217f234
 	arm_func_start func_ov35_0217f234
 func_ov35_0217f234: ; 0x0217f234
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x520
 	mov r4, r0
 	ldr r2, [r4, #0x168]
@@ -3961,7 +3961,7 @@ _0217f2f8:
 	bl _ZN5Actor18func_ov00_020c198cEv
 	cmp r0, #0
 	addeq sp, sp, #0x520
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r1, [r4, #0x168]
 	mov r2, #0x1000
 	add r0, sp, #0x470
@@ -4061,7 +4061,7 @@ _0217f2f8:
 	str r0, [sp, #0x4b0]
 	ldr r1, [sp, #0x420]
 	ldr ip, [sp, #0x424]
-	ldr fp, [sp, #0x428]
+	ldr r11, [sp, #0x428]
 	ldr sl, [sp, #0x42c]
 	ldr sb, [sp, #0x430]
 	ldr r8, [sp, #0x434]
@@ -4070,8 +4070,8 @@ _0217f2f8:
 	ldr r0, _021800a4 ; =data_027e0f74
 	str ip, [sp, #0x4b8]
 	ldr ip, [sp, #0x43c]
-	str fp, [sp, #0x4bc]
-	ldr fp, [sp, #0x440]
+	str r11, [sp, #0x4bc]
+	ldr r11, [sp, #0x440]
 	str sl, [sp, #0x4c0]
 	ldr sl, [sp, #0x444]
 	str sb, [sp, #0x4c4]
@@ -4087,8 +4087,8 @@ _0217f2f8:
 	ldr r1, [sp, #0x450]
 	str ip, [sp, #0x4d0]
 	ldr ip, [sp, #0x454]
-	str fp, [sp, #0x4d4]
-	ldr fp, [sp, #0x458]
+	str r11, [sp, #0x4d4]
+	ldr r11, [sp, #0x458]
 	str sl, [sp, #0x4d8]
 	ldr sl, [sp, #0x45c]
 	str sb, [sp, #0x4dc]
@@ -4099,7 +4099,7 @@ _0217f2f8:
 	ldr r0, [r0]
 	add r1, sp, #0x470
 	str ip, [sp, #0x4e8]
-	str fp, [sp, #0x4ec]
+	str r11, [sp, #0x4ec]
 	str sl, [sp, #0x4f0]
 	str sb, [sp, #0x4f4]
 	str r8, [sp, #0x4f8]
@@ -4116,7 +4116,7 @@ _0217f2f8:
 	add r0, sp, #0x470
 	bl func_ov00_0209a508
 	add sp, sp, #0x520
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0217f574:
 	mov r1, #6
 	add r0, r4, #0xe8
@@ -4220,7 +4220,7 @@ _0217f688:
 	blx func_02036140
 	cmp r0, #0
 	addeq sp, sp, #0x520
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0217f6f8:
 	ldr r0, [r4, #0x4e4]
 	mov r1, #1
@@ -4441,7 +4441,7 @@ _0217fa0c:
 	bl func_ov00_020bd3b0
 	cmp r0, #0
 	addeq sp, sp, #0x520
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r2, _021800b8 ; =data_027e0d0c
 	add r0, r4, #0x158
 	ldr r3, [r2]
@@ -4480,12 +4480,12 @@ _0217fa0c:
 	add r1, r7, #1
 	mov r1, r1, lsl #0x1
 	ldrsh r8, [r5, r1]
-	umull ip, fp, sl, r2
-	mla fp, sl, r3, fp
+	umull ip, r11, sl, r2
+	mla r11, sl, r3, r11
 	mov sb, sl, asr #0x1f
 	adds sl, ip, #0x800
-	mla fp, sb, r2, fp
-	adc sb, fp, #0
+	mla r11, sb, r2, r11
+	adc sb, r11, #0
 	mov sl, sl, lsr #0xc
 	orr sl, sl, sb, lsl #20
 	add r0, r0, sl
@@ -4563,16 +4563,16 @@ _0217fc10:
 	bl _ZN5Actor18func_ov00_020c198cEv
 	cmp r0, #0
 	addeq sp, sp, #0x520
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, _021800c0 ; =data_027e0c54
 	ldrb r1, [r0]
 	cmp r1, #0
 	addeq sp, sp, #0x520
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	bl func_0203608c
 	cmp r0, #0
 	addne sp, sp, #0x520
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	mov r0, #0x1f000
 	mov r1, #0x1000
 	bl Divide
@@ -4592,7 +4592,7 @@ _0217fc10:
 	blx func_02036140
 	cmp r0, #0
 	addeq sp, sp, #0x520
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r0, sp, #0x358
 	bl func_ov00_0209a4f4
 	add r0, r4, #0x48
@@ -4636,7 +4636,7 @@ _0217fd30:
 	ldr r2, [sp, #0x2f0]
 	ldr r1, [sp, #0x2f4]
 	ldr ip, [sp, #0x2f8]
-	ldr fp, [sp, #0x2fc]
+	ldr r11, [sp, #0x2fc]
 	ldr sl, [sp, #0x300]
 	ldr sb, [sp, #0x304]
 	str r2, [sp, #0x384]
@@ -4645,8 +4645,8 @@ _0217fd30:
 	ldr r1, [sp, #0x30c]
 	str ip, [sp, #0x38c]
 	ldr ip, [sp, #0x310]
-	str fp, [sp, #0x390]
-	ldr fp, [sp, #0x314]
+	str r11, [sp, #0x390]
+	ldr r11, [sp, #0x314]
 	str sl, [sp, #0x394]
 	ldr sl, [sp, #0x318]
 	str sb, [sp, #0x398]
@@ -4658,8 +4658,8 @@ _0217fd30:
 	ldr r0, _021800a4 ; =data_027e0f74
 	str ip, [sp, #0x3a4]
 	ldr ip, [sp, #0x328]
-	str fp, [sp, #0x3a8]
-	ldr fp, [sp, #0x32c]
+	str r11, [sp, #0x3a8]
+	ldr r11, [sp, #0x32c]
 	str sl, [sp, #0x3ac]
 	ldr sl, [sp, #0x330]
 	str sb, [sp, #0x3b0]
@@ -4675,8 +4675,8 @@ _0217fd30:
 	ldr r1, [sp, #0x33c]
 	str ip, [sp, #0x3bc]
 	ldr ip, [sp, #0x340]
-	str fp, [sp, #0x3c0]
-	ldr fp, [sp, #0x344]
+	str r11, [sp, #0x3c0]
+	ldr r11, [sp, #0x344]
 	str sl, [sp, #0x3c4]
 	ldr sl, [sp, #0x348]
 	str sb, [sp, #0x3c8]
@@ -4687,7 +4687,7 @@ _0217fd30:
 	ldr r0, [r0]
 	add r1, sp, #0x358
 	str ip, [sp, #0x3d4]
-	str fp, [sp, #0x3d8]
+	str r11, [sp, #0x3d8]
 	str sl, [sp, #0x3dc]
 	str sb, [sp, #0x3e0]
 	strb r8, [sp, #0x3e4]
@@ -4704,7 +4704,7 @@ _0217fd30:
 	add r0, sp, #0x358
 	bl func_ov00_0209a508
 	add sp, sp, #0x520
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0217fe50:
 	ldr r2, _021800b8 ; =data_027e0d0c
 	add r0, r4, #0x158
@@ -4746,7 +4746,7 @@ _0217fee0:
 	bl _ZN5Actor18func_ov00_020c198cEv
 	cmp r0, #0
 	addeq sp, sp, #0x520
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r0, r4, #0x48
 	add r3, sp, #0x48
 	ldmia r0, {r0, r1, r2}
@@ -4810,7 +4810,7 @@ _0217fee0:
 	add r0, sp, #0x240
 	bl func_ov00_0209a508
 	add sp, sp, #0x520
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0217fff0:
 	ldr r1, [sp, #0x48]
 	add r0, r4, #0x158
@@ -4891,7 +4891,7 @@ _0218010c:
 	bl _ZN5Actor18func_ov00_020c198cEv
 	cmp r0, #0
 	addeq sp, sp, #0x520
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r1, [r4, #0x4e4]
 	mov r2, #0
 	add r0, sp, #0x190
@@ -4945,15 +4945,15 @@ _0218010c:
 	str r3, [sp, #0x1b4]
 	sub r3, r5, #0x800
 	umull r6, r5, sl, r0
-	sub fp, lr, #1
-	mla r5, sl, fp, r5
+	sub r11, lr, #1
+	mla r5, sl, r11, r5
 	ldr r2, [sp, #0x44]
 	mla r5, sb, r0, r5
 	adds r6, r6, #0x800
 	adc r0, r5, #0
 	mov r5, r6, lsr #0xc
 	str r2, [sp, #0x10]
-	mov r2, fp
+	mov r2, r11
 	orr r5, r5, r0, lsl #20
 	ldr r0, [sp, #0xc]
 	str r2, [sp, #0x14]
@@ -4964,10 +4964,10 @@ _0218010c:
 	strb r2, [sp, #0x199]
 	mov r2, #3
 	ldr r0, [sp, #0x14]
-	umull fp, r5, r8, r1
+	umull r11, r5, r8, r1
 	mla r5, r8, r0, r5
 	mla r5, r7, r1, r5
-	adds r1, fp, #0x800
+	adds r1, r11, #0x800
 	adc r0, r5, #0
 	mov r1, r1, lsr #0xc
 	orr r1, r1, r0, lsl #20
@@ -5027,7 +5027,7 @@ _0218010c:
 	add r0, sp, #0x190
 	bl func_ov00_0209a508
 	add sp, sp, #0x520
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0218033c:
 	add r0, r4, #0x158
 	mov r1, #5
@@ -5107,7 +5107,7 @@ _02180424:
 	mov r1, #0x19
 	bl func_ov35_0217f234
 	add sp, sp, #0x520
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0218046c:
 	add r0, r4, #0x158
 	mov r1, #0xb
@@ -5198,7 +5198,7 @@ _021805ac:
 	bl _ZN5Actor18func_ov00_020c198cEv
 	cmp r0, #0
 	addeq sp, sp, #0x520
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, _021800ac ; =data_027e0fc8
 	ldr r0, [r0]
 	ldr r1, [r0]
@@ -5291,7 +5291,7 @@ _021805ac:
 	ldr r1, [sp, #0xac]
 	ldr r0, _021800a4 ; =data_027e0f74
 	ldr ip, [sp, #0xb0]
-	ldr fp, [sp, #0xb4]
+	ldr r11, [sp, #0xb4]
 	ldr sl, [sp, #0xb8]
 	str sb, [sp, #0x138]
 	ldr sb, [sp, #0xbc]
@@ -5306,8 +5306,8 @@ _021805ac:
 	ldr r1, [sp, #0xc4]
 	str ip, [sp, #0x144]
 	ldr ip, [sp, #0xc8]
-	str fp, [sp, #0x148]
-	ldr fp, [sp, #0xcc]
+	str r11, [sp, #0x148]
+	ldr r11, [sp, #0xcc]
 	str sl, [sp, #0x14c]
 	ldr sl, [sp, #0xd0]
 	str sb, [sp, #0x150]
@@ -5318,7 +5318,7 @@ _021805ac:
 	ldr r0, [r0]
 	add r1, sp, #0xe0
 	str ip, [sp, #0x15c]
-	str fp, [sp, #0x160]
+	str r11, [sp, #0x160]
 	str sl, [sp, #0x164]
 	str sb, [sp, #0x168]
 	strb r8, [sp, #0x16c]
@@ -5335,7 +5335,7 @@ _021805ac:
 	add r0, sp, #0xe0
 	bl func_ov00_0209a508
 	add sp, sp, #0x520
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _021807e0:
 	ldr r0, _021800d8 ; =data_ov00_020eec68
 	mov r2, #0
@@ -5446,7 +5446,7 @@ _02180974:
 	ldr r0, [sp, #8]
 	str r0, [r4, #0x130]
 	add sp, sp, #0x520
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 _0218098c: .word data_027e0764
 _02180990: .word 0x00000223

--- a/asm/ov36.s
+++ b/asm/ov36.s
@@ -2145,7 +2145,7 @@ _0217da68: .word data_027e0f74
 	.global func_ov36_0217da6c
 	arm_func_start func_ov36_0217da6c
 func_ov36_0217da6c: ; 0x0217da6c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x60
 	mov r4, r0
 	bl func_ov36_02184e10
@@ -2295,10 +2295,10 @@ _0217dbac:
 	adc r0, r0, #0
 	mov r5, r5, lsr #0xc
 	orr r5, r5, r0, lsl #20
-	add fp, sp, #0x28
+	add r11, sp, #0x28
 	str r6, [sp, #0x28]
 	str r5, [sp, #0x30]
-	str fp, [sp]
+	str r11, [sp]
 	mov r0, #4
 	stmib sp, {r0, lr}
 	ldr r0, _0217dd78 ; =data_027e0ff8
@@ -2311,7 +2311,7 @@ _0217dbac:
 	str r0, [sp, #0x30]
 	mov r0, #0
 	str r0, [sp, #0x2c]
-	mov r1, fp
+	mov r1, r11
 	mov r0, #4
 	str r1, [sp]
 	str r0, [sp, #4]
@@ -2329,16 +2329,16 @@ _0217dbac:
 	ldr r0, [r4, #0x130]
 	cmp r0, #1
 	addlt sp, sp, #0x60
-	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	cmp r0, #0x16
 	addge sp, sp, #0x60
-	ldmgeia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmgeia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, _0217dd64 ; =data_027e0fc8
 	add r1, r4, #0x48
 	ldr r0, [r0]
 	bl func_ov00_020bb6d4
 	add sp, sp, #0x60
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov36_0217da6c
 _0217dd64: .word data_027e0fc8
@@ -5306,7 +5306,7 @@ func_ov36_02180660: ; 0x02180660
 	.global func_ov36_02180664
 	arm_func_start func_ov36_02180664
 func_ov36_02180664: ; 0x02180664
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0xd4
 	mov r7, r0
 	ldr r0, [r7, #0x878]
@@ -5369,7 +5369,7 @@ _02180730:
 	mov r0, r0, lsl #0x10
 	ldrsh r1, [r7, #0x78]
 	mov r6, r0, asr #0x10
-	mov fp, #0
+	mov r11, #0
 	sub r0, r1, r0, asr #16
 	mov r0, r0, lsl #0x10
 	movs r0, r0, asr #0x10
@@ -5421,7 +5421,7 @@ _02180774:
 	add r2, sp, #0xc
 	str r0, [sp, #0x14]
 	ldr r0, [r7, #8]
-	stmia sp, {r0, sb, fp}
+	stmia sp, {r0, sb, r11}
 	ldr r0, _02180994 ; =data_027e0e60
 	ldr r0, [r0]
 	bl func_01ffe1cc
@@ -5510,7 +5510,7 @@ _0218091c:
 	strb r0, [r7, #0x8a6]
 	mov r0, #1
 	add sp, sp, #0xd4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov36_02180664
 _02180980: .word data_027e0d0c
@@ -6008,7 +6008,7 @@ _02181068:
 	.global func_ov36_0218108c
 	arm_func_start func_ov36_0218108c
 func_ov36_0218108c: ; 0x0218108c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x118
 	mov r4, r0
 	ldr r2, [r4, #0x878]
@@ -6049,17 +6049,17 @@ _0218110c:
 	str r2, [r4, #0x66c]
 	bl func_ov36_0217d6bc
 	add sp, sp, #0x118
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02181128:
 	mov r0, #0
 	add sp, sp, #0x118
 	str r0, [r4, #0x138]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02181138:
 	ldr r1, [r4, #0x138]
 	cmp r1, #0x1e
 	addlt sp, sp, #0x118
-	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	bl _ZN5Actor18func_ov00_020c198cEv
 	cmp r0, #0
 	beq _0218116c
@@ -6084,7 +6084,7 @@ _02181194:
 	mvn r0, #0
 	add sp, sp, #0x118
 	str r0, [r4, #0x66c]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _021811a4:
 	ldr r1, [r4, #0x66c]
 	mvn r0, #0
@@ -6234,7 +6234,7 @@ _021811a4:
 	ldr r7, [sp, #0x58]
 	str r6, [sp, #0xd8]
 	ldr r6, [sp, #0x5c]
-	mov fp, #1
+	mov r11, #1
 	str r1, [sp, #0xdc]
 	ldr r0, [r0]
 	add r1, sp, #0x68
@@ -6247,7 +6247,7 @@ _021811a4:
 	strb ip, [sp, #0xf6]
 	strb r3, [sp, #0xf7]
 	strb r2, [sp, #0xf8]
-	strb fp, [sp, #0x7c]
+	strb r11, [sp, #0x7c]
 	strb sl, [sp, #0x7e]
 	bl func_ov00_02097810
 	str r0, [r4, #0x66c]
@@ -6256,7 +6256,7 @@ _021811a4:
 	bge _02181450
 	bl func_ov00_0209a508
 	add sp, sp, #0x118
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02181450:
 	bl func_ov00_0209a508
 _02181454:
@@ -6300,7 +6300,7 @@ _021814c8:
 	mov r1, #0x16
 	bl func_ov36_0217d6bc
 	add sp, sp, #0x118
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _021814ec:
 	ldr r0, _0218155c ; =data_027e0ffc
 	ldr r1, _02181560 ; =0x000002cb
@@ -6322,7 +6322,7 @@ _021814ec:
 	ldr r0, [r0, #4]
 	bl func_ov00_02088000
 	add sp, sp, #0x118
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov36_0218108c
 _02181540: .word data_027e0f74
@@ -6340,14 +6340,14 @@ _02181568: .word data_027e1038
 	.global func_ov36_0218156c
 	arm_func_start func_ov36_0218156c
 func_ov36_0218156c: ; 0x0218156c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x118
 	mov r4, r0
 	bl _ZN5Actor18func_ov00_020c198cEv
 	cmp r0, #0
 	addeq sp, sp, #0x118
 	mov r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	str r0, [r4, #0x12c]
 	strb r0, [r4, #0x8a7]
 	ldr r0, [r4, #0x878]
@@ -6456,7 +6456,7 @@ _0218166c:
 	ldr r7, [sp, #0x58]
 	str r6, [sp, #0xd4]
 	ldr r6, [sp, #0x5c]
-	mov fp, #1
+	mov r11, #1
 	str r1, [sp, #0xd8]
 	ldr r0, [r0]
 	add r1, sp, #0x68
@@ -6470,14 +6470,14 @@ _0218166c:
 	strb ip, [sp, #0xf6]
 	strb r3, [sp, #0xf7]
 	strb r2, [sp, #0xf8]
-	strb fp, [sp, #0x7c]
+	strb r11, [sp, #0x7c]
 	bl func_ov00_02097810
 	str r0, [r4, #0x66c]
 	add r0, sp, #0x68
 	bl func_ov00_0209a508
-	mov r0, fp
+	mov r0, r11
 	add sp, sp, #0x118
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov36_0218156c
 _02181784: .word data_ov36_02186cdc
@@ -6570,7 +6570,7 @@ _021818b0: .word data_027e0f64
 	.global func_ov36_021818b4
 	arm_func_start func_ov36_021818b4
 func_ov36_021818b4: ; 0x021818b4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x118
 	ldr r1, _02181b80 ; =data_027e103c
 	mov r4, r0
@@ -6703,7 +6703,7 @@ _021818fc:
 	ldr r7, [sp, #0x58]
 	str r6, [sp, #0xd4]
 	ldr r6, [sp, #0x5c]
-	mov fp, #1
+	mov r11, #1
 	str r1, [sp, #0xd8]
 	ldr r0, [r0]
 	add r1, sp, #0x68
@@ -6717,7 +6717,7 @@ _021818fc:
 	strb ip, [sp, #0xf6]
 	strb r3, [sp, #0xf7]
 	strb r2, [sp, #0xf8]
-	strb fp, [sp, #0x7c]
+	strb r11, [sp, #0x7c]
 	bl func_ov00_02097810
 	str r0, [r4, #0x66c]
 	ldr r1, [r4, #0x168]
@@ -6731,7 +6731,7 @@ _021818fc:
 	ldr r0, _02181b9c ; =data_027e0fc8
 	mov r1, #0
 	ldr r0, [r0]
-	mov r2, fp
+	mov r2, r11
 	ldr r3, [r0]
 	ldr r3, [r3, #0x7c]
 	blx r3
@@ -6751,7 +6751,7 @@ _02181b40:
 	bl func_ov00_0209a508
 	mov r0, #1
 	add sp, sp, #0x118
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov36_021818b4
 _02181b80: .word data_027e103c
@@ -8509,7 +8509,7 @@ _02183500: .word 0x00002aab
 	.global func_ov36_02183504
 	arm_func_start func_ov36_02183504
 func_ov36_02183504: ; 0x02183504
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x14c
 	mov r5, r0
 	ldr r1, [r5, #0x810]
@@ -8526,7 +8526,7 @@ func_ov36_02183504: ; 0x02183504
 	ldr r0, [sp, #0xc]
 	add sp, sp, #0x14c
 	str r0, [r5, #0x814]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0218354c:
 	ldr r0, _02183a08 ; =data_027e0fe4
 	add r1, r5, #0x810
@@ -8577,24 +8577,24 @@ _0218354c:
 	cmp r0, #2
 	beq _0218397c
 	add sp, sp, #0x14c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02183614:
 	mov r0, r4
 	bl func_ov14_02125038
 	cmp r0, #0
 	addeq sp, sp, #0x14c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r0, sp, #0x28
 	add r1, r4, #0x48
 	bl func_ov00_020ce2f0
 	cmp r0, #0x1000
 	addge sp, sp, #0x14c
-	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	mov r0, r5
 	bl _ZN5Actor18func_ov00_020c198cEv
 	cmp r0, #0
 	addeq sp, sp, #0x14c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r0, sp, #0x9c
 	bl func_ov00_0209a4f4
 	mvn r6, #0
@@ -8736,7 +8736,7 @@ _02183614:
 	ldr r8, [sp, #0x8c]
 	str r7, [sp, #0x110]
 	ldr r7, [sp, #0x90]
-	mov fp, #1
+	mov r11, #1
 	str r1, [sp, #0x114]
 	ldr r0, [r0]
 	add r1, sp, #0x9c
@@ -8748,14 +8748,14 @@ _02183614:
 	strb ip, [sp, #0x12a]
 	strb r3, [sp, #0x12b]
 	strb r2, [sp, #0x12c]
-	strb fp, [sp, #0xb0]
+	strb r11, [sp, #0xb0]
 	strb sl, [sp, #0xb2]
 	bl func_ov00_02097810
 	str r0, [r5, #0x66c]
 	cmp r0, #0
 	blt _021838ec
 	add r2, r5, #0x26c
-	mov r3, fp
+	mov r3, r11
 	add r1, sp, #0x28
 	mov r0, r4
 	add r2, r2, #0x400
@@ -8765,7 +8765,7 @@ _021838ec:
 	add r0, sp, #0x9c
 	bl func_ov00_0209a508
 	add sp, sp, #0x14c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _021838fc:
 	ldr r1, [r4, #0x48]
 	ldr r2, _02183a14 ; =data_027e0f64
@@ -8789,7 +8789,7 @@ _021838fc:
 	ldr r1, _02183a28 ; =0x00000333
 	cmp r0, r1
 	addge sp, sp, #0x14c
-	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r2, r5, #0x26c
 	mov r0, r4
 	add r1, r5, #0x48
@@ -8798,7 +8798,7 @@ _021838fc:
 	mov r0, #2
 	add sp, sp, #0x14c
 	strb r0, [r5, #0x8a6]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0218397c:
 	ldr r1, [r4, #0x48]
 	ldr r2, _02183a14 ; =data_027e0f64
@@ -8821,7 +8821,7 @@ _0218397c:
 	bl func_ov00_020ce2f0
 	cmp r0, #0x1000
 	addge sp, sp, #0x14c
-	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	mov r2, r6
 	strb r2, [r4, #0x118]
 	mov r0, r5
@@ -8829,13 +8829,13 @@ _0218397c:
 	strb r2, [r5, #0x8a6]
 	bl func_ov36_0217d6bc
 	add sp, sp, #0x14c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _021839f4:
 	mvn r0, #0
 	str r0, [r5, #0x810]
 	str r0, [r5, #0x814]
 	add sp, sp, #0x14c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov36_02183504
 _02183a08: .word data_027e0fe4
@@ -8956,7 +8956,7 @@ _02183b78: .word data_027e0764
 	.global func_ov36_02183b7c
 	arm_func_start func_ov36_02183b7c
 func_ov36_02183b7c: ; 0x02183b7c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x58
 	mov r6, r0
 	ldrb r2, [r6, #0x8ad]
@@ -8965,7 +8965,7 @@ func_ov36_02183b7c: ; 0x02183b7c
 	beq _02183ba4
 	bl func_ov36_021840c4
 	add sp, sp, #0x58
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02183ba4:
 	ldrb r0, [r6, #0x8a6]
 	cmp r0, #0
@@ -8977,13 +8977,13 @@ _02183ba4:
 	cmp r1, r0
 	addeq sp, sp, #0x58
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02183bd0:
 	ldr r0, [r6, #0x870]
 	cmp r0, #0
 	addne sp, sp, #0x58
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, [r5, #0x14]
 	cmp r0, #0
 	beq _02183c18
@@ -9076,7 +9076,7 @@ _02183ce8:
 	ldr ip, [r6, #0x864]
 	ldrsh r2, [r6, #0x78]
 	mov r4, r0, asr #0x10
-	mov fp, #0
+	mov r11, #0
 	rsb r0, r2, r0, asr #16
 	mov r0, r0, lsl #0x10
 	mov r0, r0, lsr #0x10
@@ -9093,7 +9093,7 @@ _02183ce8:
 	umull r2, r1, ip, r1
 	adds r2, r2, #0x800
 	rsb lr, r0, #0x3800
-	mla r1, ip, fp, r1
+	mla r1, ip, r11, r1
 	mov sb, ip, asr #0x1f
 	ldr ip, _021840a0 ; =0x0000219a
 	mov r2, r2, lsr #0xc
@@ -9108,22 +9108,22 @@ _02183ce8:
 	str r2, [sp, #0x2c]
 	umull r2, r1, r8, lr
 	adds r2, r2, #0x800
-	mla r1, r8, fp, r1
+	mla r1, r8, r11, r1
 	mov r7, r8, asr #0x1f
 	mla r1, r7, lr, r1
 	adc r1, r1, #0
 	mov r2, r2, lsr #0xc
 	orr r2, r2, r1, lsl #20
 	add r0, sp, #0x24
-	str fp, [sp, #0x28]
+	str r11, [sp, #0x28]
 	str r2, [sp, #0x24]
 	bl func_01ff9cec
 	ldr r1, [sp, #0x54]
 	add r0, r1, r0
 	cmp r0, sl
 	addlt sp, sp, #0x58
-	movlt r0, fp
-	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	movlt r0, r11
+	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, [r5, #0x14]
 	cmp r0, #0
 	beq _02183f44
@@ -9214,7 +9214,7 @@ _02183f2c:
 _02183f38:
 	add sp, sp, #0x58
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02183f44:
 	ldr r0, [r5, #0x10]
 	cmp r0, #8
@@ -9305,7 +9305,7 @@ _02184078:
 	str r0, [r6, #0x870]
 	mov r0, #1
 	add sp, sp, #0x58
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov36_02183b7c
 _0218408c: .word 0x424d5459
@@ -9332,7 +9332,7 @@ _021840c0: .word func_01fffcec
 	.global func_ov36_021840c4
 	arm_func_start func_ov36_021840c4
 func_ov36_021840c4: ; 0x021840c4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x30
 	mov r5, r1
 	ldr r1, [r5, #0x10]
@@ -9352,7 +9352,7 @@ _021840ec:
 	bl func_ov00_020ceacc
 	add sp, sp, #0x30
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02184114:
 	ldr r0, [r5, #0x14]
 	cmp r0, #0
@@ -9369,28 +9369,28 @@ _02184114:
 	bl func_ov00_020ceacc
 	add sp, sp, #0x30
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02184154:
 	add sp, sp, #0x30
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02184160:
 	ldr r0, [r6, #0x870]
 	cmp r0, #0
 	addne sp, sp, #0x30
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldrb r0, [r5]
 	cmp r0, #0
 	addeq sp, sp, #0x30
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, [r6, #0x130]
 	cmp r0, #0x13
 	cmpne r0, #0x11
 	addne sp, sp, #0x30
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r3, [r5, #0x14]
 	mov r4, #0
 	cmp r3, #0
@@ -9402,7 +9402,7 @@ _02184160:
 	cmp r1, r0
 	addlt sp, sp, #0x30
 	movlt r0, r4
-	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r1, [r3, #4]
 	ldr r0, _02184414 ; =0x41525257
 	cmp r1, r0
@@ -9432,9 +9432,9 @@ _02184160:
 	mov r0, r2, lsl #0x1
 	ldrsh r2, [r1, r0]
 	ldr r0, _0218441c ; =0x00000ccd
-	mov fp, #0
+	mov r11, #0
 	umull sb, r8, r7, r0
-	mla r8, r7, fp, r8
+	mla r8, r7, r11, r8
 	mov lr, r7, asr #0x1f
 	mla r8, lr, r0, r8
 	adds sb, sb, #0x800
@@ -9448,7 +9448,7 @@ _02184160:
 	str r7, [sp, #0x2c]
 	umull r8, r7, r2, r0
 	str r3, [sp, #0x28]
-	mla r7, r2, fp, r7
+	mla r7, r2, r11, r7
 	mov r1, r2, asr #0x1f
 	mla r7, r1, r0, r7
 	adds r1, r8, #0x800
@@ -9487,11 +9487,11 @@ _021842d4:
 	bge _0218432c
 	add sp, sp, #0x30
 	mov r0, r4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02184320:
 	add sp, sp, #0x30
 	mov r0, r4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0218432c:
 	ldr r0, [r6, #0x50]
 	ldr r2, [r6, #0x4c]
@@ -9550,7 +9550,7 @@ _021843e8:
 _021843fc:
 	mov r0, #1
 	add sp, sp, #0x30
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov36_021840c4
 _02184408: .word data_027e0ffc
@@ -10014,7 +10014,7 @@ _02184a5c:
 	.global func_ov36_02184a64
 	arm_func_start func_ov36_02184a64
 func_ov36_02184a64: ; 0x02184a64
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x118
 	ldr r2, _02184dd8 ; =data_027e0f74
 	mov r5, r0
@@ -10211,9 +10211,9 @@ _02184c94:
 	ldr r8, [sp, #0x58]
 	ldr r4, [sp, #0x5c]
 	str r1, [sp, #0xdc]
-	ldr fp, _02184dd8 ; =data_027e0f74
+	ldr r11, _02184dd8 ; =data_027e0f74
 	str r0, [sp, #0xe0]
-	ldr r0, [fp]
+	ldr r0, [r11]
 	add r1, sp, #0x68
 	str sl, [sp, #0xe4]
 	str sb, [sp, #0xe8]
@@ -10235,12 +10235,12 @@ _02184c94:
 	bl func_ov00_0209a508
 	add sp, sp, #0x118
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02184dc8:
 	bl func_ov00_0209a508
 	mov r0, #1
 	add sp, sp, #0x118
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov36_02184a64
 _02184dd8: .word data_027e0f74

--- a/asm/ov36.s
+++ b/asm/ov36.s
@@ -2145,7 +2145,7 @@ _0217da68: .word data_027e0f74
 	.global func_ov36_0217da6c
 	arm_func_start func_ov36_0217da6c
 func_ov36_0217da6c: ; 0x0217da6c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x60
 	mov r4, r0
 	bl func_ov36_02184e10
@@ -2251,7 +2251,7 @@ _0217dbac:
 	add r0, r4, #0x2c
 	add r0, r0, #0x800
 	ldrh r5, [r4, #0x78]
-	add sl, r3, #0x800
+	add r10, r3, #0x800
 	ldmia r0, {r0, r1, r2}
 	mov r3, r5, asr #0x4
 	mov r5, r3, lsl #0x1
@@ -2266,7 +2266,7 @@ _0217dbac:
 	add sb, sp, #0x3c
 	ldrsh r8, [r1, r2]
 	sub lr, r0, #5
-	ldmia sl, {r0, r1, r2}
+	ldmia r10, {r0, r1, r2}
 	stmia sb, {r0, r1, r2}
 	mov r2, sb
 	ldr sb, [r4, #0x864]
@@ -2276,12 +2276,12 @@ _0217dbac:
 	str r1, [sp, #0x34]
 	ldr ip, _0217dd74 ; =0x0000099a
 	str r5, [sp, #0x38]
-	umull sl, r5, sb, ip
+	umull r10, r5, sb, ip
 	mla r5, sb, r6, r5
 	mov r0, sb, asr #0x1f
 	str r6, [sp, #0x2c]
 	mla r5, r0, ip, r5
-	adds r6, sl, #0x800
+	adds r6, r10, #0x800
 	adc r0, r5, #0
 	mov r5, r6, lsr #0xc
 	orr r5, r5, r0, lsl #20
@@ -2329,16 +2329,16 @@ _0217dbac:
 	ldr r0, [r4, #0x130]
 	cmp r0, #1
 	addlt sp, sp, #0x60
-	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	cmp r0, #0x16
 	addge sp, sp, #0x60
-	ldmgeia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmgeia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, _0217dd64 ; =data_027e0fc8
 	add r1, r4, #0x48
 	ldr r0, [r0]
 	bl func_ov00_020bb6d4
 	add sp, sp, #0x60
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov36_0217da6c
 _0217dd64: .word data_027e0fc8
@@ -5306,7 +5306,7 @@ func_ov36_02180660: ; 0x02180660
 	.global func_ov36_02180664
 	arm_func_start func_ov36_02180664
 func_ov36_02180664: ; 0x02180664
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0xd4
 	mov r7, r0
 	ldr r0, [r7, #0x878]
@@ -5361,7 +5361,7 @@ _021806cc:
 	b _02180860
 _02180730:
 	ldrsh r1, [r7, #0x78]
-	ldr sl, _0218098c ; =data_02050f54
+	ldr r10, _0218098c ; =data_02050f54
 	mov sb, #5
 	strh r1, [r0, #0x9c]
 	add r0, r1, #0x2000
@@ -5387,8 +5387,8 @@ _02180774:
 	str r3, [sp, #0x1c]
 	mov r3, r0, lsl #0x1
 	mov r0, r3, lsl #0x1
-	ldrsh lr, [sl, r0]
-	add r0, sl, r3, lsl #1
+	ldrsh lr, [r10, r0]
+	add r0, r10, r3, lsl #1
 	ldrsh ip, [r0, #2]
 	mov r0, lr, asr #0x1f
 	mov r0, r0, lsl #0xe
@@ -5510,7 +5510,7 @@ _0218091c:
 	strb r0, [r7, #0x8a6]
 	mov r0, #1
 	add sp, sp, #0xd4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov36_02180664
 _02180980: .word data_027e0d0c
@@ -6008,7 +6008,7 @@ _02181068:
 	.global func_ov36_0218108c
 	arm_func_start func_ov36_0218108c
 func_ov36_0218108c: ; 0x0218108c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x118
 	mov r4, r0
 	ldr r2, [r4, #0x878]
@@ -6049,17 +6049,17 @@ _0218110c:
 	str r2, [r4, #0x66c]
 	bl func_ov36_0217d6bc
 	add sp, sp, #0x118
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02181128:
 	mov r0, #0
 	add sp, sp, #0x118
 	str r0, [r4, #0x138]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02181138:
 	ldr r1, [r4, #0x138]
 	cmp r1, #0x1e
 	addlt sp, sp, #0x118
-	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	bl _ZN5Actor18func_ov00_020c198cEv
 	cmp r0, #0
 	beq _0218116c
@@ -6084,7 +6084,7 @@ _02181194:
 	mvn r0, #0
 	add sp, sp, #0x118
 	str r0, [r4, #0x66c]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _021811a4:
 	ldr r1, [r4, #0x66c]
 	mvn r0, #0
@@ -6115,18 +6115,18 @@ _021811a4:
 	str r2, [sp, #0x90]
 	ldr r0, [r0, #4]
 	bl func_ov00_02087d34
-	mov sl, #0
+	mov r10, #0
 	ldr r3, _0218154c ; =0x000004cd
 	ldr r2, _02181550 ; =0x00001e84
 	ldr r1, _02181554 ; =0x0000038e
 	mov r5, #0x19000
 	ldr r0, [sp]
 	str r5, [sp, #0x18]
-	str sl, [sp, #0x24]
+	str r10, [sp, #0x24]
 	str r3, [sp, #0x20]
-	str sl, [sp, #0x1c]
+	str r10, [sp, #0x1c]
 	str r2, [sp, #0x10]
-	str sl, [sp, #0x14]
+	str r10, [sp, #0x14]
 	str r1, [sp, #0xc]
 	str r0, [r4, #0x6e4]
 	ldr r0, [sp, #4]
@@ -6248,7 +6248,7 @@ _021811a4:
 	strb r3, [sp, #0xf7]
 	strb r2, [sp, #0xf8]
 	strb r11, [sp, #0x7c]
-	strb sl, [sp, #0x7e]
+	strb r10, [sp, #0x7e]
 	bl func_ov00_02097810
 	str r0, [r4, #0x66c]
 	cmp r0, #0
@@ -6256,7 +6256,7 @@ _021811a4:
 	bge _02181450
 	bl func_ov00_0209a508
 	add sp, sp, #0x118
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02181450:
 	bl func_ov00_0209a508
 _02181454:
@@ -6300,7 +6300,7 @@ _021814c8:
 	mov r1, #0x16
 	bl func_ov36_0217d6bc
 	add sp, sp, #0x118
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _021814ec:
 	ldr r0, _0218155c ; =data_027e0ffc
 	ldr r1, _02181560 ; =0x000002cb
@@ -6322,7 +6322,7 @@ _021814ec:
 	ldr r0, [r0, #4]
 	bl func_ov00_02088000
 	add sp, sp, #0x118
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov36_0218108c
 _02181540: .word data_027e0f74
@@ -6340,14 +6340,14 @@ _02181568: .word data_027e1038
 	.global func_ov36_0218156c
 	arm_func_start func_ov36_0218156c
 func_ov36_0218156c: ; 0x0218156c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x118
 	mov r4, r0
 	bl _ZN5Actor18func_ov00_020c198cEv
 	cmp r0, #0
 	addeq sp, sp, #0x118
 	mov r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	str r0, [r4, #0x12c]
 	strb r0, [r4, #0x8a7]
 	ldr r0, [r4, #0x878]
@@ -6415,7 +6415,7 @@ _0218166c:
 	str r0, [sp, #0xa4]
 	ldr r0, [sp, #0x2c]
 	ldr r1, [sp, #0xc]
-	ldr sl, [sp, #0x14]
+	ldr r10, [sp, #0x14]
 	ldr sb, [sp, #0x18]
 	str r8, [sp, #0x94]
 	ldr r8, [sp, #0x1c]
@@ -6427,8 +6427,8 @@ _0218166c:
 	ldr r0, [sp, #0x48]
 	str r1, [sp, #0xa0]
 	ldr r1, [sp, #0x28]
-	str sl, [sp, #0xa8]
-	ldr sl, [sp, #0x30]
+	str r10, [sp, #0xa8]
+	ldr r10, [sp, #0x30]
 	str sb, [sp, #0xac]
 	ldr sb, [sp, #0x34]
 	str r8, [sp, #0xb0]
@@ -6446,8 +6446,8 @@ _0218166c:
 	ldr r0, _0218178c ; =data_027e0f74
 	str r1, [sp, #0xbc]
 	ldr r1, [sp, #0x44]
-	str sl, [sp, #0xc4]
-	ldr sl, [sp, #0x4c]
+	str r10, [sp, #0xc4]
+	ldr r10, [sp, #0x4c]
 	str sb, [sp, #0xc8]
 	ldr sb, [sp, #0x50]
 	str r8, [sp, #0xcc]
@@ -6460,7 +6460,7 @@ _0218166c:
 	str r1, [sp, #0xd8]
 	ldr r0, [r0]
 	add r1, sp, #0x68
-	str sl, [sp, #0xe0]
+	str r10, [sp, #0xe0]
 	str sb, [sp, #0xe4]
 	str r8, [sp, #0xe8]
 	str r7, [sp, #0xec]
@@ -6477,7 +6477,7 @@ _0218166c:
 	bl func_ov00_0209a508
 	mov r0, r11
 	add sp, sp, #0x118
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov36_0218156c
 _02181784: .word data_ov36_02186cdc
@@ -6570,7 +6570,7 @@ _021818b0: .word data_027e0f64
 	.global func_ov36_021818b4
 	arm_func_start func_ov36_021818b4
 func_ov36_021818b4: ; 0x021818b4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x118
 	ldr r1, _02181b80 ; =data_027e103c
 	mov r4, r0
@@ -6697,7 +6697,7 @@ _021818fc:
 	str r0, [sp, #0xdc]
 	ldr r0, _02181b88 ; =data_027e0f74
 	ldr r1, [sp, #0x44]
-	ldr sl, [sp, #0x4c]
+	ldr r10, [sp, #0x4c]
 	ldr sb, [sp, #0x50]
 	ldr r8, [sp, #0x54]
 	ldr r7, [sp, #0x58]
@@ -6707,7 +6707,7 @@ _021818fc:
 	str r1, [sp, #0xd8]
 	ldr r0, [r0]
 	add r1, sp, #0x68
-	str sl, [sp, #0xe0]
+	str r10, [sp, #0xe0]
 	str sb, [sp, #0xe4]
 	str r8, [sp, #0xe8]
 	str r7, [sp, #0xec]
@@ -6751,7 +6751,7 @@ _02181b40:
 	bl func_ov00_0209a508
 	mov r0, #1
 	add sp, sp, #0x118
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov36_021818b4
 _02181b80: .word data_027e103c
@@ -7706,7 +7706,7 @@ _0218298c: .word data_027e0e60
 	.global func_ov36_02182990
 	arm_func_start func_ov36_02182990
 func_ov36_02182990: ; 0x02182990
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #0x124
 	ldr r1, _02182c64 ; =data_027e0e60
 	mov r4, r0
@@ -7859,14 +7859,14 @@ _02182a7c:
 	ldrb ip, [sp, #0x6f]
 	ldrb r3, [sp, #0x70]
 	ldr r0, _02182c7c ; =data_027e0f74
-	ldr sl, [sp, #0x5c]
+	ldr r10, [sp, #0x5c]
 	ldr sb, [sp, #0x60]
 	ldr r8, [sp, #0x64]
 	ldr r7, [sp, #0x68]
 	mov r2, #1
 	ldr r0, [r0]
 	add r1, sp, #0x74
-	str sl, [sp, #0xf0]
+	str r10, [sp, #0xf0]
 	str sb, [sp, #0xf4]
 	str r8, [sp, #0xf8]
 	str r7, [sp, #0xfc]
@@ -7889,7 +7889,7 @@ _02182a7c:
 	bl func_ov00_0209a508
 	mov r0, #1
 	add sp, sp, #0x124
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov36_02182990
 _02182c64: .word data_027e0e60
@@ -8509,7 +8509,7 @@ _02183500: .word 0x00002aab
 	.global func_ov36_02183504
 	arm_func_start func_ov36_02183504
 func_ov36_02183504: ; 0x02183504
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x14c
 	mov r5, r0
 	ldr r1, [r5, #0x810]
@@ -8526,7 +8526,7 @@ func_ov36_02183504: ; 0x02183504
 	ldr r0, [sp, #0xc]
 	add sp, sp, #0x14c
 	str r0, [r5, #0x814]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0218354c:
 	ldr r0, _02183a08 ; =data_027e0fe4
 	add r1, r5, #0x810
@@ -8577,24 +8577,24 @@ _0218354c:
 	cmp r0, #2
 	beq _0218397c
 	add sp, sp, #0x14c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02183614:
 	mov r0, r4
 	bl func_ov14_02125038
 	cmp r0, #0
 	addeq sp, sp, #0x14c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	add r0, sp, #0x28
 	add r1, r4, #0x48
 	bl func_ov00_020ce2f0
 	cmp r0, #0x1000
 	addge sp, sp, #0x14c
-	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	mov r0, r5
 	bl _ZN5Actor18func_ov00_020c198cEv
 	cmp r0, #0
 	addeq sp, sp, #0x14c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	add r0, sp, #0x9c
 	bl func_ov00_0209a4f4
 	mvn r6, #0
@@ -8616,18 +8616,18 @@ _02183614:
 	str r2, [sp, #0xc4]
 	ldr r0, [r0, #4]
 	bl func_ov00_02087d34
-	mov sl, #0
+	mov r10, #0
 	ldr r3, _02183a18 ; =0x000004cd
 	ldr r2, _02183a1c ; =0x00001e84
 	ldr r1, _02183a20 ; =0x0000038e
 	mov r6, #0x19000
 	ldr r0, [sp, #0x34]
 	str r6, [sp, #0x4c]
-	str sl, [sp, #0x58]
+	str r10, [sp, #0x58]
 	str r3, [sp, #0x54]
-	str sl, [sp, #0x50]
+	str r10, [sp, #0x50]
 	str r2, [sp, #0x44]
-	str sl, [sp, #0x48]
+	str r10, [sp, #0x48]
 	str r1, [sp, #0x40]
 	str r0, [r5, #0x6e4]
 	ldr r0, [sp, #0x38]
@@ -8749,7 +8749,7 @@ _02183614:
 	strb r3, [sp, #0x12b]
 	strb r2, [sp, #0x12c]
 	strb r11, [sp, #0xb0]
-	strb sl, [sp, #0xb2]
+	strb r10, [sp, #0xb2]
 	bl func_ov00_02097810
 	str r0, [r5, #0x66c]
 	cmp r0, #0
@@ -8765,7 +8765,7 @@ _021838ec:
 	add r0, sp, #0x9c
 	bl func_ov00_0209a508
 	add sp, sp, #0x14c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _021838fc:
 	ldr r1, [r4, #0x48]
 	ldr r2, _02183a14 ; =data_027e0f64
@@ -8789,7 +8789,7 @@ _021838fc:
 	ldr r1, _02183a28 ; =0x00000333
 	cmp r0, r1
 	addge sp, sp, #0x14c
-	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	add r2, r5, #0x26c
 	mov r0, r4
 	add r1, r5, #0x48
@@ -8798,7 +8798,7 @@ _021838fc:
 	mov r0, #2
 	add sp, sp, #0x14c
 	strb r0, [r5, #0x8a6]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0218397c:
 	ldr r1, [r4, #0x48]
 	ldr r2, _02183a14 ; =data_027e0f64
@@ -8821,7 +8821,7 @@ _0218397c:
 	bl func_ov00_020ce2f0
 	cmp r0, #0x1000
 	addge sp, sp, #0x14c
-	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	mov r2, r6
 	strb r2, [r4, #0x118]
 	mov r0, r5
@@ -8829,13 +8829,13 @@ _0218397c:
 	strb r2, [r5, #0x8a6]
 	bl func_ov36_0217d6bc
 	add sp, sp, #0x14c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _021839f4:
 	mvn r0, #0
 	str r0, [r5, #0x810]
 	str r0, [r5, #0x814]
 	add sp, sp, #0x14c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov36_02183504
 _02183a08: .word data_027e0fe4
@@ -8956,7 +8956,7 @@ _02183b78: .word data_027e0764
 	.global func_ov36_02183b7c
 	arm_func_start func_ov36_02183b7c
 func_ov36_02183b7c: ; 0x02183b7c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x58
 	mov r6, r0
 	ldrb r2, [r6, #0x8ad]
@@ -8965,7 +8965,7 @@ func_ov36_02183b7c: ; 0x02183b7c
 	beq _02183ba4
 	bl func_ov36_021840c4
 	add sp, sp, #0x58
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02183ba4:
 	ldrb r0, [r6, #0x8a6]
 	cmp r0, #0
@@ -8977,13 +8977,13 @@ _02183ba4:
 	cmp r1, r0
 	addeq sp, sp, #0x58
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02183bd0:
 	ldr r0, [r6, #0x870]
 	cmp r0, #0
 	addne sp, sp, #0x58
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, [r5, #0x14]
 	cmp r0, #0
 	beq _02183c18
@@ -9064,7 +9064,7 @@ _02183ce8:
 	add r1, sp, #0x48
 	mov r0, r3
 	bl func_ov00_020ce2f0
-	mov sl, r0
+	mov r10, r0
 	add r0, sp, #0x48
 	add r1, sp, #0x3c
 	add r2, sp, #0x30
@@ -9120,10 +9120,10 @@ _02183ce8:
 	bl func_01ff9cec
 	ldr r1, [sp, #0x54]
 	add r0, r1, r0
-	cmp r0, sl
+	cmp r0, r10
 	addlt sp, sp, #0x58
 	movlt r0, r11
-	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, [r5, #0x14]
 	cmp r0, #0
 	beq _02183f44
@@ -9214,7 +9214,7 @@ _02183f2c:
 _02183f38:
 	add sp, sp, #0x58
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02183f44:
 	ldr r0, [r5, #0x10]
 	cmp r0, #8
@@ -9305,7 +9305,7 @@ _02184078:
 	str r0, [r6, #0x870]
 	mov r0, #1
 	add sp, sp, #0x58
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov36_02183b7c
 _0218408c: .word 0x424d5459
@@ -9332,7 +9332,7 @@ _021840c0: .word func_01fffcec
 	.global func_ov36_021840c4
 	arm_func_start func_ov36_021840c4
 func_ov36_021840c4: ; 0x021840c4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x30
 	mov r5, r1
 	ldr r1, [r5, #0x10]
@@ -9352,7 +9352,7 @@ _021840ec:
 	bl func_ov00_020ceacc
 	add sp, sp, #0x30
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02184114:
 	ldr r0, [r5, #0x14]
 	cmp r0, #0
@@ -9369,28 +9369,28 @@ _02184114:
 	bl func_ov00_020ceacc
 	add sp, sp, #0x30
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02184154:
 	add sp, sp, #0x30
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02184160:
 	ldr r0, [r6, #0x870]
 	cmp r0, #0
 	addne sp, sp, #0x30
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldrb r0, [r5]
 	cmp r0, #0
 	addeq sp, sp, #0x30
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, [r6, #0x130]
 	cmp r0, #0x13
 	cmpne r0, #0x11
 	addne sp, sp, #0x30
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r3, [r5, #0x14]
 	mov r4, #0
 	cmp r3, #0
@@ -9402,7 +9402,7 @@ _02184160:
 	cmp r1, r0
 	addlt sp, sp, #0x30
 	movlt r0, r4
-	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r1, [r3, #4]
 	ldr r0, _02184414 ; =0x41525257
 	cmp r1, r0
@@ -9440,11 +9440,11 @@ _02184160:
 	adds sb, sb, #0x800
 	adc r7, r8, #0
 	mov r8, sb, lsr #0xc
-	ldr sl, [r6, #0x50]
+	ldr r10, [r6, #0x50]
 	orr r8, r8, r7, lsl #20
 	ldr r3, [r6, #0x4c]
 	ldr ip, [r6, #0x48]
-	add r7, sl, r8
+	add r7, r10, r8
 	str r7, [sp, #0x2c]
 	umull r8, r7, r2, r0
 	str r3, [sp, #0x28]
@@ -9487,11 +9487,11 @@ _021842d4:
 	bge _0218432c
 	add sp, sp, #0x30
 	mov r0, r4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02184320:
 	add sp, sp, #0x30
 	mov r0, r4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0218432c:
 	ldr r0, [r6, #0x50]
 	ldr r2, [r6, #0x4c]
@@ -9550,7 +9550,7 @@ _021843e8:
 _021843fc:
 	mov r0, #1
 	add sp, sp, #0x30
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov36_021840c4
 _02184408: .word data_027e0ffc
@@ -10014,7 +10014,7 @@ _02184a5c:
 	.global func_ov36_02184a64
 	arm_func_start func_ov36_02184a64
 func_ov36_02184a64: ; 0x02184a64
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x118
 	ldr r2, _02184dd8 ; =data_027e0f74
 	mov r5, r0
@@ -10186,7 +10186,7 @@ _02184c94:
 	ldr r0, [sp, #0x38]
 	str r1, [sp, #0xb4]
 	ldr r1, [sp, #0x34]
-	ldr sl, [sp, #8]
+	ldr r10, [sp, #8]
 	str sb, [sp, #0xbc]
 	ldr sb, [sp, #0x3c]
 	str r8, [sp, #0xc0]
@@ -10202,9 +10202,9 @@ _02184c94:
 	ldrb r3, [sp, #0x64]
 	str r1, [sp, #0xc8]
 	ldr r1, [sp, #0x48]
-	str sl, [sp, #0x9c]
+	str r10, [sp, #0x9c]
 	str sb, [sp, #0xd0]
-	ldr sl, [sp, #0x50]
+	ldr r10, [sp, #0x50]
 	str r8, [sp, #0xd4]
 	ldr sb, [sp, #0x54]
 	str r4, [sp, #0xd8]
@@ -10215,7 +10215,7 @@ _02184c94:
 	str r0, [sp, #0xe0]
 	ldr r0, [r11]
 	add r1, sp, #0x68
-	str sl, [sp, #0xe4]
+	str r10, [sp, #0xe4]
 	str sb, [sp, #0xe8]
 	str r8, [sp, #0xec]
 	str r4, [sp, #0xf0]
@@ -10235,12 +10235,12 @@ _02184c94:
 	bl func_ov00_0209a508
 	add sp, sp, #0x118
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02184dc8:
 	bl func_ov00_0209a508
 	mov r0, #1
 	add sp, sp, #0x118
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov36_02184a64
 _02184dd8: .word data_027e0f74

--- a/asm/ov36.s
+++ b/asm/ov36.s
@@ -2145,7 +2145,7 @@ _0217da68: .word data_027e0f74
 	.global func_ov36_0217da6c
 	arm_func_start func_ov36_0217da6c
 func_ov36_0217da6c: ; 0x0217da6c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x60
 	mov r4, r0
 	bl func_ov36_02184e10
@@ -2263,31 +2263,31 @@ _0217dbac:
 	mov r0, r0, lsl #0x1
 	ldrsh r7, [r1, r0]
 	mov r0, #4
-	add sb, sp, #0x3c
+	add r9, sp, #0x3c
 	ldrsh r8, [r1, r2]
 	sub lr, r0, #5
 	ldmia r10, {r0, r1, r2}
-	stmia sb, {r0, r1, r2}
-	mov r2, sb
-	ldr sb, [r4, #0x864]
+	stmia r9, {r0, r1, r2}
+	mov r2, r9
+	ldr r9, [r4, #0x864]
 	ldr r1, [r4, #0x860]
 	mov r6, #0
 	mov r5, #0x5000
 	str r1, [sp, #0x34]
 	ldr ip, _0217dd74 ; =0x0000099a
 	str r5, [sp, #0x38]
-	umull r10, r5, sb, ip
-	mla r5, sb, r6, r5
-	mov r0, sb, asr #0x1f
+	umull r10, r5, r9, ip
+	mla r5, r9, r6, r5
+	mov r0, r9, asr #0x1f
 	str r6, [sp, #0x2c]
 	mla r5, r0, ip, r5
 	adds r6, r10, #0x800
 	adc r0, r5, #0
 	mov r5, r6, lsr #0xc
 	orr r5, r5, r0, lsl #20
-	smull sb, r6, r8, r5
+	smull r9, r6, r8, r5
 	smull r5, r0, r7, r5
-	adds r8, sb, #0x800
+	adds r8, r9, #0x800
 	adc r7, r6, #0
 	adds r5, r5, #0x800
 	mov r6, r8, lsr #0xc
@@ -2329,16 +2329,16 @@ _0217dbac:
 	ldr r0, [r4, #0x130]
 	cmp r0, #1
 	addlt sp, sp, #0x60
-	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmltia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	cmp r0, #0x16
 	addge sp, sp, #0x60
-	ldmgeia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmgeia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, _0217dd64 ; =data_027e0fc8
 	add r1, r4, #0x48
 	ldr r0, [r0]
 	bl func_ov00_020bb6d4
 	add sp, sp, #0x60
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov36_0217da6c
 _0217dd64: .word data_027e0fc8
@@ -5306,7 +5306,7 @@ func_ov36_02180660: ; 0x02180660
 	.global func_ov36_02180664
 	arm_func_start func_ov36_02180664
 func_ov36_02180664: ; 0x02180664
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0xd4
 	mov r7, r0
 	ldr r0, [r7, #0x878]
@@ -5362,7 +5362,7 @@ _021806cc:
 _02180730:
 	ldrsh r1, [r7, #0x78]
 	ldr r10, _0218098c ; =data_02050f54
-	mov sb, #5
+	mov r9, #5
 	strh r1, [r0, #0x9c]
 	add r0, r1, #0x2000
 	and r0, r0, #0xc000
@@ -5421,7 +5421,7 @@ _02180774:
 	add r2, sp, #0xc
 	str r0, [sp, #0x14]
 	ldr r0, [r7, #8]
-	stmia sp, {r0, sb, r11}
+	stmia sp, {r0, r9, r11}
 	ldr r0, _02180994 ; =data_027e0e60
 	ldr r0, [r0]
 	bl func_01ffe1cc
@@ -5510,7 +5510,7 @@ _0218091c:
 	strb r0, [r7, #0x8a6]
 	mov r0, #1
 	add sp, sp, #0xd4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov36_02180664
 _02180980: .word data_027e0d0c
@@ -6008,7 +6008,7 @@ _02181068:
 	.global func_ov36_0218108c
 	arm_func_start func_ov36_0218108c
 func_ov36_0218108c: ; 0x0218108c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x118
 	mov r4, r0
 	ldr r2, [r4, #0x878]
@@ -6049,17 +6049,17 @@ _0218110c:
 	str r2, [r4, #0x66c]
 	bl func_ov36_0217d6bc
 	add sp, sp, #0x118
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02181128:
 	mov r0, #0
 	add sp, sp, #0x118
 	str r0, [r4, #0x138]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02181138:
 	ldr r1, [r4, #0x138]
 	cmp r1, #0x1e
 	addlt sp, sp, #0x118
-	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmltia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	bl _ZN5Actor18func_ov00_020c198cEv
 	cmp r0, #0
 	beq _0218116c
@@ -6084,7 +6084,7 @@ _02181194:
 	mvn r0, #0
 	add sp, sp, #0x118
 	str r0, [r4, #0x66c]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _021811a4:
 	ldr r1, [r4, #0x66c]
 	mvn r0, #0
@@ -6198,7 +6198,7 @@ _021811a4:
 	str r0, [sp, #0xb0]
 	ldr r0, [sp, #0x34]
 	ldr r1, [sp, #0x18]
-	ldr sb, [sp, #0x20]
+	ldr r9, [sp, #0x20]
 	str r8, [sp, #0xa0]
 	ldr r8, [sp, #0x24]
 	str r7, [sp, #0xa4]
@@ -6209,8 +6209,8 @@ _021811a4:
 	ldr r0, [sp, #0x4c]
 	str r1, [sp, #0xac]
 	ldr r1, [sp, #0x30]
-	str sb, [sp, #0xb4]
-	ldr sb, [sp, #0x38]
+	str r9, [sp, #0xb4]
+	ldr r9, [sp, #0x38]
 	str r8, [sp, #0xb8]
 	ldr r8, [sp, #0x3c]
 	str r7, [sp, #0xbc]
@@ -6226,8 +6226,8 @@ _021811a4:
 	ldr r0, _02181540 ; =data_027e0f74
 	str r1, [sp, #0xc4]
 	ldr r1, [sp, #0x48]
-	str sb, [sp, #0xcc]
-	ldr sb, [sp, #0x50]
+	str r9, [sp, #0xcc]
+	ldr r9, [sp, #0x50]
 	str r8, [sp, #0xd0]
 	ldr r8, [sp, #0x54]
 	str r7, [sp, #0xd4]
@@ -6238,7 +6238,7 @@ _021811a4:
 	str r1, [sp, #0xdc]
 	ldr r0, [r0]
 	add r1, sp, #0x68
-	str sb, [sp, #0xe4]
+	str r9, [sp, #0xe4]
 	str r8, [sp, #0xe8]
 	str r7, [sp, #0xec]
 	str r6, [sp, #0xf0]
@@ -6256,7 +6256,7 @@ _021811a4:
 	bge _02181450
 	bl func_ov00_0209a508
 	add sp, sp, #0x118
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02181450:
 	bl func_ov00_0209a508
 _02181454:
@@ -6300,7 +6300,7 @@ _021814c8:
 	mov r1, #0x16
 	bl func_ov36_0217d6bc
 	add sp, sp, #0x118
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _021814ec:
 	ldr r0, _0218155c ; =data_027e0ffc
 	ldr r1, _02181560 ; =0x000002cb
@@ -6322,7 +6322,7 @@ _021814ec:
 	ldr r0, [r0, #4]
 	bl func_ov00_02088000
 	add sp, sp, #0x118
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov36_0218108c
 _02181540: .word data_027e0f74
@@ -6340,14 +6340,14 @@ _02181568: .word data_027e1038
 	.global func_ov36_0218156c
 	arm_func_start func_ov36_0218156c
 func_ov36_0218156c: ; 0x0218156c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x118
 	mov r4, r0
 	bl _ZN5Actor18func_ov00_020c198cEv
 	cmp r0, #0
 	addeq sp, sp, #0x118
 	mov r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	str r0, [r4, #0x12c]
 	strb r0, [r4, #0x8a7]
 	ldr r0, [r4, #0x878]
@@ -6416,7 +6416,7 @@ _0218166c:
 	ldr r0, [sp, #0x2c]
 	ldr r1, [sp, #0xc]
 	ldr r10, [sp, #0x14]
-	ldr sb, [sp, #0x18]
+	ldr r9, [sp, #0x18]
 	str r8, [sp, #0x94]
 	ldr r8, [sp, #0x1c]
 	str r7, [sp, #0x98]
@@ -6429,8 +6429,8 @@ _0218166c:
 	ldr r1, [sp, #0x28]
 	str r10, [sp, #0xa8]
 	ldr r10, [sp, #0x30]
-	str sb, [sp, #0xac]
-	ldr sb, [sp, #0x34]
+	str r9, [sp, #0xac]
+	ldr r9, [sp, #0x34]
 	str r8, [sp, #0xb0]
 	ldr r8, [sp, #0x38]
 	str r7, [sp, #0xb4]
@@ -6448,8 +6448,8 @@ _0218166c:
 	ldr r1, [sp, #0x44]
 	str r10, [sp, #0xc4]
 	ldr r10, [sp, #0x4c]
-	str sb, [sp, #0xc8]
-	ldr sb, [sp, #0x50]
+	str r9, [sp, #0xc8]
+	ldr r9, [sp, #0x50]
 	str r8, [sp, #0xcc]
 	ldr r8, [sp, #0x54]
 	str r7, [sp, #0xd0]
@@ -6461,7 +6461,7 @@ _0218166c:
 	ldr r0, [r0]
 	add r1, sp, #0x68
 	str r10, [sp, #0xe0]
-	str sb, [sp, #0xe4]
+	str r9, [sp, #0xe4]
 	str r8, [sp, #0xe8]
 	str r7, [sp, #0xec]
 	str r6, [sp, #0xf0]
@@ -6477,7 +6477,7 @@ _0218166c:
 	bl func_ov00_0209a508
 	mov r0, r11
 	add sp, sp, #0x118
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov36_0218156c
 _02181784: .word data_ov36_02186cdc
@@ -6570,7 +6570,7 @@ _021818b0: .word data_027e0f64
 	.global func_ov36_021818b4
 	arm_func_start func_ov36_021818b4
 func_ov36_021818b4: ; 0x021818b4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x118
 	ldr r1, _02181b80 ; =data_027e103c
 	mov r4, r0
@@ -6698,7 +6698,7 @@ _021818fc:
 	ldr r0, _02181b88 ; =data_027e0f74
 	ldr r1, [sp, #0x44]
 	ldr r10, [sp, #0x4c]
-	ldr sb, [sp, #0x50]
+	ldr r9, [sp, #0x50]
 	ldr r8, [sp, #0x54]
 	ldr r7, [sp, #0x58]
 	str r6, [sp, #0xd4]
@@ -6708,7 +6708,7 @@ _021818fc:
 	ldr r0, [r0]
 	add r1, sp, #0x68
 	str r10, [sp, #0xe0]
-	str sb, [sp, #0xe4]
+	str r9, [sp, #0xe4]
 	str r8, [sp, #0xe8]
 	str r7, [sp, #0xec]
 	str r6, [sp, #0xf0]
@@ -6751,7 +6751,7 @@ _02181b40:
 	bl func_ov00_0209a508
 	mov r0, #1
 	add sp, sp, #0x118
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov36_021818b4
 _02181b80: .word data_027e103c
@@ -7053,7 +7053,7 @@ _02181fcc: .word data_027e0f64
 	.global func_ov36_02181fd0
 	arm_func_start func_ov36_02181fd0
 func_ov36_02181fd0: ; 0x02181fd0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x228
 	mov r4, r0
 	ldrb r0, [r4, #0x8aa]
@@ -7230,7 +7230,7 @@ _02182270:
 	bl func_ov00_02097b9c
 	cmp r0, #0
 	addeq sp, sp, #0x228
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	ldr r0, _0218294c ; =data_027e0f90
 	mov r1, #0
 	ldr r0, [r0]
@@ -7240,7 +7240,7 @@ _02182270:
 	mov r0, #0
 	add sp, sp, #0x228
 	str r0, [r4, #0x138]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _021822b4:
 	ldr r0, [r4, #0x138]
 	ldr r1, [r4, #0x50]
@@ -7310,13 +7310,13 @@ _02182364:
 	ldr r0, [r4, #0x138]
 	cmp r0, #0x3c
 	addlt sp, sp, #0x228
-	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmltia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	mov r0, #2
 	strb r0, [r4, #0x8aa]
 	mov r0, #0
 	add sp, sp, #0x228
 	str r0, [r4, #0x138]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _021823d4:
 	ldr r0, [r4, #0x138]
 	cmp r0, #0xf
@@ -7328,7 +7328,7 @@ _021823ec:
 	ldr r0, [r4, #0x138]
 	cmp r0, #0x1e
 	addlt sp, sp, #0x228
-	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmltia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	ldr r0, _0218295c ; =data_ov00_020eec68
 	mov r1, #0xca
 	mov r2, #0
@@ -7412,7 +7412,7 @@ _0218248c:
 	ldr r5, [sp, #0xb0]
 	str r1, [sp, #0x140]
 	ldr r1, [sp, #0xb4]
-	ldrb sb, [sp, #0xc1]
+	ldrb r9, [sp, #0xc1]
 	ldrb r8, [sp, #0xc2]
 	ldrb r7, [sp, #0xc3]
 	ldrb r6, [sp, #0xc4]
@@ -7426,7 +7426,7 @@ _0218248c:
 	str r1, [sp, #0x150]
 	ldr r0, [r0]
 	add r1, sp, #0xc8
-	strb sb, [sp, #0x155]
+	strb r9, [sp, #0x155]
 	str lr, [sp, #0x6c]
 	str ip, [sp, #0x70]
 	str r3, [sp, #0x74]
@@ -7458,7 +7458,7 @@ _021825dc:
 	str r1, [r4, #0x878]
 	bl func_ov00_0209a508
 	add sp, sp, #0x228
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _021825f8:
 	ldr r0, [r4, #0x878]
 	tst r0, #0x200000
@@ -7468,7 +7468,7 @@ _021825f8:
 	bl func_0202e58c
 	cmp r0, #0
 	addeq sp, sp, #0x228
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	add r0, r4, #0x158
 	mov r1, #0x1f
 	bl func_ov36_0217c958
@@ -7482,7 +7482,7 @@ _021825f8:
 	mov r1, #5
 	strh r1, [r0, #0x7c]
 	add sp, sp, #0x228
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _02182654:
 	mov r1, #0x6f000
 	add r0, r0, #0xc
@@ -7633,7 +7633,7 @@ _0218287c:
 	bl func_0202e58c
 	cmp r0, #0
 	addeq sp, sp, #0x228
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	ldr r0, _02182948 ; =data_027e0f74
 	ldr r1, [r4, #0x66c]
 	ldr r0, [r0]
@@ -7681,7 +7681,7 @@ _02182934:
 	bl func_ov36_0217d6bc
 _02182940:
 	add sp, sp, #0x228
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov36_02181fd0
 _02182948: .word data_027e0f74
@@ -7706,7 +7706,7 @@ _0218298c: .word data_027e0e60
 	.global func_ov36_02182990
 	arm_func_start func_ov36_02182990
 func_ov36_02182990: ; 0x02182990
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #0x124
 	ldr r1, _02182c64 ; =data_027e0e60
 	mov r4, r0
@@ -7860,14 +7860,14 @@ _02182a7c:
 	ldrb r3, [sp, #0x70]
 	ldr r0, _02182c7c ; =data_027e0f74
 	ldr r10, [sp, #0x5c]
-	ldr sb, [sp, #0x60]
+	ldr r9, [sp, #0x60]
 	ldr r8, [sp, #0x64]
 	ldr r7, [sp, #0x68]
 	mov r2, #1
 	ldr r0, [r0]
 	add r1, sp, #0x74
 	str r10, [sp, #0xf0]
-	str sb, [sp, #0xf4]
+	str r9, [sp, #0xf4]
 	str r8, [sp, #0xf8]
 	str r7, [sp, #0xfc]
 	strb r6, [sp, #0x100]
@@ -7889,7 +7889,7 @@ _02182a7c:
 	bl func_ov00_0209a508
 	mov r0, #1
 	add sp, sp, #0x124
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov36_02182990
 _02182c64: .word data_027e0e60
@@ -8509,7 +8509,7 @@ _02183500: .word 0x00002aab
 	.global func_ov36_02183504
 	arm_func_start func_ov36_02183504
 func_ov36_02183504: ; 0x02183504
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x14c
 	mov r5, r0
 	ldr r1, [r5, #0x810]
@@ -8526,7 +8526,7 @@ func_ov36_02183504: ; 0x02183504
 	ldr r0, [sp, #0xc]
 	add sp, sp, #0x14c
 	str r0, [r5, #0x814]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0218354c:
 	ldr r0, _02183a08 ; =data_027e0fe4
 	add r1, r5, #0x810
@@ -8577,24 +8577,24 @@ _0218354c:
 	cmp r0, #2
 	beq _0218397c
 	add sp, sp, #0x14c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02183614:
 	mov r0, r4
 	bl func_ov14_02125038
 	cmp r0, #0
 	addeq sp, sp, #0x14c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r0, sp, #0x28
 	add r1, r4, #0x48
 	bl func_ov00_020ce2f0
 	cmp r0, #0x1000
 	addge sp, sp, #0x14c
-	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmgeia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	mov r0, r5
 	bl _ZN5Actor18func_ov00_020c198cEv
 	cmp r0, #0
 	addeq sp, sp, #0x14c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r0, sp, #0x9c
 	bl func_ov00_0209a4f4
 	mvn r6, #0
@@ -8696,7 +8696,7 @@ _02183614:
 	str r0, [sp, #0xdc]
 	ldr r0, [sp, #0x5c]
 	ldr r1, [sp, #0x44]
-	ldr sb, [sp, #0x4c]
+	ldr r9, [sp, #0x4c]
 	str r8, [sp, #0xd0]
 	ldr r8, [sp, #0x50]
 	str r7, [sp, #0xd4]
@@ -8705,8 +8705,8 @@ _02183614:
 	ldr r0, [sp, #0x70]
 	str r1, [sp, #0xd8]
 	ldr r1, [sp, #0x58]
-	str sb, [sp, #0xe0]
-	ldr sb, [sp, #0x60]
+	str r9, [sp, #0xe0]
+	ldr r9, [sp, #0x60]
 	str r8, [sp, #0xe4]
 	ldr r8, [sp, #0x64]
 	str r7, [sp, #0xe8]
@@ -8715,8 +8715,8 @@ _02183614:
 	ldr r0, [sp, #0x84]
 	str r1, [sp, #0xec]
 	ldr r1, [sp, #0x6c]
-	str sb, [sp, #0xf4]
-	ldr sb, [sp, #0x74]
+	str r9, [sp, #0xf4]
+	ldr r9, [sp, #0x74]
 	str r8, [sp, #0xf8]
 	ldr r8, [sp, #0x78]
 	str r7, [sp, #0xfc]
@@ -8730,8 +8730,8 @@ _02183614:
 	ldr r0, _02183a24 ; =data_027e0f74
 	str r1, [sp, #0x100]
 	ldr r1, [sp, #0x80]
-	str sb, [sp, #0x108]
-	ldr sb, [sp, #0x88]
+	str r9, [sp, #0x108]
+	ldr r9, [sp, #0x88]
 	str r8, [sp, #0x10c]
 	ldr r8, [sp, #0x8c]
 	str r7, [sp, #0x110]
@@ -8740,7 +8740,7 @@ _02183614:
 	str r1, [sp, #0x114]
 	ldr r0, [r0]
 	add r1, sp, #0x9c
-	str sb, [sp, #0x11c]
+	str r9, [sp, #0x11c]
 	str r8, [sp, #0x120]
 	str r7, [sp, #0x124]
 	strb r6, [sp, #0x128]
@@ -8765,7 +8765,7 @@ _021838ec:
 	add r0, sp, #0x9c
 	bl func_ov00_0209a508
 	add sp, sp, #0x14c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _021838fc:
 	ldr r1, [r4, #0x48]
 	ldr r2, _02183a14 ; =data_027e0f64
@@ -8789,7 +8789,7 @@ _021838fc:
 	ldr r1, _02183a28 ; =0x00000333
 	cmp r0, r1
 	addge sp, sp, #0x14c
-	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmgeia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r2, r5, #0x26c
 	mov r0, r4
 	add r1, r5, #0x48
@@ -8798,7 +8798,7 @@ _021838fc:
 	mov r0, #2
 	add sp, sp, #0x14c
 	strb r0, [r5, #0x8a6]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0218397c:
 	ldr r1, [r4, #0x48]
 	ldr r2, _02183a14 ; =data_027e0f64
@@ -8821,7 +8821,7 @@ _0218397c:
 	bl func_ov00_020ce2f0
 	cmp r0, #0x1000
 	addge sp, sp, #0x14c
-	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmgeia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	mov r2, r6
 	strb r2, [r4, #0x118]
 	mov r0, r5
@@ -8829,13 +8829,13 @@ _0218397c:
 	strb r2, [r5, #0x8a6]
 	bl func_ov36_0217d6bc
 	add sp, sp, #0x14c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _021839f4:
 	mvn r0, #0
 	str r0, [r5, #0x810]
 	str r0, [r5, #0x814]
 	add sp, sp, #0x14c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov36_02183504
 _02183a08: .word data_027e0fe4
@@ -8956,7 +8956,7 @@ _02183b78: .word data_027e0764
 	.global func_ov36_02183b7c
 	arm_func_start func_ov36_02183b7c
 func_ov36_02183b7c: ; 0x02183b7c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x58
 	mov r6, r0
 	ldrb r2, [r6, #0x8ad]
@@ -8965,7 +8965,7 @@ func_ov36_02183b7c: ; 0x02183b7c
 	beq _02183ba4
 	bl func_ov36_021840c4
 	add sp, sp, #0x58
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02183ba4:
 	ldrb r0, [r6, #0x8a6]
 	cmp r0, #0
@@ -8977,13 +8977,13 @@ _02183ba4:
 	cmp r1, r0
 	addeq sp, sp, #0x58
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02183bd0:
 	ldr r0, [r6, #0x870]
 	cmp r0, #0
 	addne sp, sp, #0x58
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, [r5, #0x14]
 	cmp r0, #0
 	beq _02183c18
@@ -9094,10 +9094,10 @@ _02183ce8:
 	adds r2, r2, #0x800
 	rsb lr, r0, #0x3800
 	mla r1, ip, r11, r1
-	mov sb, ip, asr #0x1f
+	mov r9, ip, asr #0x1f
 	ldr ip, _021840a0 ; =0x0000219a
 	mov r2, r2, lsr #0xc
-	mla r1, sb, ip, r1
+	mla r1, r9, ip, r1
 	adc r1, r1, #0
 	orr r2, r2, r1, lsl #20
 	smull r2, r1, r3, r2
@@ -9123,7 +9123,7 @@ _02183ce8:
 	cmp r0, r10
 	addlt sp, sp, #0x58
 	movlt r0, r11
-	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmltia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, [r5, #0x14]
 	cmp r0, #0
 	beq _02183f44
@@ -9214,7 +9214,7 @@ _02183f2c:
 _02183f38:
 	add sp, sp, #0x58
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02183f44:
 	ldr r0, [r5, #0x10]
 	cmp r0, #8
@@ -9305,7 +9305,7 @@ _02184078:
 	str r0, [r6, #0x870]
 	mov r0, #1
 	add sp, sp, #0x58
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov36_02183b7c
 _0218408c: .word 0x424d5459
@@ -9332,7 +9332,7 @@ _021840c0: .word func_01fffcec
 	.global func_ov36_021840c4
 	arm_func_start func_ov36_021840c4
 func_ov36_021840c4: ; 0x021840c4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x30
 	mov r5, r1
 	ldr r1, [r5, #0x10]
@@ -9352,7 +9352,7 @@ _021840ec:
 	bl func_ov00_020ceacc
 	add sp, sp, #0x30
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02184114:
 	ldr r0, [r5, #0x14]
 	cmp r0, #0
@@ -9369,28 +9369,28 @@ _02184114:
 	bl func_ov00_020ceacc
 	add sp, sp, #0x30
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02184154:
 	add sp, sp, #0x30
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02184160:
 	ldr r0, [r6, #0x870]
 	cmp r0, #0
 	addne sp, sp, #0x30
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldrb r0, [r5]
 	cmp r0, #0
 	addeq sp, sp, #0x30
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, [r6, #0x130]
 	cmp r0, #0x13
 	cmpne r0, #0x11
 	addne sp, sp, #0x30
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r3, [r5, #0x14]
 	mov r4, #0
 	cmp r3, #0
@@ -9402,7 +9402,7 @@ _02184160:
 	cmp r1, r0
 	addlt sp, sp, #0x30
 	movlt r0, r4
-	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmltia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r1, [r3, #4]
 	ldr r0, _02184414 ; =0x41525257
 	cmp r1, r0
@@ -9433,13 +9433,13 @@ _02184160:
 	ldrsh r2, [r1, r0]
 	ldr r0, _0218441c ; =0x00000ccd
 	mov r11, #0
-	umull sb, r8, r7, r0
+	umull r9, r8, r7, r0
 	mla r8, r7, r11, r8
 	mov lr, r7, asr #0x1f
 	mla r8, lr, r0, r8
-	adds sb, sb, #0x800
+	adds r9, r9, #0x800
 	adc r7, r8, #0
-	mov r8, sb, lsr #0xc
+	mov r8, r9, lsr #0xc
 	ldr r10, [r6, #0x50]
 	orr r8, r8, r7, lsl #20
 	ldr r3, [r6, #0x4c]
@@ -9487,11 +9487,11 @@ _021842d4:
 	bge _0218432c
 	add sp, sp, #0x30
 	mov r0, r4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02184320:
 	add sp, sp, #0x30
 	mov r0, r4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0218432c:
 	ldr r0, [r6, #0x50]
 	ldr r2, [r6, #0x4c]
@@ -9550,7 +9550,7 @@ _021843e8:
 _021843fc:
 	mov r0, #1
 	add sp, sp, #0x30
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov36_021840c4
 _02184408: .word data_027e0ffc
@@ -10014,7 +10014,7 @@ _02184a5c:
 	.global func_ov36_02184a64
 	arm_func_start func_ov36_02184a64
 func_ov36_02184a64: ; 0x02184a64
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x118
 	ldr r2, _02184dd8 ; =data_027e0f74
 	mov r5, r0
@@ -10160,14 +10160,14 @@ _02184c68:
 	sub r4, r4, #0xa800
 _02184c94:
 	str r0, [sp, #0x88]
-	ldr sb, [sp]
+	ldr r9, [sp]
 	ldr r8, [sp, #4]
 	ldr r0, [sp, #0x10]
 	str r1, [sp, #0x8c]
 	ldr r1, [sp, #0xc]
 	str r4, [sp, #0x90]
-	str sb, [sp, #0x94]
-	ldr sb, [sp, #0x14]
+	str r9, [sp, #0x94]
+	ldr r9, [sp, #0x14]
 	mov r2, #1
 	str r8, [sp, #0x98]
 	ldr r8, [sp, #0x18]
@@ -10176,8 +10176,8 @@ _02184c94:
 	ldr r0, [sp, #0x24]
 	str r1, [sp, #0xa0]
 	ldr r1, [sp, #0x20]
-	str sb, [sp, #0xa8]
-	ldr sb, [sp, #0x28]
+	str r9, [sp, #0xa8]
+	ldr r9, [sp, #0x28]
 	str r8, [sp, #0xac]
 	ldr r8, [sp, #0x2c]
 	str r4, [sp, #0xb0]
@@ -10187,8 +10187,8 @@ _02184c94:
 	str r1, [sp, #0xb4]
 	ldr r1, [sp, #0x34]
 	ldr r10, [sp, #8]
-	str sb, [sp, #0xbc]
-	ldr sb, [sp, #0x3c]
+	str r9, [sp, #0xbc]
+	ldr r9, [sp, #0x3c]
 	str r8, [sp, #0xc0]
 	ldr r8, [sp, #0x40]
 	str r4, [sp, #0xc4]
@@ -10203,10 +10203,10 @@ _02184c94:
 	str r1, [sp, #0xc8]
 	ldr r1, [sp, #0x48]
 	str r10, [sp, #0x9c]
-	str sb, [sp, #0xd0]
+	str r9, [sp, #0xd0]
 	ldr r10, [sp, #0x50]
 	str r8, [sp, #0xd4]
-	ldr sb, [sp, #0x54]
+	ldr r9, [sp, #0x54]
 	str r4, [sp, #0xd8]
 	ldr r8, [sp, #0x58]
 	ldr r4, [sp, #0x5c]
@@ -10216,7 +10216,7 @@ _02184c94:
 	ldr r0, [r11]
 	add r1, sp, #0x68
 	str r10, [sp, #0xe4]
-	str sb, [sp, #0xe8]
+	str r9, [sp, #0xe8]
 	str r8, [sp, #0xec]
 	str r4, [sp, #0xf0]
 	strb r7, [sp, #0xf4]
@@ -10235,12 +10235,12 @@ _02184c94:
 	bl func_ov00_0209a508
 	add sp, sp, #0x118
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02184dc8:
 	bl func_ov00_0209a508
 	mov r0, #1
 	add sp, sp, #0x118
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov36_02184a64
 _02184dd8: .word data_027e0f74

--- a/asm/ov37.s
+++ b/asm/ov37.s
@@ -890,13 +890,13 @@ _0217c920: .word data_027e0e58
 	.global func_ov37_0217c924
 	arm_func_start func_ov37_0217c924
 func_ov37_0217c924: ; 0x0217c924
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x4c
 	mov r8, r0
 	bl func_ov37_0217be60
 	cmp r0, #0
 	addeq sp, sp, #0x4c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r0, r8, #0x2000
 	ldr r0, [r0, #0xfa0]
 	cmp r0, #0
@@ -910,7 +910,7 @@ func_ov37_0217c924: ; 0x0217c924
 	ldr sb, _0217cbe0 ; =data_027e0d0c
 	add r7, r1, #0x2000
 	mov r4, #0
-	rsb fp, r0, #0
+	rsb r11, r0, #0
 _0217c978:
 	ldr r0, _0217cbe4 ; =data_027e0fe4
 	mov r1, r6
@@ -966,7 +966,7 @@ _0217c978:
 	rsb r0, r1, r0, asr #16
 	mov r0, r0, lsl #0x10
 	mov r1, r0, asr #0x10
-	cmp fp, r0, asr #16
+	cmp r11, r0, asr #16
 	ldrgt r1, _0217cbdc ; =0x00007fff
 	bgt _0217ca6c
 	cmp r1, #0
@@ -991,11 +991,11 @@ _0217ca90:
 	cmp r4, #0xa
 	blt _0217c978
 	add sp, sp, #0x4c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0217caac:
 	cmp r0, #1
 	addne sp, sp, #0x4c
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r0, r8, #0x334
 	add r7, r0, #0x2c00
 	ldr r0, _0217cbdc ; =0x00007fff
@@ -1004,7 +1004,7 @@ _0217caac:
 	add sb, r1, #0x2c00
 	mov sl, #0
 	rsb r4, r0, #0
-	mov fp, #7
+	mov r11, #7
 _0217cadc:
 	ldr r0, _0217cbe4 ; =data_027e0fe4
 	mov r1, r7
@@ -1058,7 +1058,7 @@ _0217cadc:
 	movlt r0, r0, asr #0x10
 _0217cba4:
 	cmp r0, #0x4000
-	strlt fp, [r6, #0x12c]
+	strlt r11, [r6, #0x12c]
 	movge r0, #0
 	strge r0, [r6, #0x12c]
 	b _0217cbc0
@@ -1072,7 +1072,7 @@ _0217cbc0:
 	cmp sl, #4
 	blt _0217cadc
 	add sp, sp, #0x4c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov37_0217c924
 _0217cbdc: .word 0x00007fff
@@ -4189,11 +4189,11 @@ _0217f808: .word data_02050f54
 	.global func_ov37_0217f80c
 	arm_func_start func_ov37_0217f80c
 func_ov37_0217f80c: ; 0x0217f80c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x30
 	mov sl, r0
 	add r0, sl, #0x29c
-	ldr fp, _0217f89c ; =0x4c4f4e44
+	ldr r11, _0217f89c ; =0x4c4f4e44
 	ldr r4, _0217f8a0 ; =data_027e0fe8
 	add sb, r0, #0x2c00
 	mov r8, #0
@@ -4211,7 +4211,7 @@ _0217f838:
 	str r5, [sp, #0x24]
 	bl func_ov00_020c3348
 	ldr r0, [sl, #8]
-	mov r1, fp
+	mov r1, r11
 	str r0, [sp, #0x20]
 	ldr r0, [sl, #0xc]
 	add r2, sl, #0x48
@@ -4225,7 +4225,7 @@ _0217f838:
 	cmp r8, #0xa
 	blt _0217f838
 	add sp, sp, #0x30
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov37_0217f80c
 _0217f89c: .word 0x4c4f4e44
@@ -4258,11 +4258,11 @@ _0217f8e4: .word data_027e0fe4
 	.global func_ov37_0217f8e8
 	arm_func_start func_ov37_0217f8e8
 func_ov37_0217f8e8: ; 0x0217f8e8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x30
 	mov sl, r0
 	add r0, sl, #0x334
-	ldr fp, _0217f978 ; =0x4c4f4e44
+	ldr r11, _0217f978 ; =0x4c4f4e44
 	ldr r4, _0217f97c ; =data_027e0fe8
 	add sb, r0, #0x2c00
 	mov r8, #0
@@ -4280,7 +4280,7 @@ _0217f914:
 	str r5, [sp, #0x24]
 	bl func_ov00_020c3348
 	ldr r0, [sl, #8]
-	mov r1, fp
+	mov r1, r11
 	str r0, [sp, #0x20]
 	ldr r0, [sl, #0xc]
 	add r2, sl, #0x48
@@ -4294,7 +4294,7 @@ _0217f914:
 	cmp r8, #4
 	blt _0217f914
 	add sp, sp, #0x30
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov37_0217f8e8
 _0217f978: .word 0x4c4f4e44
@@ -5934,7 +5934,7 @@ func_ov37_02180f34: ; 0x02180f34
 	.global func_ov37_02180f54
 	arm_func_start func_ov37_02180f54
 func_ov37_02180f54: ; 0x02180f54
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x314
 	mov r5, r0
 	ldr r0, [r5, #0x1c]
@@ -6083,13 +6083,13 @@ _021810fc:
 	ldr r6, [r7, #0x4c]
 	ldr r0, [sp, #0x2fc]
 	adc r3, sb, #0
-	mov fp, sl, lsr #0xc
+	mov r11, sl, lsr #0xc
 	str r6, [sp, #0x30c]
-	orr fp, fp, r3, lsl #20
+	orr r11, r11, r3, lsl #20
 	smull sl, sb, r0, r1
 	ldr r3, [r7, #0x50]
 	rsb r8, r8, #0
-	add r1, r3, fp
+	add r1, r3, r11
 	smull r7, r3, r0, r8
 	adds r8, sl, #0x800
 	adc r0, sb, #0
@@ -6150,13 +6150,13 @@ _02181204:
 	ldr r6, [r7, #0x4c]
 	ldr r0, [sp, #0x2e4]
 	adc r3, sb, #0
-	mov fp, sl, lsr #0xc
+	mov r11, sl, lsr #0xc
 	str r6, [sp, #0x2f4]
-	orr fp, fp, r3, lsl #20
+	orr r11, r11, r3, lsl #20
 	smull sl, sb, r0, r1
 	ldr r3, [r7, #0x50]
 	rsb r8, r8, #0
-	add r1, r3, fp
+	add r1, r3, r11
 	smull r7, r3, r0, r8
 	adds r8, sl, #0x800
 	adc r0, sb, #0
@@ -6226,10 +6226,10 @@ _02181388:
 	add r3, sp, #0x2c0
 	ldmia r0, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
-	ldr fp, [r5, #0x1c]
+	ldr r11, [r5, #0x1c]
 	ldr r3, _02181ee0 ; =data_02050f54
-	ldrh r2, [fp, #0x78]
-	ldr r1, [fp, #0x48]
+	ldrh r2, [r11, #0x78]
+	ldr r1, [r11, #0x48]
 	ldr r0, [sp, #0x2c8]
 	mov r2, r2, asr #0x4
 	mov r4, r2, lsl #0x1
@@ -6242,13 +6242,13 @@ _02181388:
 	smull r2, r4, r0, r6
 	adds sb, r2, #0x800
 	rsb r2, r6, #0
-	ldr ip, [fp, #0x4c]
+	ldr ip, [r11, #0x4c]
 	ldr r6, [sp, #0x2c4]
 	adc r8, r4, #0
 	add sl, ip, r6
 	smull r6, r4, r0, r7
 	str ip, [sp, #0x2d0]
-	ldr r0, [fp, #0x50]
+	ldr r0, [r11, #0x50]
 	mov sb, sb, lsr #0xc
 	adds r6, r6, #0x800
 	ldr r3, [sp, #0x2c0]
@@ -6289,10 +6289,10 @@ _02181480:
 	add r3, sp, #0x2a8
 	ldmia r0, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
-	ldr fp, [r5, #0x1c]
+	ldr r11, [r5, #0x1c]
 	ldr r3, _02181ee0 ; =data_02050f54
-	ldrh r2, [fp, #0x78]
-	ldr r1, [fp, #0x48]
+	ldrh r2, [r11, #0x78]
+	ldr r1, [r11, #0x48]
 	ldr r0, [sp, #0x2b0]
 	mov r2, r2, asr #0x4
 	mov r4, r2, lsl #0x1
@@ -6305,13 +6305,13 @@ _02181480:
 	smull r2, r4, r0, r6
 	adds sb, r2, #0x800
 	rsb r2, r6, #0
-	ldr ip, [fp, #0x4c]
+	ldr ip, [r11, #0x4c]
 	ldr r6, [sp, #0x2ac]
 	adc r8, r4, #0
 	add sl, ip, r6
 	smull r6, r4, r0, r7
 	str ip, [sp, #0x2b8]
-	ldr r0, [fp, #0x50]
+	ldr r0, [r11, #0x50]
 	mov sb, sb, lsr #0xc
 	adds r6, r6, #0x800
 	ldr r3, [sp, #0x2a8]
@@ -6352,10 +6352,10 @@ _02181578:
 	add r3, sp, #0x290
 	ldmia r0, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
-	ldr fp, [r5, #0x1c]
+	ldr r11, [r5, #0x1c]
 	ldr r3, _02181ee0 ; =data_02050f54
-	ldrh r2, [fp, #0x78]
-	ldr r1, [fp, #0x48]
+	ldrh r2, [r11, #0x78]
+	ldr r1, [r11, #0x48]
 	ldr r0, [sp, #0x298]
 	mov r2, r2, asr #0x4
 	mov r4, r2, lsl #0x1
@@ -6368,13 +6368,13 @@ _02181578:
 	smull r2, r4, r0, r6
 	adds sb, r2, #0x800
 	rsb r2, r6, #0
-	ldr ip, [fp, #0x4c]
+	ldr ip, [r11, #0x4c]
 	ldr r6, [sp, #0x294]
 	adc r8, r4, #0
 	add sl, ip, r6
 	smull r6, r4, r0, r7
 	str ip, [sp, #0x2a0]
-	ldr r0, [fp, #0x50]
+	ldr r0, [r11, #0x50]
 	mov sb, sb, lsr #0xc
 	adds r6, r6, #0x800
 	ldr r3, [sp, #0x290]
@@ -6415,10 +6415,10 @@ _02181670:
 	add r3, sp, #0x278
 	ldmia r0, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
-	ldr fp, [r5, #0x1c]
+	ldr r11, [r5, #0x1c]
 	ldr r3, _02181ee0 ; =data_02050f54
-	ldrh r2, [fp, #0x78]
-	ldr r1, [fp, #0x48]
+	ldrh r2, [r11, #0x78]
+	ldr r1, [r11, #0x48]
 	ldr r0, [sp, #0x280]
 	mov r2, r2, asr #0x4
 	mov r4, r2, lsl #0x1
@@ -6431,13 +6431,13 @@ _02181670:
 	smull r2, r4, r0, r6
 	adds sb, r2, #0x800
 	rsb r2, r6, #0
-	ldr ip, [fp, #0x4c]
+	ldr ip, [r11, #0x4c]
 	ldr r6, [sp, #0x27c]
 	adc r8, r4, #0
 	add sl, ip, r6
 	smull r6, r4, r0, r7
 	str ip, [sp, #0x288]
-	ldr r0, [fp, #0x50]
+	ldr r0, [r11, #0x50]
 	mov sb, sb, lsr #0xc
 	adds r6, r6, #0x800
 	ldr r3, [sp, #0x278]
@@ -6478,10 +6478,10 @@ _02181768:
 	add r3, sp, #0x260
 	ldmia r0, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
-	ldr fp, [r5, #0x1c]
+	ldr r11, [r5, #0x1c]
 	ldr r3, _02181ee0 ; =data_02050f54
-	ldrh r2, [fp, #0x78]
-	ldr r1, [fp, #0x48]
+	ldrh r2, [r11, #0x78]
+	ldr r1, [r11, #0x48]
 	ldr r0, [sp, #0x268]
 	mov r2, r2, asr #0x4
 	mov r4, r2, lsl #0x1
@@ -6494,13 +6494,13 @@ _02181768:
 	smull r2, r4, r0, r6
 	adds sb, r2, #0x800
 	rsb r2, r6, #0
-	ldr ip, [fp, #0x4c]
+	ldr ip, [r11, #0x4c]
 	ldr r6, [sp, #0x264]
 	adc r8, r4, #0
 	add sl, ip, r6
 	smull r6, r4, r0, r7
 	str ip, [sp, #0x270]
-	ldr r0, [fp, #0x50]
+	ldr r0, [r11, #0x50]
 	mov sb, sb, lsr #0xc
 	adds r6, r6, #0x800
 	ldr r3, [sp, #0x260]
@@ -6595,10 +6595,10 @@ _0218192c:
 	add r3, sp, #0x248
 	ldmia r0, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
-	ldr fp, [r5, #0x1c]
+	ldr r11, [r5, #0x1c]
 	ldr r3, _02181ee0 ; =data_02050f54
-	ldrh r2, [fp, #0x78]
-	ldr r1, [fp, #0x48]
+	ldrh r2, [r11, #0x78]
+	ldr r1, [r11, #0x48]
 	ldr r0, [sp, #0x250]
 	mov r2, r2, asr #0x4
 	mov r4, r2, lsl #0x1
@@ -6611,13 +6611,13 @@ _0218192c:
 	smull r2, r4, r0, r6
 	adds sb, r2, #0x800
 	rsb r2, r6, #0
-	ldr ip, [fp, #0x4c]
+	ldr ip, [r11, #0x4c]
 	ldr r6, [sp, #0x24c]
 	adc r8, r4, #0
 	add sl, ip, r6
 	smull r6, r4, r0, r7
 	str ip, [sp, #0x258]
-	ldr r0, [fp, #0x50]
+	ldr r0, [r11, #0x50]
 	mov sb, sb, lsr #0xc
 	adds r6, r6, #0x800
 	ldr r3, [sp, #0x248]
@@ -6671,10 +6671,10 @@ _02181a58:
 	add r3, sp, #0x230
 	ldmia r0, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
-	ldr fp, [r5, #0x1c]
+	ldr r11, [r5, #0x1c]
 	ldr r3, _02181ee0 ; =data_02050f54
-	ldrh r2, [fp, #0x78]
-	ldr r1, [fp, #0x48]
+	ldrh r2, [r11, #0x78]
+	ldr r1, [r11, #0x48]
 	ldr r0, [sp, #0x238]
 	mov r2, r2, asr #0x4
 	mov r4, r2, lsl #0x1
@@ -6687,13 +6687,13 @@ _02181a58:
 	smull r2, r4, r0, r6
 	adds sb, r2, #0x800
 	rsb r2, r6, #0
-	ldr ip, [fp, #0x4c]
+	ldr ip, [r11, #0x4c]
 	ldr r6, [sp, #0x234]
 	adc r8, r4, #0
 	add sl, ip, r6
 	smull r6, r4, r0, r7
 	str ip, [sp, #0x240]
-	ldr r0, [fp, #0x50]
+	ldr r0, [r11, #0x50]
 	mov sb, sb, lsr #0xc
 	adds r6, r6, #0x800
 	ldr r3, [sp, #0x230]
@@ -6866,7 +6866,7 @@ _02181d00:
 	ldr r8, [sl, #0x4c]
 	ldr r7, [sp, #0x204]
 	adds lr, r1, #0x800
-	rsb fp, r2, #0
+	rsb r11, r2, #0
 	smull r2, r1, r6, r3
 	adc r6, ip, #0
 	mov ip, lr, lsr #0xc
@@ -6880,7 +6880,7 @@ _02181d00:
 	adds r1, r6, #0x800
 	ldr r6, [sl, #0x50]
 	orr r2, r2, r8, lsl #20
-	smull sl, r8, r0, fp
+	smull sl, r8, r0, r11
 	adc r0, r3, #0
 	adds r3, sl, #0x800
 	mov sl, r1, lsr #0xc
@@ -7010,10 +7010,10 @@ _02181f70:
 	add r3, sp, #0x1dc
 	ldmia r0, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
-	ldr fp, [r5, #0x1c]
+	ldr r11, [r5, #0x1c]
 	ldr r3, _02181ee0 ; =data_02050f54
-	ldrh r2, [fp, #0x78]
-	ldr r1, [fp, #0x48]
+	ldrh r2, [r11, #0x78]
+	ldr r1, [r11, #0x48]
 	ldr r0, [sp, #0x1e4]
 	mov r2, r2, asr #0x4
 	mov r4, r2, lsl #0x1
@@ -7026,13 +7026,13 @@ _02181f70:
 	smull r2, r4, r0, r6
 	adds sb, r2, #0x800
 	rsb r2, r6, #0
-	ldr ip, [fp, #0x4c]
+	ldr ip, [r11, #0x4c]
 	ldr r6, [sp, #0x1e0]
 	adc r8, r4, #0
 	add sl, ip, r6
 	smull r6, r4, r0, r7
 	str ip, [sp, #0x1ec]
-	ldr r0, [fp, #0x50]
+	ldr r0, [r11, #0x50]
 	mov sb, sb, lsr #0xc
 	adds r6, r6, #0x800
 	ldr r3, [sp, #0x1dc]
@@ -7080,7 +7080,7 @@ _02182070:
 	ldr ip, [r5, #0x1c]
 	ldr r1, _02181ee0 ; =data_02050f54
 	ldrh r0, [ip, #0x78]
-	ldr fp, [ip, #0x48]
+	ldr r11, [ip, #0x48]
 	ldr r8, [sp, #0x1cc]
 	mov r0, r0, asr #0x4
 	mov r2, r0, lsl #0x1
@@ -7092,7 +7092,7 @@ _02182070:
 	smull r1, r6, r8, r2
 	adds r7, r1, #0x800
 	rsb lr, r2, #0
-	str fp, [sp, #0x1d0]
+	str r11, [sp, #0x1d0]
 	ldr sl, [ip, #0x4c]
 	smull r2, r1, r8, r3
 	ldr sb, [sp, #0x1c8]
@@ -7114,7 +7114,7 @@ _02182070:
 	adds r3, sl, #0x800
 	mov sl, r1, lsr #0xc
 	orr sl, sl, r0, lsl #20
-	add r7, fp, r7
+	add r7, r11, r7
 	add r7, r7, sl
 	add r0, r6, r2
 	adc r1, sb, #0
@@ -7207,10 +7207,10 @@ _02182268:
 	add r3, sp, #0x1a0
 	ldmia r0, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
-	ldr fp, [r5, #0x1c]
+	ldr r11, [r5, #0x1c]
 	ldr r3, _02181ee0 ; =data_02050f54
-	ldrh r2, [fp, #0x78]
-	ldr r1, [fp, #0x48]
+	ldrh r2, [r11, #0x78]
+	ldr r1, [r11, #0x48]
 	ldr r0, [sp, #0x1a8]
 	mov r2, r2, asr #0x4
 	mov r4, r2, lsl #0x1
@@ -7223,13 +7223,13 @@ _02182268:
 	smull r2, r4, r0, r6
 	adds sb, r2, #0x800
 	rsb r2, r6, #0
-	ldr ip, [fp, #0x4c]
+	ldr ip, [r11, #0x4c]
 	ldr r6, [sp, #0x1a4]
 	adc r8, r4, #0
 	add sl, ip, r6
 	smull r6, r4, r0, r7
 	str ip, [sp, #0x1b0]
-	ldr r0, [fp, #0x50]
+	ldr r0, [r11, #0x50]
 	mov sb, sb, lsr #0xc
 	adds r6, r6, #0x800
 	ldr r3, [sp, #0x1a0]
@@ -7426,10 +7426,10 @@ _021825a4:
 	add r3, sp, #0x170
 	ldmia r0, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
-	ldr fp, [r5, #0x1c]
+	ldr r11, [r5, #0x1c]
 	ldr r3, _02181ee0 ; =data_02050f54
-	ldrh r2, [fp, #0x78]
-	ldr r1, [fp, #0x48]
+	ldrh r2, [r11, #0x78]
+	ldr r1, [r11, #0x48]
 	ldr r0, [sp, #0x178]
 	mov r2, r2, asr #0x4
 	mov r4, r2, lsl #0x1
@@ -7442,13 +7442,13 @@ _021825a4:
 	smull r2, r4, r0, r6
 	adds sb, r2, #0x800
 	rsb r2, r6, #0
-	ldr ip, [fp, #0x4c]
+	ldr ip, [r11, #0x4c]
 	ldr r6, [sp, #0x174]
 	adc r8, r4, #0
 	add sl, ip, r6
 	smull r6, r4, r0, r7
 	str ip, [sp, #0x180]
-	ldr r0, [fp, #0x50]
+	ldr r0, [r11, #0x50]
 	mov sb, sb, lsr #0xc
 	adds r6, r6, #0x800
 	ldr r3, [sp, #0x170]
@@ -7498,10 +7498,10 @@ _021826c0:
 	add r3, sp, #0x158
 	ldmia r0, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
-	ldr fp, [r5, #0x1c]
+	ldr r11, [r5, #0x1c]
 	ldr r3, _02181ee0 ; =data_02050f54
-	ldrh r2, [fp, #0x78]
-	ldr r1, [fp, #0x48]
+	ldrh r2, [r11, #0x78]
+	ldr r1, [r11, #0x48]
 	ldr r0, [sp, #0x160]
 	mov r2, r2, asr #0x4
 	mov r4, r2, lsl #0x1
@@ -7514,13 +7514,13 @@ _021826c0:
 	smull r2, r4, r0, r6
 	adds sb, r2, #0x800
 	rsb r2, r6, #0
-	ldr ip, [fp, #0x4c]
+	ldr ip, [r11, #0x4c]
 	ldr r6, [sp, #0x15c]
 	adc r8, r4, #0
 	add sl, ip, r6
 	smull r6, r4, r0, r7
 	str ip, [sp, #0x168]
-	ldr r0, [fp, #0x50]
+	ldr r0, [r11, #0x50]
 	mov sb, sb, lsr #0xc
 	adds r6, r6, #0x800
 	ldr r3, [sp, #0x158]
@@ -7570,10 +7570,10 @@ _021827dc:
 	add r3, sp, #0x140
 	ldmia r0, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
-	ldr fp, [r5, #0x1c]
+	ldr r11, [r5, #0x1c]
 	ldr r3, _02181ee0 ; =data_02050f54
-	ldrh r2, [fp, #0x78]
-	ldr r1, [fp, #0x48]
+	ldrh r2, [r11, #0x78]
+	ldr r1, [r11, #0x48]
 	ldr r0, [sp, #0x148]
 	mov r2, r2, asr #0x4
 	mov r4, r2, lsl #0x1
@@ -7586,13 +7586,13 @@ _021827dc:
 	smull r2, r4, r0, r6
 	adds sb, r2, #0x800
 	rsb r2, r6, #0
-	ldr ip, [fp, #0x4c]
+	ldr ip, [r11, #0x4c]
 	ldr r6, [sp, #0x144]
 	adc r8, r4, #0
 	add sl, ip, r6
 	smull r6, r4, r0, r7
 	str ip, [sp, #0x150]
-	ldr r0, [fp, #0x50]
+	ldr r0, [r11, #0x50]
 	mov sb, sb, lsr #0xc
 	adds r6, r6, #0x800
 	ldr r3, [sp, #0x140]
@@ -7642,10 +7642,10 @@ _021828f8:
 	add r3, sp, #0x128
 	ldmia r0, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
-	ldr fp, [r5, #0x1c]
+	ldr r11, [r5, #0x1c]
 	ldr r3, _02181ee0 ; =data_02050f54
-	ldrh r2, [fp, #0x78]
-	ldr r1, [fp, #0x48]
+	ldrh r2, [r11, #0x78]
+	ldr r1, [r11, #0x48]
 	ldr r0, [sp, #0x130]
 	mov r2, r2, asr #0x4
 	mov r4, r2, lsl #0x1
@@ -7658,13 +7658,13 @@ _021828f8:
 	smull r2, r4, r0, r6
 	adds sb, r2, #0x800
 	rsb r2, r6, #0
-	ldr ip, [fp, #0x4c]
+	ldr ip, [r11, #0x4c]
 	ldr r6, [sp, #0x12c]
 	adc r8, r4, #0
 	add sl, ip, r6
 	smull r6, r4, r0, r7
 	str ip, [sp, #0x138]
-	ldr r0, [fp, #0x50]
+	ldr r0, [r11, #0x50]
 	mov sb, sb, lsr #0xc
 	adds r6, r6, #0x800
 	ldr r3, [sp, #0x128]
@@ -7714,10 +7714,10 @@ _02182a14:
 	add r3, sp, #0x110
 	ldmia r0, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
-	ldr fp, [r5, #0x1c]
+	ldr r11, [r5, #0x1c]
 	ldr r3, _02181ee0 ; =data_02050f54
-	ldrh r2, [fp, #0x78]
-	ldr r1, [fp, #0x48]
+	ldrh r2, [r11, #0x78]
+	ldr r1, [r11, #0x48]
 	ldr r0, [sp, #0x118]
 	mov r2, r2, asr #0x4
 	mov r4, r2, lsl #0x1
@@ -7730,13 +7730,13 @@ _02182a14:
 	smull r2, r4, r0, r6
 	adds sb, r2, #0x800
 	rsb r2, r6, #0
-	ldr ip, [fp, #0x4c]
+	ldr ip, [r11, #0x4c]
 	ldr r6, [sp, #0x114]
 	adc r8, r4, #0
 	add sl, ip, r6
 	smull r6, r4, r0, r7
 	str ip, [sp, #0x120]
-	ldr r0, [fp, #0x50]
+	ldr r0, [r11, #0x50]
 	mov sb, sb, lsr #0xc
 	adds r6, r6, #0x800
 	ldr r3, [sp, #0x110]
@@ -7786,10 +7786,10 @@ _02182b30:
 	add r3, sp, #0xf8
 	ldmia r0, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
-	ldr fp, [r5, #0x1c]
+	ldr r11, [r5, #0x1c]
 	ldr r3, _02181ee0 ; =data_02050f54
-	ldrh r2, [fp, #0x78]
-	ldr r1, [fp, #0x48]
+	ldrh r2, [r11, #0x78]
+	ldr r1, [r11, #0x48]
 	ldr r0, [sp, #0x100]
 	mov r2, r2, asr #0x4
 	mov r4, r2, lsl #0x1
@@ -7802,13 +7802,13 @@ _02182b30:
 	smull r2, r4, r0, r6
 	adds sb, r2, #0x800
 	rsb r2, r6, #0
-	ldr ip, [fp, #0x4c]
+	ldr ip, [r11, #0x4c]
 	ldr r6, [sp, #0xfc]
 	adc r8, r4, #0
 	add sl, ip, r6
 	smull r6, r4, r0, r7
 	str ip, [sp, #0x108]
-	ldr r0, [fp, #0x50]
+	ldr r0, [r11, #0x50]
 	mov sb, sb, lsr #0xc
 	adds r6, r6, #0x800
 	ldr r3, [sp, #0xf8]
@@ -7858,10 +7858,10 @@ _02182c4c:
 	add r3, sp, #0xe0
 	ldmia r0, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
-	ldr fp, [r5, #0x1c]
+	ldr r11, [r5, #0x1c]
 	ldr r3, _02181ee0 ; =data_02050f54
-	ldrh r2, [fp, #0x78]
-	ldr r1, [fp, #0x48]
+	ldrh r2, [r11, #0x78]
+	ldr r1, [r11, #0x48]
 	ldr r0, [sp, #0xe8]
 	mov r2, r2, asr #0x4
 	mov r4, r2, lsl #0x1
@@ -7874,13 +7874,13 @@ _02182c4c:
 	smull r2, r4, r0, r6
 	adds sb, r2, #0x800
 	rsb r2, r6, #0
-	ldr ip, [fp, #0x4c]
+	ldr ip, [r11, #0x4c]
 	ldr r6, [sp, #0xe4]
 	adc r8, r4, #0
 	add sl, ip, r6
 	smull r6, r4, r0, r7
 	str ip, [sp, #0xf0]
-	ldr r0, [fp, #0x50]
+	ldr r0, [r11, #0x50]
 	mov sb, sb, lsr #0xc
 	adds r6, r6, #0x800
 	ldr r3, [sp, #0xe0]
@@ -7930,10 +7930,10 @@ _02182d68:
 	add r3, sp, #0xc8
 	ldmia r0, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
-	ldr fp, [r5, #0x1c]
+	ldr r11, [r5, #0x1c]
 	ldr r3, _02181ee0 ; =data_02050f54
-	ldrh r2, [fp, #0x78]
-	ldr r1, [fp, #0x48]
+	ldrh r2, [r11, #0x78]
+	ldr r1, [r11, #0x48]
 	ldr r0, [sp, #0xd0]
 	mov r2, r2, asr #0x4
 	mov r4, r2, lsl #0x1
@@ -7946,13 +7946,13 @@ _02182d68:
 	smull r2, r4, r0, r6
 	adds sb, r2, #0x800
 	rsb r2, r6, #0
-	ldr ip, [fp, #0x4c]
+	ldr ip, [r11, #0x4c]
 	ldr r6, [sp, #0xcc]
 	adc r8, r4, #0
 	add sl, ip, r6
 	smull r6, r4, r0, r7
 	str ip, [sp, #0xd8]
-	ldr r0, [fp, #0x50]
+	ldr r0, [r11, #0x50]
 	mov sb, sb, lsr #0xc
 	adds r6, r6, #0x800
 	ldr r3, [sp, #0xc8]
@@ -8002,10 +8002,10 @@ _02182e84:
 	add r3, sp, #0xb0
 	ldmia r0, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
-	ldr fp, [r5, #0x1c]
+	ldr r11, [r5, #0x1c]
 	ldr r3, _02183018 ; =data_02050f54
-	ldrh r2, [fp, #0x78]
-	ldr r1, [fp, #0x48]
+	ldrh r2, [r11, #0x78]
+	ldr r1, [r11, #0x48]
 	ldr r0, [sp, #0xb8]
 	mov r2, r2, asr #0x4
 	mov r4, r2, lsl #0x1
@@ -8018,13 +8018,13 @@ _02182e84:
 	smull r2, r4, r0, r6
 	adds sb, r2, #0x800
 	rsb r2, r6, #0
-	ldr ip, [fp, #0x4c]
+	ldr ip, [r11, #0x4c]
 	ldr r6, [sp, #0xb4]
 	adc r8, r4, #0
 	add sl, ip, r6
 	smull r6, r4, r0, r7
 	str ip, [sp, #0xc0]
-	ldr r0, [fp, #0x50]
+	ldr r0, [r11, #0x50]
 	mov sb, sb, lsr #0xc
 	adds r6, r6, #0x800
 	ldr r3, [sp, #0xb0]
@@ -8074,7 +8074,7 @@ _02182fa0:
 	add r3, sp, #0x98
 	ldmia r0, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
-	ldr fp, [r5, #0x1c]
+	ldr r11, [r5, #0x1c]
 	ldr r3, _02183018 ; =data_02050f54
 	b _02183020
 	.align 2, 0
@@ -8098,8 +8098,8 @@ _02183014: .word data_ov37_021880b8
 _02183018: .word data_02050f54
 _0218301c: .word data_ov37_021880c4
 _02183020:
-	ldrh r2, [fp, #0x78]
-	ldr r1, [fp, #0x48]
+	ldrh r2, [r11, #0x78]
+	ldr r1, [r11, #0x48]
 	ldr r0, [sp, #0xa0]
 	mov r2, r2, asr #0x4
 	mov r4, r2, lsl #0x1
@@ -8112,13 +8112,13 @@ _02183020:
 	smull r2, r4, r0, r6
 	adds sb, r2, #0x800
 	rsb r2, r6, #0
-	ldr ip, [fp, #0x4c]
+	ldr ip, [r11, #0x4c]
 	ldr r6, [sp, #0x9c]
 	adc r8, r4, #0
 	add sl, ip, r6
 	smull r6, r4, r0, r7
 	str ip, [sp, #0xa8]
-	ldr r0, [fp, #0x50]
+	ldr r0, [r11, #0x50]
 	mov sb, sb, lsr #0xc
 	adds r6, r6, #0x800
 	ldr r3, [sp, #0x98]
@@ -8168,10 +8168,10 @@ _0218310c:
 	add r3, sp, #0x80
 	ldmia r0, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
-	ldr fp, [r5, #0x1c]
+	ldr r11, [r5, #0x1c]
 	ldr r3, _02183018 ; =data_02050f54
-	ldrh r2, [fp, #0x78]
-	ldr r1, [fp, #0x48]
+	ldrh r2, [r11, #0x78]
+	ldr r1, [r11, #0x48]
 	ldr r0, [sp, #0x88]
 	mov r2, r2, asr #0x4
 	mov r4, r2, lsl #0x1
@@ -8184,13 +8184,13 @@ _0218310c:
 	smull r2, r4, r0, r6
 	adds sb, r2, #0x800
 	rsb r2, r6, #0
-	ldr ip, [fp, #0x4c]
+	ldr ip, [r11, #0x4c]
 	ldr r6, [sp, #0x84]
 	adc r8, r4, #0
 	add sl, ip, r6
 	smull r6, r4, r0, r7
 	str ip, [sp, #0x90]
-	ldr r0, [fp, #0x50]
+	ldr r0, [r11, #0x50]
 	mov sb, sb, lsr #0xc
 	adds r6, r6, #0x800
 	ldr r3, [sp, #0x80]
@@ -8240,10 +8240,10 @@ _02183228:
 	add r3, sp, #0x68
 	ldmia r0, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
-	ldr fp, [r5, #0x1c]
+	ldr r11, [r5, #0x1c]
 	ldr r3, _02183018 ; =data_02050f54
-	ldrh r2, [fp, #0x78]
-	ldr r1, [fp, #0x48]
+	ldrh r2, [r11, #0x78]
+	ldr r1, [r11, #0x48]
 	ldr r0, [sp, #0x70]
 	mov r2, r2, asr #0x4
 	mov r4, r2, lsl #0x1
@@ -8256,13 +8256,13 @@ _02183228:
 	smull r2, r4, r0, r6
 	adds sb, r2, #0x800
 	rsb r2, r6, #0
-	ldr ip, [fp, #0x4c]
+	ldr ip, [r11, #0x4c]
 	ldr r6, [sp, #0x6c]
 	adc r8, r4, #0
 	add sl, ip, r6
 	smull r6, r4, r0, r7
 	str ip, [sp, #0x78]
-	ldr r0, [fp, #0x50]
+	ldr r0, [r11, #0x50]
 	mov sb, sb, lsr #0xc
 	adds r6, r6, #0x800
 	ldr r3, [sp, #0x68]
@@ -8303,10 +8303,10 @@ _02183320:
 	add r3, sp, #0x50
 	ldmia r0, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
-	ldr fp, [r5, #0x1c]
+	ldr r11, [r5, #0x1c]
 	ldr r3, _02183018 ; =data_02050f54
-	ldrh r2, [fp, #0x78]
-	ldr r1, [fp, #0x48]
+	ldrh r2, [r11, #0x78]
+	ldr r1, [r11, #0x48]
 	ldr r0, [sp, #0x58]
 	mov r2, r2, asr #0x4
 	mov r4, r2, lsl #0x1
@@ -8319,13 +8319,13 @@ _02183320:
 	smull r2, r4, r0, r6
 	adds sb, r2, #0x800
 	rsb r2, r6, #0
-	ldr ip, [fp, #0x4c]
+	ldr ip, [r11, #0x4c]
 	ldr r6, [sp, #0x54]
 	adc r8, r4, #0
 	add sl, ip, r6
 	smull r6, r4, r0, r7
 	str ip, [sp, #0x60]
-	ldr r0, [fp, #0x50]
+	ldr r0, [r11, #0x50]
 	mov sb, sb, lsr #0xc
 	adds r6, r6, #0x800
 	ldr r3, [sp, #0x50]
@@ -8385,7 +8385,7 @@ _02183468:
 	cmp r4, #4
 	blt _02183468
 	add sp, sp, #0x314
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 _0218348c: .word data_ov37_021880d0
 _02183490: .word data_ov37_021880dc
@@ -11394,7 +11394,7 @@ _02185b4c:
 	.global func_ov37_02185b6c
 	arm_func_start func_ov37_02185b6c
 func_ov37_02185b6c: ; 0x02185b6c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x54
 	ldr r6, _02186160 ; =data_ov37_02188640
 	ldr r4, _02186164 ; =data_ov37_0218864c
@@ -11404,7 +11404,7 @@ func_ov37_02185b6c: ; 0x02185b6c
 	add r5, sp, #0x48
 	add lr, sp, #0x3c
 	add r3, sp, #0x30
-	add fp, sp, #0x24
+	add r11, sp, #0x24
 	mov sb, r0
 	mov r7, r2
 	ldmia r6, {r0, r1, r2}
@@ -11414,7 +11414,7 @@ func_ov37_02185b6c: ; 0x02185b6c
 	ldmia ip, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
 	ldmia sl, {r0, r1, r2}
-	stmia fp, {r0, r1, r2}
+	stmia r11, {r0, r1, r2}
 	ldr r0, _02186170 ; =data_ov37_02188670
 	add r3, sp, #0x18
 	ldmia r0, {r0, r1, r2}
@@ -11496,7 +11496,7 @@ _02185c20:
 	add r0, r2, r1
 	add sp, sp, #0x54
 	str r0, [r7, #8]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02185d00:
 	ldrh r1, [r4, #0x78]
 	ldr r0, [sp]
@@ -11553,7 +11553,7 @@ _02185d00:
 	add r0, r2, r1
 	add sp, sp, #0x54
 	str r0, [r7, #8]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02185de0:
 	ldrh r1, [r4, #0x78]
 	ldr r0, [sp]
@@ -11610,7 +11610,7 @@ _02185de0:
 	add r0, r2, r1
 	add sp, sp, #0x54
 	str r0, [r7, #8]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02185ec0:
 	ldrh r1, [r4, #0x78]
 	ldr r0, [sp]
@@ -11667,7 +11667,7 @@ _02185ec0:
 	add r0, r2, r1
 	add sp, sp, #0x54
 	str r0, [r7, #8]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02185fa0:
 	ldrh r1, [r4, #0x78]
 	ldr r0, [sp]
@@ -11724,7 +11724,7 @@ _02185fa0:
 	add r0, r2, r1
 	add sp, sp, #0x54
 	str r0, [r7, #8]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02186080:
 	ldrh r1, [r4, #0x78]
 	ldr r0, [sp]
@@ -11782,7 +11782,7 @@ _02186080:
 	str r0, [r7, #8]
 _02186158:
 	add sp, sp, #0x54
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov37_02185b6c
 _02186160: .word data_ov37_02188640

--- a/asm/ov37.s
+++ b/asm/ov37.s
@@ -890,13 +890,13 @@ _0217c920: .word data_027e0e58
 	.global func_ov37_0217c924
 	arm_func_start func_ov37_0217c924
 func_ov37_0217c924: ; 0x0217c924
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x4c
 	mov r8, r0
 	bl func_ov37_0217be60
 	cmp r0, #0
 	addeq sp, sp, #0x4c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r0, r8, #0x2000
 	ldr r0, [r0, #0xfa0]
 	cmp r0, #0
@@ -907,7 +907,7 @@ func_ov37_0217c924: ; 0x0217c924
 	add r6, r0, #0x2c00
 	ldr r0, _0217cbdc ; =0x00007fff
 	add r1, r8, #0xdf0
-	ldr sb, _0217cbe0 ; =data_027e0d0c
+	ldr r9, _0217cbe0 ; =data_027e0d0c
 	add r7, r1, #0x2000
 	mov r4, #0
 	rsb r11, r0, #0
@@ -951,11 +951,11 @@ _0217c978:
 	add r2, sp, #0x18
 	str r10, [r5, #0x50]
 	str r3, [r5, #0x88]
-	ldr r3, [sb]
+	ldr r3, [r9]
 	str r3, [r5, #0x60]
-	ldr r3, [sb, #4]
+	ldr r3, [r9, #4]
 	str r3, [r5, #0x64]
-	ldr r3, [sb, #8]
+	ldr r3, [r9, #8]
 	str r3, [r5, #0x68]
 	bl func_01ff9bf8
 	ldr r0, [sp, #0x18]
@@ -991,17 +991,17 @@ _0217ca90:
 	cmp r4, #0xa
 	blt _0217c978
 	add sp, sp, #0x4c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0217caac:
 	cmp r0, #1
 	addne sp, sp, #0x4c
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r0, r8, #0x334
 	add r7, r0, #0x2c00
 	ldr r0, _0217cbdc ; =0x00007fff
 	add r1, r8, #0x2f4
 	ldr r5, _0217cbe0 ; =data_027e0d0c
-	add sb, r1, #0x2c00
+	add r9, r1, #0x2c00
 	mov r10, #0
 	rsb r4, r0, #0
 	mov r11, #7
@@ -1018,14 +1018,14 @@ _0217cadc:
 	bne _0217cbb8
 	add r0, r8, #0x21c
 	mov r1, r10
-	mov r2, sb
+	mov r2, r9
 	add r3, sp, #4
 	bl func_ov37_02184054
 	add r0, r8, r10, lsl #4
 	add r2, r0, #0x2000
 	ldr r3, [r2, #0xf00]
 	ldr r1, [r2, #0xef4]
-	mov r0, sb
+	mov r0, r9
 	str r1, [r6, #0x48]
 	ldr ip, [r2, #0xef8]
 	ldr r1, _0217cbec ; =data_027e0f94
@@ -1067,12 +1067,12 @@ _0217cbb8:
 	str r0, [r6, #0x12c]
 _0217cbc0:
 	add r7, r7, #8
-	add sb, sb, #0x10
+	add r9, r9, #0x10
 	add r10, r10, #1
 	cmp r10, #4
 	blt _0217cadc
 	add sp, sp, #0x4c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov37_0217c924
 _0217cbdc: .word 0x00007fff
@@ -3788,7 +3788,7 @@ _0217f284: .word data_ov00_020e9370
 	.global func_ov37_0217f288
 	arm_func_start func_ov37_0217f288
 func_ov37_0217f288: ; 0x0217f288
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x18
 	ldr r1, _0217f370 ; =data_ov37_02187df4
 	mov r3, r0
@@ -3810,7 +3810,7 @@ func_ov37_0217f288: ; 0x0217f288
 	ldr r1, [r3, #0x48]
 	rsb ip, r2, #0
 	str r1, [sp, #0xc]
-	ldr sb, [r3, #0x4c]
+	ldr r9, [r3, #0x4c]
 	ldr r6, [sp]
 	ldr r0, [sp, #4]
 	adc r7, r7, #0
@@ -3819,7 +3819,7 @@ func_ov37_0217f288: ; 0x0217f288
 	smull r2, r5, r8, r4
 	add r1, r1, lr
 	adds r8, r2, #0x800
-	str sb, [sp, #0x10]
+	str r9, [sp, #0x10]
 	smull lr, r4, r6, r4
 	adc r7, r5, #0
 	adds r5, lr, #0x800
@@ -3828,7 +3828,7 @@ func_ov37_0217f288: ; 0x0217f288
 	mov r5, r5, lsr #0xc
 	orr r5, r5, r4, lsl #20
 	ldr r2, [r3, #0x50]
-	add r0, sb, r0
+	add r0, r9, r0
 	str r0, [sp, #0x10]
 	mov r0, r8, lsr #0xc
 	orr r0, r0, r7, lsl #20
@@ -3845,7 +3845,7 @@ func_ov37_0217f288: ; 0x0217f288
 	str r2, [sp, #0x14]
 	bl func_ov37_0217f540
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov37_0217f288
 _0217f370: .word data_ov37_02187df4
@@ -3854,7 +3854,7 @@ _0217f374: .word data_02050f54
 	.global func_ov37_0217f378
 	arm_func_start func_ov37_0217f378
 func_ov37_0217f378: ; 0x0217f378
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x18
 	ldr r1, _0217f460 ; =data_ov37_02187e00
 	mov r3, r0
@@ -3876,7 +3876,7 @@ func_ov37_0217f378: ; 0x0217f378
 	ldr r1, [r3, #0x48]
 	rsb ip, r2, #0
 	str r1, [sp, #0xc]
-	ldr sb, [r3, #0x4c]
+	ldr r9, [r3, #0x4c]
 	ldr r6, [sp]
 	ldr r0, [sp, #4]
 	adc r7, r7, #0
@@ -3885,7 +3885,7 @@ func_ov37_0217f378: ; 0x0217f378
 	smull r2, r5, r8, r4
 	add r1, r1, lr
 	adds r8, r2, #0x800
-	str sb, [sp, #0x10]
+	str r9, [sp, #0x10]
 	smull lr, r4, r6, r4
 	adc r7, r5, #0
 	adds r5, lr, #0x800
@@ -3894,7 +3894,7 @@ func_ov37_0217f378: ; 0x0217f378
 	mov r5, r5, lsr #0xc
 	orr r5, r5, r4, lsl #20
 	ldr r2, [r3, #0x50]
-	add r0, sb, r0
+	add r0, r9, r0
 	str r0, [sp, #0x10]
 	mov r0, r8, lsr #0xc
 	orr r0, r0, r7, lsl #20
@@ -3911,7 +3911,7 @@ func_ov37_0217f378: ; 0x0217f378
 	str r2, [sp, #0x14]
 	bl func_ov37_0217f540
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov37_0217f378
 _0217f460: .word data_ov37_02187e00
@@ -4189,13 +4189,13 @@ _0217f808: .word data_02050f54
 	.global func_ov37_0217f80c
 	arm_func_start func_ov37_0217f80c
 func_ov37_0217f80c: ; 0x0217f80c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x30
 	mov r10, r0
 	add r0, r10, #0x29c
 	ldr r11, _0217f89c ; =0x4c4f4e44
 	ldr r4, _0217f8a0 ; =data_027e0fe8
-	add sb, r0, #0x2c00
+	add r9, r0, #0x2c00
 	mov r8, #0
 	mov r7, #4
 	add r6, sp, #4
@@ -4216,16 +4216,16 @@ _0217f838:
 	ldr r0, [r10, #0xc]
 	add r2, r10, #0x48
 	str r0, [sp, #0x24]
-	str sb, [sp]
+	str r9, [sp]
 	ldr r0, [r4]
 	mov r3, r6
 	bl func_ov00_020c4048
-	add sb, sb, #8
+	add r9, r9, #8
 	add r8, r8, #1
 	cmp r8, #0xa
 	blt _0217f838
 	add sp, sp, #0x30
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov37_0217f80c
 _0217f89c: .word 0x4c4f4e44
@@ -4258,13 +4258,13 @@ _0217f8e4: .word data_027e0fe4
 	.global func_ov37_0217f8e8
 	arm_func_start func_ov37_0217f8e8
 func_ov37_0217f8e8: ; 0x0217f8e8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x30
 	mov r10, r0
 	add r0, r10, #0x334
 	ldr r11, _0217f978 ; =0x4c4f4e44
 	ldr r4, _0217f97c ; =data_027e0fe8
-	add sb, r0, #0x2c00
+	add r9, r0, #0x2c00
 	mov r8, #0
 	mov r7, #1
 	add r6, sp, #4
@@ -4285,16 +4285,16 @@ _0217f914:
 	ldr r0, [r10, #0xc]
 	add r2, r10, #0x48
 	str r0, [sp, #0x24]
-	str sb, [sp]
+	str r9, [sp]
 	ldr r0, [r4]
 	mov r3, r6
 	bl func_ov00_020c4048
-	add sb, sb, #8
+	add r9, r9, #8
 	add r8, r8, #1
 	cmp r8, #4
 	blt _0217f914
 	add sp, sp, #0x30
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov37_0217f8e8
 _0217f978: .word 0x4c4f4e44
@@ -5099,19 +5099,19 @@ _021803cc: .word data_02050f54
 	.global func_ov37_021803d0
 	arm_func_start func_ov37_021803d0
 func_ov37_021803d0: ; 0x021803d0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x60
 	ldr r1, [r0, #8]
 	mov r7, #0
 	tst r1, #0x10
 	ldrneb r4, [r0, #0xae]
-	ldr sb, _021804f0 ; =data_ov37_02189190
+	ldr r9, _021804f0 ; =data_ov37_02189190
 	mov r8, r7
 	mvneq r4, #0
 	add r6, sp, #0x30
 	mov r5, r7
 _021803fc:
-	ldr r1, [sb]
+	ldr r1, [r9]
 	add r0, r1, r7, lsl #2
 	ldr r0, [r0, #0x60]
 	cmp r4, r0
@@ -5124,7 +5124,7 @@ _021803fc:
 	mov r1, r5
 	bl func_0201b1bc
 	bl func_02018450
-	ldr r2, [sb]
+	ldr r2, [r9]
 	mov r1, r0
 	add r0, r2, #0xc8
 	add r2, r0, r8
@@ -5136,12 +5136,12 @@ _02180448:
 	add r8, r8, #0x30
 	blt _021803fc
 	mov r8, #0
-	ldr sb, _021804f0 ; =data_ov37_02189190
+	ldr r9, _021804f0 ; =data_ov37_02189190
 	mov r7, r8
 	add r6, sp, #0
 	mov r5, r8
 _0218046c:
-	ldr r1, [sb]
+	ldr r1, [r9]
 	add r0, r1, r8, lsl #2
 	ldr r0, [r0, #0x9c]
 	cmp r4, r0
@@ -5163,7 +5163,7 @@ _021804b0:
 	mov r1, r5
 	bl func_0201b1bc
 	bl func_02018450
-	ldr r2, [sb]
+	ldr r2, [r9]
 	mov r1, r0
 	add r0, r2, #0x314
 	add r2, r0, r7
@@ -5175,7 +5175,7 @@ _021804d8:
 	add r7, r7, #0x30
 	blt _0218046c
 	add sp, sp, #0x60
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov37_021803d0
 _021804f0: .word data_ov37_02189190
@@ -5183,19 +5183,19 @@ _021804f0: .word data_ov37_02189190
 	.global func_ov37_021804f4
 	arm_func_start func_ov37_021804f4
 func_ov37_021804f4: ; 0x021804f4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x60
 	ldr r1, [r0, #8]
 	mov r7, #0
 	tst r1, #0x10
 	ldrneb r4, [r0, #0xae]
-	ldr sb, _02180624 ; =data_ov37_02189190
+	ldr r9, _02180624 ; =data_ov37_02189190
 	mov r8, r7
 	mvneq r4, #0
 	add r6, sp, #0x30
 	mov r5, r7
 _02180520:
-	ldr r1, [sb]
+	ldr r1, [r9]
 	add r0, r1, r7, lsl #2
 	ldr r0, [r0, #0x60]
 	cmp r4, r0
@@ -5212,7 +5212,7 @@ _02180520:
 	mov r1, r5
 	bl func_0201b1bc
 	bl func_02018450
-	ldr r2, [sb]
+	ldr r2, [r9]
 	mov r1, r0
 	add r0, r2, #0xc8
 	add r2, r0, r8
@@ -5224,12 +5224,12 @@ _0218057c:
 	add r8, r8, #0x30
 	blt _02180520
 	mov r8, #0
-	ldr sb, _02180624 ; =data_ov37_02189190
+	ldr r9, _02180624 ; =data_ov37_02189190
 	mov r7, r8
 	add r6, sp, #0
 	mov r5, r8
 _021805a0:
-	ldr r1, [sb]
+	ldr r1, [r9]
 	add r0, r1, r8, lsl #2
 	ldr r0, [r0, #0x9c]
 	cmp r4, r0
@@ -5251,7 +5251,7 @@ _021805e4:
 	mov r1, r5
 	bl func_0201b1bc
 	bl func_02018450
-	ldr r2, [sb]
+	ldr r2, [r9]
 	mov r1, r0
 	add r0, r2, #0x314
 	add r2, r0, r7
@@ -5263,7 +5263,7 @@ _0218060c:
 	add r7, r7, #0x30
 	blt _021805a0
 	add sp, sp, #0x60
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov37_021804f4
 _02180624: .word data_ov37_02189190
@@ -5752,7 +5752,7 @@ func_ov37_02180cbc: ; 0x02180cbc
 	.global func_ov37_02180cc8
 	arm_func_start func_ov37_02180cc8
 func_ov37_02180cc8: ; 0x02180cc8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #8
 	mov r8, r0
 	add r3, r8, #0x20c
@@ -5814,10 +5814,10 @@ func_ov37_02180cc8: ; 0x02180cc8
 	add r0, r8, #0x28c
 	mov r5, r4
 	mov r6, r4
-	add sb, r0, #0xc00
+	add r9, r0, #0xc00
 	mov r7, r4
 _02180dc8:
-	add r0, sb, r5
+	add r0, r9, r5
 	bl func_01ff80d4
 	add r0, r8, r6
 	str r7, [r0, #0xf1c]
@@ -5897,7 +5897,7 @@ _02180e5c:
 	mov r0, r8
 	str r2, [r1, #0xbc8]
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov37_02180cc8
 _02180f04: .word data_ov37_02188bf8
@@ -5934,7 +5934,7 @@ func_ov37_02180f34: ; 0x02180f34
 	.global func_ov37_02180f54
 	arm_func_start func_ov37_02180f54
 func_ov37_02180f54: ; 0x02180f54
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x314
 	mov r5, r0
 	ldr r0, [r5, #0x1c]
@@ -6071,28 +6071,28 @@ _021810fc:
 	ldrsh r8, [r1, r6]
 	mov r0, r0, lsl #0x1
 	ldrsh r1, [r1, r0]
-	smull r6, sb, r3, r8
+	smull r6, r9, r3, r8
 	adds r10, r6, #0x800
 	str r2, [sp, #0x308]
-	adc sb, sb, #0
+	adc r9, r9, #0
 	mov r10, r10, lsr #0xc
-	orr r10, r10, sb, lsl #20
+	orr r10, r10, r9, lsl #20
 	add r2, r2, r10
-	smull r10, sb, r3, r1
+	smull r10, r9, r3, r1
 	adds r10, r10, #0x800
 	ldr r6, [r7, #0x4c]
 	ldr r0, [sp, #0x2fc]
-	adc r3, sb, #0
+	adc r3, r9, #0
 	mov r11, r10, lsr #0xc
 	str r6, [sp, #0x30c]
 	orr r11, r11, r3, lsl #20
-	smull r10, sb, r0, r1
+	smull r10, r9, r0, r1
 	ldr r3, [r7, #0x50]
 	rsb r8, r8, #0
 	add r1, r3, r11
 	smull r7, r3, r0, r8
 	adds r8, r10, #0x800
-	adc r0, sb, #0
+	adc r0, r9, #0
 	mov r8, r8, lsr #0xc
 	orr r8, r8, r0, lsl #20
 	add r0, r2, r8
@@ -6138,28 +6138,28 @@ _02181204:
 	ldrsh r8, [r1, r6]
 	mov r0, r0, lsl #0x1
 	ldrsh r1, [r1, r0]
-	smull r6, sb, r3, r8
+	smull r6, r9, r3, r8
 	adds r10, r6, #0x800
 	str r2, [sp, #0x2f0]
-	adc sb, sb, #0
+	adc r9, r9, #0
 	mov r10, r10, lsr #0xc
-	orr r10, r10, sb, lsl #20
+	orr r10, r10, r9, lsl #20
 	add r2, r2, r10
-	smull r10, sb, r3, r1
+	smull r10, r9, r3, r1
 	adds r10, r10, #0x800
 	ldr r6, [r7, #0x4c]
 	ldr r0, [sp, #0x2e4]
-	adc r3, sb, #0
+	adc r3, r9, #0
 	mov r11, r10, lsr #0xc
 	str r6, [sp, #0x2f4]
 	orr r11, r11, r3, lsl #20
-	smull r10, sb, r0, r1
+	smull r10, r9, r0, r1
 	ldr r3, [r7, #0x50]
 	rsb r8, r8, #0
 	add r1, r3, r11
 	smull r7, r3, r0, r8
 	adds r8, r10, #0x800
-	adc r0, sb, #0
+	adc r0, r9, #0
 	mov r8, r8, lsr #0xc
 	orr r8, r8, r0, lsl #20
 	add r0, r2, r8
@@ -6240,7 +6240,7 @@ _02181388:
 	ldrsh r7, [r3, r2]
 	str r1, [sp, #0x2cc]
 	smull r2, r4, r0, r6
-	adds sb, r2, #0x800
+	adds r9, r2, #0x800
 	rsb r2, r6, #0
 	ldr ip, [r11, #0x4c]
 	ldr r6, [sp, #0x2c4]
@@ -6249,22 +6249,22 @@ _02181388:
 	smull r6, r4, r0, r7
 	str ip, [sp, #0x2d0]
 	ldr r0, [r11, #0x50]
-	mov sb, sb, lsr #0xc
+	mov r9, r9, lsr #0xc
 	adds r6, r6, #0x800
 	ldr r3, [sp, #0x2c0]
-	orr sb, sb, r8, lsl #20
+	orr r9, r9, r8, lsl #20
 	str r10, [sp, #0x2d0]
 	smull r10, r8, r3, r7
-	add r7, r1, sb
+	add r7, r1, r9
 	adc r4, r4, #0
 	mov r1, r6, lsr #0xc
 	orr r1, r1, r4, lsl #20
-	adds sb, r10, #0x800
+	adds r9, r10, #0x800
 	add r0, r0, r1
 	smull r4, r2, r3, r2
 	adc r6, r8, #0
 	adds r3, r4, #0x800
-	mov r4, sb, lsr #0xc
+	mov r4, r9, lsr #0xc
 	orr r4, r4, r6, lsl #20
 	add r6, r7, r4
 	adc r2, r2, #0
@@ -6303,7 +6303,7 @@ _02181480:
 	ldrsh r7, [r3, r2]
 	str r1, [sp, #0x2b4]
 	smull r2, r4, r0, r6
-	adds sb, r2, #0x800
+	adds r9, r2, #0x800
 	rsb r2, r6, #0
 	ldr ip, [r11, #0x4c]
 	ldr r6, [sp, #0x2ac]
@@ -6312,22 +6312,22 @@ _02181480:
 	smull r6, r4, r0, r7
 	str ip, [sp, #0x2b8]
 	ldr r0, [r11, #0x50]
-	mov sb, sb, lsr #0xc
+	mov r9, r9, lsr #0xc
 	adds r6, r6, #0x800
 	ldr r3, [sp, #0x2a8]
-	orr sb, sb, r8, lsl #20
+	orr r9, r9, r8, lsl #20
 	str r10, [sp, #0x2b8]
 	smull r10, r8, r3, r7
-	add r7, r1, sb
+	add r7, r1, r9
 	adc r4, r4, #0
 	mov r1, r6, lsr #0xc
 	orr r1, r1, r4, lsl #20
-	adds sb, r10, #0x800
+	adds r9, r10, #0x800
 	add r0, r0, r1
 	smull r4, r2, r3, r2
 	adc r6, r8, #0
 	adds r3, r4, #0x800
-	mov r4, sb, lsr #0xc
+	mov r4, r9, lsr #0xc
 	orr r4, r4, r6, lsl #20
 	add r6, r7, r4
 	adc r2, r2, #0
@@ -6366,7 +6366,7 @@ _02181578:
 	ldrsh r7, [r3, r2]
 	str r1, [sp, #0x29c]
 	smull r2, r4, r0, r6
-	adds sb, r2, #0x800
+	adds r9, r2, #0x800
 	rsb r2, r6, #0
 	ldr ip, [r11, #0x4c]
 	ldr r6, [sp, #0x294]
@@ -6375,22 +6375,22 @@ _02181578:
 	smull r6, r4, r0, r7
 	str ip, [sp, #0x2a0]
 	ldr r0, [r11, #0x50]
-	mov sb, sb, lsr #0xc
+	mov r9, r9, lsr #0xc
 	adds r6, r6, #0x800
 	ldr r3, [sp, #0x290]
-	orr sb, sb, r8, lsl #20
+	orr r9, r9, r8, lsl #20
 	str r10, [sp, #0x2a0]
 	smull r10, r8, r3, r7
-	add r7, r1, sb
+	add r7, r1, r9
 	adc r4, r4, #0
 	mov r1, r6, lsr #0xc
 	orr r1, r1, r4, lsl #20
-	adds sb, r10, #0x800
+	adds r9, r10, #0x800
 	add r0, r0, r1
 	smull r4, r2, r3, r2
 	adc r6, r8, #0
 	adds r3, r4, #0x800
-	mov r4, sb, lsr #0xc
+	mov r4, r9, lsr #0xc
 	orr r4, r4, r6, lsl #20
 	add r6, r7, r4
 	adc r2, r2, #0
@@ -6429,7 +6429,7 @@ _02181670:
 	ldrsh r7, [r3, r2]
 	str r1, [sp, #0x284]
 	smull r2, r4, r0, r6
-	adds sb, r2, #0x800
+	adds r9, r2, #0x800
 	rsb r2, r6, #0
 	ldr ip, [r11, #0x4c]
 	ldr r6, [sp, #0x27c]
@@ -6438,22 +6438,22 @@ _02181670:
 	smull r6, r4, r0, r7
 	str ip, [sp, #0x288]
 	ldr r0, [r11, #0x50]
-	mov sb, sb, lsr #0xc
+	mov r9, r9, lsr #0xc
 	adds r6, r6, #0x800
 	ldr r3, [sp, #0x278]
-	orr sb, sb, r8, lsl #20
+	orr r9, r9, r8, lsl #20
 	str r10, [sp, #0x288]
 	smull r10, r8, r3, r7
-	add r7, r1, sb
+	add r7, r1, r9
 	adc r4, r4, #0
 	mov r1, r6, lsr #0xc
 	orr r1, r1, r4, lsl #20
-	adds sb, r10, #0x800
+	adds r9, r10, #0x800
 	add r0, r0, r1
 	smull r4, r2, r3, r2
 	adc r6, r8, #0
 	adds r3, r4, #0x800
-	mov r4, sb, lsr #0xc
+	mov r4, r9, lsr #0xc
 	orr r4, r4, r6, lsl #20
 	add r6, r7, r4
 	adc r2, r2, #0
@@ -6492,7 +6492,7 @@ _02181768:
 	ldrsh r7, [r3, r2]
 	str r1, [sp, #0x26c]
 	smull r2, r4, r0, r6
-	adds sb, r2, #0x800
+	adds r9, r2, #0x800
 	rsb r2, r6, #0
 	ldr ip, [r11, #0x4c]
 	ldr r6, [sp, #0x264]
@@ -6501,22 +6501,22 @@ _02181768:
 	smull r6, r4, r0, r7
 	str ip, [sp, #0x270]
 	ldr r0, [r11, #0x50]
-	mov sb, sb, lsr #0xc
+	mov r9, r9, lsr #0xc
 	adds r6, r6, #0x800
 	ldr r3, [sp, #0x260]
-	orr sb, sb, r8, lsl #20
+	orr r9, r9, r8, lsl #20
 	str r10, [sp, #0x270]
 	smull r10, r8, r3, r7
-	add r7, r1, sb
+	add r7, r1, r9
 	adc r4, r4, #0
 	mov r1, r6, lsr #0xc
 	orr r1, r1, r4, lsl #20
-	adds sb, r10, #0x800
+	adds r9, r10, #0x800
 	add r0, r0, r1
 	smull r4, r2, r3, r2
 	adc r6, r8, #0
 	adds r3, r4, #0x800
-	mov r4, sb, lsr #0xc
+	mov r4, r9, lsr #0xc
 	orr r4, r4, r6, lsl #20
 	add r6, r7, r4
 	adc r2, r2, #0
@@ -6609,7 +6609,7 @@ _0218192c:
 	ldrsh r7, [r3, r2]
 	str r1, [sp, #0x254]
 	smull r2, r4, r0, r6
-	adds sb, r2, #0x800
+	adds r9, r2, #0x800
 	rsb r2, r6, #0
 	ldr ip, [r11, #0x4c]
 	ldr r6, [sp, #0x24c]
@@ -6618,22 +6618,22 @@ _0218192c:
 	smull r6, r4, r0, r7
 	str ip, [sp, #0x258]
 	ldr r0, [r11, #0x50]
-	mov sb, sb, lsr #0xc
+	mov r9, r9, lsr #0xc
 	adds r6, r6, #0x800
 	ldr r3, [sp, #0x248]
-	orr sb, sb, r8, lsl #20
+	orr r9, r9, r8, lsl #20
 	str r10, [sp, #0x258]
 	smull r10, r8, r3, r7
-	add r7, r1, sb
+	add r7, r1, r9
 	adc r4, r4, #0
 	mov r1, r6, lsr #0xc
 	orr r1, r1, r4, lsl #20
-	adds sb, r10, #0x800
+	adds r9, r10, #0x800
 	add r0, r0, r1
 	smull r4, r2, r3, r2
 	adc r6, r8, #0
 	adds r3, r4, #0x800
-	mov r4, sb, lsr #0xc
+	mov r4, r9, lsr #0xc
 	orr r4, r4, r6, lsl #20
 	add r4, r7, r4
 	adc r2, r2, #0
@@ -6685,7 +6685,7 @@ _02181a58:
 	ldrsh r7, [r3, r2]
 	str r1, [sp, #0x23c]
 	smull r2, r4, r0, r6
-	adds sb, r2, #0x800
+	adds r9, r2, #0x800
 	rsb r2, r6, #0
 	ldr ip, [r11, #0x4c]
 	ldr r6, [sp, #0x234]
@@ -6694,22 +6694,22 @@ _02181a58:
 	smull r6, r4, r0, r7
 	str ip, [sp, #0x240]
 	ldr r0, [r11, #0x50]
-	mov sb, sb, lsr #0xc
+	mov r9, r9, lsr #0xc
 	adds r6, r6, #0x800
 	ldr r3, [sp, #0x230]
-	orr sb, sb, r8, lsl #20
+	orr r9, r9, r8, lsl #20
 	str r10, [sp, #0x240]
 	smull r10, r8, r3, r7
-	add r7, r1, sb
+	add r7, r1, r9
 	adc r4, r4, #0
 	mov r1, r6, lsr #0xc
 	orr r1, r1, r4, lsl #20
-	adds sb, r10, #0x800
+	adds r9, r10, #0x800
 	add r0, r0, r1
 	smull r4, r2, r3, r2
 	adc r6, r8, #0
 	adds r3, r4, #0x800
-	mov r4, sb, lsr #0xc
+	mov r4, r9, lsr #0xc
 	orr r4, r4, r6, lsl #20
 	add r4, r7, r4
 	adc r2, r2, #0
@@ -6851,7 +6851,7 @@ _02181d00:
 	ldr r10, [r5, #0x1c]
 	ldr r1, _02181ee0 ; =data_02050f54
 	ldrh r0, [r10, #0x78]
-	ldr sb, [r10, #0x48]
+	ldr r9, [r10, #0x48]
 	ldr r6, [sp, #0x208]
 	mov r0, r0, asr #0x4
 	mov r2, r0, lsl #0x1
@@ -6862,7 +6862,7 @@ _02181d00:
 	ldrsh r3, [r1, r0]
 	smull r1, ip, r6, r2
 	ldr r0, [sp, #0x200]
-	str sb, [sp, #0x20c]
+	str r9, [sp, #0x20c]
 	ldr r8, [r10, #0x4c]
 	ldr r7, [sp, #0x204]
 	adds lr, r1, #0x800
@@ -6887,7 +6887,7 @@ _02181d00:
 	adc r1, r8, #0
 	mov r3, r3, lsr #0xc
 	orr r10, r10, r0, lsl #20
-	add r8, sb, ip
+	add r8, r9, ip
 	add r8, r8, r10
 	add r0, r6, r2
 	orr r3, r3, r1, lsl #20
@@ -7024,7 +7024,7 @@ _02181f70:
 	ldrsh r7, [r3, r2]
 	str r1, [sp, #0x1e8]
 	smull r2, r4, r0, r6
-	adds sb, r2, #0x800
+	adds r9, r2, #0x800
 	rsb r2, r6, #0
 	ldr ip, [r11, #0x4c]
 	ldr r6, [sp, #0x1e0]
@@ -7033,21 +7033,21 @@ _02181f70:
 	smull r6, r4, r0, r7
 	str ip, [sp, #0x1ec]
 	ldr r0, [r11, #0x50]
-	mov sb, sb, lsr #0xc
+	mov r9, r9, lsr #0xc
 	adds r6, r6, #0x800
 	ldr r3, [sp, #0x1dc]
-	orr sb, sb, r8, lsl #20
+	orr r9, r9, r8, lsl #20
 	str r10, [sp, #0x1ec]
 	smull r10, r8, r3, r7
-	add r7, r1, sb
+	add r7, r1, r9
 	adc r4, r4, #0
 	mov r1, r6, lsr #0xc
 	orr r1, r1, r4, lsl #20
-	adds sb, r10, #0x800
+	adds r9, r10, #0x800
 	smull r4, r2, r3, r2
 	adc r6, r8, #0
 	adds r3, r4, #0x800
-	mov r4, sb, lsr #0xc
+	mov r4, r9, lsr #0xc
 	orr r4, r4, r6, lsl #20
 	add r4, r7, r4
 	adc r2, r2, #0
@@ -7095,20 +7095,20 @@ _02182070:
 	str r11, [sp, #0x1d0]
 	ldr r10, [ip, #0x4c]
 	smull r2, r1, r8, r3
-	ldr sb, [sp, #0x1c8]
+	ldr r9, [sp, #0x1c8]
 	adc r6, r6, #0
 	adds r2, r2, #0x800
 	mov r7, r7, lsr #0xc
 	orr r7, r7, r6, lsl #20
 	ldr r0, [sp, #0x1c4]
-	add r8, r10, sb
+	add r8, r10, r9
 	smull r6, r3, r0, r3
-	adc sb, r1, #0
+	adc r9, r1, #0
 	mov r2, r2, lsr #0xc
 	str r10, [sp, #0x1d4]
-	orr r2, r2, sb, lsl #20
+	orr r2, r2, r9, lsl #20
 	adds r1, r6, #0x800
-	smull r10, sb, r0, lr
+	smull r10, r9, r0, lr
 	ldr r6, [ip, #0x50]
 	adc r0, r3, #0
 	adds r3, r10, #0x800
@@ -7117,7 +7117,7 @@ _02182070:
 	add r7, r11, r7
 	add r7, r7, r10
 	add r0, r6, r2
-	adc r1, sb, #0
+	adc r1, r9, #0
 	mov r3, r3, lsr #0xc
 	orr r3, r3, r1, lsl #20
 	add r0, r0, r3
@@ -7221,7 +7221,7 @@ _02182268:
 	ldrsh r7, [r3, r2]
 	str r1, [sp, #0x1ac]
 	smull r2, r4, r0, r6
-	adds sb, r2, #0x800
+	adds r9, r2, #0x800
 	rsb r2, r6, #0
 	ldr ip, [r11, #0x4c]
 	ldr r6, [sp, #0x1a4]
@@ -7230,21 +7230,21 @@ _02182268:
 	smull r6, r4, r0, r7
 	str ip, [sp, #0x1b0]
 	ldr r0, [r11, #0x50]
-	mov sb, sb, lsr #0xc
+	mov r9, r9, lsr #0xc
 	adds r6, r6, #0x800
 	ldr r3, [sp, #0x1a0]
-	orr sb, sb, r8, lsl #20
+	orr r9, r9, r8, lsl #20
 	str r10, [sp, #0x1b0]
 	smull r10, r8, r3, r7
-	add r7, r1, sb
+	add r7, r1, r9
 	adc r4, r4, #0
 	mov r1, r6, lsr #0xc
 	orr r1, r1, r4, lsl #20
-	adds sb, r10, #0x800
+	adds r9, r10, #0x800
 	smull r4, r2, r3, r2
 	adc r6, r8, #0
 	adds r3, r4, #0x800
-	mov r4, sb, lsr #0xc
+	mov r4, r9, lsr #0xc
 	orr r4, r4, r6, lsl #20
 	add r4, r7, r4
 	adc r2, r2, #0
@@ -7440,7 +7440,7 @@ _021825a4:
 	ldrsh r7, [r3, r2]
 	str r1, [sp, #0x17c]
 	smull r2, r4, r0, r6
-	adds sb, r2, #0x800
+	adds r9, r2, #0x800
 	rsb r2, r6, #0
 	ldr ip, [r11, #0x4c]
 	ldr r6, [sp, #0x174]
@@ -7449,22 +7449,22 @@ _021825a4:
 	smull r6, r4, r0, r7
 	str ip, [sp, #0x180]
 	ldr r0, [r11, #0x50]
-	mov sb, sb, lsr #0xc
+	mov r9, r9, lsr #0xc
 	adds r6, r6, #0x800
 	ldr r3, [sp, #0x170]
-	orr sb, sb, r8, lsl #20
+	orr r9, r9, r8, lsl #20
 	str r10, [sp, #0x180]
 	smull r10, r8, r3, r7
-	add r7, r1, sb
+	add r7, r1, r9
 	adc r4, r4, #0
 	mov r1, r6, lsr #0xc
 	orr r1, r1, r4, lsl #20
-	adds sb, r10, #0x800
+	adds r9, r10, #0x800
 	add r0, r0, r1
 	smull r4, r2, r3, r2
 	adc r6, r8, #0
 	adds r3, r4, #0x800
-	mov r4, sb, lsr #0xc
+	mov r4, r9, lsr #0xc
 	orr r4, r4, r6, lsl #20
 	add r4, r7, r4
 	adc r2, r2, #0
@@ -7512,7 +7512,7 @@ _021826c0:
 	ldrsh r7, [r3, r2]
 	str r1, [sp, #0x164]
 	smull r2, r4, r0, r6
-	adds sb, r2, #0x800
+	adds r9, r2, #0x800
 	rsb r2, r6, #0
 	ldr ip, [r11, #0x4c]
 	ldr r6, [sp, #0x15c]
@@ -7521,22 +7521,22 @@ _021826c0:
 	smull r6, r4, r0, r7
 	str ip, [sp, #0x168]
 	ldr r0, [r11, #0x50]
-	mov sb, sb, lsr #0xc
+	mov r9, r9, lsr #0xc
 	adds r6, r6, #0x800
 	ldr r3, [sp, #0x158]
-	orr sb, sb, r8, lsl #20
+	orr r9, r9, r8, lsl #20
 	str r10, [sp, #0x168]
 	smull r10, r8, r3, r7
-	add r7, r1, sb
+	add r7, r1, r9
 	adc r4, r4, #0
 	mov r1, r6, lsr #0xc
 	orr r1, r1, r4, lsl #20
-	adds sb, r10, #0x800
+	adds r9, r10, #0x800
 	add r0, r0, r1
 	smull r4, r2, r3, r2
 	adc r6, r8, #0
 	adds r3, r4, #0x800
-	mov r4, sb, lsr #0xc
+	mov r4, r9, lsr #0xc
 	orr r4, r4, r6, lsl #20
 	add r4, r7, r4
 	adc r2, r2, #0
@@ -7584,7 +7584,7 @@ _021827dc:
 	ldrsh r7, [r3, r2]
 	str r1, [sp, #0x14c]
 	smull r2, r4, r0, r6
-	adds sb, r2, #0x800
+	adds r9, r2, #0x800
 	rsb r2, r6, #0
 	ldr ip, [r11, #0x4c]
 	ldr r6, [sp, #0x144]
@@ -7593,22 +7593,22 @@ _021827dc:
 	smull r6, r4, r0, r7
 	str ip, [sp, #0x150]
 	ldr r0, [r11, #0x50]
-	mov sb, sb, lsr #0xc
+	mov r9, r9, lsr #0xc
 	adds r6, r6, #0x800
 	ldr r3, [sp, #0x140]
-	orr sb, sb, r8, lsl #20
+	orr r9, r9, r8, lsl #20
 	str r10, [sp, #0x150]
 	smull r10, r8, r3, r7
-	add r7, r1, sb
+	add r7, r1, r9
 	adc r4, r4, #0
 	mov r1, r6, lsr #0xc
 	orr r1, r1, r4, lsl #20
-	adds sb, r10, #0x800
+	adds r9, r10, #0x800
 	add r0, r0, r1
 	smull r4, r2, r3, r2
 	adc r6, r8, #0
 	adds r3, r4, #0x800
-	mov r4, sb, lsr #0xc
+	mov r4, r9, lsr #0xc
 	orr r4, r4, r6, lsl #20
 	add r4, r7, r4
 	adc r2, r2, #0
@@ -7656,7 +7656,7 @@ _021828f8:
 	ldrsh r7, [r3, r2]
 	str r1, [sp, #0x134]
 	smull r2, r4, r0, r6
-	adds sb, r2, #0x800
+	adds r9, r2, #0x800
 	rsb r2, r6, #0
 	ldr ip, [r11, #0x4c]
 	ldr r6, [sp, #0x12c]
@@ -7665,22 +7665,22 @@ _021828f8:
 	smull r6, r4, r0, r7
 	str ip, [sp, #0x138]
 	ldr r0, [r11, #0x50]
-	mov sb, sb, lsr #0xc
+	mov r9, r9, lsr #0xc
 	adds r6, r6, #0x800
 	ldr r3, [sp, #0x128]
-	orr sb, sb, r8, lsl #20
+	orr r9, r9, r8, lsl #20
 	str r10, [sp, #0x138]
 	smull r10, r8, r3, r7
-	add r7, r1, sb
+	add r7, r1, r9
 	adc r4, r4, #0
 	mov r1, r6, lsr #0xc
 	orr r1, r1, r4, lsl #20
-	adds sb, r10, #0x800
+	adds r9, r10, #0x800
 	add r0, r0, r1
 	smull r4, r2, r3, r2
 	adc r6, r8, #0
 	adds r3, r4, #0x800
-	mov r4, sb, lsr #0xc
+	mov r4, r9, lsr #0xc
 	orr r4, r4, r6, lsl #20
 	add r4, r7, r4
 	adc r2, r2, #0
@@ -7728,7 +7728,7 @@ _02182a14:
 	ldrsh r7, [r3, r2]
 	str r1, [sp, #0x11c]
 	smull r2, r4, r0, r6
-	adds sb, r2, #0x800
+	adds r9, r2, #0x800
 	rsb r2, r6, #0
 	ldr ip, [r11, #0x4c]
 	ldr r6, [sp, #0x114]
@@ -7737,22 +7737,22 @@ _02182a14:
 	smull r6, r4, r0, r7
 	str ip, [sp, #0x120]
 	ldr r0, [r11, #0x50]
-	mov sb, sb, lsr #0xc
+	mov r9, r9, lsr #0xc
 	adds r6, r6, #0x800
 	ldr r3, [sp, #0x110]
-	orr sb, sb, r8, lsl #20
+	orr r9, r9, r8, lsl #20
 	str r10, [sp, #0x120]
 	smull r10, r8, r3, r7
-	add r7, r1, sb
+	add r7, r1, r9
 	adc r4, r4, #0
 	mov r1, r6, lsr #0xc
 	orr r1, r1, r4, lsl #20
-	adds sb, r10, #0x800
+	adds r9, r10, #0x800
 	add r0, r0, r1
 	smull r4, r2, r3, r2
 	adc r6, r8, #0
 	adds r3, r4, #0x800
-	mov r4, sb, lsr #0xc
+	mov r4, r9, lsr #0xc
 	orr r4, r4, r6, lsl #20
 	add r4, r7, r4
 	adc r2, r2, #0
@@ -7800,7 +7800,7 @@ _02182b30:
 	ldrsh r7, [r3, r2]
 	str r1, [sp, #0x104]
 	smull r2, r4, r0, r6
-	adds sb, r2, #0x800
+	adds r9, r2, #0x800
 	rsb r2, r6, #0
 	ldr ip, [r11, #0x4c]
 	ldr r6, [sp, #0xfc]
@@ -7809,22 +7809,22 @@ _02182b30:
 	smull r6, r4, r0, r7
 	str ip, [sp, #0x108]
 	ldr r0, [r11, #0x50]
-	mov sb, sb, lsr #0xc
+	mov r9, r9, lsr #0xc
 	adds r6, r6, #0x800
 	ldr r3, [sp, #0xf8]
-	orr sb, sb, r8, lsl #20
+	orr r9, r9, r8, lsl #20
 	str r10, [sp, #0x108]
 	smull r10, r8, r3, r7
-	add r7, r1, sb
+	add r7, r1, r9
 	adc r4, r4, #0
 	mov r1, r6, lsr #0xc
 	orr r1, r1, r4, lsl #20
-	adds sb, r10, #0x800
+	adds r9, r10, #0x800
 	add r0, r0, r1
 	smull r4, r2, r3, r2
 	adc r6, r8, #0
 	adds r3, r4, #0x800
-	mov r4, sb, lsr #0xc
+	mov r4, r9, lsr #0xc
 	orr r4, r4, r6, lsl #20
 	add r4, r7, r4
 	adc r2, r2, #0
@@ -7872,7 +7872,7 @@ _02182c4c:
 	ldrsh r7, [r3, r2]
 	str r1, [sp, #0xec]
 	smull r2, r4, r0, r6
-	adds sb, r2, #0x800
+	adds r9, r2, #0x800
 	rsb r2, r6, #0
 	ldr ip, [r11, #0x4c]
 	ldr r6, [sp, #0xe4]
@@ -7881,22 +7881,22 @@ _02182c4c:
 	smull r6, r4, r0, r7
 	str ip, [sp, #0xf0]
 	ldr r0, [r11, #0x50]
-	mov sb, sb, lsr #0xc
+	mov r9, r9, lsr #0xc
 	adds r6, r6, #0x800
 	ldr r3, [sp, #0xe0]
-	orr sb, sb, r8, lsl #20
+	orr r9, r9, r8, lsl #20
 	str r10, [sp, #0xf0]
 	smull r10, r8, r3, r7
-	add r7, r1, sb
+	add r7, r1, r9
 	adc r4, r4, #0
 	mov r1, r6, lsr #0xc
 	orr r1, r1, r4, lsl #20
-	adds sb, r10, #0x800
+	adds r9, r10, #0x800
 	add r0, r0, r1
 	smull r4, r2, r3, r2
 	adc r6, r8, #0
 	adds r3, r4, #0x800
-	mov r4, sb, lsr #0xc
+	mov r4, r9, lsr #0xc
 	orr r4, r4, r6, lsl #20
 	add r4, r7, r4
 	adc r2, r2, #0
@@ -7944,7 +7944,7 @@ _02182d68:
 	ldrsh r7, [r3, r2]
 	str r1, [sp, #0xd4]
 	smull r2, r4, r0, r6
-	adds sb, r2, #0x800
+	adds r9, r2, #0x800
 	rsb r2, r6, #0
 	ldr ip, [r11, #0x4c]
 	ldr r6, [sp, #0xcc]
@@ -7953,22 +7953,22 @@ _02182d68:
 	smull r6, r4, r0, r7
 	str ip, [sp, #0xd8]
 	ldr r0, [r11, #0x50]
-	mov sb, sb, lsr #0xc
+	mov r9, r9, lsr #0xc
 	adds r6, r6, #0x800
 	ldr r3, [sp, #0xc8]
-	orr sb, sb, r8, lsl #20
+	orr r9, r9, r8, lsl #20
 	str r10, [sp, #0xd8]
 	smull r10, r8, r3, r7
-	add r7, r1, sb
+	add r7, r1, r9
 	adc r4, r4, #0
 	mov r1, r6, lsr #0xc
 	orr r1, r1, r4, lsl #20
-	adds sb, r10, #0x800
+	adds r9, r10, #0x800
 	add r0, r0, r1
 	smull r4, r2, r3, r2
 	adc r6, r8, #0
 	adds r3, r4, #0x800
-	mov r4, sb, lsr #0xc
+	mov r4, r9, lsr #0xc
 	orr r4, r4, r6, lsl #20
 	add r4, r7, r4
 	adc r2, r2, #0
@@ -8016,7 +8016,7 @@ _02182e84:
 	ldrsh r7, [r3, r2]
 	str r1, [sp, #0xbc]
 	smull r2, r4, r0, r6
-	adds sb, r2, #0x800
+	adds r9, r2, #0x800
 	rsb r2, r6, #0
 	ldr ip, [r11, #0x4c]
 	ldr r6, [sp, #0xb4]
@@ -8025,22 +8025,22 @@ _02182e84:
 	smull r6, r4, r0, r7
 	str ip, [sp, #0xc0]
 	ldr r0, [r11, #0x50]
-	mov sb, sb, lsr #0xc
+	mov r9, r9, lsr #0xc
 	adds r6, r6, #0x800
 	ldr r3, [sp, #0xb0]
-	orr sb, sb, r8, lsl #20
+	orr r9, r9, r8, lsl #20
 	str r10, [sp, #0xc0]
 	smull r10, r8, r3, r7
-	add r7, r1, sb
+	add r7, r1, r9
 	adc r4, r4, #0
 	mov r1, r6, lsr #0xc
 	orr r1, r1, r4, lsl #20
-	adds sb, r10, #0x800
+	adds r9, r10, #0x800
 	add r0, r0, r1
 	smull r4, r2, r3, r2
 	adc r6, r8, #0
 	adds r3, r4, #0x800
-	mov r4, sb, lsr #0xc
+	mov r4, r9, lsr #0xc
 	orr r4, r4, r6, lsl #20
 	add r4, r7, r4
 	adc r2, r2, #0
@@ -8110,7 +8110,7 @@ _02183020:
 	ldrsh r7, [r3, r2]
 	str r1, [sp, #0xa4]
 	smull r2, r4, r0, r6
-	adds sb, r2, #0x800
+	adds r9, r2, #0x800
 	rsb r2, r6, #0
 	ldr ip, [r11, #0x4c]
 	ldr r6, [sp, #0x9c]
@@ -8119,22 +8119,22 @@ _02183020:
 	smull r6, r4, r0, r7
 	str ip, [sp, #0xa8]
 	ldr r0, [r11, #0x50]
-	mov sb, sb, lsr #0xc
+	mov r9, r9, lsr #0xc
 	adds r6, r6, #0x800
 	ldr r3, [sp, #0x98]
-	orr sb, sb, r8, lsl #20
+	orr r9, r9, r8, lsl #20
 	str r10, [sp, #0xa8]
 	smull r10, r8, r3, r7
-	add r7, r1, sb
+	add r7, r1, r9
 	adc r4, r4, #0
 	mov r1, r6, lsr #0xc
 	orr r1, r1, r4, lsl #20
-	adds sb, r10, #0x800
+	adds r9, r10, #0x800
 	add r0, r0, r1
 	smull r4, r2, r3, r2
 	adc r6, r8, #0
 	adds r3, r4, #0x800
-	mov r4, sb, lsr #0xc
+	mov r4, r9, lsr #0xc
 	orr r4, r4, r6, lsl #20
 	add r4, r7, r4
 	adc r2, r2, #0
@@ -8182,7 +8182,7 @@ _0218310c:
 	ldrsh r7, [r3, r2]
 	str r1, [sp, #0x8c]
 	smull r2, r4, r0, r6
-	adds sb, r2, #0x800
+	adds r9, r2, #0x800
 	rsb r2, r6, #0
 	ldr ip, [r11, #0x4c]
 	ldr r6, [sp, #0x84]
@@ -8191,22 +8191,22 @@ _0218310c:
 	smull r6, r4, r0, r7
 	str ip, [sp, #0x90]
 	ldr r0, [r11, #0x50]
-	mov sb, sb, lsr #0xc
+	mov r9, r9, lsr #0xc
 	adds r6, r6, #0x800
 	ldr r3, [sp, #0x80]
-	orr sb, sb, r8, lsl #20
+	orr r9, r9, r8, lsl #20
 	str r10, [sp, #0x90]
 	smull r10, r8, r3, r7
-	add r7, r1, sb
+	add r7, r1, r9
 	adc r4, r4, #0
 	mov r1, r6, lsr #0xc
 	orr r1, r1, r4, lsl #20
-	adds sb, r10, #0x800
+	adds r9, r10, #0x800
 	add r0, r0, r1
 	smull r4, r2, r3, r2
 	adc r6, r8, #0
 	adds r3, r4, #0x800
-	mov r4, sb, lsr #0xc
+	mov r4, r9, lsr #0xc
 	orr r4, r4, r6, lsl #20
 	add r4, r7, r4
 	adc r2, r2, #0
@@ -8254,7 +8254,7 @@ _02183228:
 	ldrsh r7, [r3, r2]
 	str r1, [sp, #0x74]
 	smull r2, r4, r0, r6
-	adds sb, r2, #0x800
+	adds r9, r2, #0x800
 	rsb r2, r6, #0
 	ldr ip, [r11, #0x4c]
 	ldr r6, [sp, #0x6c]
@@ -8263,22 +8263,22 @@ _02183228:
 	smull r6, r4, r0, r7
 	str ip, [sp, #0x78]
 	ldr r0, [r11, #0x50]
-	mov sb, sb, lsr #0xc
+	mov r9, r9, lsr #0xc
 	adds r6, r6, #0x800
 	ldr r3, [sp, #0x68]
-	orr sb, sb, r8, lsl #20
+	orr r9, r9, r8, lsl #20
 	str r10, [sp, #0x78]
 	smull r10, r8, r3, r7
-	add r7, r1, sb
+	add r7, r1, r9
 	adc r4, r4, #0
 	mov r1, r6, lsr #0xc
 	orr r1, r1, r4, lsl #20
-	adds sb, r10, #0x800
+	adds r9, r10, #0x800
 	add r0, r0, r1
 	smull r4, r2, r3, r2
 	adc r6, r8, #0
 	adds r3, r4, #0x800
-	mov r4, sb, lsr #0xc
+	mov r4, r9, lsr #0xc
 	orr r4, r4, r6, lsl #20
 	add r6, r7, r4
 	adc r2, r2, #0
@@ -8317,7 +8317,7 @@ _02183320:
 	ldrsh r7, [r3, r2]
 	str r1, [sp, #0x5c]
 	smull r2, r4, r0, r6
-	adds sb, r2, #0x800
+	adds r9, r2, #0x800
 	rsb r2, r6, #0
 	ldr ip, [r11, #0x4c]
 	ldr r6, [sp, #0x54]
@@ -8326,22 +8326,22 @@ _02183320:
 	smull r6, r4, r0, r7
 	str ip, [sp, #0x60]
 	ldr r0, [r11, #0x50]
-	mov sb, sb, lsr #0xc
+	mov r9, r9, lsr #0xc
 	adds r6, r6, #0x800
 	ldr r3, [sp, #0x50]
-	orr sb, sb, r8, lsl #20
+	orr r9, r9, r8, lsl #20
 	str r10, [sp, #0x60]
 	smull r10, r8, r3, r7
-	add r7, r1, sb
+	add r7, r1, r9
 	adc r4, r4, #0
 	mov r1, r6, lsr #0xc
 	orr r1, r1, r4, lsl #20
-	adds sb, r10, #0x800
+	adds r9, r10, #0x800
 	add r0, r0, r1
 	smull r4, r2, r3, r2
 	adc r6, r8, #0
 	adds r3, r4, #0x800
-	mov r4, sb, lsr #0xc
+	mov r4, r9, lsr #0xc
 	orr r4, r4, r6, lsl #20
 	add r4, r7, r4
 	adc r2, r2, #0
@@ -8385,7 +8385,7 @@ _02183468:
 	cmp r4, #4
 	blt _02183468
 	add sp, sp, #0x314
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 _0218348c: .word data_ov37_021880d0
 _02183490: .word data_ov37_021880dc
@@ -9243,25 +9243,25 @@ _02183f84: .word 0x00003333
 	.global func_ov37_02183f88
 	arm_func_start func_ov37_02183f88
 func_ov37_02183f88: ; 0x02183f88
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	mov r10, r0
 	add r0, r10, #0x31c
 	add r1, r10, #0x28c
-	mov sb, #0
+	mov r9, #0
 	add r7, r0, #0xc00
 	add r8, r1, #0xc00
-	mov r4, sb
+	mov r4, r9
 	mov r5, #1
 	mov r6, #2
 _02183fb0:
-	add r0, r10, sb, lsl #2
+	add r0, r10, r9, lsl #2
 	ldr r0, [r0, #0xf7c]
 	cmp r0, #0
 	beq _0218403c
 	mov r0, r10
-	mov r1, sb
+	mov r1, r9
 	bl func_ov37_02183e9c
-	add r1, r10, sb, lsl #2
+	add r1, r10, r9, lsl #2
 	ldr r0, [r1, #0xf7c]
 	cmp r0, #1
 	bne _02183ff0
@@ -9286,19 +9286,19 @@ _0218400c:
 	mov r1, r4
 	bl func_ov37_0217ff40
 _02184024:
-	add r0, r10, sb, lsl #2
+	add r0, r10, r9, lsl #2
 	add r0, r0, #0x1000
 	ldr r0, [r0, #0x57c]
 	mov r1, r8
 	mov r2, r7
 	bl func_ov00_020c5e88
 _0218403c:
-	add sb, sb, #1
-	cmp sb, #4
+	add r9, r9, #1
+	cmp r9, #4
 	add r7, r7, #0xc
 	add r8, r8, #0x24
 	blt _02183fb0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	arm_func_end func_ov37_02183f88
 
 	.global func_ov37_02184054
@@ -11394,7 +11394,7 @@ _02185b4c:
 	.global func_ov37_02185b6c
 	arm_func_start func_ov37_02185b6c
 func_ov37_02185b6c: ; 0x02185b6c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x54
 	ldr r6, _02186160 ; =data_ov37_02188640
 	ldr r4, _02186164 ; =data_ov37_0218864c
@@ -11405,7 +11405,7 @@ func_ov37_02185b6c: ; 0x02185b6c
 	add lr, sp, #0x3c
 	add r3, sp, #0x30
 	add r11, sp, #0x24
-	mov sb, r0
+	mov r9, r0
 	mov r7, r2
 	ldmia r6, {r0, r1, r2}
 	stmia r5, {r0, r1, r2}
@@ -11423,12 +11423,12 @@ func_ov37_02185b6c: ; 0x02185b6c
 	add r3, sp, #0xc
 	ldmia r0, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
-	ldr r4, [sb, #0x1c]
+	ldr r4, [r9, #0x1c]
 	add r3, sp, #0
 	add r0, r4, #0x48
 	ldmia r0, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
-	ldr r0, [sb, #0xc8]
+	ldr r0, [r9, #0xc8]
 	cmp r8, #5
 	str r0, [sp, #4]
 	addls pc, pc, r8, lsl #2
@@ -11496,7 +11496,7 @@ _02185c20:
 	add r0, r2, r1
 	add sp, sp, #0x54
 	str r0, [r7, #8]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02185d00:
 	ldrh r1, [r4, #0x78]
 	ldr r0, [sp]
@@ -11553,7 +11553,7 @@ _02185d00:
 	add r0, r2, r1
 	add sp, sp, #0x54
 	str r0, [r7, #8]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02185de0:
 	ldrh r1, [r4, #0x78]
 	ldr r0, [sp]
@@ -11610,7 +11610,7 @@ _02185de0:
 	add r0, r2, r1
 	add sp, sp, #0x54
 	str r0, [r7, #8]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02185ec0:
 	ldrh r1, [r4, #0x78]
 	ldr r0, [sp]
@@ -11667,7 +11667,7 @@ _02185ec0:
 	add r0, r2, r1
 	add sp, sp, #0x54
 	str r0, [r7, #8]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02185fa0:
 	ldrh r1, [r4, #0x78]
 	ldr r0, [sp]
@@ -11724,7 +11724,7 @@ _02185fa0:
 	add r0, r2, r1
 	add sp, sp, #0x54
 	str r0, [r7, #8]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02186080:
 	ldrh r1, [r4, #0x78]
 	ldr r0, [sp]
@@ -11782,7 +11782,7 @@ _02186080:
 	str r0, [r7, #8]
 _02186158:
 	add sp, sp, #0x54
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov37_02185b6c
 _02186160: .word data_ov37_02188640

--- a/asm/ov37.s
+++ b/asm/ov37.s
@@ -890,13 +890,13 @@ _0217c920: .word data_027e0e58
 	.global func_ov37_0217c924
 	arm_func_start func_ov37_0217c924
 func_ov37_0217c924: ; 0x0217c924
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x4c
 	mov r8, r0
 	bl func_ov37_0217be60
 	cmp r0, #0
 	addeq sp, sp, #0x4c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	add r0, r8, #0x2000
 	ldr r0, [r0, #0xfa0]
 	cmp r0, #0
@@ -922,14 +922,14 @@ _0217c978:
 	ldrb r0, [r0, #0xe90]
 	cmp r0, #0
 	beq _0217ca88
-	ldr sl, _0217cbe8 ; =data_ov37_02187dcc
+	ldr r10, _0217cbe8 ; =data_ov37_02187dcc
 	add lr, sp, #0x24
-	ldmia sl!, {r0, r1, r2, r3}
+	ldmia r10!, {r0, r1, r2, r3}
 	mov ip, lr
 	stmia lr!, {r0, r1, r2, r3}
-	ldmia sl!, {r0, r1, r2, r3}
+	ldmia r10!, {r0, r1, r2, r3}
 	stmia lr!, {r0, r1, r2, r3}
-	ldmia sl, {r0, r1}
+	ldmia r10, {r0, r1}
 	stmia lr, {r0, r1}
 	add r0, sp, #6
 	str r0, [sp]
@@ -944,12 +944,12 @@ _0217c978:
 	ldr r1, [r2, #0xdf0]
 	mov r0, r7
 	str r1, [r5, #0x48]
-	ldr sl, [r2, #0xdf4]
+	ldr r10, [r2, #0xdf4]
 	ldr r1, _0217cbec ; =data_027e0f94
-	str sl, [r5, #0x4c]
-	ldr sl, [r2, #0xdf8]
+	str r10, [r5, #0x4c]
+	ldr r10, [r2, #0xdf8]
 	add r2, sp, #0x18
-	str sl, [r5, #0x50]
+	str r10, [r5, #0x50]
 	str r3, [r5, #0x88]
 	ldr r3, [sb]
 	str r3, [r5, #0x60]
@@ -991,18 +991,18 @@ _0217ca90:
 	cmp r4, #0xa
 	blt _0217c978
 	add sp, sp, #0x4c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0217caac:
 	cmp r0, #1
 	addne sp, sp, #0x4c
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	add r0, r8, #0x334
 	add r7, r0, #0x2c00
 	ldr r0, _0217cbdc ; =0x00007fff
 	add r1, r8, #0x2f4
 	ldr r5, _0217cbe0 ; =data_027e0d0c
 	add sb, r1, #0x2c00
-	mov sl, #0
+	mov r10, #0
 	rsb r4, r0, #0
 	mov r11, #7
 _0217cadc:
@@ -1012,16 +1012,16 @@ _0217cadc:
 	bl _ZN12ActorManager8GetActorEP8ActorRef
 	mov r6, r0
 	add r0, r8, #0x21c
-	mov r1, sl
+	mov r1, r10
 	bl func_ov37_02183e18
 	cmp r0, #2
 	bne _0217cbb8
 	add r0, r8, #0x21c
-	mov r1, sl
+	mov r1, r10
 	mov r2, sb
 	add r3, sp, #4
 	bl func_ov37_02184054
-	add r0, r8, sl, lsl #4
+	add r0, r8, r10, lsl #4
 	add r2, r0, #0x2000
 	ldr r3, [r2, #0xf00]
 	ldr r1, [r2, #0xef4]
@@ -1068,11 +1068,11 @@ _0217cbb8:
 _0217cbc0:
 	add r7, r7, #8
 	add sb, sb, #0x10
-	add sl, sl, #1
-	cmp sl, #4
+	add r10, r10, #1
+	cmp r10, #4
 	blt _0217cadc
 	add sp, sp, #0x4c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov37_0217c924
 _0217cbdc: .word 0x00007fff
@@ -4189,10 +4189,10 @@ _0217f808: .word data_02050f54
 	.global func_ov37_0217f80c
 	arm_func_start func_ov37_0217f80c
 func_ov37_0217f80c: ; 0x0217f80c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x30
-	mov sl, r0
-	add r0, sl, #0x29c
+	mov r10, r0
+	add r0, r10, #0x29c
 	ldr r11, _0217f89c ; =0x4c4f4e44
 	ldr r4, _0217f8a0 ; =data_027e0fe8
 	add sb, r0, #0x2c00
@@ -4201,7 +4201,7 @@ func_ov37_0217f80c: ; 0x0217f80c
 	add r6, sp, #4
 	mvn r5, #0
 _0217f838:
-	add r0, sl, r8
+	add r0, r10, r8
 	add r1, r0, #0x2000
 	mov r0, r6
 	strb r7, [r1, #0xe90]
@@ -4210,11 +4210,11 @@ _0217f838:
 	str r5, [sp, #0x20]
 	str r5, [sp, #0x24]
 	bl func_ov00_020c3348
-	ldr r0, [sl, #8]
+	ldr r0, [r10, #8]
 	mov r1, r11
 	str r0, [sp, #0x20]
-	ldr r0, [sl, #0xc]
-	add r2, sl, #0x48
+	ldr r0, [r10, #0xc]
+	add r2, r10, #0x48
 	str r0, [sp, #0x24]
 	str sb, [sp]
 	ldr r0, [r4]
@@ -4225,7 +4225,7 @@ _0217f838:
 	cmp r8, #0xa
 	blt _0217f838
 	add sp, sp, #0x30
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov37_0217f80c
 _0217f89c: .word 0x4c4f4e44
@@ -4258,10 +4258,10 @@ _0217f8e4: .word data_027e0fe4
 	.global func_ov37_0217f8e8
 	arm_func_start func_ov37_0217f8e8
 func_ov37_0217f8e8: ; 0x0217f8e8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x30
-	mov sl, r0
-	add r0, sl, #0x334
+	mov r10, r0
+	add r0, r10, #0x334
 	ldr r11, _0217f978 ; =0x4c4f4e44
 	ldr r4, _0217f97c ; =data_027e0fe8
 	add sb, r0, #0x2c00
@@ -4270,7 +4270,7 @@ func_ov37_0217f8e8: ; 0x0217f8e8
 	add r6, sp, #4
 	mvn r5, #0
 _0217f914:
-	add r0, sl, r8
+	add r0, r10, r8
 	add r1, r0, #0x2000
 	mov r0, r6
 	strb r7, [r1, #0xe90]
@@ -4279,11 +4279,11 @@ _0217f914:
 	str r5, [sp, #0x20]
 	str r5, [sp, #0x24]
 	bl func_ov00_020c3348
-	ldr r0, [sl, #8]
+	ldr r0, [r10, #8]
 	mov r1, r11
 	str r0, [sp, #0x20]
-	ldr r0, [sl, #0xc]
-	add r2, sl, #0x48
+	ldr r0, [r10, #0xc]
+	add r2, r10, #0x48
 	str r0, [sp, #0x24]
 	str sb, [sp]
 	ldr r0, [r4]
@@ -4294,7 +4294,7 @@ _0217f914:
 	cmp r8, #4
 	blt _0217f914
 	add sp, sp, #0x30
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov37_0217f8e8
 _0217f978: .word 0x4c4f4e44
@@ -5934,7 +5934,7 @@ func_ov37_02180f34: ; 0x02180f34
 	.global func_ov37_02180f54
 	arm_func_start func_ov37_02180f54
 func_ov37_02180f54: ; 0x02180f54
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x314
 	mov r5, r0
 	ldr r0, [r5, #0x1c]
@@ -6072,26 +6072,26 @@ _021810fc:
 	mov r0, r0, lsl #0x1
 	ldrsh r1, [r1, r0]
 	smull r6, sb, r3, r8
-	adds sl, r6, #0x800
+	adds r10, r6, #0x800
 	str r2, [sp, #0x308]
 	adc sb, sb, #0
-	mov sl, sl, lsr #0xc
-	orr sl, sl, sb, lsl #20
-	add r2, r2, sl
-	smull sl, sb, r3, r1
-	adds sl, sl, #0x800
+	mov r10, r10, lsr #0xc
+	orr r10, r10, sb, lsl #20
+	add r2, r2, r10
+	smull r10, sb, r3, r1
+	adds r10, r10, #0x800
 	ldr r6, [r7, #0x4c]
 	ldr r0, [sp, #0x2fc]
 	adc r3, sb, #0
-	mov r11, sl, lsr #0xc
+	mov r11, r10, lsr #0xc
 	str r6, [sp, #0x30c]
 	orr r11, r11, r3, lsl #20
-	smull sl, sb, r0, r1
+	smull r10, sb, r0, r1
 	ldr r3, [r7, #0x50]
 	rsb r8, r8, #0
 	add r1, r3, r11
 	smull r7, r3, r0, r8
-	adds r8, sl, #0x800
+	adds r8, r10, #0x800
 	adc r0, sb, #0
 	mov r8, r8, lsr #0xc
 	orr r8, r8, r0, lsl #20
@@ -6139,26 +6139,26 @@ _02181204:
 	mov r0, r0, lsl #0x1
 	ldrsh r1, [r1, r0]
 	smull r6, sb, r3, r8
-	adds sl, r6, #0x800
+	adds r10, r6, #0x800
 	str r2, [sp, #0x2f0]
 	adc sb, sb, #0
-	mov sl, sl, lsr #0xc
-	orr sl, sl, sb, lsl #20
-	add r2, r2, sl
-	smull sl, sb, r3, r1
-	adds sl, sl, #0x800
+	mov r10, r10, lsr #0xc
+	orr r10, r10, sb, lsl #20
+	add r2, r2, r10
+	smull r10, sb, r3, r1
+	adds r10, r10, #0x800
 	ldr r6, [r7, #0x4c]
 	ldr r0, [sp, #0x2e4]
 	adc r3, sb, #0
-	mov r11, sl, lsr #0xc
+	mov r11, r10, lsr #0xc
 	str r6, [sp, #0x2f4]
 	orr r11, r11, r3, lsl #20
-	smull sl, sb, r0, r1
+	smull r10, sb, r0, r1
 	ldr r3, [r7, #0x50]
 	rsb r8, r8, #0
 	add r1, r3, r11
 	smull r7, r3, r0, r8
-	adds r8, sl, #0x800
+	adds r8, r10, #0x800
 	adc r0, sb, #0
 	mov r8, r8, lsr #0xc
 	orr r8, r8, r0, lsl #20
@@ -6245,7 +6245,7 @@ _02181388:
 	ldr ip, [r11, #0x4c]
 	ldr r6, [sp, #0x2c4]
 	adc r8, r4, #0
-	add sl, ip, r6
+	add r10, ip, r6
 	smull r6, r4, r0, r7
 	str ip, [sp, #0x2d0]
 	ldr r0, [r11, #0x50]
@@ -6253,13 +6253,13 @@ _02181388:
 	adds r6, r6, #0x800
 	ldr r3, [sp, #0x2c0]
 	orr sb, sb, r8, lsl #20
-	str sl, [sp, #0x2d0]
-	smull sl, r8, r3, r7
+	str r10, [sp, #0x2d0]
+	smull r10, r8, r3, r7
 	add r7, r1, sb
 	adc r4, r4, #0
 	mov r1, r6, lsr #0xc
 	orr r1, r1, r4, lsl #20
-	adds sb, sl, #0x800
+	adds sb, r10, #0x800
 	add r0, r0, r1
 	smull r4, r2, r3, r2
 	adc r6, r8, #0
@@ -6308,7 +6308,7 @@ _02181480:
 	ldr ip, [r11, #0x4c]
 	ldr r6, [sp, #0x2ac]
 	adc r8, r4, #0
-	add sl, ip, r6
+	add r10, ip, r6
 	smull r6, r4, r0, r7
 	str ip, [sp, #0x2b8]
 	ldr r0, [r11, #0x50]
@@ -6316,13 +6316,13 @@ _02181480:
 	adds r6, r6, #0x800
 	ldr r3, [sp, #0x2a8]
 	orr sb, sb, r8, lsl #20
-	str sl, [sp, #0x2b8]
-	smull sl, r8, r3, r7
+	str r10, [sp, #0x2b8]
+	smull r10, r8, r3, r7
 	add r7, r1, sb
 	adc r4, r4, #0
 	mov r1, r6, lsr #0xc
 	orr r1, r1, r4, lsl #20
-	adds sb, sl, #0x800
+	adds sb, r10, #0x800
 	add r0, r0, r1
 	smull r4, r2, r3, r2
 	adc r6, r8, #0
@@ -6371,7 +6371,7 @@ _02181578:
 	ldr ip, [r11, #0x4c]
 	ldr r6, [sp, #0x294]
 	adc r8, r4, #0
-	add sl, ip, r6
+	add r10, ip, r6
 	smull r6, r4, r0, r7
 	str ip, [sp, #0x2a0]
 	ldr r0, [r11, #0x50]
@@ -6379,13 +6379,13 @@ _02181578:
 	adds r6, r6, #0x800
 	ldr r3, [sp, #0x290]
 	orr sb, sb, r8, lsl #20
-	str sl, [sp, #0x2a0]
-	smull sl, r8, r3, r7
+	str r10, [sp, #0x2a0]
+	smull r10, r8, r3, r7
 	add r7, r1, sb
 	adc r4, r4, #0
 	mov r1, r6, lsr #0xc
 	orr r1, r1, r4, lsl #20
-	adds sb, sl, #0x800
+	adds sb, r10, #0x800
 	add r0, r0, r1
 	smull r4, r2, r3, r2
 	adc r6, r8, #0
@@ -6434,7 +6434,7 @@ _02181670:
 	ldr ip, [r11, #0x4c]
 	ldr r6, [sp, #0x27c]
 	adc r8, r4, #0
-	add sl, ip, r6
+	add r10, ip, r6
 	smull r6, r4, r0, r7
 	str ip, [sp, #0x288]
 	ldr r0, [r11, #0x50]
@@ -6442,13 +6442,13 @@ _02181670:
 	adds r6, r6, #0x800
 	ldr r3, [sp, #0x278]
 	orr sb, sb, r8, lsl #20
-	str sl, [sp, #0x288]
-	smull sl, r8, r3, r7
+	str r10, [sp, #0x288]
+	smull r10, r8, r3, r7
 	add r7, r1, sb
 	adc r4, r4, #0
 	mov r1, r6, lsr #0xc
 	orr r1, r1, r4, lsl #20
-	adds sb, sl, #0x800
+	adds sb, r10, #0x800
 	add r0, r0, r1
 	smull r4, r2, r3, r2
 	adc r6, r8, #0
@@ -6497,7 +6497,7 @@ _02181768:
 	ldr ip, [r11, #0x4c]
 	ldr r6, [sp, #0x264]
 	adc r8, r4, #0
-	add sl, ip, r6
+	add r10, ip, r6
 	smull r6, r4, r0, r7
 	str ip, [sp, #0x270]
 	ldr r0, [r11, #0x50]
@@ -6505,13 +6505,13 @@ _02181768:
 	adds r6, r6, #0x800
 	ldr r3, [sp, #0x260]
 	orr sb, sb, r8, lsl #20
-	str sl, [sp, #0x270]
-	smull sl, r8, r3, r7
+	str r10, [sp, #0x270]
+	smull r10, r8, r3, r7
 	add r7, r1, sb
 	adc r4, r4, #0
 	mov r1, r6, lsr #0xc
 	orr r1, r1, r4, lsl #20
-	adds sb, sl, #0x800
+	adds sb, r10, #0x800
 	add r0, r0, r1
 	smull r4, r2, r3, r2
 	adc r6, r8, #0
@@ -6614,7 +6614,7 @@ _0218192c:
 	ldr ip, [r11, #0x4c]
 	ldr r6, [sp, #0x24c]
 	adc r8, r4, #0
-	add sl, ip, r6
+	add r10, ip, r6
 	smull r6, r4, r0, r7
 	str ip, [sp, #0x258]
 	ldr r0, [r11, #0x50]
@@ -6622,13 +6622,13 @@ _0218192c:
 	adds r6, r6, #0x800
 	ldr r3, [sp, #0x248]
 	orr sb, sb, r8, lsl #20
-	str sl, [sp, #0x258]
-	smull sl, r8, r3, r7
+	str r10, [sp, #0x258]
+	smull r10, r8, r3, r7
 	add r7, r1, sb
 	adc r4, r4, #0
 	mov r1, r6, lsr #0xc
 	orr r1, r1, r4, lsl #20
-	adds sb, sl, #0x800
+	adds sb, r10, #0x800
 	add r0, r0, r1
 	smull r4, r2, r3, r2
 	adc r6, r8, #0
@@ -6690,7 +6690,7 @@ _02181a58:
 	ldr ip, [r11, #0x4c]
 	ldr r6, [sp, #0x234]
 	adc r8, r4, #0
-	add sl, ip, r6
+	add r10, ip, r6
 	smull r6, r4, r0, r7
 	str ip, [sp, #0x240]
 	ldr r0, [r11, #0x50]
@@ -6698,13 +6698,13 @@ _02181a58:
 	adds r6, r6, #0x800
 	ldr r3, [sp, #0x230]
 	orr sb, sb, r8, lsl #20
-	str sl, [sp, #0x240]
-	smull sl, r8, r3, r7
+	str r10, [sp, #0x240]
+	smull r10, r8, r3, r7
 	add r7, r1, sb
 	adc r4, r4, #0
 	mov r1, r6, lsr #0xc
 	orr r1, r1, r4, lsl #20
-	adds sb, sl, #0x800
+	adds sb, r10, #0x800
 	add r0, r0, r1
 	smull r4, r2, r3, r2
 	adc r6, r8, #0
@@ -6848,10 +6848,10 @@ _02181d00:
 	add r3, sp, #0x200
 	ldmia r0, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
-	ldr sl, [r5, #0x1c]
+	ldr r10, [r5, #0x1c]
 	ldr r1, _02181ee0 ; =data_02050f54
-	ldrh r0, [sl, #0x78]
-	ldr sb, [sl, #0x48]
+	ldrh r0, [r10, #0x78]
+	ldr sb, [r10, #0x48]
 	ldr r6, [sp, #0x208]
 	mov r0, r0, asr #0x4
 	mov r2, r0, lsl #0x1
@@ -6863,7 +6863,7 @@ _02181d00:
 	smull r1, ip, r6, r2
 	ldr r0, [sp, #0x200]
 	str sb, [sp, #0x20c]
-	ldr r8, [sl, #0x4c]
+	ldr r8, [r10, #0x4c]
 	ldr r7, [sp, #0x204]
 	adds lr, r1, #0x800
 	rsb r11, r2, #0
@@ -6878,17 +6878,17 @@ _02181d00:
 	adc r8, r1, #0
 	mov r2, r2, lsr #0xc
 	adds r1, r6, #0x800
-	ldr r6, [sl, #0x50]
+	ldr r6, [r10, #0x50]
 	orr r2, r2, r8, lsl #20
-	smull sl, r8, r0, r11
+	smull r10, r8, r0, r11
 	adc r0, r3, #0
-	adds r3, sl, #0x800
-	mov sl, r1, lsr #0xc
+	adds r3, r10, #0x800
+	mov r10, r1, lsr #0xc
 	adc r1, r8, #0
 	mov r3, r3, lsr #0xc
-	orr sl, sl, r0, lsl #20
+	orr r10, r10, r0, lsl #20
 	add r8, sb, ip
-	add r8, r8, sl
+	add r8, r8, r10
 	add r0, r6, r2
 	orr r3, r3, r1, lsl #20
 	add r0, r0, r3
@@ -7029,7 +7029,7 @@ _02181f70:
 	ldr ip, [r11, #0x4c]
 	ldr r6, [sp, #0x1e0]
 	adc r8, r4, #0
-	add sl, ip, r6
+	add r10, ip, r6
 	smull r6, r4, r0, r7
 	str ip, [sp, #0x1ec]
 	ldr r0, [r11, #0x50]
@@ -7037,13 +7037,13 @@ _02181f70:
 	adds r6, r6, #0x800
 	ldr r3, [sp, #0x1dc]
 	orr sb, sb, r8, lsl #20
-	str sl, [sp, #0x1ec]
-	smull sl, r8, r3, r7
+	str r10, [sp, #0x1ec]
+	smull r10, r8, r3, r7
 	add r7, r1, sb
 	adc r4, r4, #0
 	mov r1, r6, lsr #0xc
 	orr r1, r1, r4, lsl #20
-	adds sb, sl, #0x800
+	adds sb, r10, #0x800
 	smull r4, r2, r3, r2
 	adc r6, r8, #0
 	adds r3, r4, #0x800
@@ -7093,7 +7093,7 @@ _02182070:
 	adds r7, r1, #0x800
 	rsb lr, r2, #0
 	str r11, [sp, #0x1d0]
-	ldr sl, [ip, #0x4c]
+	ldr r10, [ip, #0x4c]
 	smull r2, r1, r8, r3
 	ldr sb, [sp, #0x1c8]
 	adc r6, r6, #0
@@ -7101,21 +7101,21 @@ _02182070:
 	mov r7, r7, lsr #0xc
 	orr r7, r7, r6, lsl #20
 	ldr r0, [sp, #0x1c4]
-	add r8, sl, sb
+	add r8, r10, sb
 	smull r6, r3, r0, r3
 	adc sb, r1, #0
 	mov r2, r2, lsr #0xc
-	str sl, [sp, #0x1d4]
+	str r10, [sp, #0x1d4]
 	orr r2, r2, sb, lsl #20
 	adds r1, r6, #0x800
-	smull sl, sb, r0, lr
+	smull r10, sb, r0, lr
 	ldr r6, [ip, #0x50]
 	adc r0, r3, #0
-	adds r3, sl, #0x800
-	mov sl, r1, lsr #0xc
-	orr sl, sl, r0, lsl #20
+	adds r3, r10, #0x800
+	mov r10, r1, lsr #0xc
+	orr r10, r10, r0, lsl #20
 	add r7, r11, r7
-	add r7, r7, sl
+	add r7, r7, r10
 	add r0, r6, r2
 	adc r1, sb, #0
 	mov r3, r3, lsr #0xc
@@ -7226,7 +7226,7 @@ _02182268:
 	ldr ip, [r11, #0x4c]
 	ldr r6, [sp, #0x1a4]
 	adc r8, r4, #0
-	add sl, ip, r6
+	add r10, ip, r6
 	smull r6, r4, r0, r7
 	str ip, [sp, #0x1b0]
 	ldr r0, [r11, #0x50]
@@ -7234,13 +7234,13 @@ _02182268:
 	adds r6, r6, #0x800
 	ldr r3, [sp, #0x1a0]
 	orr sb, sb, r8, lsl #20
-	str sl, [sp, #0x1b0]
-	smull sl, r8, r3, r7
+	str r10, [sp, #0x1b0]
+	smull r10, r8, r3, r7
 	add r7, r1, sb
 	adc r4, r4, #0
 	mov r1, r6, lsr #0xc
 	orr r1, r1, r4, lsl #20
-	adds sb, sl, #0x800
+	adds sb, r10, #0x800
 	smull r4, r2, r3, r2
 	adc r6, r8, #0
 	adds r3, r4, #0x800
@@ -7445,7 +7445,7 @@ _021825a4:
 	ldr ip, [r11, #0x4c]
 	ldr r6, [sp, #0x174]
 	adc r8, r4, #0
-	add sl, ip, r6
+	add r10, ip, r6
 	smull r6, r4, r0, r7
 	str ip, [sp, #0x180]
 	ldr r0, [r11, #0x50]
@@ -7453,13 +7453,13 @@ _021825a4:
 	adds r6, r6, #0x800
 	ldr r3, [sp, #0x170]
 	orr sb, sb, r8, lsl #20
-	str sl, [sp, #0x180]
-	smull sl, r8, r3, r7
+	str r10, [sp, #0x180]
+	smull r10, r8, r3, r7
 	add r7, r1, sb
 	adc r4, r4, #0
 	mov r1, r6, lsr #0xc
 	orr r1, r1, r4, lsl #20
-	adds sb, sl, #0x800
+	adds sb, r10, #0x800
 	add r0, r0, r1
 	smull r4, r2, r3, r2
 	adc r6, r8, #0
@@ -7517,7 +7517,7 @@ _021826c0:
 	ldr ip, [r11, #0x4c]
 	ldr r6, [sp, #0x15c]
 	adc r8, r4, #0
-	add sl, ip, r6
+	add r10, ip, r6
 	smull r6, r4, r0, r7
 	str ip, [sp, #0x168]
 	ldr r0, [r11, #0x50]
@@ -7525,13 +7525,13 @@ _021826c0:
 	adds r6, r6, #0x800
 	ldr r3, [sp, #0x158]
 	orr sb, sb, r8, lsl #20
-	str sl, [sp, #0x168]
-	smull sl, r8, r3, r7
+	str r10, [sp, #0x168]
+	smull r10, r8, r3, r7
 	add r7, r1, sb
 	adc r4, r4, #0
 	mov r1, r6, lsr #0xc
 	orr r1, r1, r4, lsl #20
-	adds sb, sl, #0x800
+	adds sb, r10, #0x800
 	add r0, r0, r1
 	smull r4, r2, r3, r2
 	adc r6, r8, #0
@@ -7589,7 +7589,7 @@ _021827dc:
 	ldr ip, [r11, #0x4c]
 	ldr r6, [sp, #0x144]
 	adc r8, r4, #0
-	add sl, ip, r6
+	add r10, ip, r6
 	smull r6, r4, r0, r7
 	str ip, [sp, #0x150]
 	ldr r0, [r11, #0x50]
@@ -7597,13 +7597,13 @@ _021827dc:
 	adds r6, r6, #0x800
 	ldr r3, [sp, #0x140]
 	orr sb, sb, r8, lsl #20
-	str sl, [sp, #0x150]
-	smull sl, r8, r3, r7
+	str r10, [sp, #0x150]
+	smull r10, r8, r3, r7
 	add r7, r1, sb
 	adc r4, r4, #0
 	mov r1, r6, lsr #0xc
 	orr r1, r1, r4, lsl #20
-	adds sb, sl, #0x800
+	adds sb, r10, #0x800
 	add r0, r0, r1
 	smull r4, r2, r3, r2
 	adc r6, r8, #0
@@ -7661,7 +7661,7 @@ _021828f8:
 	ldr ip, [r11, #0x4c]
 	ldr r6, [sp, #0x12c]
 	adc r8, r4, #0
-	add sl, ip, r6
+	add r10, ip, r6
 	smull r6, r4, r0, r7
 	str ip, [sp, #0x138]
 	ldr r0, [r11, #0x50]
@@ -7669,13 +7669,13 @@ _021828f8:
 	adds r6, r6, #0x800
 	ldr r3, [sp, #0x128]
 	orr sb, sb, r8, lsl #20
-	str sl, [sp, #0x138]
-	smull sl, r8, r3, r7
+	str r10, [sp, #0x138]
+	smull r10, r8, r3, r7
 	add r7, r1, sb
 	adc r4, r4, #0
 	mov r1, r6, lsr #0xc
 	orr r1, r1, r4, lsl #20
-	adds sb, sl, #0x800
+	adds sb, r10, #0x800
 	add r0, r0, r1
 	smull r4, r2, r3, r2
 	adc r6, r8, #0
@@ -7733,7 +7733,7 @@ _02182a14:
 	ldr ip, [r11, #0x4c]
 	ldr r6, [sp, #0x114]
 	adc r8, r4, #0
-	add sl, ip, r6
+	add r10, ip, r6
 	smull r6, r4, r0, r7
 	str ip, [sp, #0x120]
 	ldr r0, [r11, #0x50]
@@ -7741,13 +7741,13 @@ _02182a14:
 	adds r6, r6, #0x800
 	ldr r3, [sp, #0x110]
 	orr sb, sb, r8, lsl #20
-	str sl, [sp, #0x120]
-	smull sl, r8, r3, r7
+	str r10, [sp, #0x120]
+	smull r10, r8, r3, r7
 	add r7, r1, sb
 	adc r4, r4, #0
 	mov r1, r6, lsr #0xc
 	orr r1, r1, r4, lsl #20
-	adds sb, sl, #0x800
+	adds sb, r10, #0x800
 	add r0, r0, r1
 	smull r4, r2, r3, r2
 	adc r6, r8, #0
@@ -7805,7 +7805,7 @@ _02182b30:
 	ldr ip, [r11, #0x4c]
 	ldr r6, [sp, #0xfc]
 	adc r8, r4, #0
-	add sl, ip, r6
+	add r10, ip, r6
 	smull r6, r4, r0, r7
 	str ip, [sp, #0x108]
 	ldr r0, [r11, #0x50]
@@ -7813,13 +7813,13 @@ _02182b30:
 	adds r6, r6, #0x800
 	ldr r3, [sp, #0xf8]
 	orr sb, sb, r8, lsl #20
-	str sl, [sp, #0x108]
-	smull sl, r8, r3, r7
+	str r10, [sp, #0x108]
+	smull r10, r8, r3, r7
 	add r7, r1, sb
 	adc r4, r4, #0
 	mov r1, r6, lsr #0xc
 	orr r1, r1, r4, lsl #20
-	adds sb, sl, #0x800
+	adds sb, r10, #0x800
 	add r0, r0, r1
 	smull r4, r2, r3, r2
 	adc r6, r8, #0
@@ -7877,7 +7877,7 @@ _02182c4c:
 	ldr ip, [r11, #0x4c]
 	ldr r6, [sp, #0xe4]
 	adc r8, r4, #0
-	add sl, ip, r6
+	add r10, ip, r6
 	smull r6, r4, r0, r7
 	str ip, [sp, #0xf0]
 	ldr r0, [r11, #0x50]
@@ -7885,13 +7885,13 @@ _02182c4c:
 	adds r6, r6, #0x800
 	ldr r3, [sp, #0xe0]
 	orr sb, sb, r8, lsl #20
-	str sl, [sp, #0xf0]
-	smull sl, r8, r3, r7
+	str r10, [sp, #0xf0]
+	smull r10, r8, r3, r7
 	add r7, r1, sb
 	adc r4, r4, #0
 	mov r1, r6, lsr #0xc
 	orr r1, r1, r4, lsl #20
-	adds sb, sl, #0x800
+	adds sb, r10, #0x800
 	add r0, r0, r1
 	smull r4, r2, r3, r2
 	adc r6, r8, #0
@@ -7949,7 +7949,7 @@ _02182d68:
 	ldr ip, [r11, #0x4c]
 	ldr r6, [sp, #0xcc]
 	adc r8, r4, #0
-	add sl, ip, r6
+	add r10, ip, r6
 	smull r6, r4, r0, r7
 	str ip, [sp, #0xd8]
 	ldr r0, [r11, #0x50]
@@ -7957,13 +7957,13 @@ _02182d68:
 	adds r6, r6, #0x800
 	ldr r3, [sp, #0xc8]
 	orr sb, sb, r8, lsl #20
-	str sl, [sp, #0xd8]
-	smull sl, r8, r3, r7
+	str r10, [sp, #0xd8]
+	smull r10, r8, r3, r7
 	add r7, r1, sb
 	adc r4, r4, #0
 	mov r1, r6, lsr #0xc
 	orr r1, r1, r4, lsl #20
-	adds sb, sl, #0x800
+	adds sb, r10, #0x800
 	add r0, r0, r1
 	smull r4, r2, r3, r2
 	adc r6, r8, #0
@@ -8021,7 +8021,7 @@ _02182e84:
 	ldr ip, [r11, #0x4c]
 	ldr r6, [sp, #0xb4]
 	adc r8, r4, #0
-	add sl, ip, r6
+	add r10, ip, r6
 	smull r6, r4, r0, r7
 	str ip, [sp, #0xc0]
 	ldr r0, [r11, #0x50]
@@ -8029,13 +8029,13 @@ _02182e84:
 	adds r6, r6, #0x800
 	ldr r3, [sp, #0xb0]
 	orr sb, sb, r8, lsl #20
-	str sl, [sp, #0xc0]
-	smull sl, r8, r3, r7
+	str r10, [sp, #0xc0]
+	smull r10, r8, r3, r7
 	add r7, r1, sb
 	adc r4, r4, #0
 	mov r1, r6, lsr #0xc
 	orr r1, r1, r4, lsl #20
-	adds sb, sl, #0x800
+	adds sb, r10, #0x800
 	add r0, r0, r1
 	smull r4, r2, r3, r2
 	adc r6, r8, #0
@@ -8115,7 +8115,7 @@ _02183020:
 	ldr ip, [r11, #0x4c]
 	ldr r6, [sp, #0x9c]
 	adc r8, r4, #0
-	add sl, ip, r6
+	add r10, ip, r6
 	smull r6, r4, r0, r7
 	str ip, [sp, #0xa8]
 	ldr r0, [r11, #0x50]
@@ -8123,13 +8123,13 @@ _02183020:
 	adds r6, r6, #0x800
 	ldr r3, [sp, #0x98]
 	orr sb, sb, r8, lsl #20
-	str sl, [sp, #0xa8]
-	smull sl, r8, r3, r7
+	str r10, [sp, #0xa8]
+	smull r10, r8, r3, r7
 	add r7, r1, sb
 	adc r4, r4, #0
 	mov r1, r6, lsr #0xc
 	orr r1, r1, r4, lsl #20
-	adds sb, sl, #0x800
+	adds sb, r10, #0x800
 	add r0, r0, r1
 	smull r4, r2, r3, r2
 	adc r6, r8, #0
@@ -8187,7 +8187,7 @@ _0218310c:
 	ldr ip, [r11, #0x4c]
 	ldr r6, [sp, #0x84]
 	adc r8, r4, #0
-	add sl, ip, r6
+	add r10, ip, r6
 	smull r6, r4, r0, r7
 	str ip, [sp, #0x90]
 	ldr r0, [r11, #0x50]
@@ -8195,13 +8195,13 @@ _0218310c:
 	adds r6, r6, #0x800
 	ldr r3, [sp, #0x80]
 	orr sb, sb, r8, lsl #20
-	str sl, [sp, #0x90]
-	smull sl, r8, r3, r7
+	str r10, [sp, #0x90]
+	smull r10, r8, r3, r7
 	add r7, r1, sb
 	adc r4, r4, #0
 	mov r1, r6, lsr #0xc
 	orr r1, r1, r4, lsl #20
-	adds sb, sl, #0x800
+	adds sb, r10, #0x800
 	add r0, r0, r1
 	smull r4, r2, r3, r2
 	adc r6, r8, #0
@@ -8259,7 +8259,7 @@ _02183228:
 	ldr ip, [r11, #0x4c]
 	ldr r6, [sp, #0x6c]
 	adc r8, r4, #0
-	add sl, ip, r6
+	add r10, ip, r6
 	smull r6, r4, r0, r7
 	str ip, [sp, #0x78]
 	ldr r0, [r11, #0x50]
@@ -8267,13 +8267,13 @@ _02183228:
 	adds r6, r6, #0x800
 	ldr r3, [sp, #0x68]
 	orr sb, sb, r8, lsl #20
-	str sl, [sp, #0x78]
-	smull sl, r8, r3, r7
+	str r10, [sp, #0x78]
+	smull r10, r8, r3, r7
 	add r7, r1, sb
 	adc r4, r4, #0
 	mov r1, r6, lsr #0xc
 	orr r1, r1, r4, lsl #20
-	adds sb, sl, #0x800
+	adds sb, r10, #0x800
 	add r0, r0, r1
 	smull r4, r2, r3, r2
 	adc r6, r8, #0
@@ -8322,7 +8322,7 @@ _02183320:
 	ldr ip, [r11, #0x4c]
 	ldr r6, [sp, #0x54]
 	adc r8, r4, #0
-	add sl, ip, r6
+	add r10, ip, r6
 	smull r6, r4, r0, r7
 	str ip, [sp, #0x60]
 	ldr r0, [r11, #0x50]
@@ -8330,13 +8330,13 @@ _02183320:
 	adds r6, r6, #0x800
 	ldr r3, [sp, #0x50]
 	orr sb, sb, r8, lsl #20
-	str sl, [sp, #0x60]
-	smull sl, r8, r3, r7
+	str r10, [sp, #0x60]
+	smull r10, r8, r3, r7
 	add r7, r1, sb
 	adc r4, r4, #0
 	mov r1, r6, lsr #0xc
 	orr r1, r1, r4, lsl #20
-	adds sb, sl, #0x800
+	adds sb, r10, #0x800
 	add r0, r0, r1
 	smull r4, r2, r3, r2
 	adc r6, r8, #0
@@ -8385,7 +8385,7 @@ _02183468:
 	cmp r4, #4
 	blt _02183468
 	add sp, sp, #0x314
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 _0218348c: .word data_ov37_021880d0
 _02183490: .word data_ov37_021880dc
@@ -9243,10 +9243,10 @@ _02183f84: .word 0x00003333
 	.global func_ov37_02183f88
 	arm_func_start func_ov37_02183f88
 func_ov37_02183f88: ; 0x02183f88
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
-	mov sl, r0
-	add r0, sl, #0x31c
-	add r1, sl, #0x28c
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	mov r10, r0
+	add r0, r10, #0x31c
+	add r1, r10, #0x28c
 	mov sb, #0
 	add r7, r0, #0xc00
 	add r8, r1, #0xc00
@@ -9254,14 +9254,14 @@ func_ov37_02183f88: ; 0x02183f88
 	mov r5, #1
 	mov r6, #2
 _02183fb0:
-	add r0, sl, sb, lsl #2
+	add r0, r10, sb, lsl #2
 	ldr r0, [r0, #0xf7c]
 	cmp r0, #0
 	beq _0218403c
-	mov r0, sl
+	mov r0, r10
 	mov r1, sb
 	bl func_ov37_02183e9c
-	add r1, sl, sb, lsl #2
+	add r1, r10, sb, lsl #2
 	ldr r0, [r1, #0xf7c]
 	cmp r0, #1
 	bne _02183ff0
@@ -9286,7 +9286,7 @@ _0218400c:
 	mov r1, r4
 	bl func_ov37_0217ff40
 _02184024:
-	add r0, sl, sb, lsl #2
+	add r0, r10, sb, lsl #2
 	add r0, r0, #0x1000
 	ldr r0, [r0, #0x57c]
 	mov r1, r8
@@ -9298,7 +9298,7 @@ _0218403c:
 	add r7, r7, #0xc
 	add r8, r8, #0x24
 	blt _02183fb0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	arm_func_end func_ov37_02183f88
 
 	.global func_ov37_02184054
@@ -11394,13 +11394,13 @@ _02185b4c:
 	.global func_ov37_02185b6c
 	arm_func_start func_ov37_02185b6c
 func_ov37_02185b6c: ; 0x02185b6c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x54
 	ldr r6, _02186160 ; =data_ov37_02188640
 	ldr r4, _02186164 ; =data_ov37_0218864c
 	mov r8, r1
 	ldr ip, _02186168 ; =data_ov37_02188658
-	ldr sl, _0218616c ; =data_ov37_02188664
+	ldr r10, _0218616c ; =data_ov37_02188664
 	add r5, sp, #0x48
 	add lr, sp, #0x3c
 	add r3, sp, #0x30
@@ -11413,7 +11413,7 @@ func_ov37_02185b6c: ; 0x02185b6c
 	stmia lr, {r0, r1, r2}
 	ldmia ip, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
-	ldmia sl, {r0, r1, r2}
+	ldmia r10, {r0, r1, r2}
 	stmia r11, {r0, r1, r2}
 	ldr r0, _02186170 ; =data_ov37_02188670
 	add r3, sp, #0x18
@@ -11496,7 +11496,7 @@ _02185c20:
 	add r0, r2, r1
 	add sp, sp, #0x54
 	str r0, [r7, #8]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02185d00:
 	ldrh r1, [r4, #0x78]
 	ldr r0, [sp]
@@ -11553,7 +11553,7 @@ _02185d00:
 	add r0, r2, r1
 	add sp, sp, #0x54
 	str r0, [r7, #8]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02185de0:
 	ldrh r1, [r4, #0x78]
 	ldr r0, [sp]
@@ -11610,7 +11610,7 @@ _02185de0:
 	add r0, r2, r1
 	add sp, sp, #0x54
 	str r0, [r7, #8]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02185ec0:
 	ldrh r1, [r4, #0x78]
 	ldr r0, [sp]
@@ -11667,7 +11667,7 @@ _02185ec0:
 	add r0, r2, r1
 	add sp, sp, #0x54
 	str r0, [r7, #8]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02185fa0:
 	ldrh r1, [r4, #0x78]
 	ldr r0, [sp]
@@ -11724,7 +11724,7 @@ _02185fa0:
 	add r0, r2, r1
 	add sp, sp, #0x54
 	str r0, [r7, #8]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02186080:
 	ldrh r1, [r4, #0x78]
 	ldr r0, [sp]
@@ -11782,7 +11782,7 @@ _02186080:
 	str r0, [r7, #8]
 _02186158:
 	add sp, sp, #0x54
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov37_02185b6c
 _02186160: .word data_ov37_02188640

--- a/asm/ov38.s
+++ b/asm/ov38.s
@@ -320,7 +320,7 @@ _0217c180: .word 0x474f3145
 	.global func_ov38_0217c184
 	arm_func_start func_ov38_0217c184
 func_ov38_0217c184: ; 0x0217c184
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x28
 	ldr r0, _0217c518 ; =data_027e0ce0
 	mov r1, #0x2bc
@@ -380,7 +380,7 @@ _0217c250:
 	ldr r5, _0217c520 ; =data_ov38_02189248
 	mov r7, #0
 	mvn r4, #0
-	mov fp, #1
+	mov r11, #1
 _0217c26c:
 	ldrsh r1, [r8]
 	mov r0, r5
@@ -406,7 +406,7 @@ _0217c26c:
 	ldrsh r3, [sl, #4]
 	bl func_02005414
 	mov r0, r5
-	mov r1, fp
+	mov r1, r11
 	bl func_02005398
 	add r8, r8, #6
 	add sb, sb, #6
@@ -552,7 +552,7 @@ _0217c26c:
 	ldr r0, [r0, #0xa8]
 	bl func_0200e2c0
 	add sp, sp, #0x28
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov38_0217c184
 _0217c518: .word data_027e0ce0
@@ -1341,7 +1341,7 @@ _0217cf8c: .word data_02050f54
 	.global func_ov38_0217cf90
 	arm_func_start func_ov38_0217cf90
 func_ov38_0217cf90: ; 0x0217cf90
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x6c
 	ldr r1, _0217d504 ; =gItemManager
 	mov r2, #0
@@ -1365,7 +1365,7 @@ _0217cfdc:
 	strb r0, [sl, #0x118]
 	add sp, sp, #0x6c
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0217cff0:
 	ldr r0, _0217d50c ; =data_ov38_021889b8
 	add r3, sp, #0x60
@@ -1564,7 +1564,7 @@ _0217cff0:
 	add r6, sp, #0x18
 	ldr r5, _0217d548 ; =data_ov38_02189224
 	ldr r4, _0217d54c ; =data_027e0fe8
-	ldr fp, _0217d550 ; =data_027e0fe4
+	ldr r11, _0217d550 ; =data_027e0fe4
 	b _0217d360
 _0217d30c:
 	mov r0, r8
@@ -1582,7 +1582,7 @@ _0217d30c:
 	add r2, sl, #0x48
 	mov r3, r8
 	bl func_ov00_020c4048
-	ldr r0, [fp]
+	ldr r0, [r11]
 	mov r1, r6
 	bl _ZN12ActorManager8GetActorEP8ActorRef
 	str r0, [r5, sb, lsl #2]
@@ -1693,7 +1693,7 @@ _0217d360:
 	str r0, [r1, #0x30]
 	mov r0, #1
 	add sp, sp, #0x6c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov38_0217cf90
 _0217d504: .word gItemManager
@@ -7422,7 +7422,7 @@ _0218259c: .word 0x0000059a
 	.global func_ov38_021825a0
 	arm_func_start func_ov38_021825a0
 func_ov38_021825a0: ; 0x021825a0
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0xc4
 	mov sb, r0
 	add r1, sb, #0x1000
@@ -7480,7 +7480,7 @@ _02182610:
 	mov r8, r4, asr #0xc
 	bl Approach_thunk
 	add r3, sb, #0x1000
-	rsb fp, r7, #0
+	rsb r11, r7, #0
 	ldr ip, [r3, #0x44]
 	ldr r2, _02182d98 ; =0x0000299a
 	rsb r7, r8, #0
@@ -7499,7 +7499,7 @@ _02182610:
 	str r2, [sb, #0xfdc]
 	ldr r2, [r3, #0x44]
 	add r1, sb, #0x3d8
-	smull r8, r2, fp, r2
+	smull r8, r2, r11, r2
 	adds r8, r8, #0x800
 	adc r2, r2, #0
 	mov r8, r8, lsr #0xc
@@ -7585,7 +7585,7 @@ _02182808:
 _02182810:
 	cmp r4, #0
 	addeq sp, sp, #0xc4
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, [sb, #0x2c4]
 	add r1, sb, #0x1b4
 	add r4, r1, r0, lsl #7
@@ -7599,7 +7599,7 @@ _02182810:
 	bl func_0202e310
 	cmp r0, #0
 	addeq sp, sp, #0xc4
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02182854:
 	ldr r0, _02182d9c ; =data_027e0ffc
 	ldr r1, _02182da0 ; =0x00000446
@@ -7607,7 +7607,7 @@ _02182854:
 	mov r3, #0
 	bl func_ov00_020ceacc
 	add sp, sp, #0xc4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02182870:
 	add r0, sb, #0x38
 	ldr r1, [r1, #0x3c]
@@ -7796,21 +7796,21 @@ _02182b14:
 	mov r3, #0
 	bl func_ov00_020ceacc
 	add sp, sp, #0xc4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02182b44:
 	add r0, r4, #0xc
 	mov r1, #0x79000
 	bl func_0202e310
 	cmp r0, #0
 	addeq sp, sp, #0xc4
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, _02182d9c ; =data_027e0ffc
 	ldr r1, _02182dac ; =0x00000448
 	add r2, sb, #0x48
 	mov r3, #0
 	bl func_ov00_020ceacc
 	add sp, sp, #0xc4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02182b78:
 	add r0, sb, #0x38
 	ldr r1, [r1, #0x3c]
@@ -7898,7 +7898,7 @@ _02182b78:
 	mov r3, #0
 	bl func_ov00_020ceacc
 	add sp, sp, #0xc4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02182cd4:
 	sub r2, r0, #1
 	str r2, [r1, #0x54]
@@ -7935,21 +7935,21 @@ _02182cd4:
 	str r4, [sp, #0x38]
 	bl func_ov38_0217e26c
 	add sp, sp, #0xc4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02182d64:
 	ldr r0, [r1, #0x54]
 	cmp r0, #0
 	subne r0, r0, #1
 	strne r0, [r1, #0x54]
 	addne sp, sp, #0xc4
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r0, r2, #1
 	str r0, [r1, #0x68]
 	mov r0, #0x3c
 	str r0, [r1, #0x54]
 _02182d8c:
 	add sp, sp, #0xc4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov38_021825a0
 _02182d94: .word data_02050f54
@@ -8175,14 +8175,14 @@ _02183078: .word 0x0000043e
 	.global func_ov38_0218307c
 	arm_func_start func_ov38_0218307c
 func_ov38_0218307c: ; 0x0218307c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x3c
 	mov sl, r0
 	ldr r4, _02183148 ; =0x00000e66
 	add r8, sl, #0x2f0
 	mov sb, #0
 	add r7, sp, #0x18
-	mov fp, #0xc
+	mov r11, #0xc
 	add r6, sp, #0xc
 	add r5, sp, #0
 _021830a4:
@@ -8191,7 +8191,7 @@ _021830a4:
 	bl func_ov38_02182e28
 	add r0, r0, #0x24
 	mov r1, r7
-	mov r2, fp
+	mov r2, r11
 	bl func_02007908
 	mov r0, sl
 	mov r1, sb
@@ -8226,7 +8226,7 @@ _021830a4:
 	add r8, r8, #0x240
 	blt _021830a4
 	add sp, sp, #0x3c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov38_0218307c
 _02183148: .word 0x00000e66
@@ -8422,7 +8422,7 @@ _021833c8:
 	.global func_ov38_021833f4
 	arm_func_start func_ov38_021833f4
 func_ov38_021833f4: ; 0x021833f4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0xc
 	mov sl, r0
 	mov sb, r1
@@ -8431,7 +8431,7 @@ func_ov38_021833f4: ; 0x021833f4
 	mov r8, r6
 	mov r7, #0
 	mov r4, #0xc
-	mov fp, #0x18
+	mov r11, #0x18
 _0218341c:
 	cmp sb, #0
 	bne _0218348c
@@ -8444,7 +8444,7 @@ _0218341c:
 	bl func_02007908
 	add r0, r5, #0xc
 	add r1, r8, #0x14
-	mov r2, fp
+	mov r2, r11
 	bl func_02007908
 	add r0, r5, #0x24
 	add r1, r8, #0x38
@@ -8470,7 +8470,7 @@ _0218348c:
 	add r6, r6, #0x240
 	blt _0218341c
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov38_021833f4
 _021834b0: .word 0x00000e66
@@ -9456,7 +9456,7 @@ _02184258: .word data_027e0fe4
 	.global func_ov38_0218425c
 	arm_func_start func_ov38_0218425c
 func_ov38_0218425c: ; 0x0218425c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0xcc
 	mov r1, #0
 	mov r5, r0
@@ -9475,12 +9475,12 @@ _02184298:
 	mov r0, #0x1000
 	str r0, [sp, #0x14]
 	mov r6, #0x8000
-	mov fp, #0xaf0
+	mov r11, #0xaf0
 	ldr r4, _0218454c ; =0x00005348
 	b _021842c4
 _021842b0:
 	mov r0, #0xa000
-	ldr fp, _02184550 ; =0x00006b6c
+	ldr r11, _02184550 ; =0x00006b6c
 	ldr r4, _02184554 ; =0xffffb364
 	str r0, [sp, #0x14]
 	mov r6, #0x11000
@@ -9507,13 +9507,13 @@ _021842c4:
 	ldr r3, [r5, #0x1c]
 	str r3, [sp, #0x30]
 	bl func_01ff9bf8
-	sub r0, r4, fp
+	sub r0, r4, r11
 	mov r0, r0, lsl #0x10
 	mov r0, r0, asr #0x10
 	str r0, [sp, #4]
 	mov r0, r0, lsl #0xb
 	add r0, r0, #0x800
-	add r0, fp, r0, asr #12
+	add r0, r11, r0, asr #12
 	mov r1, r0, lsl #0x10
 	mov r2, r7
 	add r0, sp, #0xa8
@@ -9553,7 +9553,7 @@ _02184374:
 	ldr r0, [sp, #8]
 	cmp r0, #0
 	addle sp, sp, #0xcc
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, [sp, #0x14]
 	sub r0, r6, r0
 	str r0, [sp, #0xc]
@@ -9603,7 +9603,7 @@ _0218446c:
 	ldr r2, [sp, #0x10]
 	mul r1, r8, r1
 	add r1, r1, #0x800
-	add r1, fp, r1, asr #12
+	add r1, r11, r1, asr #12
 	mov r1, r1, lsl #0x10
 	mla r3, r2, r8, r3
 	adds r7, r7, #0x800
@@ -9649,7 +9649,7 @@ _0218446c:
 	cmp r4, r0
 	blt _021843f4
 	add sp, sp, #0xcc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov38_0218425c
 _0218454c: .word 0x00005348
@@ -9666,7 +9666,7 @@ _02184570: .word data_027e0fe4
 	.global func_ov38_02184574
 	arm_func_start func_ov38_02184574
 func_ov38_02184574: ; 0x02184574
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x14
 	add r0, r0, #0x1000
 	str r0, [sp, #8]
@@ -9703,7 +9703,7 @@ _021845b0:
 	cmp r4, r0
 	addge sp, sp, #0x14
 	movge r0, #0
-	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02184608:
 	cmp r1, #2
 	bne _02184708
@@ -9728,10 +9728,10 @@ _02184608:
 	bne _021846a8
 	mov r0, r7
 	bl func_ov29_02172c28
-	mov fp, r0
+	mov r11, r0
 	mov r0, r8
 	bl func_ov29_02172c28
-	sub r0, r0, fp
+	sub r0, r0, r11
 	mov r1, r0, lsl #0x10
 	ldr r0, [sp, #0xc]
 	cmp r0, r1, asr #16
@@ -9781,11 +9781,11 @@ _02184708:
 	cmp r0, #0
 	addeq sp, sp, #0x14
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	bl func_ov29_021733f4
 	mov r0, #1
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov38_02184574
 _02184738: .word 0x00007fff
@@ -10267,7 +10267,7 @@ _02184d98: .word func_ov38_02184d6c
 	.global func_ov38_02184d9c
 	arm_func_start func_ov38_02184d9c
 func_ov38_02184d9c: ; 0x02184d9c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x1c
 	mov sl, r0
 	mov r0, r2
@@ -10280,7 +10280,7 @@ func_ov38_02184d9c: ; 0x02184d9c
 	mov r1, #3
 	mov r4, #0
 	bl func_01ff9b4c
-	ldr fp, _02184ed8 ; =data_027e0d0c
+	ldr r11, _02184ed8 ; =data_027e0d0c
 	mov r5, r0
 	mov r7, sl
 	add r8, sl, #0x38
@@ -10298,8 +10298,8 @@ _02184de4:
 	mov r3, r8
 	bl func_01ff9e64
 	add r6, r6, #1
-	ldr r1, [fp, #8]
-	ldmia fp, {r0, r2}
+	ldr r1, [r11, #8]
+	ldmia r11, {r0, r2}
 	str r0, [r7, #0x44]
 	str r2, [r7, #0x48]
 	str r1, [r7, #0x4c]
@@ -10346,7 +10346,7 @@ _02184de4:
 	mov r1, r1, lsl #0xc
 	strh r1, [r0, #0x3a]
 	add sp, sp, #0x1c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov38_02184d9c
 _02184ed8: .word data_027e0d0c
@@ -10357,7 +10357,7 @@ _02184ee4: .word data_ov38_02189224
 	.global func_ov38_02184ee8
 	arm_func_start func_ov38_02184ee8
 func_ov38_02184ee8: ; 0x02184ee8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0xd4
 	mov sl, r0
 	mov r6, r1
@@ -10458,7 +10458,7 @@ _0218500c:
 	ldr r1, [sl, #0x228]
 	ldr r2, _021854d0 ; =0x0000019a
 	add r0, sl, #0x224
-	mov fp, #0x2c00
+	mov r11, #0x2c00
 	mov sb, #0
 	bl Approach_thunk
 	ldr r1, _021854d4 ; =0x00000b9a
@@ -10546,7 +10546,7 @@ _02185198:
 	bl func_01ff9bf8
 	add r0, sp, #0x74
 	bl func_01ff9cec
-	sub r0, r0, fp
+	sub r0, r0, r11
 	str r0, [sp]
 	add r0, sp, #0x74
 	bl func_01fffb4c
@@ -10563,7 +10563,7 @@ _02185198:
 	bl func_01ff9bc4
 _02185200:
 	ldr r0, _021854d8 ; =0x00000666
-	sub fp, fp, #0x1600
+	sub r11, r11, #0x1600
 	sub r0, r0, sb
 	mov r0, r0, lsl #0xb
 	add sb, sb, r0, asr #12
@@ -10745,7 +10745,7 @@ _021854ac:
 	mov r0, #0
 	strb r0, [sl, #0x23c]
 	add sp, sp, #0xd4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov38_02184ee8
 _021854c8: .word 0x00000e66
@@ -10829,7 +10829,7 @@ _021855c4: .word data_ov38_021891e0
 	.global func_ov38_021855c8
 	arm_func_start func_ov38_021855c8
 func_ov38_021855c8: ; 0x021855c8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x38
 	add sb, r0, #4
 	mov r3, #2
@@ -10848,7 +10848,7 @@ func_ov38_021855c8: ; 0x021855c8
 	mov r6, #0x17
 	mov r5, #0xc
 	mov r4, #0x11
-	mov fp, sl
+	mov r11, sl
 _02185618:
 	mov r1, r8
 	mov r2, r7
@@ -10859,8 +10859,8 @@ _02185618:
 	mov r2, r5
 	bl func_01ffa9fc
 	mov r0, r4
-	mov r1, fp
-	mov r2, fp
+	mov r1, r11
+	mov r2, r11
 	bl func_01ffa9fc
 	add sl, sl, #1
 	cmp sl, #4
@@ -10877,7 +10877,7 @@ _02185618:
 	ldr r1, [r1, #0x7c]
 	bl func_01ffa94c
 	add sp, sp, #0x38
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov38_021855c8
 _02185688: .word data_027e03c8
@@ -13053,7 +13053,7 @@ _02187628: .word data_027e0fc8
 	.global func_ov38_0218762c
 	arm_func_start func_ov38_0218762c
 func_ov38_0218762c: ; 0x0218762c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0xec
 	ldr r1, _02187944 ; =data_ov38_021891e0
 	mov r2, #0
@@ -13111,8 +13111,8 @@ func_ov38_0218762c: ; 0x0218762c
 	str r2, [r0, #0x144]
 	ldr r1, [r0, #0x1b0]
 	str r1, [r0, #0x148]
-	ldr fp, [r0, #0x1b4]
-	str fp, [r0, #0x14c]
+	ldr r11, [r0, #0x1b4]
+	str r11, [r0, #0x14c]
 	ldr sl, [r0, #0x1b8]
 	str sl, [sp]
 	str sl, [r0, #0x150]
@@ -13221,7 +13221,7 @@ func_ov38_0218762c: ; 0x0218762c
 	str ip, [sp, #0x8c]
 	str r3, [sp, #0xc4]
 	ldr r3, [sp, #0x28]
-	str fp, [sp, #0x9c]
+	str r11, [sp, #0x9c]
 	strb r3, [sp, #0xc8]
 	ldr r3, [sp, #0x2c]
 	str sl, [sp, #0x84]
@@ -13250,7 +13250,7 @@ func_ov38_0218762c: ; 0x0218762c
 	str r1, [r4, #0x2e4]
 	bl func_ov00_0209a508
 	add sp, sp, #0xec
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov38_0218762c
 _02187944: .word data_ov38_021891e0

--- a/asm/ov38.s
+++ b/asm/ov38.s
@@ -320,7 +320,7 @@ _0217c180: .word 0x474f3145
 	.global func_ov38_0217c184
 	arm_func_start func_ov38_0217c184
 func_ov38_0217c184: ; 0x0217c184
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x28
 	ldr r0, _0217c518 ; =data_027e0ce0
 	mov r1, #0x2bc
@@ -375,7 +375,7 @@ _0217c244:
 	streq r0, [sp, #0x20]
 _0217c250:
 	ldr r8, _0217c534 ; =data_ov38_021889a6
-	ldr sb, [sp, #0x24]
+	ldr r9, [sp, #0x24]
 	ldr r10, [sp, #0x20]
 	ldr r5, _0217c520 ; =data_ov38_02189248
 	mov r7, #0
@@ -388,9 +388,9 @@ _0217c26c:
 	ldrsh r3, [r8, #4]
 	bl func_020053c4
 	mov r0, r5
-	ldrsh r1, [sb]
-	ldrsh r2, [sb, #2]
-	ldrsh r3, [sb, #4]
+	ldrsh r1, [r9]
+	ldrsh r2, [r9, #2]
+	ldrsh r3, [r9, #4]
 	bl func_02005414
 	mov r0, r5
 	mov r1, r4
@@ -409,7 +409,7 @@ _0217c26c:
 	mov r1, r11
 	bl func_02005398
 	add r8, r8, #6
-	add sb, sb, #6
+	add r9, r9, #6
 	add r10, r10, #6
 	add r7, r7, #1
 	cmp r7, #3
@@ -552,7 +552,7 @@ _0217c26c:
 	ldr r0, [r0, #0xa8]
 	bl func_0200e2c0
 	add sp, sp, #0x28
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov38_0217c184
 _0217c518: .word data_027e0ce0
@@ -1341,7 +1341,7 @@ _0217cf8c: .word data_02050f54
 	.global func_ov38_0217cf90
 	arm_func_start func_ov38_0217cf90
 func_ov38_0217cf90: ; 0x0217cf90
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x6c
 	ldr r1, _0217d504 ; =gItemManager
 	mov r2, #0
@@ -1365,7 +1365,7 @@ _0217cfdc:
 	strb r0, [r10, #0x118]
 	add sp, sp, #0x6c
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0217cff0:
 	ldr r0, _0217d50c ; =data_ov38_021889b8
 	add r3, sp, #0x60
@@ -1558,7 +1558,7 @@ _0217cff0:
 	mov r1, #3
 	add r0, r10, #0x1000
 	str r1, [r0, #0x6c]
-	mov sb, #0
+	mov r9, #0
 	add r8, sp, #0x34
 	mvn r7, #0
 	add r6, sp, #0x18
@@ -1576,7 +1576,7 @@ _0217d30c:
 	ldr r0, [r4]
 	str r7, [sp, #0x18]
 	str r7, [sp, #0x1c]
-	strh sb, [sp, #0x34]
+	strh r9, [sp, #0x34]
 	ldr r1, _0217d554 ; =0x474f3145
 	str r6, [sp]
 	add r2, r10, #0x48
@@ -1585,11 +1585,11 @@ _0217d30c:
 	ldr r0, [r11]
 	mov r1, r6
 	bl _ZN12ActorManager8GetActorEP8ActorRef
-	str r0, [r5, sb, lsl #2]
+	str r0, [r5, r9, lsl #2]
 	str r10, [r0, #0x204]
-	add sb, sb, #1
+	add r9, r9, #1
 _0217d360:
-	cmp sb, #5
+	cmp r9, #5
 	blt _0217d30c
 	ldr r1, [r10, #0x18]
 	mov r0, #2
@@ -1693,7 +1693,7 @@ _0217d360:
 	str r0, [r1, #0x30]
 	mov r0, #1
 	add sp, sp, #0x6c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov38_0217cf90
 _0217d504: .word gItemManager
@@ -5174,7 +5174,7 @@ _021805d8: .word data_027e0764
 	.global func_ov38_021805dc
 	arm_func_start func_ov38_021805dc
 func_ov38_021805dc: ; 0x021805dc
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x40
 	mov r4, r0
 	ldr r0, [r4, #0x2c4]
@@ -5220,24 +5220,24 @@ func_ov38_021805dc: ; 0x021805dc
 	adds r5, ip, r5
 	adc lr, r3, r7
 	mov r6, #0x64
-	umull r0, sb, lr, r6
+	umull r0, r9, lr, r6
 	mov r7, #0
-	mla sb, lr, r7, sb
+	mla r9, lr, r7, r9
 	mov r0, r7
-	mla sb, r0, r6, sb
+	mla r9, r0, r6, r9
 	stmia r8, {r5, lr}
-	cmp sb, #0x1e
+	cmp r9, #0x1e
 	ble _0218072c
-	umull sb, r6, r2, r5
+	umull r9, r6, r2, r5
 	mla r6, r2, lr, r6
 	mla r6, r1, r5, r6
-	adds sb, ip, sb
+	adds r9, ip, r9
 	adc r5, r3, r6
 	mov r1, #0x1f
 	umull r2, r3, r5, r1
 	mla r3, r5, r7, r3
 	mla r3, r0, r1, r3
-	str sb, [r8]
+	str r9, [r8]
 	str r5, [r8, #4]
 	add r2, r3, #0x3c
 	add r1, r4, #0x1000
@@ -5466,7 +5466,7 @@ _02180a20:
 	str r3, [sp]
 	bl func_ov38_0217cb2c
 	add sp, sp, #0x40
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov38_021805dc
 _02180a44: .word data_027e0764
@@ -7422,10 +7422,10 @@ _0218259c: .word 0x0000059a
 	.global func_ov38_021825a0
 	arm_func_start func_ov38_021825a0
 func_ov38_021825a0: ; 0x021825a0
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0xc4
-	mov sb, r0
-	add r1, sb, #0x1000
+	mov r9, r0
+	add r1, r9, #0x1000
 	ldr r2, [r1, #0x68]
 	cmp r2, #3
 	addls pc, pc, r2, lsl #2
@@ -7453,9 +7453,9 @@ _021825d0:
 	mov r0, r0, lsl #0x10
 	mov r6, r0, asr #0x10
 _02182610:
-	add r1, sb, #0x1000
+	add r1, r9, #0x1000
 	ldrsh r2, [r1, #0x84]
-	add r0, sb, #0x38
+	add r0, r9, #0x38
 	ldr r4, _02182d94 ; =data_02050f54
 	add r2, r2, r6
 	strh r2, [r1, #0x84]
@@ -7479,7 +7479,7 @@ _02182610:
 	mov r7, r5, asr #0xc
 	mov r8, r4, asr #0xc
 	bl Approach_thunk
-	add r3, sb, #0x1000
+	add r3, r9, #0x1000
 	rsb r11, r7, #0
 	ldr ip, [r3, #0x44]
 	ldr r2, _02182d98 ; =0x0000299a
@@ -7496,25 +7496,25 @@ _02182610:
 	orr r8, r8, r2, lsl #20
 	add r2, r8, #0x66
 	add r2, r2, #0x1e00
-	str r2, [sb, #0xfdc]
+	str r2, [r9, #0xfdc]
 	ldr r2, [r3, #0x44]
-	add r1, sb, #0x3d8
+	add r1, r9, #0x3d8
 	smull r8, r2, r11, r2
 	adds r8, r8, #0x800
 	adc r2, r2, #0
 	mov r8, r8, lsr #0xc
 	orr r8, r8, r2, lsl #20
 	add r2, r8, r5, asr #12
-	str r2, [sb, #0xfd8]
+	str r2, [r9, #0xfd8]
 	ldr r2, [r3, #0x44]
-	add r0, sb, #0x48
+	add r0, r9, #0x48
 	smull r5, r2, r7, r2
 	adds r5, r5, #0x800
 	adc r2, r2, #0
 	mov r5, r5, lsr #0xc
 	orr r5, r5, r2, lsl #20
 	add r2, r5, r4, asr #12
-	str r2, [sb, #0xfe0]
+	str r2, [r9, #0xfe0]
 	mov r2, #0x29
 	str r2, [sp]
 	ldr r2, [r3, #0x40]
@@ -7526,7 +7526,7 @@ _02182610:
 	mov r0, r0, lsr #0x10
 	mov r0, r0, asr #0x4
 	mov r1, r0, lsl #0x1
-	add r0, sb, #0x1000
+	add r0, r9, #0x1000
 	ldr r3, [r0, #0x44]
 	mov r2, #0
 	mul r0, r3, r3
@@ -7542,37 +7542,37 @@ _02182610:
 	mov r1, r0, lsl #0x1
 	ldrsh r3, [r2, r3]
 	ldrsh r2, [r2, r1]
-	mov r0, sb
+	mov r0, r9
 	add r1, sp, #0xa8
 	str r2, [sp, #0xb4]
 	add r2, sp, #0xb8
 	str r3, [sp, #0xac]
 	bl func_ov38_0217e26c
-	add r0, sb, #0x1000
+	add r0, r9, #0x1000
 	ldr r1, [r0, #0x54]
 	mov r4, #1
 	cmp r1, #0
 	bne _02182808
-	add r0, sb, #0x44
+	add r0, r9, #0x44
 	add r0, r0, #0x1000
 	mov r1, #0x1000
 	mov r2, #0x14
 	bl Approach_thunk
 	cmp r0, #0
 	beq _02182810
-	ldr r0, [sb, #0x2c4]
-	add r1, sb, #0x1b4
+	ldr r0, [r9, #0x2c4]
+	add r1, r9, #0x1b4
 	add r0, r1, r0, lsl #7
 	add r0, r0, #0xc
 	bl func_0202e544
 	cmp r0, #0
 	beq _02182810
-	mov r0, sb
+	mov r0, r9
 	mov r1, #0x17
 	mov r2, r4
 	mov r3, #0x200
 	bl func_ov38_0217d570
-	add r0, sb, #0x1000
+	add r0, r9, #0x1000
 	ldr r1, [r0, #0x68]
 	mov r4, #0
 	add r1, r1, #1
@@ -7585,9 +7585,9 @@ _02182808:
 _02182810:
 	cmp r4, #0
 	addeq sp, sp, #0xc4
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
-	ldr r0, [sb, #0x2c4]
-	add r1, sb, #0x1b4
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
+	ldr r0, [r9, #0x2c4]
+	add r1, r9, #0x1b4
 	add r4, r1, r0, lsl #7
 	add r0, r4, #0xc
 	mov r1, #0x1000
@@ -7599,45 +7599,45 @@ _02182810:
 	bl func_0202e310
 	cmp r0, #0
 	addeq sp, sp, #0xc4
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02182854:
 	ldr r0, _02182d9c ; =data_027e0ffc
 	ldr r1, _02182da0 ; =0x00000446
-	add r2, sb, #0x48
+	add r2, r9, #0x48
 	mov r3, #0
 	bl func_ov00_020ceacc
 	add sp, sp, #0xc4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02182870:
-	add r0, sb, #0x38
+	add r0, r9, #0x38
 	ldr r1, [r1, #0x3c]
 	add r0, r0, #0x1000
 	mov r2, #0x66
 	bl Approach_thunk
 	mov r0, #0x29
 	str r0, [sp]
-	add r0, sb, #0x1000
-	add r1, sb, #0x3d8
+	add r0, r9, #0x1000
+	add r1, r9, #0x3d8
 	ldr r2, [r0, #0x40]
 	ldr r3, [r0, #0x38]
-	add r0, sb, #0x48
+	add r0, r9, #0x48
 	add r1, r1, #0xc00
 	bl func_ov38_0217ca70
 	mov r1, #0
 	mov r0, #0x1000
 	str r0, [sp, #0xa4]
-	add r0, sb, #0x1000
+	add r0, r9, #0x1000
 	str r1, [sp, #0x9c]
 	str r1, [sp, #0xa0]
 	ldrsh r1, [r0, #0x94]
 	add r0, sp, #0x9c
 	bl func_ov00_020a61ac
-	add r0, sb, #0x1000
+	add r0, r9, #0x1000
 	ldrb r4, [r0, #0xa3]
 	ldr r3, [sp, #0x9c]
-	ldr r2, [sb, #0xfb4]
+	ldr r2, [r9, #0xfb4]
 	ldr r1, [sp, #0xa4]
-	ldr r0, [sb, #0xfac]
+	ldr r0, [r9, #0xfac]
 	mul r2, r3, r2
 	mul r0, r1, r0
 	cmp r4, #0
@@ -7658,14 +7658,14 @@ _02182918:
 _02182920:
 	mov r5, #0
 _02182924:
-	ldr r0, [sb, #0x2c4]
-	add r1, sb, #0x1b4
+	ldr r0, [r9, #0x2c4]
+	add r1, r9, #0x1b4
 	add r4, r1, r0, lsl #7
 	add r0, r4, #0xc
 	bl func_0202e58c
 	cmp r0, #0
 	beq _021829c0
-	add r0, sb, #0x1000
+	add r0, r9, #0x1000
 	ldr r1, [r0, #0x68]
 	mov r3, #0x96
 	add r1, r1, #1
@@ -7674,28 +7674,28 @@ _02182924:
 	str r1, [r0, #0x58]
 	mov r6, #0
 	strh r6, [r0, #0x84]
-	ldr r1, [sb, #0xfd8]
+	ldr r1, [r9, #0xfd8]
 	add r2, r3, #0x9d
-	str r1, [sb, #0xfe4]
-	ldr r5, [sb, #0xfdc]
+	str r1, [r9, #0xfe4]
+	ldr r5, [r9, #0xfdc]
 	mov r1, #0x800
-	str r5, [sb, #0xfe8]
-	ldr r5, [sb, #0xfe0]
-	str r5, [sb, #0xfec]
+	str r5, [r9, #0xfe8]
+	ldr r5, [r9, #0xfe0]
+	str r5, [r9, #0xfec]
 	str r3, [r0, #0x54]
 	strh r6, [r0, #0x82]
 	str r6, [r0, #0x38]
 	str r2, [r0, #0x40]
 	str r1, [r0, #0x3c]
-	ldr r2, [sb, #0x18]
-	ldr r1, [sb, #0x1c]
-	ldr r0, [sb, #0x14]
-	str r0, [sb, #0xfd8]
-	str r2, [sb, #0xfdc]
-	str r1, [sb, #0xfe0]
-	ldr r0, [sb, #0xfdc]
+	ldr r2, [r9, #0x18]
+	ldr r1, [r9, #0x1c]
+	ldr r0, [r9, #0x14]
+	str r0, [r9, #0xfd8]
+	str r2, [r9, #0xfdc]
+	str r1, [r9, #0xfe0]
+	ldr r0, [r9, #0xfdc]
 	sub r0, r0, #0xa000
-	str r0, [sb, #0xfdc]
+	str r0, [r9, #0xfdc]
 	b _02182b14
 _021829c0:
 	ldr r0, [r4, #0x14]
@@ -7703,7 +7703,7 @@ _021829c0:
 	bge _02182a7c
 	cmp r5, #0
 	bne _02182a7c
-	add r0, sb, #0x44
+	add r0, r9, #0x44
 	mov r3, #0
 	mov r1, #0x1000
 	add r0, r0, #0x1000
@@ -7712,12 +7712,12 @@ _021829c0:
 	str r1, [sp, #0x94]
 	str r3, [sp, #0x98]
 	bl Approach_thunk
-	add r0, sb, #0x82
+	add r0, r9, #0x82
 	add r0, r0, #0x1000
 	mov r1, #0x300
 	mov r2, #0x40
 	bl func_0202b154
-	add r0, sb, #0x1000
+	add r0, r9, #0x1000
 	ldrb r1, [r0, #0xa3]
 	ldrsh r0, [r0, #0x82]
 	mov r6, #0
@@ -7738,7 +7738,7 @@ _021829c0:
 	ldrsh r3, [r1, r0]
 	add r1, sp, #0x80
 	add r2, sp, #0x90
-	mov r0, sb
+	mov r0, r9
 	str r6, [sp, #0x80]
 	str r5, [sp, #0x84]
 	str r6, [sp, #0x88]
@@ -7751,7 +7751,7 @@ _02182a7c:
 	str r0, [sp, #0x7c]
 	str r0, [sp, #0x68]
 	str r0, [sp, #0x50]
-	add r0, sb, #0x1000
+	add r0, r9, #0x1000
 	str r1, [sp, #0x70]
 	str r1, [sp, #0x74]
 	str r1, [sp, #0x78]
@@ -7762,13 +7762,13 @@ _02182a7c:
 	ldrsh r1, [r0, #0x94]
 	add r0, sp, #0x48
 	bl func_ov00_020a61ac
-	ldr r1, [sb, #0xfac]
+	ldr r1, [r9, #0xfac]
 	add r0, sp, #0x54
 	str r1, [sp, #8]
-	ldr r2, [sb, #0xfb0]
+	ldr r2, [r9, #0xfb0]
 	add r1, sp, #8
 	str r2, [sp, #0xc]
-	ldr r3, [sb, #0xfb4]
+	ldr r3, [r9, #0xfb4]
 	add r2, sp, #0x48
 	str r3, [sp, #0x10]
 	bl func_ov00_020d5f98
@@ -7776,11 +7776,11 @@ _02182a7c:
 	add r0, sp, #0x54
 	add r1, sp, #0x70
 	bl func_ov00_020d59f0
-	add r0, sb, #0x3b8
+	add r0, r9, #0x3b8
 	add r1, sp, #0x54
 	add r0, r0, #0xc00
 	bl func_ov00_020d5eac
-	mov r0, sb
+	mov r0, r9
 	add r1, sp, #0x70
 	add r2, sp, #0x64
 	bl func_ov38_0217e26c
@@ -7792,50 +7792,50 @@ _02182b14:
 	beq _02182b44
 	ldr r0, _02182d9c ; =data_027e0ffc
 	ldr r1, _02182da8 ; =0x00000447
-	add r2, sb, #0x48
+	add r2, r9, #0x48
 	mov r3, #0
 	bl func_ov00_020ceacc
 	add sp, sp, #0xc4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02182b44:
 	add r0, r4, #0xc
 	mov r1, #0x79000
 	bl func_0202e310
 	cmp r0, #0
 	addeq sp, sp, #0xc4
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, _02182d9c ; =data_027e0ffc
 	ldr r1, _02182dac ; =0x00000448
-	add r2, sb, #0x48
+	add r2, r9, #0x48
 	mov r3, #0
 	bl func_ov00_020ceacc
 	add sp, sp, #0xc4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02182b78:
-	add r0, sb, #0x38
+	add r0, r9, #0x38
 	ldr r1, [r1, #0x3c]
 	add r0, r0, #0x1000
 	mov r2, #0x66
 	bl Approach_thunk
 	mov r0, #0x29
-	add r1, sb, #0x3d8
+	add r1, r9, #0x3d8
 	str r0, [sp]
-	add r0, sb, #0x1000
+	add r0, r9, #0x1000
 	ldr r2, [r0, #0x40]
 	ldr r3, [r0, #0x38]
-	add r0, sb, #0x48
+	add r0, r9, #0x48
 	add r1, r1, #0xc00
 	bl func_ov38_0217ca70
 	mov r1, #0x10
-	add r0, sb, #0x82
+	add r0, r9, #0x82
 	str r1, [sp]
-	add r1, sb, #0x1000
+	add r1, r9, #0x1000
 	ldr r2, [r1, #0x40]
 	add r0, r0, #0x1000
 	mov r1, #0x600
 	mov r3, #0x400
 	bl func_ov38_0217c994
-	add r1, sb, #0x1000
+	add r1, r9, #0x1000
 	ldr r0, [r1, #0x54]
 	cmp r0, #0
 	bne _02182cd4
@@ -7845,8 +7845,8 @@ _02182b78:
 	str r2, [r1, #0x68]
 	mov r2, #0x2d
 	str r2, [r1, #0x54]
-	ldr r2, [sb, #0x50]
-	ldr r1, [sb, #0x48]
+	ldr r2, [r9, #0x50]
+	ldr r1, [r9, #0x48]
 	rsb r0, r0, #0
 	str r1, [sp, #0x3c]
 	str r0, [sp, #0x40]
@@ -7894,16 +7894,16 @@ _02182b78:
 	bl func_ov00_020c7508
 	ldr r0, _02182d9c ; =data_027e0ffc
 	ldr r1, _02182db4 ; =0x00000449
-	add r2, sb, #0x48
+	add r2, r9, #0x48
 	mov r3, #0
 	bl func_ov00_020ceacc
 	add sp, sp, #0xc4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02182cd4:
 	sub r2, r0, #1
 	str r2, [r1, #0x54]
 	mov r4, #0
-	add r0, sb, #0x82
+	add r0, r9, #0x82
 	mov r3, #0x1000
 	add r0, r0, #0x1000
 	mov r1, #0x200
@@ -7912,7 +7912,7 @@ _02182cd4:
 	str r3, [sp, #0x24]
 	str r4, [sp, #0x28]
 	bl func_0202b154
-	add r0, sb, #0x1000
+	add r0, r9, #0x1000
 	ldrsh r0, [r0, #0x82]
 	mov r3, r4
 	ldr r1, _02182d94 ; =data_02050f54
@@ -7928,28 +7928,28 @@ _02182cd4:
 	ldrsh r4, [r1, r0]
 	add r1, sp, #0x2c
 	add r2, sp, #0x20
-	mov r0, sb
+	mov r0, r9
 	str r3, [sp, #0x2c]
 	str r5, [sp, #0x30]
 	str r3, [sp, #0x34]
 	str r4, [sp, #0x38]
 	bl func_ov38_0217e26c
 	add sp, sp, #0xc4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02182d64:
 	ldr r0, [r1, #0x54]
 	cmp r0, #0
 	subne r0, r0, #1
 	strne r0, [r1, #0x54]
 	addne sp, sp, #0xc4
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r0, r2, #1
 	str r0, [r1, #0x68]
 	mov r0, #0x3c
 	str r0, [r1, #0x54]
 _02182d8c:
 	add sp, sp, #0xc4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov38_021825a0
 _02182d94: .word data_02050f54
@@ -8175,33 +8175,33 @@ _02183078: .word 0x0000043e
 	.global func_ov38_0218307c
 	arm_func_start func_ov38_0218307c
 func_ov38_0218307c: ; 0x0218307c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x3c
 	mov r10, r0
 	ldr r4, _02183148 ; =0x00000e66
 	add r8, r10, #0x2f0
-	mov sb, #0
+	mov r9, #0
 	add r7, sp, #0x18
 	mov r11, #0xc
 	add r6, sp, #0xc
 	add r5, sp, #0
 _021830a4:
 	mov r0, r10
-	mov r1, sb
+	mov r1, r9
 	bl func_ov38_02182e28
 	add r0, r0, #0x24
 	mov r1, r7
 	mov r2, r11
 	bl func_02007908
 	mov r0, r10
-	mov r1, sb
+	mov r1, r9
 	bl func_ov38_02182e28
 	add r0, r0, #0x24
 	mov r1, r6
 	mov r2, #0xc
 	bl func_02007908
 	mov r0, r10
-	mov r1, sb
+	mov r1, r9
 	bl func_ov38_02182e28
 	mov r1, r5
 	mov r2, #0xc
@@ -8219,14 +8219,14 @@ _021830a4:
 	mov r0, r8
 	mov r1, r7
 	mov r2, r6
-	mov r3, sb
+	mov r3, r9
 	bl func_ov38_02184d9c
-	add sb, sb, #1
-	cmp sb, #5
+	add r9, r9, #1
+	cmp r9, #5
 	add r8, r8, #0x240
 	blt _021830a4
 	add sp, sp, #0x3c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov38_0218307c
 _02183148: .word 0x00000e66
@@ -8422,10 +8422,10 @@ _021833c8:
 	.global func_ov38_021833f4
 	arm_func_start func_ov38_021833f4
 func_ov38_021833f4: ; 0x021833f4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0xc
 	mov r10, r0
-	mov sb, r1
+	mov r9, r1
 	bl func_ov38_02185584
 	add r6, r10, #0x2f0
 	mov r8, r6
@@ -8433,7 +8433,7 @@ func_ov38_021833f4: ; 0x021833f4
 	mov r4, #0xc
 	mov r11, #0x18
 _0218341c:
-	cmp sb, #0
+	cmp r9, #0
 	bne _0218348c
 	mov r0, r10
 	mov r1, r7
@@ -8470,7 +8470,7 @@ _0218348c:
 	add r6, r6, #0x240
 	blt _0218341c
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov38_021833f4
 _021834b0: .word 0x00000e66
@@ -9456,7 +9456,7 @@ _02184258: .word data_027e0fe4
 	.global func_ov38_0218425c
 	arm_func_start func_ov38_0218425c
 func_ov38_0218425c: ; 0x0218425c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0xcc
 	mov r1, #0
 	mov r5, r0
@@ -9539,7 +9539,7 @@ _02184374:
 	bl func_ov00_020c3348
 	mov r0, #1
 	add r8, sp, #0x64
-	ldr sb, _0218455c ; =data_ov38_021889cc
+	ldr r9, _0218455c ; =data_ov38_021889cc
 	strh r0, [sp, #0x7c]
 	ldr r7, _02184560 ; =0x021793cc
 	str r8, [sp, #0x18]
@@ -9548,12 +9548,12 @@ _02184374:
 	ldr r0, [r7]
 	mov r4, #0
 	str r0, [sp, #8]
-	ldmia sb, {r0, r1}
+	ldmia r9, {r0, r1}
 	stmia r8, {r0, r1}
 	ldr r0, [sp, #8]
 	cmp r0, #0
 	addle sp, sp, #0xcc
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, [sp, #0x14]
 	sub r0, r6, r0
 	str r0, [sp, #0xc]
@@ -9580,10 +9580,10 @@ _021843f4:
 	umull r7, lr, ip, r1
 	mla lr, ip, r0, lr
 	ldr r2, [r6, #0xc]
-	ldr sb, [r6, #0x10]
+	ldr r9, [r6, #0x10]
 	mla lr, r2, r1, lr
 	ldr r8, [r6, #0x14]
-	adds r0, sb, r7
+	adds r0, r9, r7
 	adc r2, r8, lr
 	stmia r6, {r0, r2}
 	cmp r10, #0
@@ -9595,10 +9595,10 @@ _021843f4:
 	mov r2, r1
 _0218446c:
 	add r8, r3, r2
-	ldr sb, [sp, #0xc]
+	ldr r9, [sp, #0xc]
 	mov r2, r8, asr #0x1f
-	umull r7, r3, sb, r8
-	mla r3, sb, r2, r3
+	umull r7, r3, r9, r8
+	mla r3, r9, r2, r3
 	ldr r1, [sp, #4]
 	ldr r2, [sp, #0x10]
 	mul r1, r8, r1
@@ -9649,7 +9649,7 @@ _0218446c:
 	cmp r4, r0
 	blt _021843f4
 	add sp, sp, #0xcc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov38_0218425c
 _0218454c: .word 0x00005348
@@ -9666,7 +9666,7 @@ _02184570: .word data_027e0fe4
 	.global func_ov38_02184574
 	arm_func_start func_ov38_02184574
 func_ov38_02184574: ; 0x02184574
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x14
 	add r0, r0, #0x1000
 	str r0, [sp, #8]
@@ -9693,7 +9693,7 @@ _021845b0:
 	moveq r1, #4
 	ldr r0, _0218473c ; =data_ov38_02189224
 	subne r1, r6, #1
-	ldr sb, [r0, r1, lsl #2]
+	ldr r9, [r0, r1, lsl #2]
 	ldr r1, [r7, #0x130]
 	sub r0, r1, #3
 	cmp r0, #1
@@ -9703,7 +9703,7 @@ _021845b0:
 	cmp r4, r0
 	addge sp, sp, #0x14
 	movge r0, #0
-	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmgeia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02184608:
 	cmp r1, #2
 	bne _02184708
@@ -9747,13 +9747,13 @@ _0218469c:
 	cmp r1, r0
 	blt _02184708
 _021846a8:
-	ldr r0, [sb, #0x130]
+	ldr r0, [r9, #0x130]
 	cmp r0, #3
 	bne _02184700
 	mov r0, r7
 	bl func_ov29_02172c28
 	mov r8, r0
-	mov r0, sb
+	mov r0, r9
 	bl func_ov29_02172c28
 	sub r0, r0, r8
 	mov r1, r0, lsl #0x10
@@ -9781,11 +9781,11 @@ _02184708:
 	cmp r0, #0
 	addeq sp, sp, #0x14
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	bl func_ov29_021733f4
 	mov r0, #1
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov38_02184574
 _02184738: .word 0x00007fff
@@ -9882,36 +9882,36 @@ _02184878: .word 0x474f3143
 	.global func_ov38_0218487c
 	arm_func_start func_ov38_0218487c
 func_ov38_0218487c: ; 0x0218487c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	add r3, r0, #0x1000
 	ldr r1, [r3, #0x60]
 	cmp r1, #0
 	bne _02184a08
 	ldr r1, [r0, #0x2d8]
 	cmp r1, #0xe
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	ldr ip, _02184a14 ; =data_027e0764
 	mov r2, #0
 	ldr r4, [ip]
 	ldmib ip, {r1, r6}
-	umull r10, sb, r6, r4
-	mla sb, r6, r1, sb
+	umull r10, r9, r6, r4
+	mla r9, r6, r1, r9
 	ldr r5, [ip, #0xc]
 	ldr r8, [ip, #0x10]
-	mla sb, r5, r4, sb
+	mla r9, r5, r4, r9
 	adds r1, r8, r10
 	ldr r7, [ip, #0x14]
 	mov r10, #0x64
-	adc sb, r7, sb
-	umull r4, lr, sb, r10
-	mla lr, sb, r2, lr
+	adc r9, r7, r9
+	umull r4, lr, r9, r10
+	mla lr, r9, r2, lr
 	mov r4, r2
 	mla lr, r4, r10, lr
-	stmia ip, {r1, sb}
+	stmia ip, {r1, r9}
 	cmp lr, #0x41
 	bge _02184924
 	umull lr, r10, r6, r1
-	mla r10, r6, sb, r10
+	mla r10, r6, r9, r10
 	adds lr, r8, lr
 	mla r10, r5, r1, r10
 	adc r7, r7, r10
@@ -9927,7 +9927,7 @@ func_ov38_0218487c: ; 0x0218487c
 _02184924:
 	cmp lr, #0x5f
 	umull lr, r10, r6, r1
-	mla r10, r6, sb, r10
+	mla r10, r6, r9, r10
 	bge _02184964
 	mla r10, r5, r1, r10
 	adds lr, r8, lr
@@ -9984,11 +9984,11 @@ _02184990:
 	str r2, [r1, #0x60]
 _02184a00:
 	bl func_ov38_02184744
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _02184a08:
 	sub r0, r1, #1
 	str r0, [r3, #0x60]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov38_0218487c
 _02184a14: .word data_027e0764
@@ -10267,13 +10267,13 @@ _02184d98: .word func_ov38_02184d6c
 	.global func_ov38_02184d9c
 	arm_func_start func_ov38_02184d9c
 func_ov38_02184d9c: ; 0x02184d9c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x1c
 	mov r10, r0
 	mov r0, r2
 	add r2, sp, #0x10
 	str r3, [sp]
-	mov sb, r1
+	mov r9, r1
 	str r3, [r10, #0x234]
 	bl func_01ff9bf8
 	mov r0, #0x1000
@@ -10286,13 +10286,13 @@ func_ov38_02184d9c: ; 0x02184d9c
 	add r8, r10, #0x38
 	mov r6, r4
 _02184de4:
-	ldr r1, [sb]
+	ldr r1, [r9]
 	mov r0, r4
 	str r1, [r7, #0x38]
-	ldr r2, [sb, #4]
+	ldr r2, [r9, #4]
 	add r1, sp, #0x10
 	str r2, [r7, #0x3c]
-	ldr r3, [sb, #8]
+	ldr r3, [r9, #8]
 	mov r2, r8
 	str r3, [r7, #0x40]
 	mov r3, r8
@@ -10346,7 +10346,7 @@ _02184de4:
 	mov r1, r1, lsl #0xc
 	strh r1, [r0, #0x3a]
 	add sp, sp, #0x1c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov38_02184d9c
 _02184ed8: .word data_027e0d0c
@@ -10357,7 +10357,7 @@ _02184ee4: .word data_ov38_02189224
 	.global func_ov38_02184ee8
 	arm_func_start func_ov38_02184ee8
 func_ov38_02184ee8: ; 0x02184ee8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0xd4
 	mov r10, r0
 	mov r6, r1
@@ -10443,11 +10443,11 @@ _0218500c:
 	mov r3, r3, lsl #0xb
 	mov r3, r3, asr #0xc
 	add r3, r3, #0x800
-	umull sb, r6, r3, r1
+	umull r9, r6, r3, r1
 	mla r6, r3, r2, r6
 	mov r2, r3, asr #0x1f
 	mla r6, r2, r1, r6
-	adds r3, sb, #0x800
+	adds r3, r9, #0x800
 	adc r1, r6, #0
 	mov r2, r3, lsr #0xc
 	orr r2, r2, r1, lsl #20
@@ -10459,7 +10459,7 @@ _0218500c:
 	ldr r2, _021854d0 ; =0x0000019a
 	add r0, r10, #0x224
 	mov r11, #0x2c00
-	mov sb, #0
+	mov r9, #0
 	bl Approach_thunk
 	ldr r1, _021854d4 ; =0x00000b9a
 	add r0, r10, #0x22c
@@ -10538,7 +10538,7 @@ _02185198:
 	ldrb r0, [r10, #0x23c]
 	cmp r0, #0
 	beq _02185214
-	cmp sb, #0
+	cmp r9, #0
 	beq _02185200
 	add r0, r10, #0x214
 	add r1, r5, #0x34
@@ -10553,7 +10553,7 @@ _02185198:
 	cmp r0, #0
 	beq _02185200
 	ldr r0, [sp]
-	mul r1, r0, sb
+	mul r1, r0, r9
 	mov r1, r1, asr #0xc
 	add r0, sp, #0x74
 	bl func_01fffbec
@@ -10564,9 +10564,9 @@ _02185198:
 _02185200:
 	ldr r0, _021854d8 ; =0x00000666
 	sub r11, r11, #0x1600
-	sub r0, r0, sb
+	sub r0, r0, r9
 	mov r0, r0, lsl #0xb
-	add sb, sb, r0, asr #12
+	add r9, r9, r0, asr #12
 _02185214:
 	ldr r0, [sp, #0xcc]
 	ldr r1, [sp, #0xc8]
@@ -10745,7 +10745,7 @@ _021854ac:
 	mov r0, #0
 	strb r0, [r10, #0x23c]
 	add sp, sp, #0xd4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov38_02184ee8
 _021854c8: .word 0x00000e66
@@ -10829,9 +10829,9 @@ _021855c4: .word data_ov38_021891e0
 	.global func_ov38_021855c8
 	arm_func_start func_ov38_021855c8
 func_ov38_021855c8: ; 0x021855c8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x38
-	add sb, r0, #4
+	add r9, r0, #4
 	mov r3, #2
 	add r1, sp, #4
 	mov r0, #0x10
@@ -10852,7 +10852,7 @@ func_ov38_021855c8: ; 0x021855c8
 _02185618:
 	mov r1, r8
 	mov r2, r7
-	add r0, sb, #0x10
+	add r0, r9, #0x10
 	bl func_0202de3c
 	mov r0, r6
 	mov r1, r7
@@ -10864,7 +10864,7 @@ _02185618:
 	bl func_01ffa9fc
 	add r10, r10, #1
 	cmp r10, #4
-	add sb, sb, #0x50
+	add r9, r9, #0x50
 	blt _02185618
 	mov r3, #4
 	add r1, sp, #0
@@ -10877,7 +10877,7 @@ _02185618:
 	ldr r1, [r1, #0x7c]
 	bl func_01ffa94c
 	add sp, sp, #0x38
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov38_021855c8
 _02185688: .word data_027e03c8
@@ -13053,7 +13053,7 @@ _02187628: .word data_027e0fc8
 	.global func_ov38_0218762c
 	arm_func_start func_ov38_0218762c
 func_ov38_0218762c: ; 0x0218762c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0xec
 	ldr r1, _02187944 ; =data_ov38_021891e0
 	mov r2, #0
@@ -13085,8 +13085,8 @@ func_ov38_0218762c: ; 0x0218762c
 	strb r2, [sp, #0x50]
 	bl func_ov38_02185c4c
 	ldr r0, _02187944 ; =data_ov38_021891e0
-	ldr sb, [r0, #0x180]
-	str sb, [r0, #0x118]
+	ldr r9, [r0, #0x180]
+	str r9, [r0, #0x118]
 	ldr r8, [r0, #0x184]
 	str r8, [r0, #0x11c]
 	ldr r7, [r0, #0x188]
@@ -13194,7 +13194,7 @@ func_ov38_0218762c: ; 0x0218762c
 	ldr r3, _02187954 ; =data_027e0f74
 	str r1, [sp, #0xb4]
 	ldr r1, [sp, #0x18]
-	str sb, [sp, #0x68]
+	str r9, [sp, #0x68]
 	str r1, [sp, #0xb8]
 	ldr r1, [sp, #0x1c]
 	str r8, [sp, #0x6c]
@@ -13250,7 +13250,7 @@ func_ov38_0218762c: ; 0x0218762c
 	str r1, [r4, #0x2e4]
 	bl func_ov00_0209a508
 	add sp, sp, #0xec
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov38_0218762c
 _02187944: .word data_ov38_021891e0

--- a/asm/ov38.s
+++ b/asm/ov38.s
@@ -320,7 +320,7 @@ _0217c180: .word 0x474f3145
 	.global func_ov38_0217c184
 	arm_func_start func_ov38_0217c184
 func_ov38_0217c184: ; 0x0217c184
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x28
 	ldr r0, _0217c518 ; =data_027e0ce0
 	mov r1, #0x2bc
@@ -376,7 +376,7 @@ _0217c244:
 _0217c250:
 	ldr r8, _0217c534 ; =data_ov38_021889a6
 	ldr sb, [sp, #0x24]
-	ldr sl, [sp, #0x20]
+	ldr r10, [sp, #0x20]
 	ldr r5, _0217c520 ; =data_ov38_02189248
 	mov r7, #0
 	mvn r4, #0
@@ -401,16 +401,16 @@ _0217c26c:
 	ldrsh r3, [r8, #4]
 	bl func_020053c4
 	mov r0, r5
-	ldrsh r1, [sl]
-	ldrsh r2, [sl, #2]
-	ldrsh r3, [sl, #4]
+	ldrsh r1, [r10]
+	ldrsh r2, [r10, #2]
+	ldrsh r3, [r10, #4]
 	bl func_02005414
 	mov r0, r5
 	mov r1, r11
 	bl func_02005398
 	add r8, r8, #6
 	add sb, sb, #6
-	add sl, sl, #6
+	add r10, r10, #6
 	add r7, r7, #1
 	cmp r7, #3
 	blt _0217c26c
@@ -552,7 +552,7 @@ _0217c26c:
 	ldr r0, [r0, #0xa8]
 	bl func_0200e2c0
 	add sp, sp, #0x28
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov38_0217c184
 _0217c518: .word data_027e0ce0
@@ -1341,14 +1341,14 @@ _0217cf8c: .word data_02050f54
 	.global func_ov38_0217cf90
 	arm_func_start func_ov38_0217cf90
 func_ov38_0217cf90: ; 0x0217cf90
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x6c
 	ldr r1, _0217d504 ; =gItemManager
 	mov r2, #0
 	ldr r3, [r1]
 	ldr r1, _0217d508 ; =data_027e0f74
 	strh r2, [r3, #0xba]
-	mov sl, r0
+	mov r10, r0
 	ldr r0, [r1]
 	mov r1, #0xf7
 	bl func_ov00_02097760
@@ -1362,10 +1362,10 @@ func_ov38_0217cf90: ; 0x0217cf90
 	beq _0217cff0
 _0217cfdc:
 	mov r0, #0
-	strb r0, [sl, #0x118]
+	strb r0, [r10, #0x118]
 	add sp, sp, #0x6c
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0217cff0:
 	ldr r0, _0217d50c ; =data_ov38_021889b8
 	add r3, sp, #0x60
@@ -1373,48 +1373,48 @@ _0217cff0:
 	stmia r3, {r0, r1, r2}
 	ldr r0, [sp, #0x60]
 	mov r2, #0x800
-	str r0, [sl, #0x7c]
+	str r0, [r10, #0x7c]
 	ldr r1, [sp, #0x64]
-	add r0, sl, #0x100
-	str r1, [sl, #0x80]
+	add r0, r10, #0x100
+	str r1, [r10, #0x80]
 	ldr r3, [sp, #0x68]
 	mov r1, #0x118
-	str r3, [sl, #0x84]
-	str r2, [sl, #0x88]
+	str r3, [r10, #0x84]
+	str r2, [r10, #0x88]
 	strh r1, [r0, #0x22]
 	strh r1, [r0, #0x20]
 	ldrsh r2, [r0, #0x20]
-	add r0, sl, #0x1000
+	add r0, r10, #0x1000
 	mov r1, #0
 	sub r2, r2, #0x3c
 	strh r2, [r0, #0x7e]
-	str r1, [sl, #0x2bc]
-	str r1, [sl, #0x2c0]
-	add r0, sl, #0x158
-	str r1, [sl, #0x2c4]
+	str r1, [r10, #0x2bc]
+	str r1, [r10, #0x2c0]
+	add r0, r10, #0x158
+	str r1, [r10, #0x2c4]
 	ldr r1, [r0]
 	ldr r1, [r1, #8]
 	blx r1
-	str r0, [sl, #0x1bc]
-	add r0, sl, #0x158
+	str r0, [r10, #0x1bc]
+	add r0, r10, #0x158
 	ldr r1, [r0]
 	ldr r1, [r1, #8]
 	blx r1
-	str r0, [sl, #0x23c]
-	str sl, [sl, #0x188]
+	str r0, [r10, #0x23c]
+	str r10, [r10, #0x188]
 	mov r0, #3
 	str r0, [sp]
 	ldr r1, _0217d510 ; =func_ov38_0217cc2c
-	add r0, sl, #0x15c
+	add r0, r10, #0x15c
 	mov r2, #0
 	mov r3, #6
 	bl func_02018c90
 	mov r1, #0
-	mov r0, sl
+	mov r0, r10
 	mov r2, r1
 	mov r3, r1
 	bl func_ov38_0217d570
-	add r0, sl, #0x158
+	add r0, r10, #0x158
 	ldr r1, [r0]
 	ldr r1, [r1, #8]
 	blx r1
@@ -1423,7 +1423,7 @@ _0217cff0:
 	bl func_0201e388
 	ldr r1, _0217d518 ; =data_ov38_021891e0
 	str r0, [r1, #0x30]
-	add r0, sl, #0x158
+	add r0, r10, #0x158
 	ldr r1, [r0]
 	ldr r1, [r1, #8]
 	blx r1
@@ -1432,7 +1432,7 @@ _0217cff0:
 	bl func_0201e388
 	ldr r1, _0217d518 ; =data_ov38_021891e0
 	str r0, [r1, #0x20]
-	add r0, sl, #0x158
+	add r0, r10, #0x158
 	ldr r1, [r0]
 	ldr r1, [r1, #8]
 	blx r1
@@ -1441,7 +1441,7 @@ _0217cff0:
 	bl func_0201e388
 	ldr r1, _0217d518 ; =data_ov38_021891e0
 	str r0, [r1, #0x24]
-	add r0, sl, #0x158
+	add r0, r10, #0x158
 	ldr r1, [r0]
 	ldr r1, [r1, #8]
 	blx r1
@@ -1450,7 +1450,7 @@ _0217cff0:
 	bl func_0201e388
 	ldr r1, _0217d518 ; =data_ov38_021891e0
 	str r0, [r1, #0x2c]
-	add r0, sl, #0x158
+	add r0, r10, #0x158
 	ldr r1, [r0]
 	ldr r1, [r1, #8]
 	blx r1
@@ -1459,7 +1459,7 @@ _0217cff0:
 	bl func_0201e388
 	ldr r1, _0217d518 ; =data_ov38_021891e0
 	str r0, [r1, #0x28]
-	add r0, sl, #0x158
+	add r0, r10, #0x158
 	ldr r1, [r0]
 	ldr r1, [r1, #8]
 	blx r1
@@ -1468,7 +1468,7 @@ _0217cff0:
 	bl func_0201e388
 	ldr r1, _0217d518 ; =data_ov38_021891e0
 	str r0, [r1, #0x34]
-	add r0, sl, #0x158
+	add r0, r10, #0x158
 	ldr r1, [r0]
 	ldr r1, [r1, #8]
 	blx r1
@@ -1477,7 +1477,7 @@ _0217cff0:
 	bl func_0201e388
 	ldr r1, _0217d518 ; =data_ov38_021891e0
 	str r0, [r1, #0x38]
-	add r0, sl, #0x158
+	add r0, r10, #0x158
 	ldr r1, [r0]
 	ldr r1, [r1, #8]
 	blx r1
@@ -1486,7 +1486,7 @@ _0217cff0:
 	bl func_0201e388
 	ldr r1, _0217d518 ; =data_ov38_021891e0
 	str r0, [r1, #0x3c]
-	add r0, sl, #0x158
+	add r0, r10, #0x158
 	ldr r1, [r0]
 	ldr r1, [r1, #8]
 	blx r1
@@ -1496,21 +1496,21 @@ _0217cff0:
 	ldr r2, _0217d518 ; =data_ov38_021891e0
 	ldr r3, _0217d53c ; =data_027e0d0c
 	str r0, [r2, #0x40]
-	ldrsh r0, [sl, #0x78]
-	add r1, sl, #0x1000
+	ldrsh r0, [r10, #0x78]
+	add r1, r10, #0x1000
 	ldr r5, _0217d540 ; =data_02050f54
 	strh r0, [r1, #0x7c]
 	ldr r0, [r3]
 	mov r2, #0
-	str r0, [sl, #0x60]
+	str r0, [r10, #0x60]
 	ldr r1, [r3, #4]
-	add r0, sl, #0x3b8
-	str r1, [sl, #0x64]
+	add r0, r10, #0x3b8
+	str r1, [r10, #0x64]
 	ldr r1, [r3, #8]
 	add r0, r0, #0xc00
-	str r1, [sl, #0x68]
-	ldrsh r3, [sl, #0x78]
-	add r1, sl, #0x394
+	str r1, [r10, #0x68]
+	ldrsh r3, [r10, #0x78]
+	add r1, r10, #0x394
 	add r1, r1, #0xc00
 	add r3, r3, r3, lsr #31
 	mov r3, r3, lsl #0xf
@@ -1521,13 +1521,13 @@ _0217cff0:
 	add r3, r3, #1
 	mov r3, r3, lsl #0x1
 	ldrsh r4, [r5, r4]
-	str r2, [sl, #0xfb8]
+	str r2, [r10, #0xfb8]
 	ldrsh r3, [r5, r3]
-	str r4, [sl, #0xfbc]
-	str r2, [sl, #0xfc0]
-	str r3, [sl, #0xfc4]
+	str r4, [r10, #0xfbc]
+	str r2, [r10, #0xfc0]
+	str r3, [r10, #0xfc4]
 	bl func_ov00_020d5cd8
-	add r0, sl, #0x364
+	add r0, r10, #0x364
 	ldr r5, _0217d544 ; =data_027e01b8
 	add r4, r0, #0xc00
 	ldmia r5!, {r0, r1, r2, r3}
@@ -1536,7 +1536,7 @@ _0217cff0:
 	stmia r4!, {r0, r1, r2, r3}
 	ldmia r5, {r0, r1, r2, r3}
 	stmia r4, {r0, r1, r2, r3}
-	add r0, sl, #0x334
+	add r0, r10, #0x334
 	ldr r5, _0217d544 ; =data_027e01b8
 	add r4, r0, #0xc00
 	ldmia r5!, {r0, r1, r2, r3}
@@ -1545,18 +1545,18 @@ _0217cff0:
 	stmia r4!, {r0, r1, r2, r3}
 	ldmia r5, {r0, r1, r2, r3}
 	stmia r4, {r0, r1, r2, r3}
-	add r1, sl, #0x388
-	add r0, sl, #0x48
+	add r1, r10, #0x388
+	add r0, r10, #0x48
 	add r1, r1, #0xc00
 	mov r2, #0xc
 	bl func_02007908
-	add r1, sl, #0x358
-	add r0, sl, #0x48
+	add r1, r10, #0x358
+	add r0, r10, #0x48
 	add r1, r1, #0xc00
 	mov r2, #0xc
 	bl func_02007908
 	mov r1, #3
-	add r0, sl, #0x1000
+	add r0, r10, #0x1000
 	str r1, [r0, #0x6c]
 	mov sb, #0
 	add r8, sp, #0x34
@@ -1579,30 +1579,30 @@ _0217d30c:
 	strh sb, [sp, #0x34]
 	ldr r1, _0217d554 ; =0x474f3145
 	str r6, [sp]
-	add r2, sl, #0x48
+	add r2, r10, #0x48
 	mov r3, r8
 	bl func_ov00_020c4048
 	ldr r0, [r11]
 	mov r1, r6
 	bl _ZN12ActorManager8GetActorEP8ActorRef
 	str r0, [r5, sb, lsl #2]
-	str sl, [r0, #0x204]
+	str r10, [r0, #0x204]
 	add sb, sb, #1
 _0217d360:
 	cmp sb, #5
 	blt _0217d30c
-	ldr r1, [sl, #0x18]
+	ldr r1, [r10, #0x18]
 	mov r0, #2
 	sub r1, r1, #0x800
-	str r1, [sl, #0x58]
-	str r1, [sl, #0x4c]
-	str r0, [sl, #0x12c]
-	add r0, sl, #0x1000
+	str r1, [r10, #0x58]
+	str r1, [r10, #0x4c]
+	str r0, [r10, #0x12c]
+	add r0, r10, #0x1000
 	mov r1, #0
 	str r1, [r0, #0x74]
 	str r1, [r0, #0x60]
 	mov r0, #4
-	strb r0, [sl, #0x124]
+	strb r0, [r10, #0x124]
 	bl func_ov29_0216ffe8
 	bl func_ov29_0217159c
 	mov r4, #0
@@ -1613,29 +1613,29 @@ _0217d360:
 	orr r2, r2, #0x4000
 	orr r2, r2, #0xc00000
 	orr r3, r2, #0x59000000
-	add r0, sl, #4
+	add r0, r10, #4
 	str r4, [r1, #0xc]
 	str r4, [r1]
 	str r4, [r1, #4]
 	str r4, [r1, #8]
-	ldr r6, [sl, #0x48]
+	ldr r6, [r10, #0x48]
 	ldr r5, _0217d558 ; =0x000014cd
 	str r6, [sp, #0x20]
-	ldr r6, [sl, #0x4c]
+	ldr r6, [r10, #0x4c]
 	mov r2, #0x2000
 	str r6, [sp, #0x24]
-	ldr r6, [sl, #0x50]
+	ldr r6, [r10, #0x50]
 	add r0, r0, #0x1000
 	str r6, [sp, #0x28]
 	str r5, [sp, #0x2c]
 	str r2, [sp, #0x30]
-	ldr r2, [sl, #8]
+	ldr r2, [r10, #8]
 	str r3, [sp, #0x14]
 	str r4, [sp]
 	ldr r4, [r0]
 	ldr r4, [r4, #0x10]
 	blx r4
-	add r0, sl, #0x2c8
+	add r0, r10, #0x2c8
 	mov r1, #0
 	bl func_ov38_0217be04
 	ldr r1, _0217d550 ; =data_027e0fe4
@@ -1647,7 +1647,7 @@ _0217d360:
 	add r1, sp, #0xc
 	ldr r0, [r0]
 	bl _ZN12ActorManager8GetActorEP8ActorRef
-	str r0, [sl, #0xff4]
+	str r0, [r10, #0xff4]
 	ldr r1, _0217d550 ; =data_027e0fe4
 	ldr r2, _0217d560 ; =0x4e415649
 	ldr r1, [r1]
@@ -1661,39 +1661,39 @@ _0217d360:
 	str r3, [sp, #0xc]
 	str r2, [sp, #0x10]
 	bl _ZN12ActorManager8GetActorEP8ActorRef
-	str r0, [sl, #0xff8]
-	mov r0, sl
+	str r0, [r10, #0xff8]
+	mov r0, r10
 	mov r1, #0
 	bl func_ov38_02185720
 	ldr r1, _0217d564 ; =data_027e0fec
 	ldr r0, _0217d568 ; =data_ov29_0217a4ac
 	ldr r1, [r1]
-	add r2, sl, #0x1000
+	add r2, r10, #0x1000
 	add r1, r1, #0x3e8
 	add r1, r1, #0x1000
 	ldr r1, [r1, #8]
 	str r1, [r2]
 	bl func_ov29_0216d86c
-	add r1, sl, #0x1000
-	str r0, [sl, #0xffc]
+	add r1, r10, #0x1000
+	str r0, [r10, #0xffc]
 	ldr r0, [r1]
 	ldr r1, _0217d56c ; =data_ov38_021890cc
 	bl func_ov29_0216db60
 	mov r4, r0
-	add r0, sl, #0x1000
+	add r0, r10, #0x1000
 	ldr r0, [r0]
 	mov r1, r4
 	bl func_ov29_0216db74
-	add r2, sl, #0x1000
+	add r2, r10, #0x1000
 	str r0, [r2, #0x2c]
 	ldr r0, [r2]
 	mov r1, r4
 	bl func_ov29_0216dba8
-	add r1, sl, #0x1000
+	add r1, r10, #0x1000
 	str r0, [r1, #0x30]
 	mov r0, #1
 	add sp, sp, #0x6c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov38_0217cf90
 _0217d504: .word gItemManager
@@ -7422,7 +7422,7 @@ _0218259c: .word 0x0000059a
 	.global func_ov38_021825a0
 	arm_func_start func_ov38_021825a0
 func_ov38_021825a0: ; 0x021825a0
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0xc4
 	mov sb, r0
 	add r1, sb, #0x1000
@@ -7484,13 +7484,13 @@ _02182610:
 	ldr ip, [r3, #0x44]
 	ldr r2, _02182d98 ; =0x0000299a
 	rsb r7, r8, #0
-	umull sl, lr, ip, r2
+	umull r10, lr, ip, r2
 	mov r2, #0
 	mla lr, ip, r2, lr
 	ldr r2, _02182d98 ; =0x0000299a
 	mov r8, ip, asr #0x1f
 	mla lr, r8, r2, lr
-	adds r8, sl, #0x800
+	adds r8, r10, #0x800
 	adc r2, lr, #0
 	mov r8, r8, lsr #0xc
 	orr r8, r8, r2, lsl #20
@@ -7585,7 +7585,7 @@ _02182808:
 _02182810:
 	cmp r4, #0
 	addeq sp, sp, #0xc4
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, [sb, #0x2c4]
 	add r1, sb, #0x1b4
 	add r4, r1, r0, lsl #7
@@ -7599,7 +7599,7 @@ _02182810:
 	bl func_0202e310
 	cmp r0, #0
 	addeq sp, sp, #0xc4
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02182854:
 	ldr r0, _02182d9c ; =data_027e0ffc
 	ldr r1, _02182da0 ; =0x00000446
@@ -7607,7 +7607,7 @@ _02182854:
 	mov r3, #0
 	bl func_ov00_020ceacc
 	add sp, sp, #0xc4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02182870:
 	add r0, sb, #0x38
 	ldr r1, [r1, #0x3c]
@@ -7796,21 +7796,21 @@ _02182b14:
 	mov r3, #0
 	bl func_ov00_020ceacc
 	add sp, sp, #0xc4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02182b44:
 	add r0, r4, #0xc
 	mov r1, #0x79000
 	bl func_0202e310
 	cmp r0, #0
 	addeq sp, sp, #0xc4
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, _02182d9c ; =data_027e0ffc
 	ldr r1, _02182dac ; =0x00000448
 	add r2, sb, #0x48
 	mov r3, #0
 	bl func_ov00_020ceacc
 	add sp, sp, #0xc4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02182b78:
 	add r0, sb, #0x38
 	ldr r1, [r1, #0x3c]
@@ -7898,7 +7898,7 @@ _02182b78:
 	mov r3, #0
 	bl func_ov00_020ceacc
 	add sp, sp, #0xc4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02182cd4:
 	sub r2, r0, #1
 	str r2, [r1, #0x54]
@@ -7935,21 +7935,21 @@ _02182cd4:
 	str r4, [sp, #0x38]
 	bl func_ov38_0217e26c
 	add sp, sp, #0xc4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02182d64:
 	ldr r0, [r1, #0x54]
 	cmp r0, #0
 	subne r0, r0, #1
 	strne r0, [r1, #0x54]
 	addne sp, sp, #0xc4
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	add r0, r2, #1
 	str r0, [r1, #0x68]
 	mov r0, #0x3c
 	str r0, [r1, #0x54]
 _02182d8c:
 	add sp, sp, #0xc4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov38_021825a0
 _02182d94: .word data_02050f54
@@ -8175,32 +8175,32 @@ _02183078: .word 0x0000043e
 	.global func_ov38_0218307c
 	arm_func_start func_ov38_0218307c
 func_ov38_0218307c: ; 0x0218307c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x3c
-	mov sl, r0
+	mov r10, r0
 	ldr r4, _02183148 ; =0x00000e66
-	add r8, sl, #0x2f0
+	add r8, r10, #0x2f0
 	mov sb, #0
 	add r7, sp, #0x18
 	mov r11, #0xc
 	add r6, sp, #0xc
 	add r5, sp, #0
 _021830a4:
-	mov r0, sl
+	mov r0, r10
 	mov r1, sb
 	bl func_ov38_02182e28
 	add r0, r0, #0x24
 	mov r1, r7
 	mov r2, r11
 	bl func_02007908
-	mov r0, sl
+	mov r0, r10
 	mov r1, sb
 	bl func_ov38_02182e28
 	add r0, r0, #0x24
 	mov r1, r6
 	mov r2, #0xc
 	bl func_02007908
-	mov r0, sl
+	mov r0, r10
 	mov r1, sb
 	bl func_ov38_02182e28
 	mov r1, r5
@@ -8226,7 +8226,7 @@ _021830a4:
 	add r8, r8, #0x240
 	blt _021830a4
 	add sp, sp, #0x3c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov38_0218307c
 _02183148: .word 0x00000e66
@@ -8422,12 +8422,12 @@ _021833c8:
 	.global func_ov38_021833f4
 	arm_func_start func_ov38_021833f4
 func_ov38_021833f4: ; 0x021833f4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0xc
-	mov sl, r0
+	mov r10, r0
 	mov sb, r1
 	bl func_ov38_02185584
-	add r6, sl, #0x2f0
+	add r6, r10, #0x2f0
 	mov r8, r6
 	mov r7, #0
 	mov r4, #0xc
@@ -8435,7 +8435,7 @@ func_ov38_021833f4: ; 0x021833f4
 _0218341c:
 	cmp sb, #0
 	bne _0218348c
-	mov r0, sl
+	mov r0, r10
 	mov r1, r7
 	bl func_ov38_02182e28
 	mov r5, r0
@@ -8470,7 +8470,7 @@ _0218348c:
 	add r6, r6, #0x240
 	blt _0218341c
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov38_021833f4
 _021834b0: .word 0x00000e66
@@ -9456,7 +9456,7 @@ _02184258: .word data_027e0fe4
 	.global func_ov38_0218425c
 	arm_func_start func_ov38_0218425c
 func_ov38_0218425c: ; 0x0218425c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0xcc
 	mov r1, #0
 	mov r5, r0
@@ -9553,7 +9553,7 @@ _02184374:
 	ldr r0, [sp, #8]
 	cmp r0, #0
 	addle sp, sp, #0xcc
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, [sp, #0x14]
 	sub r0, r6, r0
 	str r0, [sp, #0xc]
@@ -9571,8 +9571,8 @@ _021843f4:
 	ldmia r0, {r0, r1, r2}
 	stmia r7, {r0, r1, r2}
 	sub r0, r8, r3
-	add sl, r0, #1
-	cmp sl, #0
+	add r10, r0, #1
+	cmp r10, #0
 	movle r2, #0
 	ble _0218446c
 	ldr r1, [r6]
@@ -9586,12 +9586,12 @@ _021843f4:
 	adds r0, sb, r7
 	adc r2, r8, lr
 	stmia r6, {r0, r2}
-	cmp sl, #0
+	cmp r10, #0
 	beq _0218446c
-	umull r0, r1, r2, sl
+	umull r0, r1, r2, r10
 	mov r0, #0
 	mla r1, r2, r0, r1
-	mla r1, r0, sl, r1
+	mla r1, r0, r10, r1
 	mov r2, r1
 _0218446c:
 	add r8, r3, r2
@@ -9649,7 +9649,7 @@ _0218446c:
 	cmp r4, r0
 	blt _021843f4
 	add sp, sp, #0xcc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov38_0218425c
 _0218454c: .word 0x00005348
@@ -9666,7 +9666,7 @@ _02184570: .word data_027e0fe4
 	.global func_ov38_02184574
 	arm_func_start func_ov38_02184574
 func_ov38_02184574: ; 0x02184574
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x14
 	add r0, r0, #0x1000
 	str r0, [sp, #8]
@@ -9703,7 +9703,7 @@ _021845b0:
 	cmp r4, r0
 	addge sp, sp, #0x14
 	movge r0, #0
-	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02184608:
 	cmp r1, #2
 	bne _02184708
@@ -9717,11 +9717,11 @@ _02184608:
 	ldrsh r1, [r1, #0x94]
 	sub r0, r1, r0
 	mov r0, r0, lsl #0x10
-	movs sl, r0, asr #0x10
-	rsbmi r0, sl, #0
+	movs r10, r0, asr #0x10
+	rsbmi r0, r10, #0
 	movmi r0, r0, lsl #0x10
-	movmi sl, r0, asr #0x10
-	cmp sl, r5
+	movmi r10, r0, asr #0x10
+	cmp r10, r5
 	bge _02184708
 	ldr r0, [r8, #0x130]
 	cmp r0, #3
@@ -9771,7 +9771,7 @@ _021846f4:
 	cmp r1, r0
 	blt _02184708
 _02184700:
-	mov r5, sl
+	mov r5, r10
 	str r7, [sp, #4]
 _02184708:
 	add r6, r6, #1
@@ -9781,11 +9781,11 @@ _02184708:
 	cmp r0, #0
 	addeq sp, sp, #0x14
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	bl func_ov29_021733f4
 	mov r0, #1
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov38_02184574
 _02184738: .word 0x00007fff
@@ -9882,39 +9882,39 @@ _02184878: .word 0x474f3143
 	.global func_ov38_0218487c
 	arm_func_start func_ov38_0218487c
 func_ov38_0218487c: ; 0x0218487c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	add r3, r0, #0x1000
 	ldr r1, [r3, #0x60]
 	cmp r1, #0
 	bne _02184a08
 	ldr r1, [r0, #0x2d8]
 	cmp r1, #0xe
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	ldr ip, _02184a14 ; =data_027e0764
 	mov r2, #0
 	ldr r4, [ip]
 	ldmib ip, {r1, r6}
-	umull sl, sb, r6, r4
+	umull r10, sb, r6, r4
 	mla sb, r6, r1, sb
 	ldr r5, [ip, #0xc]
 	ldr r8, [ip, #0x10]
 	mla sb, r5, r4, sb
-	adds r1, r8, sl
+	adds r1, r8, r10
 	ldr r7, [ip, #0x14]
-	mov sl, #0x64
+	mov r10, #0x64
 	adc sb, r7, sb
-	umull r4, lr, sb, sl
+	umull r4, lr, sb, r10
 	mla lr, sb, r2, lr
 	mov r4, r2
-	mla lr, r4, sl, lr
+	mla lr, r4, r10, lr
 	stmia ip, {r1, sb}
 	cmp lr, #0x41
 	bge _02184924
-	umull lr, sl, r6, r1
-	mla sl, r6, sb, sl
+	umull lr, r10, r6, r1
+	mla r10, r6, sb, r10
 	adds lr, r8, lr
-	mla sl, r5, r1, sl
-	adc r7, r7, sl
+	mla r10, r5, r1, r10
+	adc r7, r7, r10
 	mov r1, #0x1f
 	umull r5, r6, r7, r1
 	mla r6, r7, r2, r6
@@ -9926,12 +9926,12 @@ func_ov38_0218487c: ; 0x0218487c
 	b _02184990
 _02184924:
 	cmp lr, #0x5f
-	umull lr, sl, r6, r1
-	mla sl, r6, sb, sl
+	umull lr, r10, r6, r1
+	mla r10, r6, sb, r10
 	bge _02184964
-	mla sl, r5, r1, sl
+	mla r10, r5, r1, r10
 	adds lr, r8, lr
-	adc r7, r7, sl
+	adc r7, r7, r10
 	mov r1, #0x4c
 	umull r5, r6, r7, r1
 	mla r6, r7, r2, r6
@@ -9942,9 +9942,9 @@ _02184924:
 	str r1, [r3, #0x60]
 	b _02184990
 _02184964:
-	mla sl, r5, r1, sl
+	mla r10, r5, r1, r10
 	adds lr, r8, lr
-	adc r7, r7, sl
+	adc r7, r7, r10
 	mov r1, #0x1f
 	umull r5, r6, r7, r1
 	mla r6, r7, r2, r6
@@ -9984,11 +9984,11 @@ _02184990:
 	str r2, [r1, #0x60]
 _02184a00:
 	bl func_ov38_02184744
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _02184a08:
 	sub r0, r1, #1
 	str r0, [r3, #0x60]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov38_0218487c
 _02184a14: .word data_027e0764
@@ -10267,14 +10267,14 @@ _02184d98: .word func_ov38_02184d6c
 	.global func_ov38_02184d9c
 	arm_func_start func_ov38_02184d9c
 func_ov38_02184d9c: ; 0x02184d9c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x1c
-	mov sl, r0
+	mov r10, r0
 	mov r0, r2
 	add r2, sp, #0x10
 	str r3, [sp]
 	mov sb, r1
-	str r3, [sl, #0x234]
+	str r3, [r10, #0x234]
 	bl func_01ff9bf8
 	mov r0, #0x1000
 	mov r1, #3
@@ -10282,8 +10282,8 @@ func_ov38_02184d9c: ; 0x02184d9c
 	bl func_01ff9b4c
 	ldr r11, _02184ed8 ; =data_027e0d0c
 	mov r5, r0
-	mov r7, sl
-	add r8, sl, #0x38
+	mov r7, r10
+	add r8, r10, #0x38
 	mov r6, r4
 _02184de4:
 	ldr r1, [sb]
@@ -10321,32 +10321,32 @@ _02184de4:
 	mov r1, r1, lsl #0x1
 	mov r2, r1, lsl #0x1
 	ldr r3, _02184ee0 ; =data_02050f54
-	str r0, [sl, #0x220]
+	str r0, [r10, #0x220]
 	mov r4, #0
 	add r1, r1, #1
-	strb r4, [sl, #0x23c]
-	add r0, sl, #0x200
+	strb r4, [r10, #0x23c]
+	add r0, r10, #0x200
 	strh r4, [r0, #0x38]
 	mov r1, r1, lsl #0x1
 	ldrsh r0, [r3, r1]
 	ldrsh r2, [r3, r2]
-	str r4, [sl, #0x204]
+	str r4, [r10, #0x204]
 	ldr r1, _02184ee4 ; =data_ov38_02189224
-	str r2, [sl, #0x208]
-	str r4, [sl, #0x20c]
-	str r0, [sl, #0x210]
+	str r2, [r10, #0x208]
+	str r4, [r10, #0x20c]
+	str r0, [r10, #0x210]
 	ldr r0, [sp]
 	ldr r0, [r1, r0, lsl #2]
-	str sl, [r0, #0x208]
+	str r10, [r0, #0x208]
 	ldr r0, [sp]
 	ldr r0, [r1, r0, lsl #2]
 	bl func_ov29_02172e88
-	ldr r1, [sl, #0x234]
-	add r0, sl, #0x200
+	ldr r1, [r10, #0x234]
+	add r0, r10, #0x200
 	mov r1, r1, lsl #0xc
 	strh r1, [r0, #0x3a]
 	add sp, sp, #0x1c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov38_02184d9c
 _02184ed8: .word data_027e0d0c
@@ -10357,13 +10357,13 @@ _02184ee4: .word data_ov38_02189224
 	.global func_ov38_02184ee8
 	arm_func_start func_ov38_02184ee8
 func_ov38_02184ee8: ; 0x02184ee8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0xd4
-	mov sl, r0
+	mov r10, r0
 	mov r6, r1
 	add r8, sp, #0xb0
-	add r5, sl, #4
-	add r3, sl, #0xf4
+	add r5, r10, #4
+	add r3, r10, #0xf4
 	mov r0, r6
 	mov r1, r8
 	mov r2, #0xc
@@ -10392,7 +10392,7 @@ func_ov38_02184ee8: ; 0x02184ee8
 	mov r1, r8
 	mov r3, r2
 	bl func_01ff9e64
-	add r0, sl, #0x200
+	add r0, r10, #0x200
 	ldrsh r1, [r0, #0x3a]
 	add r1, r1, #0x500
 	strh r1, [r0, #0x3a]
@@ -10402,10 +10402,10 @@ func_ov38_02184ee8: ; 0x02184ee8
 	ldr r0, [r8, #8]
 	str r1, [sp, #0x8c]
 	str r0, [sp, #0x94]
-	ldrb r0, [sl, #0x23c]
+	ldrb r0, [r10, #0x23c]
 	cmp r0, #0
 	beq _0218500c
-	add r0, sl, #0x214
+	add r0, r10, #0x214
 	add r3, sp, #0x80
 	ldmia r0, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
@@ -10431,7 +10431,7 @@ func_ov38_02184ee8: ; 0x02184ee8
 	mov r3, r2
 	bl func_01ff9e64
 _0218500c:
-	add r0, sl, #0x200
+	add r0, r10, #0x200
 	ldrh r1, [r0, #0x3a]
 	ldr r0, _021854cc ; =data_02050f54
 	mov r2, #0
@@ -10453,22 +10453,22 @@ _0218500c:
 	orr r2, r2, r1, lsl #20
 	add r1, r2, #0x33
 	add r1, r1, #0x100
-	str r1, [sl, #0x220]
+	str r1, [r10, #0x220]
 	bl func_01fffbec
-	ldr r1, [sl, #0x228]
+	ldr r1, [r10, #0x228]
 	ldr r2, _021854d0 ; =0x0000019a
-	add r0, sl, #0x224
+	add r0, r10, #0x224
 	mov r11, #0x2c00
 	mov sb, #0
 	bl Approach_thunk
 	ldr r1, _021854d4 ; =0x00000b9a
-	add r0, sl, #0x22c
-	str r1, [sl, #0x228]
-	ldr r1, [sl, #0x230]
+	add r0, r10, #0x22c
+	str r1, [r10, #0x228]
+	ldr r1, [r10, #0x230]
 	mov r2, #0xcd
 	bl Approach_thunk
 	ldr r0, _021854d8 ; =0x00000666
-	str r0, [sl, #0x230]
+	str r0, [r10, #0x230]
 	rsb r0, r0, #0x1400
 	str r0, [sp, #0x10]
 _021850ac:
@@ -10535,12 +10535,12 @@ _02185188:
 	str r0, [sp, #0xc0]
 	str r0, [sp, #0xc4]
 _02185198:
-	ldrb r0, [sl, #0x23c]
+	ldrb r0, [r10, #0x23c]
 	cmp r0, #0
 	beq _02185214
 	cmp sb, #0
 	beq _02185200
-	add r0, sl, #0x214
+	add r0, r10, #0x214
 	add r1, r5, #0x34
 	add r2, sp, #0x74
 	bl func_01ff9bf8
@@ -10580,10 +10580,10 @@ _02185214:
 	ldr r1, [sp, #0xc0]
 	str r0, [sp, #0x64]
 	str r1, [sp, #0x60]
-	ldr r1, [sl, #0x22c]
+	ldr r1, [r10, #0x22c]
 	add r0, sp, #0x68
 	bl func_01fffbec
-	ldr r1, [sl, #0x22c]
+	ldr r1, [r10, #0x22c]
 	add r0, sp, #0x5c
 	bl func_01fffbec
 	add r0, r5, #0x40
@@ -10602,19 +10602,19 @@ _02185214:
 	add r0, sp, #0x8c
 	bl func_01fffbec
 	ldr r2, [r5, #0x40]
-	ldr r1, [sl, #0x224]
+	ldr r1, [r10, #0x224]
 	add r0, r5, #0x34
 	mul r1, r2, r1
 	mov r1, r1, asr #0xc
 	str r1, [r5, #0x40]
 	ldr r3, [r5, #0x44]
-	ldr r2, [sl, #0x224]
+	ldr r2, [r10, #0x224]
 	add r1, r5, #0x40
 	mul r2, r3, r2
 	mov r2, r2, asr #0xc
 	str r2, [r5, #0x44]
 	ldr ip, [r5, #0x48]
-	ldr r3, [sl, #0x224]
+	ldr r3, [r10, #0x224]
 	mov r2, r0
 	mul r3, ip, r3
 	mov r3, r3, asr #0xc
@@ -10623,7 +10623,7 @@ _02185214:
 	sub r3, r3, #0x14
 	str r3, [r5, #0x44]
 	bl func_01ff9bc4
-	ldr r1, [sl]
+	ldr r1, [r10]
 	cmp r1, #0
 	beq _02185304
 	mov r0, r5
@@ -10659,7 +10659,7 @@ _02185304:
 	bl func_02007908
 	b _021854ac
 _02185378:
-	ldrb r0, [sl, #0x23c]
+	ldrb r0, [r10, #0x23c]
 	cmp r0, #0
 	beq _021853bc
 	mov r0, #0
@@ -10723,18 +10723,18 @@ _021853e8:
 	add r1, sp, #0x4c
 	mov r2, #0xc00
 	bl func_ov00_020d59f0
-	add r0, sl, #0x204
+	add r0, r10, #0x204
 	add r1, sp, #0x2c
 	bl func_ov00_020d5eac
-	add r0, sl, #0x204
+	add r0, r10, #0x204
 	add r1, sp, #0x3c
 	bl func_ov00_020d5eac
-	add r0, sl, #0x204
+	add r0, r10, #0x204
 	bl func_ov00_020d5c54
-	add r0, sl, #0x204
+	add r0, r10, #0x204
 	add r1, r5, #0x10
 	bl func_ov00_020d5cd8
-	ldr r1, [sl, #0x234]
+	ldr r1, [r10, #0x234]
 	ldr r0, _021854e0 ; =data_ov38_02189224
 	ldr r0, [r0, r1, lsl #2]
 	bl func_ov29_02172bc0
@@ -10743,9 +10743,9 @@ _021854ac:
 	cmp r5, r0
 	bne _021850ac
 	mov r0, #0
-	strb r0, [sl, #0x23c]
+	strb r0, [r10, #0x23c]
 	add sp, sp, #0xd4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov38_02184ee8
 _021854c8: .word 0x00000e66
@@ -10829,7 +10829,7 @@ _021855c4: .word data_ov38_021891e0
 	.global func_ov38_021855c8
 	arm_func_start func_ov38_021855c8
 func_ov38_021855c8: ; 0x021855c8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x38
 	add sb, r0, #4
 	mov r3, #2
@@ -10842,13 +10842,13 @@ func_ov38_021855c8: ; 0x021855c8
 	mov r2, r1
 	mov r0, #0x11
 	bl func_01ffa9fc
-	mov sl, #0
+	mov r10, #0
 	ldr r8, _02185688 ; =data_027e03c8
 	add r7, sp, #8
 	mov r6, #0x17
 	mov r5, #0xc
 	mov r4, #0x11
-	mov r11, sl
+	mov r11, r10
 _02185618:
 	mov r1, r8
 	mov r2, r7
@@ -10862,8 +10862,8 @@ _02185618:
 	mov r1, r11
 	mov r2, r11
 	bl func_01ffa9fc
-	add sl, sl, #1
-	cmp sl, #4
+	add r10, r10, #1
+	cmp r10, #4
 	add sb, sb, #0x50
 	blt _02185618
 	mov r3, #4
@@ -10877,7 +10877,7 @@ _02185618:
 	ldr r1, [r1, #0x7c]
 	bl func_01ffa94c
 	add sp, sp, #0x38
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov38_021855c8
 _02185688: .word data_027e03c8
@@ -13053,7 +13053,7 @@ _02187628: .word data_027e0fc8
 	.global func_ov38_0218762c
 	arm_func_start func_ov38_0218762c
 func_ov38_0218762c: ; 0x0218762c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0xec
 	ldr r1, _02187944 ; =data_ov38_021891e0
 	mov r2, #0
@@ -13113,60 +13113,60 @@ func_ov38_0218762c: ; 0x0218762c
 	str r1, [r0, #0x148]
 	ldr r11, [r0, #0x1b4]
 	str r11, [r0, #0x14c]
-	ldr sl, [r0, #0x1b8]
-	str sl, [sp]
-	str sl, [r0, #0x150]
-	ldr sl, [r0, #0x1bc]
-	str sl, [sp, #4]
-	str sl, [r0, #0x154]
-	ldr sl, [r0, #0x1c0]
-	str sl, [sp, #8]
-	str sl, [r0, #0x158]
-	ldr sl, [r0, #0x1c4]
-	str sl, [sp, #0xc]
-	str sl, [r0, #0x15c]
-	ldr sl, [r0, #0x1c8]
-	str sl, [sp, #0x10]
-	str sl, [r0, #0x160]
-	ldr sl, [r0, #0x1cc]
-	str sl, [sp, #0x14]
-	str sl, [r0, #0x164]
-	ldr sl, [r0, #0x1d0]
-	str sl, [sp, #0x18]
-	str sl, [r0, #0x168]
-	ldr sl, [r0, #0x1d4]
-	str sl, [sp, #0x1c]
-	str sl, [r0, #0x16c]
-	ldr sl, [r0, #0x1d8]
-	str sl, [sp, #0x20]
-	str sl, [r0, #0x170]
-	ldr sl, [r0, #0x1dc]
-	str sl, [sp, #0x24]
-	str sl, [r0, #0x174]
-	ldrb sl, [r0, #0x1e0]
-	str sl, [sp, #0x28]
-	strb sl, [r0, #0x178]
-	ldrb sl, [r0, #0x1e1]
-	str sl, [sp, #0x2c]
-	strb sl, [r0, #0x179]
-	ldrb sl, [r0, #0x1e2]
-	str sl, [sp, #0x30]
-	strb sl, [r0, #0x17a]
-	ldrb sl, [r0, #0x1e3]
-	str sl, [sp, #0x34]
-	strb sl, [r0, #0x17b]
-	ldrb sl, [r0, #0x1e4]
-	str sl, [sp, #0x38]
-	strb sl, [r0, #0x17c]
-	ldr sl, [r0, #0x1f4]
-	str sl, [r0, #0x1e8]
-	ldr sl, [r0, #0x1f8]
-	str sl, [r0, #0x1ec]
-	ldr sl, [r0, #0x1fc]
-	str sl, [r0, #0x1f0]
-	mov sl, #0
-	str sl, [r0, #0x104]
-	add sl, r5, #0x8800
+	ldr r10, [r0, #0x1b8]
+	str r10, [sp]
+	str r10, [r0, #0x150]
+	ldr r10, [r0, #0x1bc]
+	str r10, [sp, #4]
+	str r10, [r0, #0x154]
+	ldr r10, [r0, #0x1c0]
+	str r10, [sp, #8]
+	str r10, [r0, #0x158]
+	ldr r10, [r0, #0x1c4]
+	str r10, [sp, #0xc]
+	str r10, [r0, #0x15c]
+	ldr r10, [r0, #0x1c8]
+	str r10, [sp, #0x10]
+	str r10, [r0, #0x160]
+	ldr r10, [r0, #0x1cc]
+	str r10, [sp, #0x14]
+	str r10, [r0, #0x164]
+	ldr r10, [r0, #0x1d0]
+	str r10, [sp, #0x18]
+	str r10, [r0, #0x168]
+	ldr r10, [r0, #0x1d4]
+	str r10, [sp, #0x1c]
+	str r10, [r0, #0x16c]
+	ldr r10, [r0, #0x1d8]
+	str r10, [sp, #0x20]
+	str r10, [r0, #0x170]
+	ldr r10, [r0, #0x1dc]
+	str r10, [sp, #0x24]
+	str r10, [r0, #0x174]
+	ldrb r10, [r0, #0x1e0]
+	str r10, [sp, #0x28]
+	strb r10, [r0, #0x178]
+	ldrb r10, [r0, #0x1e1]
+	str r10, [sp, #0x2c]
+	strb r10, [r0, #0x179]
+	ldrb r10, [r0, #0x1e2]
+	str r10, [sp, #0x30]
+	strb r10, [r0, #0x17a]
+	ldrb r10, [r0, #0x1e3]
+	str r10, [sp, #0x34]
+	strb r10, [r0, #0x17b]
+	ldrb r10, [r0, #0x1e4]
+	str r10, [sp, #0x38]
+	strb r10, [r0, #0x17c]
+	ldr r10, [r0, #0x1f4]
+	str r10, [r0, #0x1e8]
+	ldr r10, [r0, #0x1f8]
+	str r10, [r0, #0x1ec]
+	ldr r10, [r0, #0x1fc]
+	str r10, [r0, #0x1f0]
+	mov r10, #0
+	str r10, [r0, #0x104]
+	add r10, r5, #0x8800
 	sub r5, lr, #0x1000
 	ldr lr, [r4, #0x14]
 	str lr, [r0, #0x1f4]
@@ -13176,7 +13176,7 @@ func_ov38_0218762c: ; 0x0218762c
 	str lr, [r0, #0x1fc]
 	str r1, [sp, #0x98]
 	ldr r1, [sp]
-	str sl, [r0, #0x19c]
+	str r10, [r0, #0x19c]
 	str r1, [sp, #0xa0]
 	ldr r1, [sp, #4]
 	str r3, [sp, #0x90]
@@ -13224,7 +13224,7 @@ func_ov38_0218762c: ; 0x0218762c
 	str r11, [sp, #0x9c]
 	strb r3, [sp, #0xc8]
 	ldr r3, [sp, #0x2c]
-	str sl, [sp, #0x84]
+	str r10, [sp, #0x84]
 	strb r3, [sp, #0xc9]
 	ldr r3, [sp, #0x30]
 	str r5, [sp, #0x88]
@@ -13250,7 +13250,7 @@ func_ov38_0218762c: ; 0x0218762c
 	str r1, [r4, #0x2e4]
 	bl func_ov00_0209a508
 	add sp, sp, #0xec
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov38_0218762c
 _02187944: .word data_ov38_021891e0

--- a/asm/ov39.s
+++ b/asm/ov39.s
@@ -2320,7 +2320,7 @@ _0217dd18: .word data_027e0f94
 	.global func_ov39_0217dd1c
 	arm_func_start func_ov39_0217dd1c
 func_ov39_0217dd1c: ; 0x0217dd1c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x9c
 	mov r5, r0
 	add r0, r5, #0x3ec
@@ -2453,12 +2453,12 @@ _0217de6c:
 	mov r4, #0x5000
 	ldr r1, [r5, #0x4c]
 	mov ip, #0
-	umull sb, r8, r7, r4
+	umull r9, r8, r7, r4
 	add lr, r1, #0x1000
 	mla r8, r7, ip, r8
 	mov r6, r7, asr #0x1f
 	mla r8, r6, r4, r8
-	adds r6, sb, #0x800
+	adds r6, r9, #0x800
 	ldr r2, [r5, #0x50]
 	ldr r0, [r5, #0x48]
 	adc r4, r8, #0
@@ -2488,7 +2488,7 @@ _0217df70:
 	str r4, [sp, #0x14]
 	bl func_ov05_02102c2c
 	add sp, sp, #0x9c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov39_0217dd1c
 _0217dfac: .word data_02050f54
@@ -2945,19 +2945,19 @@ func_ov39_0217e55c: ; 0x0217e55c
 	.global func_ov39_0217e5b0
 	arm_func_start func_ov39_0217e5b0
 func_ov39_0217e5b0: ; 0x0217e5b0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x48
 	mov r4, r0
 	ldrb r0, [r4, #0xc9c]
 	cmp r0, #0
 	addne sp, sp, #0x48
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, [r4, #0x158]
 	tst r0, #0x800
 	addne sp, sp, #0x48
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	cmp r1, #3
 	addls pc, pc, r1, lsl #2
 	b _0217e69c
@@ -2970,7 +2970,7 @@ _0217e600:
 	cmp r2, #1
 	addgt sp, sp, #0x48
 	movgt r0, #0
-	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	mov r0, #6
 	mul r0, r2, r0
 	ldr r1, _0217e808 ; =data_ov39_02186548
@@ -2981,7 +2981,7 @@ _0217e628:
 	cmp r2, #1
 	addgt sp, sp, #0x48
 	movgt r0, #0
-	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	mov r0, #6
 	mul r0, r2, r0
 	ldr r1, _0217e810 ; =data_ov39_021865d8
@@ -2992,7 +2992,7 @@ _0217e650:
 	cmp r2, #1
 	addgt sp, sp, #0x48
 	movgt r0, #0
-	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	mov r0, #6
 	mul r0, r2, r0
 	ldr r1, _0217e814 ; =data_ov39_02186620
@@ -3003,7 +3003,7 @@ _0217e678:
 	cmp r2, #1
 	addgt sp, sp, #0x48
 	movgt r0, #0
-	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	mov r0, #6
 	mul r0, r2, r0
 	ldr r1, _0217e818 ; =data_ov39_02186590
@@ -3011,7 +3011,7 @@ _0217e678:
 	add r7, r1, r0, lsl #2
 _0217e69c:
 	ldrh r0, [r4, #0x78]
-	mov sb, #0
+	mov r9, #0
 	ldr r2, _0217e820 ; =data_02050f54
 	mov r0, r0, asr #0x4
 	mov r1, r0, lsl #0x1
@@ -3021,7 +3021,7 @@ _0217e69c:
 	ldrsh r1, [r2, r1]
 	ldrsh r0, [r2, r0]
 	ldr r11, _0217e824 ; =data_027e0f90
-	str sb, [sp, #0x1c]
+	str r9, [sp, #0x1c]
 	str r1, [sp, #0x18]
 	str r0, [sp, #0x20]
 	add r6, sp, #0x3c
@@ -3094,15 +3094,15 @@ _0217e6dc:
 	movne r0, #0
 	strneb r0, [r1, #0x25c]
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0217e7ec:
-	add sb, sb, #1
-	cmp sb, #2
+	add r9, r9, #1
+	cmp r9, #2
 	add r7, r7, #0xc
 	blt _0217e6dc
 	mov r0, #0
 	add sp, sp, #0x48
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov39_0217e5b0
 _0217e808: .word data_ov39_02186548
@@ -3799,7 +3799,7 @@ _0217f108: .word data_ov29_0217bd28
 	.global func_ov39_0217f10c
 	arm_func_start func_ov39_0217f10c
 func_ov39_0217f10c: ; 0x0217f10c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x1c
 	mov r5, r0
 	ldr r1, _0217f264 ; =data_027e0fac
@@ -3828,13 +3828,13 @@ func_ov39_0217f10c: ; 0x0217f10c
 	ldrsh ip, [r3, r2]
 	ldr r3, _0217f270 ; =0x00002b33
 	mov r0, r8
-	umull sb, r8, r7, r3
+	umull r9, r8, r7, r3
 	mov r3, #0
 	mla r8, r7, r3, r8
 	ldr r3, _0217f270 ; =0x00002b33
 	mov r6, r7, asr #0x1f
 	mla r8, r6, r3, r8
-	adds r6, sb, #0x800
+	adds r6, r9, #0x800
 	ldr r10, [sp, #4]
 	adc r3, r8, #0
 	mov r6, r6, lsr #0xc
@@ -3885,7 +3885,7 @@ _0217f23c:
 	ldr r0, [r0]
 	bl func_ov00_020bd4fc
 	add sp, sp, #0x1c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov39_0217f10c
 _0217f264: .word data_027e0fac
@@ -4320,7 +4320,7 @@ func_ov39_0217f7d8: ; 0x0217f7d8
 	.global func_ov39_0217f810
 	arm_func_start func_ov39_0217f810
 func_ov39_0217f810: ; 0x0217f810
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #0x18
 	mov r4, r0
 	ldr r0, [r4, #0x284]
@@ -4341,7 +4341,7 @@ func_ov39_0217f810: ; 0x0217f810
 	str r1, [r0, #0x58]
 	ldr r1, [r4, #0x50]
 	str r1, [r0, #0x5c]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _0217f868:
 	bl _ZN5Actor16IsFollowedByLinkEv
 	cmp r0, #0
@@ -4364,18 +4364,18 @@ _0217f868:
 	ldrsh r8, [r5, r6]
 	mov ip, #0xcd
 	add r3, r3, #1
-	umull r10, sb, r8, ip
+	umull r10, r9, r8, ip
 	mov r3, r3, lsl #0x1
 	ldrsh lr, [r5, r3]
 	add r3, sp, #0xc
 	stmia r3, {r0, r1, r2}
 	umull r6, r5, lr, ip
-	mla sb, r8, r7, sb
+	mla r9, r8, r7, r9
 	mov r0, r8, asr #0x1f
-	mla sb, r0, ip, sb
+	mla r9, r0, ip, r9
 	adds r10, r10, #0x800
 	mla r5, lr, r7, r5
-	adc r1, sb, #0
+	adc r1, r9, #0
 	mov r0, r10, lsr #0xc
 	orr r0, r0, r1, lsl #20
 	adds r1, r6, #0x800
@@ -4411,7 +4411,7 @@ _0217f868:
 	ldr r0, [sp, #0x14]
 	add sp, sp, #0x18
 	str r0, [r1, #0x5c]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _0217f97c:
 	ldrsh r0, [r4, #0x78]
 	ldr r2, _0217fa38 ; =data_02050f54
@@ -4459,7 +4459,7 @@ _0217f97c:
 	ldr r0, [r4, #0x284]
 	strh r1, [r0, #0x78]
 	add sp, sp, #0x18
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov39_0217f810
 _0217fa38: .word data_02050f54
@@ -6682,7 +6682,7 @@ _02181998: .word data_02050f54
 	.global func_ov39_0218199c
 	arm_func_start func_ov39_0218199c
 func_ov39_0218199c: ; 0x0218199c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #0x40
 	mov r4, #1
 	mov r10, r0
@@ -6694,9 +6694,9 @@ func_ov39_0218199c: ; 0x0218199c
 	mov r7, r0, asr #0x10
 	add r0, r7, #0xab
 	mov r3, #0x3800
-	add sb, r0, #0x2a00
+	add r9, r0, #0x2a00
 	ldr r2, _02181cbc ; =data_027e0f94
-	mov r1, sb, lsl #0x10
+	mov r1, r9, lsl #0x10
 	ldr r0, [r2]
 	str r6, [sp, #0x34]
 	str r6, [sp, #0x38]
@@ -6849,7 +6849,7 @@ _02181bd4:
 _02181c04:
 	add r0, r0, #0x400
 	mov r1, #0x13
-	strh sb, [r2, #0x64]
+	strh r9, [r2, #0x64]
 	bl func_ov39_0217ca2c
 _02181c14:
 	ldr r0, [r10, #0x7fc]
@@ -6893,7 +6893,7 @@ _02181c14:
 	bl func_ov00_020ceacc
 	mov r0, #1
 	add sp, sp, #0x40
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov39_0218199c
 _02181cbc: .word data_027e0f94
@@ -8918,7 +8918,7 @@ _021838b8:
 	.global func_ov39_021838c4
 	arm_func_start func_ov39_021838c4
 func_ov39_021838c4: ; 0x021838c4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x124
 	mov r4, r0
 	ldr r0, _02183c10 ; =data_027e0ffc
@@ -9041,7 +9041,7 @@ func_ov39_021838c4: ; 0x021838c4
 	ldr r6, [sp, #0xc]
 	ldr r5, [sp, #0x10]
 	ldr r10, [sp, #0x14]
-	ldr sb, [sp, #0x18]
+	ldr r9, [sp, #0x18]
 	ldr r8, [sp, #0x1c]
 	ldr r7, [sp, #0x24]
 	str r6, [sp, #0xa0]
@@ -9050,8 +9050,8 @@ func_ov39_021838c4: ; 0x021838c4
 	ldr r5, [sp, #0x38]
 	str r10, [sp, #0xa8]
 	ldr r10, [sp, #0x3c]
-	str sb, [sp, #0xac]
-	ldr sb, [sp, #0x40]
+	str r9, [sp, #0xac]
+	ldr r9, [sp, #0x40]
 	str r8, [sp, #0xb0]
 	ldr r8, [sp, #0x44]
 	str r7, [sp, #0xb8]
@@ -9067,8 +9067,8 @@ func_ov39_021838c4: ; 0x021838c4
 	ldrb r1, [sp, #0x70]
 	str r10, [sp, #0xd0]
 	ldr r10, [sp, #0x54]
-	str sb, [sp, #0xd4]
-	ldr sb, [sp, #0x58]
+	str r9, [sp, #0xd4]
+	ldr r9, [sp, #0x58]
 	str r8, [sp, #0xd8]
 	ldr r8, [sp, #0x5c]
 	str r7, [sp, #0xdc]
@@ -9086,7 +9086,7 @@ func_ov39_021838c4: ; 0x021838c4
 	str r11, [sp, #0xbc]
 	str r11, [sp, #0xc0]
 	str r11, [sp, #0xc4]
-	str sb, [sp, #0xec]
+	str r9, [sp, #0xec]
 	str r8, [sp, #0xf0]
 	str r7, [sp, #0xf4]
 	str r6, [sp, #0xf8]
@@ -9128,7 +9128,7 @@ func_ov39_021838c4: ; 0x021838c4
 	bl func_ov00_0209a508
 	mov r0, #1
 	add sp, sp, #0x124
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov39_021838c4
 _02183c10: .word data_027e0ffc
@@ -10331,23 +10331,23 @@ _02184d3c: .word data_02050f54
 	.global func_ov39_02184d40
 	arm_func_start func_ov39_02184d40
 func_ov39_02184d40: ; 0x02184d40
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	ldr r2, [r0, #0x30]
 	cmp r1, r2
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	str r1, [r0, #0x30]
 	cmp r1, #3
 	addls pc, pc, r1, lsl #2
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02184d60: ; jump table
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc} ; case 0
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc} ; case 0
 	b _02184d70 ; case 1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc} ; case 2
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc} ; case 2
 	b _02184d7c ; case 3
 _02184d70:
 	mov r1, #0xa
 	str r1, [r0, #0x34]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02184d7c:
 	ldr lr, _02184e64 ; =data_027e0764
 	mov ip, #0
@@ -10391,13 +10391,13 @@ _02184d7c:
 	strh r2, [r0, #0x40]
 	ldr r5, [lr]
 	ldmib lr, {r4, r7}
-	umull sb, r8, r7, r5
+	umull r9, r8, r7, r5
 	mla r8, r7, r4, r8
 	ldr r6, [lr, #0xc]
 	ldr r11, [lr, #0x10]
 	mla r8, r6, r5, r8
 	ldr r10, [lr, #0x14]
-	adds r4, r11, sb
+	adds r4, r11, r9
 	adc r5, r10, r8
 	stmia lr, {r4, r5}
 	umull lr, r4, r5, r3
@@ -10406,7 +10406,7 @@ _02184d7c:
 	sub r2, r3, #0x4000
 	add r1, r4, r2
 	strh r1, [r0, #0x42]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov39_02184d40
 _02184e64: .word data_027e0764
@@ -10415,7 +10415,7 @@ _02184e68: .word 0x00002aab
 	.global func_ov39_02184e6c
 	arm_func_start func_ov39_02184e6c
 func_ov39_02184e6c: ; 0x02184e6c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x30
 	mov r4, r0
 	ldr r0, [r4, #0x30]
@@ -10558,10 +10558,10 @@ _02184fc8:
 	ldmib r2, {r3, r5, lr}
 	umull r7, r6, r5, ip
 	mla r6, r5, r3, r6
-	ldr sb, [r2, #0x10]
+	ldr r9, [r2, #0x10]
 	mla r6, lr, ip, r6
 	ldr r8, [r2, #0x14]
-	adds r3, sb, r7
+	adds r3, r9, r7
 	adc r5, r8, r6
 	stmia r2, {r3, r5}
 	umull r2, r3, r5, r0
@@ -10582,7 +10582,7 @@ _021850c4:
 	add r0, r4, #0x3e
 	bl func_0202b154
 	add sp, sp, #0x30
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov39_02184e6c
 _021850e8: .word 0xffffce39

--- a/asm/ov39.s
+++ b/asm/ov39.s
@@ -2945,19 +2945,19 @@ func_ov39_0217e55c: ; 0x0217e55c
 	.global func_ov39_0217e5b0
 	arm_func_start func_ov39_0217e5b0
 func_ov39_0217e5b0: ; 0x0217e5b0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x48
 	mov r4, r0
 	ldrb r0, [r4, #0xc9c]
 	cmp r0, #0
 	addne sp, sp, #0x48
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, [r4, #0x158]
 	tst r0, #0x800
 	addne sp, sp, #0x48
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	cmp r1, #3
 	addls pc, pc, r1, lsl #2
 	b _0217e69c
@@ -2970,7 +2970,7 @@ _0217e600:
 	cmp r2, #1
 	addgt sp, sp, #0x48
 	movgt r0, #0
-	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	mov r0, #6
 	mul r0, r2, r0
 	ldr r1, _0217e808 ; =data_ov39_02186548
@@ -2981,7 +2981,7 @@ _0217e628:
 	cmp r2, #1
 	addgt sp, sp, #0x48
 	movgt r0, #0
-	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	mov r0, #6
 	mul r0, r2, r0
 	ldr r1, _0217e810 ; =data_ov39_021865d8
@@ -2992,7 +2992,7 @@ _0217e650:
 	cmp r2, #1
 	addgt sp, sp, #0x48
 	movgt r0, #0
-	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	mov r0, #6
 	mul r0, r2, r0
 	ldr r1, _0217e814 ; =data_ov39_02186620
@@ -3003,7 +3003,7 @@ _0217e678:
 	cmp r2, #1
 	addgt sp, sp, #0x48
 	movgt r0, #0
-	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	mov r0, #6
 	mul r0, r2, r0
 	ldr r1, _0217e818 ; =data_ov39_02186590
@@ -3068,14 +3068,14 @@ _0217e6dc:
 	add r2, sp, #0x24
 	bl func_01ff9bf8
 	ldr r0, [r11]
-	mov sl, #0
+	mov r10, #0
 	mov r1, r5
 	mov r2, r6
 	mov r3, r8
 	bl _ZN10PlayerBase18func_ov00_020a7c60EP5Vec3pS1_i
 	cmp r0, #0
-	movne sl, #1
-	cmp sl, #0
+	movne r10, #1
+	cmp r10, #0
 	beq _0217e7ec
 	ldr r0, _0217e824 ; =data_027e0f90
 	add r2, sp, #0x18
@@ -3094,7 +3094,7 @@ _0217e6dc:
 	movne r0, #0
 	strneb r0, [r1, #0x25c]
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0217e7ec:
 	add sb, sb, #1
 	cmp sb, #2
@@ -3102,7 +3102,7 @@ _0217e7ec:
 	blt _0217e6dc
 	mov r0, #0
 	add sp, sp, #0x48
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov39_0217e5b0
 _0217e808: .word data_ov39_02186548
@@ -3799,7 +3799,7 @@ _0217f108: .word data_ov29_0217bd28
 	.global func_ov39_0217f10c
 	arm_func_start func_ov39_0217f10c
 func_ov39_0217f10c: ; 0x0217f10c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x1c
 	mov r5, r0
 	ldr r1, _0217f264 ; =data_027e0fac
@@ -3835,11 +3835,11 @@ func_ov39_0217f10c: ; 0x0217f10c
 	mov r6, r7, asr #0x1f
 	mla r8, r6, r3, r8
 	adds r6, sb, #0x800
-	ldr sl, [sp, #4]
+	ldr r10, [sp, #4]
 	adc r3, r8, #0
 	mov r6, r6, lsr #0xc
 	orr r6, r6, r3, lsl #20
-	add r3, sl, r6
+	add r3, r10, r6
 	str r3, [sp, #4]
 	ldr r3, _0217f270 ; =0x00002b33
 	mov r11, ip, asr #0x1f
@@ -3885,7 +3885,7 @@ _0217f23c:
 	ldr r0, [r0]
 	bl func_ov00_020bd4fc
 	add sp, sp, #0x1c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov39_0217f10c
 _0217f264: .word data_027e0fac
@@ -4320,7 +4320,7 @@ func_ov39_0217f7d8: ; 0x0217f7d8
 	.global func_ov39_0217f810
 	arm_func_start func_ov39_0217f810
 func_ov39_0217f810: ; 0x0217f810
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #0x18
 	mov r4, r0
 	ldr r0, [r4, #0x284]
@@ -4341,7 +4341,7 @@ func_ov39_0217f810: ; 0x0217f810
 	str r1, [r0, #0x58]
 	ldr r1, [r4, #0x50]
 	str r1, [r0, #0x5c]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _0217f868:
 	bl _ZN5Actor16IsFollowedByLinkEv
 	cmp r0, #0
@@ -4364,7 +4364,7 @@ _0217f868:
 	ldrsh r8, [r5, r6]
 	mov ip, #0xcd
 	add r3, r3, #1
-	umull sl, sb, r8, ip
+	umull r10, sb, r8, ip
 	mov r3, r3, lsl #0x1
 	ldrsh lr, [r5, r3]
 	add r3, sp, #0xc
@@ -4373,10 +4373,10 @@ _0217f868:
 	mla sb, r8, r7, sb
 	mov r0, r8, asr #0x1f
 	mla sb, r0, ip, sb
-	adds sl, sl, #0x800
+	adds r10, r10, #0x800
 	mla r5, lr, r7, r5
 	adc r1, sb, #0
-	mov r0, sl, lsr #0xc
+	mov r0, r10, lsr #0xc
 	orr r0, r0, r1, lsl #20
 	adds r1, r6, #0x800
 	mov r2, r1, lsr #0xc
@@ -4411,7 +4411,7 @@ _0217f868:
 	ldr r0, [sp, #0x14]
 	add sp, sp, #0x18
 	str r0, [r1, #0x5c]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _0217f97c:
 	ldrsh r0, [r4, #0x78]
 	ldr r2, _0217fa38 ; =data_02050f54
@@ -4459,7 +4459,7 @@ _0217f97c:
 	ldr r0, [r4, #0x284]
 	strh r1, [r0, #0x78]
 	add sp, sp, #0x18
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov39_0217f810
 _0217fa38: .word data_02050f54
@@ -6682,10 +6682,10 @@ _02181998: .word data_02050f54
 	.global func_ov39_0218199c
 	arm_func_start func_ov39_0218199c
 func_ov39_0218199c: ; 0x0218199c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #0x40
 	mov r4, #1
-	mov sl, r0
+	mov r10, r0
 	mov r5, r4
 	bl _ZN5Actor14GetAngleToLinkEv
 	mov r6, #0
@@ -6701,26 +6701,26 @@ func_ov39_0218199c: ; 0x0218199c
 	str r6, [sp, #0x34]
 	str r6, [sp, #0x38]
 	str r3, [sp, #0x3c]
-	str r0, [sl, #0x274]
+	str r0, [r10, #0x274]
 	ldr r3, [r2, #4]
 	add r0, sp, #0x34
-	str r3, [sl, #0x278]
+	str r3, [r10, #0x278]
 	ldr r2, [r2, #8]
 	mov r1, r1, asr #0x10
-	str r2, [sl, #0x27c]
+	str r2, [r10, #0x27c]
 	bl func_ov00_020a61ac
-	ldr r1, [sl, #0x274]
+	ldr r1, [r10, #0x274]
 	add r0, sp, #0x34
 	str r1, [sp, #0xc]
-	ldr r2, [sl, #0x278]
+	ldr r2, [r10, #0x278]
 	add r1, sp, #0xc
 	str r2, [sp, #0x10]
-	ldr r3, [sl, #0x27c]
+	ldr r3, [r10, #0x27c]
 	mov r2, r0
 	str r3, [sp, #0x14]
 	bl func_01ff9bc4
 	add r1, sp, #0x34
-	mov r0, sl
+	mov r0, r10
 	bl func_ov39_0217eaa0
 	cmp r0, #0
 	mov r3, #0
@@ -6735,18 +6735,18 @@ func_ov39_0218199c: ; 0x0218199c
 	mov r1, r1, asr #0x10
 	movne r5, r6
 	bl func_ov00_020a61ac
-	ldr r1, [sl, #0x274]
+	ldr r1, [r10, #0x274]
 	add r0, sp, #0x34
 	str r1, [sp]
-	ldr r2, [sl, #0x278]
+	ldr r2, [r10, #0x278]
 	add r1, sp, #0
 	str r2, [sp, #4]
-	ldr r3, [sl, #0x27c]
+	ldr r3, [r10, #0x27c]
 	mov r2, r0
 	str r3, [sp, #8]
 	bl func_01ff9bc4
 	add r1, sp, #0x34
-	mov r0, sl
+	mov r0, r10
 	bl func_ov39_0217eaa0
 	cmp r0, #0
 	movne r4, #0
@@ -6834,12 +6834,12 @@ _02181bcc:
 	cmp r5, #0
 	movne r6, #0
 _02181bd4:
-	mov r0, sl
+	mov r0, r10
 	bl func_ov39_0217e404
-	str r0, [sl, #0x1b4]
+	str r0, [r10, #0x1b4]
 	cmp r6, #0
-	add r0, sl, #0x3ec
-	add r2, sl, #0x100
+	add r0, r10, #0x3ec
+	add r2, r10, #0x100
 	beq _02181c04
 	add r0, r0, #0x400
 	mov r1, #0x14
@@ -6852,38 +6852,38 @@ _02181c04:
 	strh sb, [r2, #0x64]
 	bl func_ov39_0217ca2c
 _02181c14:
-	ldr r0, [sl, #0x7fc]
+	ldr r0, [r10, #0x7fc]
 	mov r3, #0
 	str r3, [r0, #0x10]
 	mov r2, #0x8f
-	add r0, sl, #0x100
+	add r0, r10, #0x100
 	strh r7, [r0, #0x66]
 	add r1, r2, r2, lsl #3
-	str r2, [sl, #0x6c]
-	str r3, [sl, #0x60]
+	str r2, [r10, #0x6c]
+	str r3, [r10, #0x60]
 	mov r0, r1, asr #0x1
-	str r0, [sl, #0x64]
-	str r3, [sl, #0x68]
-	ldr r0, [sl, #0x158]
+	str r0, [r10, #0x64]
+	str r3, [r10, #0x68]
+	ldr r0, [r10, #0x158]
 	sub r5, r2, #0x90
 	orr r0, r0, #0x2400
 	bic r1, r0, #0x2000000
 	orr r0, r1, #0x4000000
 	orr r0, r0, #0x40000
-	str r0, [sl, #0x158]
-	str r5, [sl, #0x88]
-	ldr r0, [sl, #0x284]
+	str r0, [r10, #0x158]
+	str r5, [r10, #0x88]
+	ldr r0, [r10, #0x284]
 	add r4, sp, #0x18
 	add r0, r0, #0x7c
 	ldmia r0, {r0, r1, r2}
 	stmia r4, {r0, r1, r2}
 	str r5, [sp, #0x24]
-	ldr r5, [sl, #0x284]
+	ldr r5, [r10, #0x284]
 	ldr r1, [sp, #0x18]
 	ldr r0, _02181cc8 ; =data_027e0ffc
 	str r1, [r5, #0x7c]
 	ldr r1, [sp, #0x1c]
-	add r2, sl, #0x48
+	add r2, r10, #0x48
 	str r1, [r5, #0x80]
 	ldr r4, [sp, #0x20]
 	mov r1, #0x324
@@ -6893,7 +6893,7 @@ _02181c14:
 	bl func_ov00_020ceacc
 	mov r0, #1
 	add sp, sp, #0x40
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov39_0218199c
 _02181cbc: .word data_027e0f94
@@ -8918,7 +8918,7 @@ _021838b8:
 	.global func_ov39_021838c4
 	arm_func_start func_ov39_021838c4
 func_ov39_021838c4: ; 0x021838c4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x124
 	mov r4, r0
 	ldr r0, _02183c10 ; =data_027e0ffc
@@ -9040,7 +9040,7 @@ func_ov39_021838c4: ; 0x021838c4
 	mov r11, #0
 	ldr r6, [sp, #0xc]
 	ldr r5, [sp, #0x10]
-	ldr sl, [sp, #0x14]
+	ldr r10, [sp, #0x14]
 	ldr sb, [sp, #0x18]
 	ldr r8, [sp, #0x1c]
 	ldr r7, [sp, #0x24]
@@ -9048,8 +9048,8 @@ func_ov39_021838c4: ; 0x021838c4
 	ldr r6, [sp, #0x34]
 	str r5, [sp, #0xa4]
 	ldr r5, [sp, #0x38]
-	str sl, [sp, #0xa8]
-	ldr sl, [sp, #0x3c]
+	str r10, [sp, #0xa8]
+	ldr r10, [sp, #0x3c]
 	str sb, [sp, #0xac]
 	ldr sb, [sp, #0x40]
 	str r8, [sp, #0xb0]
@@ -9065,8 +9065,8 @@ func_ov39_021838c4: ; 0x021838c4
 	ldrb r3, [sp, #0x6e]
 	ldrb r2, [sp, #0x6f]
 	ldrb r1, [sp, #0x70]
-	str sl, [sp, #0xd0]
-	ldr sl, [sp, #0x54]
+	str r10, [sp, #0xd0]
+	ldr r10, [sp, #0x54]
 	str sb, [sp, #0xd4]
 	ldr sb, [sp, #0x58]
 	str r8, [sp, #0xd8]
@@ -9077,7 +9077,7 @@ func_ov39_021838c4: ; 0x021838c4
 	ldr r6, [sp, #0x64]
 	str r5, [sp, #0xe4]
 	ldr r5, [sp, #0x68]
-	str sl, [sp, #0xe8]
+	str r10, [sp, #0xe8]
 	str r0, [sp, #0x20]
 	str r11, [sp, #0x30]
 	str r11, [sp, #0x2c]
@@ -9128,7 +9128,7 @@ func_ov39_021838c4: ; 0x021838c4
 	bl func_ov00_0209a508
 	mov r0, #1
 	add sp, sp, #0x124
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov39_021838c4
 _02183c10: .word data_027e0ffc
@@ -10331,23 +10331,23 @@ _02184d3c: .word data_02050f54
 	.global func_ov39_02184d40
 	arm_func_start func_ov39_02184d40
 func_ov39_02184d40: ; 0x02184d40
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	ldr r2, [r0, #0x30]
 	cmp r1, r2
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	str r1, [r0, #0x30]
 	cmp r1, #3
 	addls pc, pc, r1, lsl #2
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02184d60: ; jump table
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc} ; case 0
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc} ; case 0
 	b _02184d70 ; case 1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc} ; case 2
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc} ; case 2
 	b _02184d7c ; case 3
 _02184d70:
 	mov r1, #0xa
 	str r1, [r0, #0x34]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02184d7c:
 	ldr lr, _02184e64 ; =data_027e0764
 	mov ip, #0
@@ -10396,9 +10396,9 @@ _02184d7c:
 	ldr r6, [lr, #0xc]
 	ldr r11, [lr, #0x10]
 	mla r8, r6, r5, r8
-	ldr sl, [lr, #0x14]
+	ldr r10, [lr, #0x14]
 	adds r4, r11, sb
-	adc r5, sl, r8
+	adc r5, r10, r8
 	stmia lr, {r4, r5}
 	umull lr, r4, r5, r3
 	mla r4, r5, ip, r4
@@ -10406,7 +10406,7 @@ _02184d7c:
 	sub r2, r3, #0x4000
 	add r1, r4, r2
 	strh r1, [r0, #0x42]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov39_02184d40
 _02184e64: .word data_027e0764
@@ -10415,7 +10415,7 @@ _02184e68: .word 0x00002aab
 	.global func_ov39_02184e6c
 	arm_func_start func_ov39_02184e6c
 func_ov39_02184e6c: ; 0x02184e6c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x30
 	mov r4, r0
 	ldr r0, [r4, #0x30]
@@ -10530,8 +10530,8 @@ _02184fc8:
 	mov r1, #0x2e
 	umull r3, r5, r6, r1
 	mla r5, r6, r11, r5
-	mov sl, r11
-	mla r5, sl, r1, r5
+	mov r10, r11
+	mla r5, r10, r1, r5
 	str r6, [r2, #4]
 	add r1, r5, #0x2d
 	str r1, [r4, #0x34]
@@ -10549,7 +10549,7 @@ _02184fc8:
 	str r5, [r2]
 	umull r3, r5, r6, r0
 	mla r5, r6, r11, r5
-	mla r5, sl, r0, r5
+	mla r5, r10, r0, r5
 	sub r1, r0, #0x4000
 	str r6, [r2, #4]
 	add r1, r5, r1
@@ -10566,7 +10566,7 @@ _02184fc8:
 	stmia r2, {r3, r5}
 	umull r2, r3, r5, r0
 	mla r3, r5, r11, r3
-	mla r3, sl, r0, r3
+	mla r3, r10, r0, r3
 	sub r1, r0, #0x4000
 	add r0, r3, r1
 	strh r0, [r4, #0x42]
@@ -10582,7 +10582,7 @@ _021850c4:
 	add r0, r4, #0x3e
 	bl func_0202b154
 	add sp, sp, #0x30
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov39_02184e6c
 _021850e8: .word 0xffffce39

--- a/asm/ov39.s
+++ b/asm/ov39.s
@@ -2945,19 +2945,19 @@ func_ov39_0217e55c: ; 0x0217e55c
 	.global func_ov39_0217e5b0
 	arm_func_start func_ov39_0217e5b0
 func_ov39_0217e5b0: ; 0x0217e5b0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x48
 	mov r4, r0
 	ldrb r0, [r4, #0xc9c]
 	cmp r0, #0
 	addne sp, sp, #0x48
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, [r4, #0x158]
 	tst r0, #0x800
 	addne sp, sp, #0x48
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	cmp r1, #3
 	addls pc, pc, r1, lsl #2
 	b _0217e69c
@@ -2970,7 +2970,7 @@ _0217e600:
 	cmp r2, #1
 	addgt sp, sp, #0x48
 	movgt r0, #0
-	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	mov r0, #6
 	mul r0, r2, r0
 	ldr r1, _0217e808 ; =data_ov39_02186548
@@ -2981,7 +2981,7 @@ _0217e628:
 	cmp r2, #1
 	addgt sp, sp, #0x48
 	movgt r0, #0
-	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	mov r0, #6
 	mul r0, r2, r0
 	ldr r1, _0217e810 ; =data_ov39_021865d8
@@ -2992,7 +2992,7 @@ _0217e650:
 	cmp r2, #1
 	addgt sp, sp, #0x48
 	movgt r0, #0
-	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	mov r0, #6
 	mul r0, r2, r0
 	ldr r1, _0217e814 ; =data_ov39_02186620
@@ -3003,7 +3003,7 @@ _0217e678:
 	cmp r2, #1
 	addgt sp, sp, #0x48
 	movgt r0, #0
-	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	mov r0, #6
 	mul r0, r2, r0
 	ldr r1, _0217e818 ; =data_ov39_02186590
@@ -3020,7 +3020,7 @@ _0217e69c:
 	mov r0, r0, lsl #0x1
 	ldrsh r1, [r2, r1]
 	ldrsh r0, [r2, r0]
-	ldr fp, _0217e824 ; =data_027e0f90
+	ldr r11, _0217e824 ; =data_027e0f90
 	str sb, [sp, #0x1c]
 	str r1, [sp, #0x18]
 	str r0, [sp, #0x20]
@@ -3067,7 +3067,7 @@ _0217e6dc:
 	mov r1, r5
 	add r2, sp, #0x24
 	bl func_01ff9bf8
-	ldr r0, [fp]
+	ldr r0, [r11]
 	mov sl, #0
 	mov r1, r5
 	mov r2, r6
@@ -3094,7 +3094,7 @@ _0217e6dc:
 	movne r0, #0
 	strneb r0, [r1, #0x25c]
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0217e7ec:
 	add sb, sb, #1
 	cmp sb, #2
@@ -3102,7 +3102,7 @@ _0217e7ec:
 	blt _0217e6dc
 	mov r0, #0
 	add sp, sp, #0x48
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov39_0217e5b0
 _0217e808: .word data_ov39_02186548
@@ -3799,7 +3799,7 @@ _0217f108: .word data_ov29_0217bd28
 	.global func_ov39_0217f10c
 	arm_func_start func_ov39_0217f10c
 func_ov39_0217f10c: ; 0x0217f10c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x1c
 	mov r5, r0
 	ldr r1, _0217f264 ; =data_027e0fac
@@ -3842,13 +3842,13 @@ func_ov39_0217f10c: ; 0x0217f10c
 	add r3, sl, r6
 	str r3, [sp, #4]
 	ldr r3, _0217f270 ; =0x00002b33
-	mov fp, ip, asr #0x1f
+	mov r11, ip, asr #0x1f
 	umull r7, r6, ip, r3
 	mov r3, #0
 	mla r6, ip, r3, r6
 	ldr r3, _0217f270 ; =0x00002b33
 	adds r7, r7, #0x800
-	mla r6, fp, r3, r6
+	mla r6, r11, r3, r6
 	adc r3, r6, #0
 	mov r6, r7, lsr #0xc
 	ldr lr, [sp, #0xc]
@@ -3885,7 +3885,7 @@ _0217f23c:
 	ldr r0, [r0]
 	bl func_ov00_020bd4fc
 	add sp, sp, #0x1c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov39_0217f10c
 _0217f264: .word data_027e0fac
@@ -8918,7 +8918,7 @@ _021838b8:
 	.global func_ov39_021838c4
 	arm_func_start func_ov39_021838c4
 func_ov39_021838c4: ; 0x021838c4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x124
 	mov r4, r0
 	ldr r0, _02183c10 ; =data_027e0ffc
@@ -9037,7 +9037,7 @@ func_ov39_021838c4: ; 0x021838c4
 	str r2, [sp, #0x18]
 	str r1, [sp, #0x1c]
 	bl _ZN5Actor14GetAngleToLinkEv
-	mov fp, #0
+	mov r11, #0
 	ldr r6, [sp, #0xc]
 	ldr r5, [sp, #0x10]
 	ldr sl, [sp, #0x14]
@@ -9079,13 +9079,13 @@ func_ov39_021838c4: ; 0x021838c4
 	ldr r5, [sp, #0x68]
 	str sl, [sp, #0xe8]
 	str r0, [sp, #0x20]
-	str fp, [sp, #0x30]
-	str fp, [sp, #0x2c]
-	str fp, [sp, #0x28]
+	str r11, [sp, #0x30]
+	str r11, [sp, #0x2c]
+	str r11, [sp, #0x28]
 	str r0, [sp, #0xb4]
-	str fp, [sp, #0xbc]
-	str fp, [sp, #0xc0]
-	str fp, [sp, #0xc4]
+	str r11, [sp, #0xbc]
+	str r11, [sp, #0xc0]
+	str r11, [sp, #0xc4]
 	str sb, [sp, #0xec]
 	str r8, [sp, #0xf0]
 	str r7, [sp, #0xf4]
@@ -9099,9 +9099,9 @@ func_ov39_021838c4: ; 0x021838c4
 	mov r1, r0, lsl #0x10
 	add r0, sp, #0
 	mov r1, r1, asr #0x10
-	str fp, [sp]
-	str fp, [sp, #4]
-	str fp, [sp, #8]
+	str r11, [sp]
+	str r11, [sp, #4]
+	str r11, [sp, #8]
 	bl func_ov00_020a61ac
 	add r0, sp, #0
 	add r1, r4, #0x48
@@ -9128,7 +9128,7 @@ func_ov39_021838c4: ; 0x021838c4
 	bl func_ov00_0209a508
 	mov r0, #1
 	add sp, sp, #0x124
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov39_021838c4
 _02183c10: .word data_027e0ffc
@@ -10331,23 +10331,23 @@ _02184d3c: .word data_02050f54
 	.global func_ov39_02184d40
 	arm_func_start func_ov39_02184d40
 func_ov39_02184d40: ; 0x02184d40
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	ldr r2, [r0, #0x30]
 	cmp r1, r2
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	str r1, [r0, #0x30]
 	cmp r1, #3
 	addls pc, pc, r1, lsl #2
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02184d60: ; jump table
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc} ; case 0
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc} ; case 0
 	b _02184d70 ; case 1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc} ; case 2
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc} ; case 2
 	b _02184d7c ; case 3
 _02184d70:
 	mov r1, #0xa
 	str r1, [r0, #0x34]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02184d7c:
 	ldr lr, _02184e64 ; =data_027e0764
 	mov ip, #0
@@ -10394,10 +10394,10 @@ _02184d7c:
 	umull sb, r8, r7, r5
 	mla r8, r7, r4, r8
 	ldr r6, [lr, #0xc]
-	ldr fp, [lr, #0x10]
+	ldr r11, [lr, #0x10]
 	mla r8, r6, r5, r8
 	ldr sl, [lr, #0x14]
-	adds r4, fp, sb
+	adds r4, r11, sb
 	adc r5, sl, r8
 	stmia lr, {r4, r5}
 	umull lr, r4, r5, r3
@@ -10406,7 +10406,7 @@ _02184d7c:
 	sub r2, r3, #0x4000
 	add r1, r4, r2
 	strh r1, [r0, #0x42]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov39_02184d40
 _02184e64: .word data_027e0764
@@ -10415,7 +10415,7 @@ _02184e68: .word 0x00002aab
 	.global func_ov39_02184e6c
 	arm_func_start func_ov39_02184e6c
 func_ov39_02184e6c: ; 0x02184e6c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x30
 	mov r4, r0
 	ldr r0, [r4, #0x30]
@@ -10515,7 +10515,7 @@ _02184fc8:
 	strgt r0, [r4, #0x34]
 	bgt _021850bc
 	ldr r2, _021850f4 ; =data_027e0764
-	mov fp, #0
+	mov r11, #0
 	ldr r3, [r2]
 	ldmib r2, {r1, r5}
 	umull r7, r6, r5, r3
@@ -10529,8 +10529,8 @@ _02184fc8:
 	str r3, [r2]
 	mov r1, #0x2e
 	umull r3, r5, r6, r1
-	mla r5, r6, fp, r5
-	mov sl, fp
+	mla r5, r6, r11, r5
+	mov sl, r11
 	mla r5, sl, r1, r5
 	str r6, [r2, #4]
 	add r1, r5, #0x2d
@@ -10548,7 +10548,7 @@ _02184fc8:
 	adc r6, r3, r6
 	str r5, [r2]
 	umull r3, r5, r6, r0
-	mla r5, r6, fp, r5
+	mla r5, r6, r11, r5
 	mla r5, sl, r0, r5
 	sub r1, r0, #0x4000
 	str r6, [r2, #4]
@@ -10565,7 +10565,7 @@ _02184fc8:
 	adc r5, r8, r6
 	stmia r2, {r3, r5}
 	umull r2, r3, r5, r0
-	mla r3, r5, fp, r3
+	mla r3, r5, r11, r3
 	mla r3, sl, r0, r3
 	sub r1, r0, #0x4000
 	add r0, r3, r1
@@ -10582,7 +10582,7 @@ _021850c4:
 	add r0, r4, #0x3e
 	bl func_0202b154
 	add sp, sp, #0x30
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov39_02184e6c
 _021850e8: .word 0xffffce39

--- a/asm/ov40.s
+++ b/asm/ov40.s
@@ -1737,7 +1737,7 @@ _0217d4d8: .word data_ov00_020e9370
 	.global func_ov40_0217d4dc
 	arm_func_start func_ov40_0217d4dc
 func_ov40_0217d4dc: ; 0x0217d4dc
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	mov r4, r0
 	ldr r2, [r4, #0x1b8]
 	ldr r1, _0217d6ec ; =0x00000106
@@ -1841,7 +1841,7 @@ _0217d648:
 	ldr r1, [r1, #8]
 	blx r1
 	ldrb r8, [r0, #0x18]
-	mov sb, #0
+	mov r9, #0
 	cmp r8, #0
 	bls _0217d6d4
 	ldr r7, _0217d6f0 ; =data_ov00_020e9360
@@ -1855,11 +1855,11 @@ _0217d670:
 	ldr r1, [r0]
 	ldr r1, [r1, #8]
 	blx r1
-	mov r1, sb
+	mov r1, r9
 	mov r2, r5
 	bl func_02019534
-	add sb, sb, #1
-	cmp sb, r8
+	add r9, r9, #1
+	cmp r9, r8
 	blo _0217d670
 	b _0217d6d4
 _0217d6ac:
@@ -1879,7 +1879,7 @@ _0217d6d4:
 	ldr r2, [r0]
 	ldr r2, [r2, #0x18]
 	blx r2
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov40_0217d4dc
 _0217d6ec: .word 0x00000106
@@ -2292,12 +2292,12 @@ _0217dbd0:
 	.global func_ov40_0217dbec
 	arm_func_start func_ov40_0217dbec
 func_ov40_0217dbec: ; 0x0217dbec
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	mov r10, r0
 	ldr r2, [r10, #0x3c]
 	add r0, r10, #0x10
 	str r2, [r10, #0x4c]
-	mov sb, r1
+	mov r9, r1
 	bl func_ov40_0217ec84
 	ldr r7, [r10, #4]
 	ldr r1, [r10, #8]
@@ -2310,7 +2310,7 @@ func_ov40_0217dbec: ; 0x0217dbec
 	mov r11, #1
 _0217dc2c:
 	ldr r6, [r7]
-	mov r1, sb
+	mov r1, r9
 	mov r0, r6
 	bl func_ov40_0217ec84
 	cmp r0, #0
@@ -2330,7 +2330,7 @@ _0217dc70:
 	orr r1, r4, r5, lsl #16
 	mov r0, r8
 	str r1, [r10, #0x48]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	arm_func_end func_ov40_0217dbec
 
 	.global func_ov40_0217dc80
@@ -3089,31 +3089,31 @@ func_ov40_0217e59c: ; 0x0217e59c
 	.global func_ov40_0217e5a4
 	arm_func_start func_ov40_0217e5a4
 func_ov40_0217e5a4: ; 0x0217e5a4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
-	mov sb, r1
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
+	mov r9, r1
 	mov r10, r0
 	mov r8, r2
 	ldr r1, _0217e6f0 ; =data_ov40_02188010
-	mov r0, sb
+	mov r0, r9
 	mov r2, #4
 	bl func_0204366c
 	cmp r0, #0
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
-	ldrh r1, [sb, #4]
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
+	ldrh r1, [r9, #4]
 	ldr r0, _0217e6f4 ; =0x0000feff
 	cmp r1, r0
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
-	ldrh r1, [sb, #6]
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
+	ldrh r1, [r9, #6]
 	cmp r1, #1
 	movlo r0, #0
-	ldmloia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmloia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	cmp r1, #3
 	movhi r0, #0
-	ldmhiia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
-	ldr r1, [sb, #0xc]
-	add r7, sb, #0x20
+	ldmhiia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
+	ldr r1, [r9, #0xc]
+	add r7, r9, #0x20
 	cmp r1, #0
 	mov r6, #0
 	bls _0217e6e8
@@ -3145,7 +3145,7 @@ _0217e658:
 	cmp r0, #0
 	bne _0217e6d0
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0217e678:
 	mov r0, r10
 	mov r1, r7
@@ -3154,7 +3154,7 @@ _0217e678:
 	cmp r0, #0
 	bne _0217e6d0
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0217e698:
 	mov r0, r10
 	mov r1, r7
@@ -3162,7 +3162,7 @@ _0217e698:
 	cmp r0, #0
 	bne _0217e6d0
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0217e6b4:
 	mov r0, r10
 	mov r1, r7
@@ -3170,17 +3170,17 @@ _0217e6b4:
 	bl func_ov40_0217e77c
 	cmp r0, #0
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0217e6d0:
 	ldr r1, [r7]
-	ldr r0, [sb, #0xc]
+	ldr r0, [r9, #0xc]
 	add r6, r6, #1
 	cmp r6, r0
 	add r7, r7, r1
 	blo _0217e620
 _0217e6e8:
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov40_0217e5a4
 _0217e6f0: .word data_ov40_02188010
@@ -3635,15 +3635,15 @@ func_ov40_0217ec68: ; 0x0217ec68
 	.global func_ov40_0217ec84
 	arm_func_start func_ov40_0217ec84
 func_ov40_0217ec84: ; 0x0217ec84
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
-	mov sb, r0
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
+	mov r9, r0
 	mov r8, r1
 	mov r7, #0
 _0217ec94:
-	ldrh r0, [sb, #0x18]
+	ldrh r0, [r9, #0x18]
 	tst r0, #0x8000
 	beq _0217ed00
-	ldr r0, [sb, #0x14]
+	ldr r0, [r9, #0x14]
 	cmp r0, #8
 	addls pc, pc, r0, lsl #2
 	b _0217ecf8
@@ -3659,125 +3659,125 @@ _0217ecb0: ; jump table
 	b _0217ecf8 ; case 8
 _0217ecd4:
 	mov r0, #8
-	str r0, [sb, #0x14]
-	ldrb r0, [sb, #0x24]
+	str r0, [r9, #0x14]
+	ldrb r0, [r9, #0x24]
 	cmp r0, #0
 	beq _0217ecf8
-	mov r0, sb
+	mov r0, r9
 	ldr r1, [r0]
 	ldr r1, [r1, #0x28]
 	blx r1
 _0217ecf8:
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _0217ed00:
-	ldr r0, [sb, #0x14]
+	ldr r0, [r9, #0x14]
 	cmp r0, #8
 	bne _0217ed24
-	mov r0, sb
+	mov r0, r9
 	ldr r1, [r0]
 	ldr r1, [r1, #0x24]
 	blx r1
 	mov r0, #2
-	str r0, [sb, #0x14]
+	str r0, [r9, #0x14]
 _0217ed24:
-	ldr r0, [sb, #0xc]
+	ldr r0, [r9, #0xc]
 	cmp r0, #0
 	beq _0217ed3c
 	ldr r0, [r0, #0x4c]
 	cmp r0, #0
 	bgt _0217ed48
 _0217ed3c:
-	ldr r0, [sb, #0x2c]
+	ldr r0, [r9, #0x2c]
 	cmp r0, #0
 	ble _0217ed78
 _0217ed48:
-	ldrb r0, [sb, #0x24]
+	ldrb r0, [r9, #0x24]
 	cmp r0, #0
 	beq _0217ed70
 	mov r1, #4
-	mov r0, sb
-	str r1, [sb, #0x14]
+	mov r0, r9
+	str r1, [r9, #0x14]
 	ldr r2, [r0]
 	mov r1, r8
 	ldr r2, [r2, #0x30]
 	blx r2
 _0217ed70:
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _0217ed78:
 	mov r6, #1
 	mov r5, #2
 	mov r10, r6
 	mov r4, #0
 _0217ed88:
-	ldr r0, [sb, #0x34]
-	str r0, [sb, #0x30]
+	ldr r0, [r9, #0x34]
+	str r0, [r9, #0x30]
 	cmp r0, #0
 	bne _0217ede8
-	ldrb r0, [sb, #0x24]
+	ldrb r0, [r9, #0x24]
 	cmp r0, #0
 	beq _0217ede0
 	cmp r7, #0
 	bne _0217edc0
-	mov r0, sb
+	mov r0, r9
 	ldr r2, [r0]
 	mov r1, #0
 	ldr r2, [r2, #0x30]
 	blx r2
 _0217edc0:
 	mov r0, #0
-	strb r0, [sb, #0x24]
+	strb r0, [r9, #0x24]
 	mov r1, #1
-	mov r0, sb
-	str r1, [sb, #0x14]
+	mov r0, r9
+	str r1, [r9, #0x14]
 	ldr r1, [r0]
 	ldr r1, [r1, #0x28]
 	blx r1
 _0217ede0:
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _0217ede8:
-	ldrb r0, [sb, #0x24]
+	ldrb r0, [r9, #0x24]
 	cmp r0, #0
 	bne _0217ee08
-	mov r0, sb
-	strb r6, [sb, #0x24]
+	mov r0, r9
+	strb r6, [r9, #0x24]
 	ldr r1, [r0]
 	ldr r1, [r1, #0x24]
 	blx r1
 _0217ee08:
-	str r5, [sb, #0x14]
-	ldr r1, [sb, #0x28]
+	str r5, [r9, #0x14]
+	ldr r1, [r9, #0x28]
 	cmp r1, #0
 	bne _0217ee2c
-	mov r0, sb
+	mov r0, r9
 	bl func_ov40_0217ef24
-	ldr r1, [sb, #0x28]
+	ldr r1, [r9, #0x28]
 	cmp r1, #0
 	beq _0217ec94
 _0217ee2c:
 	mov r7, r10
 	cmp r8, r1
 	blo _0217ee54
-	mov r0, sb
-	str r4, [sb, #0x28]
+	mov r0, r9
+	str r4, [r9, #0x28]
 	ldr r2, [r0]
 	sub r8, r8, r1
 	ldr r2, [r2, #0x30]
 	blx r2
 	b _0217ed88
 _0217ee54:
-	ldr r1, [sb, #0x28]
-	mov r0, sb
+	ldr r1, [r9, #0x28]
+	mov r0, r9
 	sub r1, r1, r8
-	str r1, [sb, #0x28]
+	str r1, [r9, #0x28]
 	ldr r2, [r0]
 	mov r1, r8
 	ldr r2, [r2, #0x30]
 	blx r2
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	arm_func_end func_ov40_0217ec84
 
 	.global func_ov40_0217ee7c
@@ -4103,7 +4103,7 @@ _0217f20c:
 	.global func_ov40_0217f21c
 	arm_func_start func_ov40_0217f21c
 func_ov40_0217f21c: ; 0x0217f21c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	mov r7, r0
 	mov r6, r1
 	mov r5, r2
@@ -4113,98 +4113,98 @@ func_ov40_0217f21c: ; 0x0217f21c
 	cmp r3, #0x10
 	bge _0217f318
 	cmp r3, #3
-	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	cmp r3, #1
-	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmltia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	beq _0217f274
 	cmp r3, #2
 	beq _0217f2a8
 	cmp r3, #3
 	beq _0217f2e0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _0217f268:
 	cmp r3, #0x12
 	beq _0217f350
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _0217f274:
-	mov sb, #0
+	mov r9, #0
 	cmp r5, #0
-	ldmlsia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
-	mov r8, sb
+	ldmlsia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
+	mov r8, r9
 _0217f284:
-	ldr r1, [r6, sb, lsl #2]
+	ldr r1, [r6, r9, lsl #2]
 	mov r0, r7
 	mov r2, r4
 	mov r3, r8
 	bl func_ov40_0217f388
-	add sb, sb, #1
-	cmp sb, r5
+	add r9, r9, #1
+	cmp r9, r5
 	blo _0217f284
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _0217f2a8:
-	mov sb, #0
+	mov r9, #0
 	cmp r5, #0
-	ldmlsia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmlsia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	mov r8, #4
 _0217f2b8:
-	ldr r1, [r6, sb, lsl #2]
+	ldr r1, [r6, r9, lsl #2]
 	mov r0, r7
 	mov r2, r4
 	mov r3, r8
 	bl func_ov40_0217f39c
-	add sb, sb, #1
-	cmp sb, r5
+	add r9, r9, #1
+	cmp r9, r5
 	add r4, r4, #4
 	blo _0217f2b8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _0217f2e0:
-	mov sb, #0
+	mov r9, #0
 	cmp r5, #0
-	ldmlsia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmlsia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	mov r8, #4
 _0217f2f0:
-	ldr r1, [r6, sb, lsl #2]
+	ldr r1, [r6, r9, lsl #2]
 	mov r0, r7
 	mov r2, r4
 	mov r3, r8
 	bl func_ov40_0217f3c4
-	add sb, sb, #1
-	cmp sb, r5
+	add r9, r9, #1
+	cmp r9, r5
 	add r4, r4, #4
 	blo _0217f2f0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _0217f318:
-	mov sb, #0
+	mov r9, #0
 	cmp r5, #0
-	ldmlsia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmlsia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	mov r8, #4
 _0217f328:
-	ldr r1, [r6, sb, lsl #2]
+	ldr r1, [r6, r9, lsl #2]
 	mov r0, r7
 	mov r2, r4
 	mov r3, r8
 	bl func_ov40_0217f3ec
-	add sb, sb, #1
-	cmp sb, r5
+	add r9, r9, #1
+	cmp r9, r5
 	add r4, r4, #4
 	blo _0217f328
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _0217f350:
-	mov sb, #0
+	mov r9, #0
 	cmp r5, #0
-	ldmlsia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmlsia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	mov r8, #4
 _0217f360:
-	ldr r1, [r6, sb, lsl #2]
+	ldr r1, [r6, r9, lsl #2]
 	mov r0, r7
 	mov r2, r4
 	mov r3, r8
 	bl func_ov40_0217f3f0
-	add sb, sb, #1
-	cmp sb, r5
+	add r9, r9, #1
+	cmp r9, r5
 	add r4, r4, #4
 	blo _0217f360
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	arm_func_end func_ov40_0217f21c
 
 	.global func_ov40_0217f388
@@ -4276,7 +4276,7 @@ _0217f41c: .word func_ov00_020a0134
 	.global func_ov40_0217f420
 	arm_func_start func_ov40_0217f420
 func_ov40_0217f420: ; 0x0217f420
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	mov r5, r0
 	ldr r2, [r5, #0xc]
 	ldr r0, [r5, #0x1c]
@@ -4284,22 +4284,22 @@ func_ov40_0217f420: ; 0x0217f420
 	mov r4, r1
 	mov r7, #0
 	cmp r0, #0
-	ldmlsia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
-	mov sb, r7
+	ldmlsia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
+	mov r9, r7
 _0217f448:
 	ldr r6, [r5, #0x20]
 	mov r1, r4
-	add r0, r6, sb
+	add r0, r6, r9
 	bl func_ov00_020a00c0
 	mov r1, r8
-	add r0, r6, sb
+	add r0, r6, r9
 	bl func_ov00_020a00e0
 	ldr r0, [r5, #0x1c]
 	add r7, r7, #1
 	cmp r7, r0
-	add sb, sb, #0x10
+	add r9, r9, #0x10
 	blo _0217f448
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	arm_func_end func_ov40_0217f420
 
 	.global func_ov40_0217f47c
@@ -10360,7 +10360,7 @@ _02183e50: .word data_027e0fe0
 	.global func_ov40_02183e54
 	arm_func_start func_ov40_02183e54
 func_ov40_02183e54: ; 0x02183e54
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	mov r10, r0
 	bl func_ov40_0217bf30
 	ldr r0, _02183f28 ; =data_ov40_021891d4
@@ -10384,15 +10384,15 @@ func_ov40_02183e54: ; 0x02183e54
 	mov r2, #0x200
 	str r3, [r10, #0x830]
 	blx func_0202f194
-	mov sb, #0
+	mov r9, #0
 	ldr r4, _02183f2c ; =data_027e0ce0
-	mov r8, sb
+	mov r8, r9
 	mov r7, #4
 	mov r6, #1
 	mov r5, #0xc000
 	mov r11, #0x200
 _02183ed0:
-	add r0, r10, sb, lsl #2
+	add r0, r10, r9, lsl #2
 	str r8, [r0, #0x808]
 	str r8, [r0, #0x810]
 	str r7, [r0, #0x818]
@@ -10401,19 +10401,19 @@ _02183ed0:
 	mov r1, r5
 	mov r2, r7
 	blx func_0201739c
-	add r1, r10, sb, lsl #2
+	add r1, r10, r9, lsl #2
 	str r0, [r1, #0x834]
 	ldr r0, [r4, #4]
 	mov r1, r11
 	mov r2, #4
 	blx func_0201739c
-	add r1, r10, sb, lsl #2
-	add sb, sb, #1
+	add r1, r10, r9, lsl #2
+	add r9, r9, #1
 	str r0, [r1, #0x83c]
-	cmp sb, #2
+	cmp r9, #2
 	blo _02183ed0
 	mov r0, r10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov40_02183e54
 _02183f28: .word data_ov40_021891d4
@@ -11284,7 +11284,7 @@ _02184a7c: .word 0x00001b94
 	.global func_ov40_02184a80
 	arm_func_start func_ov40_02184a80
 func_ov40_02184a80: ; 0x02184a80
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0xc
 	ldr r4, [r1, #0x38]
 	str r0, [sp]
@@ -11314,7 +11314,7 @@ func_ov40_02184a80: ; 0x02184a80
 	ldr r1, [sp, #8]
 	mov r5, r2, asr #0xa
 	ldr r2, [sp]
-	mov sb, r1, lsr #0x1
+	mov r9, r1, lsr #0x1
 	and r1, r10, #0x1f
 	add r1, r1, #0x1f
 	mov r0, #0x1f000
@@ -11342,7 +11342,7 @@ func_ov40_02184a80: ; 0x02184a80
 	mov r1, r10, lsl #0x1b
 	mul r0, r3, r0
 	add r0, r0, #0x800
-	cmp sb, #0
+	cmp r9, #0
 	mov r2, #0
 	mov lr, r0, asr #0xc
 	ble _02184bf0
@@ -11375,7 +11375,7 @@ _02184b78:
 	orr r3, r3, ip, lsl #5
 	orr r0, r3, r0, lsl #10
 	strh r0, [r8], #2
-	cmp r2, sb
+	cmp r2, r9
 	blt _02184b78
 _02184bf0:
 	ldr r0, [sp]
@@ -11383,18 +11383,18 @@ _02184bf0:
 	ldr r0, [r0, #0xc]
 	bl func_0200e2a4
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	arm_func_end func_ov40_02184a80
 
 	.global func_ov40_02184c08
 	arm_func_start func_ov40_02184c08
 func_ov40_02184c08: ; 0x02184c08
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	mov r4, r0
 	ldr r1, [r4]
 	ldr r0, [r4, #4]
 	cmp r1, r0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	str r1, [r4, #4]
 	ldr r0, [r4, #0x14]
 	ldr ip, [r4, #8]
@@ -11412,7 +11412,7 @@ _02184c44:
 	mov r0, r0, asr #0x5
 	and r1, r7, #0x7c00
 	mov r1, r1, asr #0xa
-	and sb, r7, #0x1f
+	and r9, r7, #0x1f
 	mul r7, r0, r2
 	and r8, r3, #0x3e0
 	and r10, r3, #0x7c00
@@ -11420,7 +11420,7 @@ _02184c44:
 	add r6, r6, #1
 	mov r1, r10, asr #0xa
 	and r10, r3, #0x1f
-	mul r3, sb, r2
+	mul r3, r9, r2
 	rsb r2, r2, #0x1000
 	mla r0, r1, r2, r0
 	mov r1, r8, asr #0x5
@@ -11443,7 +11443,7 @@ _02184cb8:
 	ldr r3, [r4, #0x14]
 	mov r0, #1
 	bl func_02017d30
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	arm_func_end func_ov40_02184c08
 
 	.global func_ov40_02184cdc
@@ -12932,12 +12932,12 @@ _02185e1c: .word data_02068ebc
 	.global func_ov40_02185e20
 	arm_func_start func_ov40_02185e20
 func_ov40_02185e20: ; 0x02185e20
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x34
 	cmp r1, #0
 	mov r10, r0
 	addne sp, sp, #0x34
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r1, _0218613c ; =data_027e0c68
 	add r0, r10, #0xa000
 	ldr r2, [r1, #0x14]
@@ -12978,7 +12978,7 @@ _02185ea0:
 	str r0, [sp, #0xc]
 	cmp r0, r1
 	addeq sp, sp, #0x34
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	sub r0, r0, r1
 	str r0, [sp, #8]
 	cmp r0, #0
@@ -13031,9 +13031,9 @@ _02185f40:
 	mov r1, r0
 	mov r0, r10
 	bl func_ov40_021861b0
-	mov sb, r0
+	mov r9, r0
 	ldr r0, [sp, #0x1c]
-	cmp sb, r0
+	cmp r9, r0
 	bne _02185fc8
 	mov r0, r10
 	mov r1, #0x1b
@@ -13065,12 +13065,12 @@ _02186000:
 	mov r1, r0
 	mov r0, r10
 	bl func_ov40_021861b0
-	cmp sb, #0x640000
+	cmp r9, #0x640000
 	beq _02186040
 	ldr r1, [sp, #0x20]
-	cmp sb, r1
+	cmp r9, r1
 	beq _02186068
-	cmp sb, r4
+	cmp r9, r4
 	beq _021860bc
 	b _021860d8
 _02186040:
@@ -13146,7 +13146,7 @@ _02186128:
 	add r1, r10, #0xa000
 	str r0, [r1, #0xd58]
 	add sp, sp, #0x34
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov40_02185e20
 _0218613c: .word data_027e0c68
@@ -13229,7 +13229,7 @@ _0218622c: .word data_027e0c68
 	.global func_ov40_02186230
 	arm_func_start func_ov40_02186230
 func_ov40_02186230: ; 0x02186230
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x24
 	sub sp, sp, #0x400
 	mov r11, r3
@@ -13244,7 +13244,7 @@ func_ov40_02186230: ; 0x02186230
 	mov r1, #0x1c
 	mov r2, #6
 	str r3, [sp, #0xc]
-	ldr sb, [sp, #0x448]
+	ldr r9, [sp, #0x448]
 	bl func_02029a5c
 	mov r4, #0
 	str r0, [sp, #0x20]
@@ -13252,7 +13252,7 @@ func_ov40_02186230: ; 0x02186230
 	cmp r0, #0
 	addle sp, sp, #0x24
 	addle sp, sp, #0x400
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r7, sp, #0x24
 _02186294:
 	ldr r0, [sp, #0x1c]
@@ -13279,7 +13279,7 @@ _021862dc:
 	ble _0218632c
 _021862e8:
 	ldr r0, _02186368 ; =data_ov00_020eacd0
-	str sb, [sp]
+	str r9, [sp]
 	stmib sp, {r0, r4}
 	ldr r3, [r7]
 	ldr r0, [sp, #0x10]
@@ -13310,7 +13310,7 @@ _0218633c:
 	blt _02186294
 	add sp, sp, #0x24
 	add sp, sp, #0x400
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov40_02186230
 _02186364: .word 0xc000c000
@@ -13337,16 +13337,16 @@ func_ov40_0218636c: ; 0x0218636c
 	.global func_ov40_021863a0
 	arm_func_start func_ov40_021863a0
 func_ov40_021863a0: ; 0x021863a0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	ldr r4, [sp, #0x20]
 	ldr r0, [sp, #0x28]
 	mla r2, r4, r3, r2
 	ldr r5, [sp, #0x24]
 	movs r4, r0, lsl #0x6
-	ldmmiia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmmiia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	add r0, r4, #0x3f
 	cmp r0, #0x2a00
-	ldmgeia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmgeia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	add lr, r1, r2, lsl #5
 	mov ip, #0
 	mov r3, #1
@@ -13354,7 +13354,7 @@ func_ov40_021863a0: ; 0x021863a0
 	mov r1, ip
 	mov r0, r3
 	mov r8, ip
-	mov sb, r2
+	mov r9, r2
 _021863e8:
 	ldrb r6, [lr]
 	tst r6, #0xf
@@ -13378,7 +13378,7 @@ _0218641c:
 	ldr r6, [r5, r6, lsl #2]
 	and r7, r7, #0x1f
 	tst r6, r0, lsl r7
-	movne r6, sb
+	movne r6, r9
 	moveq r6, r8
 	ldrb r7, [lr]
 	and r6, r6, #0xff
@@ -13390,13 +13390,13 @@ _02186454:
 	add lr, lr, #1
 	add r4, r4, #2
 	blo _021863e8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	arm_func_end func_ov40_021863a0
 
 	.global func_ov40_0218646c
 	arm_func_start func_ov40_0218646c
 func_ov40_0218646c: ; 0x0218646c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0xa0
 	mov r5, r0
 	ldr r0, _021865fc ; =data_027e05f4
@@ -13441,9 +13441,9 @@ _0218650c:
 	mov ip, r0
 	add r7, r5, lr, lsl #5
 _02186514:
-	add sb, r7, #0x9000
-	ldrb sb, [sb, #0x854]
-	cmp sb, #0
+	add r9, r7, #0x9000
+	ldrb r9, [r9, #0x854]
+	cmp r9, #0
 	movne r2, r10
 	bne _02186538
 	add r7, r7, #1
@@ -13467,8 +13467,8 @@ _02186560:
 	cmp r1, #0x1c
 	blt _02186500
 	add r0, r11, #1
-	sub sb, r0, r6
-	rsb r0, sb, #0x20
+	sub r9, r0, r6
+	rsb r0, r9, #0x20
 	add r0, r0, r0, lsr #31
 	mov r10, r0, asr #0x1
 	mov r8, #0
@@ -13483,7 +13483,7 @@ _0218658c:
 	mov r2, r8
 	mov r3, #0x1c
 	add r0, r7, #0x9800
-	str sb, [sp, #0x10]
+	str r9, [sp, #0x10]
 	bl func_ov40_0218636c
 	add r8, r8, #1
 	cmp r8, #6
@@ -13504,7 +13504,7 @@ _021865cc:
 	cmp r7, #0x100
 	blt _021865c8
 	add sp, sp, #0xa0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov40_0218646c
 _021865fc: .word data_027e05f4
@@ -14628,7 +14628,7 @@ func_ov40_021873f4: ; 0x021873f4
 	.global func_ov40_02187410
 	arm_func_start func_ov40_02187410
 func_ov40_02187410: ; 0x02187410
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	mov r10, r0
 	bl func_ov40_0217c2b8
 	ldr r2, _02187548 ; =gItemManager
@@ -14670,7 +14670,7 @@ _02187464:
 	mov r7, #0
 	ldr r1, [r0, #8]
 	ldr r8, _02187554 ; =data_ov40_02188330
-	ldr sb, _02187558 ; =data_ov40_02188300
+	ldr r9, _02187558 ; =data_ov40_02188300
 	add r6, r0, r1
 	mov r4, r7
 	mov r11, r7
@@ -14687,7 +14687,7 @@ _021874c4:
 	mov r2, r4
 	bl func_02019570
 	add r0, r6, #4
-	mov r1, sb
+	mov r1, r9
 	bl func_0201e388
 	add r1, r10, r7, lsl #2
 	str r0, [r1, #0x7f4]
@@ -14700,14 +14700,14 @@ _021874c4:
 	mov r2, r11
 	bl func_02019570
 	add r8, r8, #0x10
-	add sb, sb, #0x10
+	add r9, r9, #0x10
 	add r7, r7, #1
 	cmp r7, #3
 	blo _021874c4
 	mov r0, r10
 	bl func_ov40_021875d8
 	ldr r0, [sp]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov40_02187410
 _02187548: .word gItemManager
@@ -15235,7 +15235,7 @@ _02187bbc: .word data_ov40_02189a24
 	.global func_ov40_02187bc0
 	arm_func_start func_ov40_02187bc0
 func_ov40_02187bc0: ; 0x02187bc0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x48
 	ldr r11, [r2]
 	str r2, [sp, #4]
@@ -15244,7 +15244,7 @@ func_ov40_02187bc0: ; 0x02187bc0
 	ldr r2, _02187da4 ; =0x00ff0002
 	mov r10, r0
 	orr r0, r4, r5, lsl #16
-	mov sb, r1
+	mov r9, r1
 	str r3, [sp, #8]
 	cmp r0, r2
 	bne _02187d80
@@ -15311,25 +15311,25 @@ _02187c90:
 	ldr r1, _02187db0 ; =data_020579f8
 	sub r0, r5, r0
 	str r1, [sp, #0x14]
-	ldr r1, [sb, #4]
+	ldr r1, [r9, #4]
 	add r0, r0, r0, lsr #31
 	str r1, [sp, #0x18]
-	ldrsh r3, [sb, #8]
+	ldrsh r3, [r9, #8]
 	mov r1, #1
 	cmp r4, #0
 	strh r3, [sp, #0x1c]
-	ldrsh r2, [sb, #0xa]
+	ldrsh r2, [r9, #0xa]
 	add r0, r3, r0, asr #1
 	mov r8, #0
 	strh r2, [sp, #0x1e]
-	ldrsh r2, [sb, #0xc]
+	ldrsh r2, [r9, #0xc]
 	strh r2, [sp, #0x20]
-	ldrsh r2, [sb, #0xe]
+	ldrsh r2, [r9, #0xe]
 	strh r2, [sp, #0x22]
-	ldr r2, [sb, #0x10]
+	ldr r2, [r9, #0x10]
 	str r2, [sp, #0x24]
 	strh r0, [sp, #0x1c]
-	ldrsh r0, [sb, #0xa]
+	ldrsh r0, [r9, #0xa]
 	sub r0, r0, #9
 	strh r0, [sp, #0x1e]
 	strh r1, [sp, #0x22]
@@ -15357,11 +15357,11 @@ _02187d80:
 	ldr r2, [sp, #4]
 	ldr r3, [sp, #8]
 	mov r0, r10
-	mov r1, sb
+	mov r1, r9
 	str r4, [sp]
 	bl func_0203b814
 	add sp, sp, #0x48
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov40_02187bc0
 _02187da4: .word 0x00ff0002

--- a/asm/ov40.s
+++ b/asm/ov40.s
@@ -2292,7 +2292,7 @@ _0217dbd0:
 	.global func_ov40_0217dbec
 	arm_func_start func_ov40_0217dbec
 func_ov40_0217dbec: ; 0x0217dbec
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	mov sl, r0
 	ldr r2, [sl, #0x3c]
 	add r0, sl, #0x10
@@ -2307,7 +2307,7 @@ func_ov40_0217dbec: ; 0x0217dbec
 	mov r4, #0xf
 	mov r5, #0
 	beq _0217dc70
-	mov fp, #1
+	mov r11, #1
 _0217dc2c:
 	ldr r6, [r7]
 	mov r1, sb
@@ -2316,7 +2316,7 @@ _0217dc2c:
 	cmp r0, #0
 	ldr r2, [r6, #0x14]
 	cmpeq r8, #0
-	movne r8, fp
+	movne r8, r11
 	ldr r1, [sl, #4]
 	ldr r0, [sl, #8]
 	add r7, r7, #4
@@ -2330,7 +2330,7 @@ _0217dc70:
 	orr r1, r4, r5, lsl #16
 	mov r0, r8
 	str r1, [sl, #0x48]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	arm_func_end func_ov40_0217dbec
 
 	.global func_ov40_0217dc80
@@ -3089,7 +3089,7 @@ func_ov40_0217e59c: ; 0x0217e59c
 	.global func_ov40_0217e5a4
 	arm_func_start func_ov40_0217e5a4
 func_ov40_0217e5a4: ; 0x0217e5a4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	mov sb, r1
 	mov sl, r0
 	mov r8, r2
@@ -3099,26 +3099,26 @@ func_ov40_0217e5a4: ; 0x0217e5a4
 	bl func_0204366c
 	cmp r0, #0
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldrh r1, [sb, #4]
 	ldr r0, _0217e6f4 ; =0x0000feff
 	cmp r1, r0
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldrh r1, [sb, #6]
 	cmp r1, #1
 	movlo r0, #0
-	ldmloia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmloia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	cmp r1, #3
 	movhi r0, #0
-	ldmhiia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmhiia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r1, [sb, #0xc]
 	add r7, sb, #0x20
 	cmp r1, #0
 	mov r6, #0
 	bls _0217e6e8
 	ldr r5, _0217e6f8 ; =0x4a435442
-	ldr fp, _0217e6fc ; =0x4a465642
+	ldr r11, _0217e6fc ; =0x4a465642
 	sub r4, r0, #0xff00
 _0217e620:
 	ldr r0, [r7, #4]
@@ -3129,7 +3129,7 @@ _0217e620:
 	beq _0217e6d0
 	b _0217e6b4
 _0217e63c:
-	cmp r0, fp
+	cmp r0, r11
 	bhi _0217e64c
 	beq _0217e658
 	b _0217e6b4
@@ -3145,7 +3145,7 @@ _0217e658:
 	cmp r0, #0
 	bne _0217e6d0
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0217e678:
 	mov r0, sl
 	mov r1, r7
@@ -3154,7 +3154,7 @@ _0217e678:
 	cmp r0, #0
 	bne _0217e6d0
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0217e698:
 	mov r0, sl
 	mov r1, r7
@@ -3162,7 +3162,7 @@ _0217e698:
 	cmp r0, #0
 	bne _0217e6d0
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0217e6b4:
 	mov r0, sl
 	mov r1, r7
@@ -3170,7 +3170,7 @@ _0217e6b4:
 	bl func_ov40_0217e77c
 	cmp r0, #0
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0217e6d0:
 	ldr r1, [r7]
 	ldr r0, [sb, #0xc]
@@ -3180,7 +3180,7 @@ _0217e6d0:
 	blo _0217e620
 _0217e6e8:
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov40_0217e5a4
 _0217e6f0: .word data_ov40_02188010
@@ -10360,7 +10360,7 @@ _02183e50: .word data_027e0fe0
 	.global func_ov40_02183e54
 	arm_func_start func_ov40_02183e54
 func_ov40_02183e54: ; 0x02183e54
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	mov sl, r0
 	bl func_ov40_0217bf30
 	ldr r0, _02183f28 ; =data_ov40_021891d4
@@ -10390,7 +10390,7 @@ func_ov40_02183e54: ; 0x02183e54
 	mov r7, #4
 	mov r6, #1
 	mov r5, #0xc000
-	mov fp, #0x200
+	mov r11, #0x200
 _02183ed0:
 	add r0, sl, sb, lsl #2
 	str r8, [r0, #0x808]
@@ -10404,7 +10404,7 @@ _02183ed0:
 	add r1, sl, sb, lsl #2
 	str r0, [r1, #0x834]
 	ldr r0, [r4, #4]
-	mov r1, fp
+	mov r1, r11
 	mov r2, #4
 	blx func_0201739c
 	add r1, sl, sb, lsl #2
@@ -10413,7 +10413,7 @@ _02183ed0:
 	cmp sb, #2
 	blo _02183ed0
 	mov r0, sl
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov40_02183e54
 _02183f28: .word data_ov40_021891d4
@@ -11284,7 +11284,7 @@ _02184a7c: .word 0x00001b94
 	.global func_ov40_02184a80
 	arm_func_start func_ov40_02184a80
 func_ov40_02184a80: ; 0x02184a80
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0xc
 	ldr r4, [r1, #0x38]
 	str r0, [sp]
@@ -11326,7 +11326,7 @@ func_ov40_02184a80: ; 0x02184a80
 	mul r1, r6, r0
 	add r1, r1, #0x800
 	add r0, r4, #0x1f
-	mov fp, r1, asr #0xc
+	mov r11, r1, asr #0xc
 	mov r1, r0, lsl #0xc
 	mov r0, #0x1f000
 	bl Divide
@@ -11357,7 +11357,7 @@ _02184b78:
 	and sl, sl, #0x1f
 	add r0, r0, sl
 	add sl, r3, r0
-	mul r0, sl, fp
+	mul r0, sl, r11
 	add r0, r0, r1, lsr #15
 	mov r3, r0, asr #0xc
 	mul r0, sl, r6
@@ -11383,23 +11383,23 @@ _02184bf0:
 	ldr r0, [r0, #0xc]
 	bl func_0200e2a4
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	arm_func_end func_ov40_02184a80
 
 	.global func_ov40_02184c08
 	arm_func_start func_ov40_02184c08
 func_ov40_02184c08: ; 0x02184c08
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	mov r4, r0
 	ldr r1, [r4]
 	ldr r0, [r4, #4]
 	cmp r1, r0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	str r1, [r4, #4]
 	ldr r0, [r4, #0x14]
 	ldr ip, [r4, #8]
-	mov fp, r0, lsr #0x1
-	cmp fp, #0
+	mov r11, r0, lsr #0x1
+	cmp r11, #0
 	ldr lr, [r4, #0xc]
 	ldr r5, [r4, #0x10]
 	mov r6, #0
@@ -11431,7 +11431,7 @@ _02184c44:
 	mov r3, r0, asr #0xc
 	orr r0, r1, r2, asr #12
 	orr r0, r0, r3, lsl #10
-	cmp r6, fp
+	cmp r6, r11
 	strh r0, [r5], #2
 	blt _02184c44
 _02184cb8:
@@ -11443,7 +11443,7 @@ _02184cb8:
 	ldr r3, [r4, #0x14]
 	mov r0, #1
 	bl func_02017d30
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	arm_func_end func_ov40_02184c08
 
 	.global func_ov40_02184cdc
@@ -12932,12 +12932,12 @@ _02185e1c: .word data_02068ebc
 	.global func_ov40_02185e20
 	arm_func_start func_ov40_02185e20
 func_ov40_02185e20: ; 0x02185e20
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x34
 	cmp r1, #0
 	mov sl, r0
 	addne sp, sp, #0x34
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r1, _0218613c ; =data_027e0c68
 	add r0, sl, #0xa000
 	ldr r2, [r1, #0x14]
@@ -12978,11 +12978,11 @@ _02185ea0:
 	str r0, [sp, #0xc]
 	cmp r0, r1
 	addeq sp, sp, #0x34
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	sub r0, r0, r1
 	str r0, [sp, #8]
 	cmp r0, #0
-	mov fp, #0
+	mov r11, #0
 	ble _02186128
 	ldr r1, _02186144 ; =data_ov40_021897d4
 	ldr r4, _02186148 ; =0x00640003
@@ -13138,15 +13138,15 @@ _02186108:
 	strb r0, [r5, #0xd62]
 _02186118:
 	ldr r0, [sp, #8]
-	add fp, fp, #1
-	cmp fp, r0
+	add r11, r11, #1
+	cmp r11, r0
 	blt _02185f40
 _02186128:
 	ldr r0, [sp, #0xc]
 	add r1, sl, #0xa000
 	str r0, [r1, #0xd58]
 	add sp, sp, #0x34
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov40_02185e20
 _0218613c: .word data_027e0c68
@@ -13229,10 +13229,10 @@ _0218622c: .word data_027e0c68
 	.global func_ov40_02186230
 	arm_func_start func_ov40_02186230
 func_ov40_02186230: ; 0x02186230
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x24
 	sub sp, sp, #0x400
-	mov fp, r3
+	mov r11, r3
 	mov r3, #0
 	str r3, [sp]
 	str r3, [sp, #4]
@@ -13252,7 +13252,7 @@ func_ov40_02186230: ; 0x02186230
 	cmp r0, #0
 	addle sp, sp, #0x24
 	addle sp, sp, #0x400
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r7, sp, #0x24
 _02186294:
 	ldr r0, [sp, #0x1c]
@@ -13286,7 +13286,7 @@ _021862e8:
 	mov r2, r3, lsl #0x7
 	mov r3, r3, lsl #0x18
 	add r2, sl, r2, lsr #26
-	add r3, fp, r3, lsr #27
+	add r3, r11, r3, lsr #27
 	ldr r1, [sp, #0x14]
 	add r2, r6, r2
 	add r3, r8, r3
@@ -13310,7 +13310,7 @@ _0218633c:
 	blt _02186294
 	add sp, sp, #0x24
 	add sp, sp, #0x400
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov40_02186230
 _02186364: .word 0xc000c000
@@ -13396,7 +13396,7 @@ _02186454:
 	.global func_ov40_0218646c
 	arm_func_start func_ov40_0218646c
 func_ov40_0218646c: ; 0x0218646c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0xa0
 	mov r5, r0
 	ldr r0, _021865fc ; =data_027e05f4
@@ -13429,7 +13429,7 @@ func_ov40_0218646c: ; 0x0218646c
 	blx func_02016fcc
 	mvn r6, #0
 	mov r1, #0
-	mov fp, r6
+	mov r11, r6
 	mov r8, r6
 	mov sl, #1
 	mov r0, r1
@@ -13455,7 +13455,7 @@ _02186538:
 	beq _02186550
 	cmp r6, r8
 	moveq r6, r1
-	mov fp, r1
+	mov r11, r1
 	b _02186560
 _02186550:
 	add r3, r3, #1
@@ -13466,19 +13466,19 @@ _02186560:
 	add r1, r1, #1
 	cmp r1, #0x1c
 	blt _02186500
-	add r0, fp, #1
+	add r0, r11, #1
 	sub sb, r0, r6
 	rsb r0, sb, #0x20
 	add r0, r0, r0, lsr #31
 	mov sl, r0, asr #0x1
 	mov r8, #0
 	add r7, r5, #0x54
-	mov fp, #0x20
+	mov r11, #0x20
 _0218658c:
 	stmia sp, {r7, sl}
 	add r0, r4, r8
 	str r0, [sp, #8]
-	str fp, [sp, #0xc]
+	str r11, [sp, #0xc]
 	mov r1, r6
 	mov r2, r8
 	mov r3, #0x1c
@@ -13504,7 +13504,7 @@ _021865cc:
 	cmp r7, #0x100
 	blt _021865c8
 	add sp, sp, #0xa0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov40_0218646c
 _021865fc: .word data_027e05f4
@@ -14628,7 +14628,7 @@ func_ov40_021873f4: ; 0x021873f4
 	.global func_ov40_02187410
 	arm_func_start func_ov40_02187410
 func_ov40_02187410: ; 0x02187410
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	mov sl, r0
 	bl func_ov40_0217c2b8
 	ldr r2, _02187548 ; =gItemManager
@@ -14673,7 +14673,7 @@ _02187464:
 	ldr sb, _02187558 ; =data_ov40_02188300
 	add r6, r0, r1
 	mov r4, r7
-	mov fp, r7
+	mov r11, r7
 _021874c4:
 	mov r1, r8
 	add r0, r6, #4
@@ -14697,7 +14697,7 @@ _021874c4:
 	blx r1
 	add r1, sl, r7, lsl #2
 	ldr r1, [r1, #0x7f4]
-	mov r2, fp
+	mov r2, r11
 	bl func_02019570
 	add r8, r8, #0x10
 	add sb, sb, #0x10
@@ -14707,7 +14707,7 @@ _021874c4:
 	mov r0, sl
 	bl func_ov40_021875d8
 	ldr r0, [sp]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov40_02187410
 _02187548: .word gItemManager
@@ -15235,12 +15235,12 @@ _02187bbc: .word data_ov40_02189a24
 	.global func_ov40_02187bc0
 	arm_func_start func_ov40_02187bc0
 func_ov40_02187bc0: ; 0x02187bc0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x48
-	ldr fp, [r2]
+	ldr r11, [r2]
 	str r2, [sp, #4]
-	ldrb r5, [fp, #3]
-	ldrh r4, [fp, #4]
+	ldrb r5, [r11, #3]
+	ldrh r4, [r11, #4]
 	ldr r2, _02187da4 ; =0x00ff0002
 	mov sl, r0
 	orr r0, r4, r5, lsl #16
@@ -15248,9 +15248,9 @@ func_ov40_02187bc0: ; 0x02187bc0
 	str r3, [sp, #8]
 	cmp r0, r2
 	bne _02187d80
-	ldrb r0, [fp, #2]
+	ldrb r0, [r11, #2]
 	mov r5, #0
-	ldrb r6, [fp, #6]
+	ldrb r6, [r11, #6]
 	sub r0, r0, #7
 	mov r4, r0, lsr #0x1
 	ldr r0, [sp, #4]
@@ -15294,9 +15294,9 @@ _02187c90:
 	add r1, sp, #0x28
 	str r0, [sp, #0xc]
 	ldr r3, [sp, #0xc]
-	add r0, fp, #7
+	add r0, r11, #7
 	mov r2, r4, lsl #0x1
-	ldr fp, [sl, #0x2c]
+	ldr r11, [sl, #0x2c]
 	sub r5, r5, r3
 	bl func_02007ad8
 	add r1, sp, #0x28
@@ -15350,7 +15350,7 @@ _02187d4c:
 	blo _02187d4c
 _02187d74:
 	ldr r0, [sp, #0xc]
-	str fp, [sl, #0x2c]
+	str r11, [sl, #0x2c]
 	str r0, [sl, #0x30]
 _02187d80:
 	ldr r4, [sp, #0x70]
@@ -15361,7 +15361,7 @@ _02187d80:
 	str r4, [sp]
 	bl func_0203b814
 	add sp, sp, #0x48
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov40_02187bc0
 _02187da4: .word 0x00ff0002

--- a/asm/ov40.s
+++ b/asm/ov40.s
@@ -2292,15 +2292,15 @@ _0217dbd0:
 	.global func_ov40_0217dbec
 	arm_func_start func_ov40_0217dbec
 func_ov40_0217dbec: ; 0x0217dbec
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
-	mov sl, r0
-	ldr r2, [sl, #0x3c]
-	add r0, sl, #0x10
-	str r2, [sl, #0x4c]
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	mov r10, r0
+	ldr r2, [r10, #0x3c]
+	add r0, r10, #0x10
+	str r2, [r10, #0x4c]
 	mov sb, r1
 	bl func_ov40_0217ec84
-	ldr r7, [sl, #4]
-	ldr r1, [sl, #8]
+	ldr r7, [r10, #4]
+	ldr r1, [r10, #8]
 	mov r8, r0
 	add r0, r7, r1, lsl #2
 	cmp r7, r0
@@ -2317,8 +2317,8 @@ _0217dc2c:
 	ldr r2, [r6, #0x14]
 	cmpeq r8, #0
 	movne r8, r11
-	ldr r1, [sl, #4]
-	ldr r0, [sl, #8]
+	ldr r1, [r10, #4]
+	ldr r0, [r10, #8]
 	add r7, r7, #4
 	add r0, r1, r0, lsl #2
 	moveq r8, #0
@@ -2329,8 +2329,8 @@ _0217dc2c:
 _0217dc70:
 	orr r1, r4, r5, lsl #16
 	mov r0, r8
-	str r1, [sl, #0x48]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	str r1, [r10, #0x48]
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	arm_func_end func_ov40_0217dbec
 
 	.global func_ov40_0217dc80
@@ -3089,9 +3089,9 @@ func_ov40_0217e59c: ; 0x0217e59c
 	.global func_ov40_0217e5a4
 	arm_func_start func_ov40_0217e5a4
 func_ov40_0217e5a4: ; 0x0217e5a4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	mov sb, r1
-	mov sl, r0
+	mov r10, r0
 	mov r8, r2
 	ldr r1, _0217e6f0 ; =data_ov40_02188010
 	mov r0, sb
@@ -3099,19 +3099,19 @@ func_ov40_0217e5a4: ; 0x0217e5a4
 	bl func_0204366c
 	cmp r0, #0
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldrh r1, [sb, #4]
 	ldr r0, _0217e6f4 ; =0x0000feff
 	cmp r1, r0
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldrh r1, [sb, #6]
 	cmp r1, #1
 	movlo r0, #0
-	ldmloia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmloia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	cmp r1, #3
 	movhi r0, #0
-	ldmhiia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmhiia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r1, [sb, #0xc]
 	add r7, sb, #0x20
 	cmp r1, #0
@@ -3138,39 +3138,39 @@ _0217e64c:
 	beq _0217e698
 	b _0217e6b4
 _0217e658:
-	mov r0, sl
+	mov r0, r10
 	mov r1, r7
 	mov r2, r8
 	bl func_ov40_0217e700
 	cmp r0, #0
 	bne _0217e6d0
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0217e678:
-	mov r0, sl
+	mov r0, r10
 	mov r1, r7
 	mov r2, r8
 	bl func_ov40_0217e740
 	cmp r0, #0
 	bne _0217e6d0
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0217e698:
-	mov r0, sl
+	mov r0, r10
 	mov r1, r7
 	bl func_ov40_0217e748
 	cmp r0, #0
 	bne _0217e6d0
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0217e6b4:
-	mov r0, sl
+	mov r0, r10
 	mov r1, r7
 	mov r2, r8
 	bl func_ov40_0217e77c
 	cmp r0, #0
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0217e6d0:
 	ldr r1, [r7]
 	ldr r0, [sb, #0xc]
@@ -3180,7 +3180,7 @@ _0217e6d0:
 	blo _0217e620
 _0217e6e8:
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov40_0217e5a4
 _0217e6f0: .word data_ov40_02188010
@@ -3635,7 +3635,7 @@ func_ov40_0217ec68: ; 0x0217ec68
 	.global func_ov40_0217ec84
 	arm_func_start func_ov40_0217ec84
 func_ov40_0217ec84: ; 0x0217ec84
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	mov sb, r0
 	mov r8, r1
 	mov r7, #0
@@ -3669,7 +3669,7 @@ _0217ecd4:
 	blx r1
 _0217ecf8:
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _0217ed00:
 	ldr r0, [sb, #0x14]
 	cmp r0, #8
@@ -3704,11 +3704,11 @@ _0217ed48:
 	blx r2
 _0217ed70:
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _0217ed78:
 	mov r6, #1
 	mov r5, #2
-	mov sl, r6
+	mov r10, r6
 	mov r4, #0
 _0217ed88:
 	ldr r0, [sb, #0x34]
@@ -3736,7 +3736,7 @@ _0217edc0:
 	blx r1
 _0217ede0:
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _0217ede8:
 	ldrb r0, [sb, #0x24]
 	cmp r0, #0
@@ -3757,7 +3757,7 @@ _0217ee08:
 	cmp r1, #0
 	beq _0217ec94
 _0217ee2c:
-	mov r7, sl
+	mov r7, r10
 	cmp r8, r1
 	blo _0217ee54
 	mov r0, sb
@@ -3777,7 +3777,7 @@ _0217ee54:
 	ldr r2, [r2, #0x30]
 	blx r2
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	arm_func_end func_ov40_0217ec84
 
 	.global func_ov40_0217ee7c
@@ -10360,29 +10360,29 @@ _02183e50: .word data_027e0fe0
 	.global func_ov40_02183e54
 	arm_func_start func_ov40_02183e54
 func_ov40_02183e54: ; 0x02183e54
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
-	mov sl, r0
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	mov r10, r0
 	bl func_ov40_0217bf30
 	ldr r0, _02183f28 ; =data_ov40_021891d4
 	mov r3, #0
-	str r0, [sl]
-	str r3, [sl, #0x7f4]
+	str r0, [r10]
+	str r3, [r10, #0x7f4]
 	sub r0, r3, #1
-	str r0, [sl, #0x7f8]
-	str r0, [sl, #0x7fc]
-	str r3, [sl, #0x800]
-	str r3, [sl, #0x804]
-	add r0, sl, #0x800
+	str r0, [r10, #0x7f8]
+	str r0, [r10, #0x7fc]
+	str r3, [r10, #0x800]
+	str r3, [r10, #0x804]
+	add r0, r10, #0x800
 	strh r3, [r0, #0x28]
 	mov r2, #1
 	strh r2, [r0, #0x2a]
-	add r1, sl, #0x44
-	strb r2, [sl, #0x82c]
-	strb r2, [sl, #0x82d]
+	add r1, r10, #0x44
+	strb r2, [r10, #0x82c]
+	strb r2, [r10, #0x82d]
 	add r0, r1, #0x800
 	mov r1, #0x800
 	mov r2, #0x200
-	str r3, [sl, #0x830]
+	str r3, [r10, #0x830]
 	blx func_0202f194
 	mov sb, #0
 	ldr r4, _02183f2c ; =data_027e0ce0
@@ -10392,7 +10392,7 @@ func_ov40_02183e54: ; 0x02183e54
 	mov r5, #0xc000
 	mov r11, #0x200
 _02183ed0:
-	add r0, sl, sb, lsl #2
+	add r0, r10, sb, lsl #2
 	str r8, [r0, #0x808]
 	str r8, [r0, #0x810]
 	str r7, [r0, #0x818]
@@ -10401,19 +10401,19 @@ _02183ed0:
 	mov r1, r5
 	mov r2, r7
 	blx func_0201739c
-	add r1, sl, sb, lsl #2
+	add r1, r10, sb, lsl #2
 	str r0, [r1, #0x834]
 	ldr r0, [r4, #4]
 	mov r1, r11
 	mov r2, #4
 	blx func_0201739c
-	add r1, sl, sb, lsl #2
+	add r1, r10, sb, lsl #2
 	add sb, sb, #1
 	str r0, [r1, #0x83c]
 	cmp sb, #2
 	blo _02183ed0
-	mov r0, sl
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	mov r0, r10
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov40_02183e54
 _02183f28: .word data_ov40_021891d4
@@ -11284,7 +11284,7 @@ _02184a7c: .word 0x00001b94
 	.global func_ov40_02184a80
 	arm_func_start func_ov40_02184a80
 func_ov40_02184a80: ; 0x02184a80
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0xc
 	ldr r4, [r1, #0x38]
 	str r0, [sp]
@@ -11295,7 +11295,7 @@ func_ov40_02184a80: ; 0x02184a80
 	mov r0, r0, lsl #0x10
 	mov r2, r0, lsr #0xd
 	ldr r0, [sp]
-	ldrh sl, [sp, #0x34]
+	ldrh r10, [sp, #0x34]
 	str r2, [r0, #0x18]
 	ldrh r1, [r1, #0x30]
 	ldr r2, [r0, #0x14]
@@ -11305,17 +11305,17 @@ func_ov40_02184a80: ; 0x02184a80
 	cmp r2, r1, lsl #3
 	strlo r2, [sp, #8]
 	ldr r0, [sp, #8]
-	and r3, sl, #0x3e0
+	and r3, r10, #0x3e0
 	cmp r0, r2
 	movlo r1, r0
 	ldrlo r0, [sp]
-	and r2, sl, #0x7c00
+	and r2, r10, #0x7c00
 	strlo r1, [r0, #0x14]
 	ldr r1, [sp, #8]
 	mov r5, r2, asr #0xa
 	ldr r2, [sp]
 	mov sb, r1, lsr #0x1
-	and r1, sl, #0x1f
+	and r1, r10, #0x1f
 	add r1, r1, #0x1f
 	mov r0, #0x1f000
 	mov r1, r1, lsl #0xc
@@ -11339,7 +11339,7 @@ func_ov40_02184a80: ; 0x02184a80
 	mov r1, r1, lsl #0xc
 	bl Divide
 	ldr r3, [sp, #0x30]
-	mov r1, sl, lsl #0x1b
+	mov r1, r10, lsl #0x1b
 	mul r0, r3, r0
 	add r0, r0, #0x800
 	cmp sb, #0
@@ -11347,23 +11347,23 @@ func_ov40_02184a80: ; 0x02184a80
 	mov lr, r0, asr #0xc
 	ble _02184bf0
 _02184b78:
-	ldrh sl, [r7]
+	ldrh r10, [r7]
 	add r2, r2, #1
 	add r7, r7, #2
-	mov r0, sl, asr #0xa
+	mov r0, r10, asr #0xa
 	and r3, r0, #0x1f
-	and r0, sl, #0x1f
-	mov sl, sl, asr #0x5
-	and sl, sl, #0x1f
-	add r0, r0, sl
-	add sl, r3, r0
-	mul r0, sl, r11
+	and r0, r10, #0x1f
+	mov r10, r10, asr #0x5
+	and r10, r10, #0x1f
+	add r0, r0, r10
+	add r10, r3, r0
+	mul r0, r10, r11
 	add r0, r0, r1, lsr #15
 	mov r3, r0, asr #0xc
-	mul r0, sl, r6
+	mul r0, r10, r6
 	add r0, r0, r4, lsl #12
 	mov ip, r0, asr #0xc
-	mul r0, sl, lr
+	mul r0, r10, lr
 	add r0, r0, r5, lsl #12
 	cmp r3, #0x1f
 	movgt r3, #0x1f
@@ -11383,18 +11383,18 @@ _02184bf0:
 	ldr r0, [r0, #0xc]
 	bl func_0200e2a4
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	arm_func_end func_ov40_02184a80
 
 	.global func_ov40_02184c08
 	arm_func_start func_ov40_02184c08
 func_ov40_02184c08: ; 0x02184c08
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	mov r4, r0
 	ldr r1, [r4]
 	ldr r0, [r4, #4]
 	cmp r1, r0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	str r1, [r4, #4]
 	ldr r0, [r4, #0x14]
 	ldr ip, [r4, #8]
@@ -11415,18 +11415,18 @@ _02184c44:
 	and sb, r7, #0x1f
 	mul r7, r0, r2
 	and r8, r3, #0x3e0
-	and sl, r3, #0x7c00
+	and r10, r3, #0x7c00
 	mul r0, r1, r2
 	add r6, r6, #1
-	mov r1, sl, asr #0xa
-	and sl, r3, #0x1f
+	mov r1, r10, asr #0xa
+	and r10, r3, #0x1f
 	mul r3, sb, r2
 	rsb r2, r2, #0x1000
 	mla r0, r1, r2, r0
 	mov r1, r8, asr #0x5
 	mla r7, r1, r2, r7
 	mov r1, r7, asr #0xc
-	mla r2, sl, r2, r3
+	mla r2, r10, r2, r3
 	mov r1, r1, lsl #0x5
 	mov r3, r0, asr #0xc
 	orr r0, r1, r2, asr #12
@@ -11443,7 +11443,7 @@ _02184cb8:
 	ldr r3, [r4, #0x14]
 	mov r0, #1
 	bl func_02017d30
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	arm_func_end func_ov40_02184c08
 
 	.global func_ov40_02184cdc
@@ -12932,14 +12932,14 @@ _02185e1c: .word data_02068ebc
 	.global func_ov40_02185e20
 	arm_func_start func_ov40_02185e20
 func_ov40_02185e20: ; 0x02185e20
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x34
 	cmp r1, #0
-	mov sl, r0
+	mov r10, r0
 	addne sp, sp, #0x34
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r1, _0218613c ; =data_027e0c68
-	add r0, sl, #0xa000
+	add r0, r10, #0xa000
 	ldr r2, [r1, #0x14]
 	ldr r1, [r0, #0xd5c]
 	ldr r2, [r2]
@@ -12950,23 +12950,23 @@ func_ov40_02185e20: ; 0x02185e20
 	add r0, r1, r0
 	str r0, [sp, #0x10]
 	bge _02185ea0
-	add r0, sl, #0xd60
+	add r0, r10, #0xd60
 	add r0, r0, #0xa000
 	bl func_ov40_02185cd4
 	ldr r1, [sp, #0x10]
 	cmp r1, r0
 	bne _02185e90
-	add r0, sl, #0xa000
+	add r0, r10, #0xa000
 	ldr r1, [r0, #0xd5c]
 	add r1, r1, #0x1000
 	str r1, [r0, #0xd5c]
 _02185e90:
-	add r0, sl, #0xa000
+	add r0, r10, #0xa000
 	ldr r1, [r0, #0xd54]
 	add r1, r1, #0x1000
 	str r1, [r0, #0xd54]
 _02185ea0:
-	add r5, sl, #0xa000
+	add r5, r10, #0xa000
 	ldr r2, [r5, #0xd54]
 	ldr r1, [r5, #0xd58]
 	mov r0, r2, asr #0xb
@@ -12978,7 +12978,7 @@ _02185ea0:
 	str r0, [sp, #0xc]
 	cmp r0, r1
 	addeq sp, sp, #0x34
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	sub r0, r0, r1
 	str r0, [sp, #8]
 	cmp r0, #0
@@ -12987,13 +12987,13 @@ _02185ea0:
 	ldr r1, _02186144 ; =data_ov40_021897d4
 	ldr r4, _02186148 ; =0x00640003
 	ldrsh r0, [r1, #0x20]
-	add r8, sl, #0x54
+	add r8, r10, #0x54
 	str r0, [sp, #0x14]
 	ldrsh r0, [r1, #0x22]
-	add r1, sl, #0x164
+	add r1, r10, #0x164
 	add r7, r1, #0xac00
 	str r0, [sp, #0x18]
-	add r0, sl, #0xd60
+	add r0, r10, #0xd60
 	add r6, r0, #0xa000
 	sub r0, r4, #2
 	str r0, [sp, #0x24]
@@ -13029,13 +13029,13 @@ _02185f40:
 	mov r0, r6
 	bl func_ov40_02185cd4
 	mov r1, r0
-	mov r0, sl
+	mov r0, r10
 	bl func_ov40_021861b0
 	mov sb, r0
 	ldr r0, [sp, #0x1c]
 	cmp sb, r0
 	bne _02185fc8
-	mov r0, sl
+	mov r0, r10
 	mov r1, #0x1b
 	bl func_ov40_0218646c
 	mov r0, #0
@@ -13051,7 +13051,7 @@ _02185fc8:
 	mov r3, r2
 	str r3, [sp, #4]
 	ldr r3, [r5, #0xd64]
-	mov r0, sl
+	mov r0, r10
 	add r3, r3, #0x800
 	mov r3, r3, asr #0xc
 	add r3, r3, #0xd2
@@ -13063,7 +13063,7 @@ _02186000:
 	strh r1, [r6]
 	bl func_ov40_02185cd4
 	mov r1, r0
-	mov r0, sl
+	mov r0, r10
 	bl func_ov40_021861b0
 	cmp sb, #0x640000
 	beq _02186040
@@ -13127,13 +13127,13 @@ _021860d8:
 	bne _02186118
 _021860f4:
 	ldr r0, _0218614c ; =data_02068ebc
-	str r0, [sl, #0x2c]
+	str r0, [r10, #0x2c]
 	mov r0, #0xd
 	strb r0, [r5, #0xd62]
 	b _02186118
 _02186108:
 	ldr r0, _02186150 ; =data_02068eac
-	str r0, [sl, #0x2c]
+	str r0, [r10, #0x2c]
 	mov r0, #8
 	strb r0, [r5, #0xd62]
 _02186118:
@@ -13143,10 +13143,10 @@ _02186118:
 	blt _02185f40
 _02186128:
 	ldr r0, [sp, #0xc]
-	add r1, sl, #0xa000
+	add r1, r10, #0xa000
 	str r0, [r1, #0xd58]
 	add sp, sp, #0x34
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov40_02185e20
 _0218613c: .word data_027e0c68
@@ -13229,7 +13229,7 @@ _0218622c: .word data_027e0c68
 	.global func_ov40_02186230
 	arm_func_start func_ov40_02186230
 func_ov40_02186230: ; 0x02186230
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x24
 	sub sp, sp, #0x400
 	mov r11, r3
@@ -13238,7 +13238,7 @@ func_ov40_02186230: ; 0x02186230
 	str r3, [sp, #4]
 	str r0, [sp, #0x10]
 	str r1, [sp, #0x14]
-	mov sl, r2
+	mov r10, r2
 	str r3, [sp, #8]
 	add r0, sp, #0x24
 	mov r1, #0x1c
@@ -13252,7 +13252,7 @@ func_ov40_02186230: ; 0x02186230
 	cmp r0, #0
 	addle sp, sp, #0x24
 	addle sp, sp, #0x400
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	add r7, sp, #0x24
 _02186294:
 	ldr r0, [sp, #0x1c]
@@ -13285,7 +13285,7 @@ _021862e8:
 	ldr r0, [sp, #0x10]
 	mov r2, r3, lsl #0x7
 	mov r3, r3, lsl #0x18
-	add r2, sl, r2, lsr #26
+	add r2, r10, r2, lsr #26
 	add r3, r11, r3, lsr #27
 	ldr r1, [sp, #0x14]
 	add r2, r6, r2
@@ -13310,7 +13310,7 @@ _0218633c:
 	blt _02186294
 	add sp, sp, #0x24
 	add sp, sp, #0x400
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov40_02186230
 _02186364: .word 0xc000c000
@@ -13396,7 +13396,7 @@ _02186454:
 	.global func_ov40_0218646c
 	arm_func_start func_ov40_0218646c
 func_ov40_0218646c: ; 0x0218646c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0xa0
 	mov r5, r0
 	ldr r0, _021865fc ; =data_027e05f4
@@ -13431,7 +13431,7 @@ func_ov40_0218646c: ; 0x0218646c
 	mov r1, #0
 	mov r11, r6
 	mov r8, r6
-	mov sl, #1
+	mov r10, #1
 	mov r0, r1
 _02186500:
 	mov r2, #0
@@ -13444,7 +13444,7 @@ _02186514:
 	add sb, r7, #0x9000
 	ldrb sb, [sb, #0x854]
 	cmp sb, #0
-	movne r2, sl
+	movne r2, r10
 	bne _02186538
 	add r7, r7, #1
 	add ip, ip, #1
@@ -13470,12 +13470,12 @@ _02186560:
 	sub sb, r0, r6
 	rsb r0, sb, #0x20
 	add r0, r0, r0, lsr #31
-	mov sl, r0, asr #0x1
+	mov r10, r0, asr #0x1
 	mov r8, #0
 	add r7, r5, #0x54
 	mov r11, #0x20
 _0218658c:
-	stmia sp, {r7, sl}
+	stmia sp, {r7, r10}
 	add r0, r4, r8
 	str r0, [sp, #8]
 	str r11, [sp, #0xc]
@@ -13504,7 +13504,7 @@ _021865cc:
 	cmp r7, #0x100
 	blt _021865c8
 	add sp, sp, #0xa0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov40_0218646c
 _021865fc: .word data_027e05f4
@@ -14628,8 +14628,8 @@ func_ov40_021873f4: ; 0x021873f4
 	.global func_ov40_02187410
 	arm_func_start func_ov40_02187410
 func_ov40_02187410: ; 0x02187410
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
-	mov sl, r0
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	mov r10, r0
 	bl func_ov40_0217c2b8
 	ldr r2, _02187548 ; =gItemManager
 	ldr r1, _0218754c ; =0x91a2b3c5
@@ -14638,7 +14638,7 @@ func_ov40_02187410: ; 0x02187410
 	ldr r3, [r3, #0xc]
 	umull r0, r4, r3, r1
 	mov r4, r4, lsr #0xb
-	str r4, [sl, #0x800]
+	str r4, [r10, #0x800]
 	ldr r0, [r2]
 	ldr r2, [r0, #0xc]
 	umull r0, r1, r2, r1
@@ -14651,19 +14651,19 @@ func_ov40_02187410: ; 0x02187410
 	movhs r0, #2
 _02187464:
 	add r0, r0, #1
-	str r0, [sl, #0x804]
-	ldr r0, [sl, #0x800]
+	str r0, [r10, #0x804]
+	ldr r0, [r10, #0x800]
 	cmp r0, #0
 	moveq r0, #0
-	streq r0, [sl, #0x804]
+	streq r0, [r10, #0x804]
 	ldr r0, _02187550 ; =data_027e0f74
 	ldr r0, [r0]
 	bl func_ov00_02097c08
 	cmp r0, #0x15
 	cmpne r0, #0x16
 	moveq r0, #0
-	streq r0, [sl, #0x804]
-	ldr r0, [sl, #0x158]
+	streq r0, [r10, #0x804]
+	ldr r0, [r10, #0x158]
 	ldr r1, [r0]
 	ldr r1, [r1, #8]
 	blx r1
@@ -14679,7 +14679,7 @@ _021874c4:
 	add r0, r6, #4
 	bl func_0201e388
 	mov r5, r0
-	ldr r0, [sl, #0x158]
+	ldr r0, [r10, #0x158]
 	ldr r1, [r0]
 	ldr r1, [r1, #8]
 	blx r1
@@ -14689,13 +14689,13 @@ _021874c4:
 	add r0, r6, #4
 	mov r1, sb
 	bl func_0201e388
-	add r1, sl, r7, lsl #2
+	add r1, r10, r7, lsl #2
 	str r0, [r1, #0x7f4]
-	ldr r0, [sl, #0x158]
+	ldr r0, [r10, #0x158]
 	ldr r1, [r0]
 	ldr r1, [r1, #8]
 	blx r1
-	add r1, sl, r7, lsl #2
+	add r1, r10, r7, lsl #2
 	ldr r1, [r1, #0x7f4]
 	mov r2, r11
 	bl func_02019570
@@ -14704,10 +14704,10 @@ _021874c4:
 	add r7, r7, #1
 	cmp r7, #3
 	blo _021874c4
-	mov r0, sl
+	mov r0, r10
 	bl func_ov40_021875d8
 	ldr r0, [sp]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov40_02187410
 _02187548: .word gItemManager
@@ -15235,14 +15235,14 @@ _02187bbc: .word data_ov40_02189a24
 	.global func_ov40_02187bc0
 	arm_func_start func_ov40_02187bc0
 func_ov40_02187bc0: ; 0x02187bc0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x48
 	ldr r11, [r2]
 	str r2, [sp, #4]
 	ldrb r5, [r11, #3]
 	ldrh r4, [r11, #4]
 	ldr r2, _02187da4 ; =0x00ff0002
-	mov sl, r0
+	mov r10, r0
 	orr r0, r4, r5, lsl #16
 	mov sb, r1
 	str r3, [sp, #8]
@@ -15269,7 +15269,7 @@ _02187c28:
 	cmp r1, #0
 	cmpne r1, #0xa
 	beq _02187c90
-	ldr r8, [sl, #0x2c]
+	ldr r8, [r10, #0x2c]
 	mov r0, r8
 	bl func_02023ea4
 	mov r1, r0
@@ -15280,7 +15280,7 @@ _02187c28:
 	mov r0, r8
 	bl func_02023eec
 	ldrsb r1, [r0, #2]
-	ldr r0, [sl, #0x30]
+	ldr r0, [r10, #0x30]
 	add r7, r7, #1
 	add r0, r1, r0
 	add r5, r5, r0
@@ -15290,13 +15290,13 @@ _02187c80:
 	cmp r7, r6
 	blt _02187c28
 _02187c90:
-	ldr r0, [sl, #0x30]
+	ldr r0, [r10, #0x30]
 	add r1, sp, #0x28
 	str r0, [sp, #0xc]
 	ldr r3, [sp, #0xc]
 	add r0, r11, #7
 	mov r2, r4, lsl #0x1
-	ldr r11, [sl, #0x2c]
+	ldr r11, [r10, #0x2c]
 	sub r5, r5, r3
 	bl func_02007ad8
 	add r1, sp, #0x28
@@ -15304,9 +15304,9 @@ _02187c90:
 	mov r3, #0
 	strh r3, [r1, r0]
 	ldr r2, _02187dac ; =data_02068e8c
-	mov r0, sl
-	str r2, [sl, #0x2c]
-	str r3, [sl, #0x30]
+	mov r0, r10
+	str r2, [r10, #0x2c]
+	str r3, [r10, #0x30]
 	bl func_02033cbc
 	ldr r1, _02187db0 ; =data_020579f8
 	sub r0, r5, r0
@@ -15341,7 +15341,7 @@ _02187d4c:
 	str r7, [sp]
 	mov r0, r8, lsl #0x1
 	ldrh r1, [r6, r0]
-	mov r0, sl
+	mov r0, r10
 	mov r2, r5
 	mov r3, r7
 	bl func_020334b4
@@ -15350,18 +15350,18 @@ _02187d4c:
 	blo _02187d4c
 _02187d74:
 	ldr r0, [sp, #0xc]
-	str r11, [sl, #0x2c]
-	str r0, [sl, #0x30]
+	str r11, [r10, #0x2c]
+	str r0, [r10, #0x30]
 _02187d80:
 	ldr r4, [sp, #0x70]
 	ldr r2, [sp, #4]
 	ldr r3, [sp, #8]
-	mov r0, sl
+	mov r0, r10
 	mov r1, sb
 	str r4, [sp]
 	bl func_0203b814
 	add sp, sp, #0x48
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov40_02187bc0
 _02187da4: .word 0x00ff0002

--- a/asm/ov41.s
+++ b/asm/ov41.s
@@ -3185,12 +3185,12 @@ _0218be1c: .word data_027e0c68
 	.global func_ov41_0218be20
 	arm_func_start func_ov41_0218be20
 func_ov41_0218be20: ; 0x0218be20
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x14
 	mov sl, r0
 	mov r5, #0
 	add sb, sl, #0x470
-	mov fp, r5
+	mov r11, r5
 	add r4, sp, #8
 _0218be3c:
 	ldr r6, [sl, #0x48]
@@ -3227,9 +3227,9 @@ _0218be84:
 	str r0, [sp, #0xc]
 	str r6, [sp, #8]
 	str r8, [sp, #0x10]
-	str fp, [sp]
+	str r11, [sp]
 	ldr r0, _0218bf10 ; =data_027e0e58
-	str fp, [sp, #4]
+	str r11, [sp, #4]
 	ldr r0, [r0]
 	mov r1, #0x1ac
 	mov r2, r4
@@ -3246,7 +3246,7 @@ _0218bef4:
 	add sb, sb, #8
 	blt _0218be3c
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov41_0218be20
 _0218bf0c: .word data_027e0fe4
@@ -3257,7 +3257,7 @@ _0218bf18: .word 0x00000482
 	.global func_ov41_0218bf1c
 	arm_func_start func_ov41_0218bf1c
 func_ov41_0218bf1c: ; 0x0218bf1c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x4c
 	mov sl, r0
 	ldr r0, [sl, #0x48]
@@ -3270,7 +3270,7 @@ func_ov41_0218bf1c: ; 0x0218bf1c
 	add r4, sl, #0x500
 	str r0, [sp, #0x48]
 	strb r8, [sl, #0x527]
-	mov fp, r8
+	mov r11, r8
 	add r6, sp, #0x34
 	add r5, sp, #8
 	mvn r7, #0
@@ -3323,9 +3323,9 @@ _0218bff0:
 	ldr r0, [sp, #0x48]
 	str r1, [sp, #0x34]
 	str r0, [sp, #0x3c]
-	str fp, [sp]
+	str r11, [sp]
 	ldr r0, _0218c0c8 ; =data_027e0e58
-	str fp, [sp, #4]
+	str r11, [sp, #4]
 	ldr r0, [r0]
 	mov r1, #0x1ac
 	mov r2, r6
@@ -3371,7 +3371,7 @@ _0218c094:
 	cmp r8, #4
 	blt _0218bf60
 	add sp, sp, #0x4c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov41_0218bf1c
 _0218c0c8: .word data_027e0e58

--- a/asm/ov41.s
+++ b/asm/ov41.s
@@ -3185,11 +3185,11 @@ _0218be1c: .word data_027e0c68
 	.global func_ov41_0218be20
 	arm_func_start func_ov41_0218be20
 func_ov41_0218be20: ; 0x0218be20
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x14
 	mov r10, r0
 	mov r5, #0
-	add sb, r10, #0x470
+	add r9, r10, #0x470
 	mov r11, r5
 	add r4, sp, #8
 _0218be3c:
@@ -3213,7 +3213,7 @@ _0218be3c:
 	addeq r6, r6, #0x2800
 _0218be84:
 	ldr r0, _0218bf0c ; =data_027e0fe4
-	mov r1, sb
+	mov r1, r9
 	ldr r0, [r0]
 	bl _ZN12ActorManager8GetActorEP8ActorRef
 	cmp r0, #0
@@ -3243,10 +3243,10 @@ _0218be84:
 _0218bef4:
 	add r5, r5, #1
 	cmp r5, #4
-	add sb, sb, #8
+	add r9, r9, #8
 	blt _0218be3c
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov41_0218be20
 _0218bf0c: .word data_027e0fe4
@@ -3257,14 +3257,14 @@ _0218bf18: .word 0x00000482
 	.global func_ov41_0218bf1c
 	arm_func_start func_ov41_0218bf1c
 func_ov41_0218bf1c: ; 0x0218bf1c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x4c
 	mov r10, r0
 	ldr r0, [r10, #0x48]
 	mov r8, #0
 	str r0, [sp, #0x40]
 	ldr r0, [r10, #0x4c]
-	add sb, r10, #0x470
+	add r9, r10, #0x470
 	str r0, [sp, #0x44]
 	ldr r0, [r10, #0x50]
 	add r4, r10, #0x500
@@ -3360,18 +3360,18 @@ _0218c08c:
 	strh r0, [sp, #8]
 _0218c094:
 	ldr r0, _0218c0d4 ; =data_027e0fe8
-	str sb, [sp]
+	str r9, [sp]
 	ldr r0, [r0]
 	ldr r1, _0218c0d8 ; =0x4f53574f
 	add r2, sp, #0x40
 	mov r3, r5
 	bl func_ov00_020c4048
 	add r8, r8, #1
-	add sb, sb, #8
+	add r9, r9, #8
 	cmp r8, #4
 	blt _0218bf60
 	add sp, sp, #0x4c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov41_0218bf1c
 _0218c0c8: .word data_027e0e58

--- a/asm/ov41.s
+++ b/asm/ov41.s
@@ -3185,18 +3185,18 @@ _0218be1c: .word data_027e0c68
 	.global func_ov41_0218be20
 	arm_func_start func_ov41_0218be20
 func_ov41_0218be20: ; 0x0218be20
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x14
-	mov sl, r0
+	mov r10, r0
 	mov r5, #0
-	add sb, sl, #0x470
+	add sb, r10, #0x470
 	mov r11, r5
 	add r4, sp, #8
 _0218be3c:
-	ldr r6, [sl, #0x48]
-	ldr r8, [sl, #0x50]
+	ldr r6, [r10, #0x48]
+	ldr r8, [r10, #0x50]
 	cmp r5, #0
-	ldr r7, [sl, #0x4c]
+	ldr r7, [r10, #0x4c]
 	addeq r8, r8, #0x1000
 	subeq r6, r6, #0x2800
 	beq _0218be84
@@ -3246,7 +3246,7 @@ _0218bef4:
 	add sb, sb, #8
 	blt _0218be3c
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov41_0218be20
 _0218bf0c: .word data_027e0fe4
@@ -3257,33 +3257,33 @@ _0218bf18: .word 0x00000482
 	.global func_ov41_0218bf1c
 	arm_func_start func_ov41_0218bf1c
 func_ov41_0218bf1c: ; 0x0218bf1c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x4c
-	mov sl, r0
-	ldr r0, [sl, #0x48]
+	mov r10, r0
+	ldr r0, [r10, #0x48]
 	mov r8, #0
 	str r0, [sp, #0x40]
-	ldr r0, [sl, #0x4c]
-	add sb, sl, #0x470
+	ldr r0, [r10, #0x4c]
+	add sb, r10, #0x470
 	str r0, [sp, #0x44]
-	ldr r0, [sl, #0x50]
-	add r4, sl, #0x500
+	ldr r0, [r10, #0x50]
+	add r4, r10, #0x500
 	str r0, [sp, #0x48]
-	strb r8, [sl, #0x527]
+	strb r8, [r10, #0x527]
 	mov r11, r8
 	add r6, sp, #0x34
 	add r5, sp, #8
 	mvn r7, #0
 _0218bf60:
 	cmp r8, #0
-	add r0, sl, r8, lsl #3
+	add r0, r10, r8, lsl #3
 	str r7, [r0, #0x470]
 	str r7, [r0, #0x474]
-	ldr r0, [sl, #0x48]
+	ldr r0, [r10, #0x48]
 	str r0, [sp, #0x40]
-	ldr r1, [sl, #0x4c]
+	ldr r1, [r10, #0x4c]
 	str r1, [sp, #0x44]
-	ldr r1, [sl, #0x50]
+	ldr r1, [r10, #0x50]
 	str r1, [sp, #0x48]
 	bne _0218bfa0
 	add r1, r1, #0x1000
@@ -3371,7 +3371,7 @@ _0218c094:
 	cmp r8, #4
 	blt _0218bf60
 	add sp, sp, #0x4c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov41_0218bf1c
 _0218c0c8: .word data_027e0e58

--- a/asm/ov42.s
+++ b/asm/ov42.s
@@ -758,18 +758,18 @@ _02189ef8: .word 0x000001c2
 	.global func_ov42_02189efc
 	arm_func_start func_ov42_02189efc
 func_ov42_02189efc: ; 0x02189efc
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x10
 	mov sl, r0
 	ldr r0, [sl, #0x60]
 	cmp r0, #0
 	addle sp, sp, #0x10
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	sub r0, r0, #1
 	cmp r0, #0
 	addgt sp, sp, #0x10
 	str r0, [sl, #0x60]
-	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	mov r1, #0
 	add r0, sp, #0
 _02189f34:
@@ -807,7 +807,7 @@ _02189f54:
 	ldr r4, _0218a058 ; =data_027e0fe4
 	add sb, sl, #0x28
 	mov r6, r7
-	mov fp, #3
+	mov r11, #3
 	add r5, sp, #0
 _02189fc0:
 	ldr r0, [r4]
@@ -821,7 +821,7 @@ _02189fc0:
 	bl func_ov42_0218c0ec
 _02189fe4:
 	mov r0, r8
-	mov r1, fp
+	mov r1, r11
 	bl func_ov42_0218c0ec
 	ldr r1, [r5, r7, lsl #2]
 	mov r0, r8
@@ -848,7 +848,7 @@ _0218a034:
 	mov r0, r4
 	bl func_ov42_0218c690
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov42_02189efc
 _0218a054: .word data_027e0764

--- a/asm/ov42.s
+++ b/asm/ov42.s
@@ -262,7 +262,7 @@ _02189830: .word data_ov09_0211f5b4
 	.global func_ov42_02189834
 	arm_func_start func_ov42_02189834
 func_ov42_02189834: ; 0x02189834
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #0x80
 	mov r7, r0
 	bl func_ov42_021897dc
@@ -369,7 +369,7 @@ _02189918:
 	ldr r8, _02189b0c ; =data_027e0fe8
 	mov r5, #0
 	add r6, r7, #0x10
-	add sb, sp, #0x10
+	add r9, sp, #0x10
 _021899d4:
 	ldr r0, [sp, #0xc]
 	mov r1, r10
@@ -378,7 +378,7 @@ _021899d4:
 	str r6, [sp]
 	ldr r0, [r8]
 	mov r2, r4
-	mov r3, sb
+	mov r3, r9
 	bl func_ov00_020c4048
 	add r5, r5, #1
 	cmp r5, #3
@@ -394,7 +394,7 @@ _021899d4:
 	str r0, [sp, #0xc]
 	add r5, r7, #0x28
 	mov r4, #0
-	add sb, sp, #4
+	add r9, sp, #4
 	add r8, sp, #0x10
 _02189a38:
 	ldr r0, [sp, #0xc]
@@ -403,7 +403,7 @@ _02189a38:
 	str r0, [sp, #0xc]
 	str r5, [sp]
 	ldr r0, [r6]
-	mov r2, sb
+	mov r2, r9
 	mov r3, r8
 	bl func_ov00_020c4048
 	add r4, r4, #1
@@ -444,7 +444,7 @@ _02189a74:
 	mov r1, #1
 	strb r1, [r0, #0x24]
 	add sp, sp, #0x80
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov42_02189834
 _02189af4: .word data_027e0e60
@@ -493,16 +493,16 @@ _02189b80: .word data_027e0ffc
 	.global func_ov42_02189b84
 	arm_func_start func_ov42_02189b84
 func_ov42_02189b84: ; 0x02189b84
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	mov r4, r0
 	mov r8, #0
 	ldr r5, _02189ccc ; =data_027e0fe4
-	add sb, r4, #0x10
+	add r9, r4, #0x10
 	mov r7, r8
 	mvn r6, #0
 _02189ba0:
 	ldr r0, [r5]
-	mov r1, sb
+	mov r1, r9
 	bl _ZN12ActorManager8GetActorEP8ActorRef
 	cmp r0, #0
 	strneb r7, [r0, #0x118]
@@ -511,16 +511,16 @@ _02189ba0:
 	add r8, r8, #1
 	str r6, [r0, #0x14]
 	cmp r8, #3
-	add sb, sb, #8
+	add r9, r9, #8
 	blt _02189ba0
 	mov r8, #0
 	ldr r5, _02189ccc ; =data_027e0fe4
-	add sb, r4, #0x28
+	add r9, r4, #0x28
 	mov r7, r8
 	mvn r6, #0
 _02189be4:
 	ldr r0, [r5]
-	mov r1, sb
+	mov r1, r9
 	bl _ZN12ActorManager8GetActorEP8ActorRef
 	cmp r0, #0
 	strneb r7, [r0, #0x118]
@@ -529,7 +529,7 @@ _02189be4:
 	add r8, r8, #1
 	str r6, [r0, #0x2c]
 	cmp r8, #3
-	add sb, sb, #8
+	add r9, r9, #8
 	blt _02189be4
 	ldr r0, _02189cd0 ; =gItemManager
 	ldr r0, [r0]
@@ -577,7 +577,7 @@ _02189c88:
 	str r1, [r0, #0x20]
 	mov r1, #1
 	strb r1, [r0, #0x24]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov42_02189b84
 _02189ccc: .word data_027e0fe4
@@ -758,18 +758,18 @@ _02189ef8: .word 0x000001c2
 	.global func_ov42_02189efc
 	arm_func_start func_ov42_02189efc
 func_ov42_02189efc: ; 0x02189efc
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x10
 	mov r10, r0
 	ldr r0, [r10, #0x60]
 	cmp r0, #0
 	addle sp, sp, #0x10
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	sub r0, r0, #1
 	cmp r0, #0
 	addgt sp, sp, #0x10
 	str r0, [r10, #0x60]
-	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	mov r1, #0
 	add r0, sp, #0
 _02189f34:
@@ -805,13 +805,13 @@ _02189f54:
 	blt _02189f54
 	mov r7, #0
 	ldr r4, _0218a058 ; =data_027e0fe4
-	add sb, r10, #0x28
+	add r9, r10, #0x28
 	mov r6, r7
 	mov r11, #3
 	add r5, sp, #0
 _02189fc0:
 	ldr r0, [r4]
-	mov r1, sb
+	mov r1, r9
 	bl _ZN12ActorManager8GetActorEP8ActorRef
 	mov r8, r0
 	ldr r1, [r8, #0x204]
@@ -828,7 +828,7 @@ _02189fe4:
 	bl func_ov42_0218c690
 	add r7, r7, #1
 	cmp r7, #3
-	add sb, sb, #8
+	add r9, r9, #8
 	blt _02189fc0
 	ldr r0, _0218a058 ; =data_027e0fe4
 	add r1, r10, #0x10
@@ -848,7 +848,7 @@ _0218a034:
 	mov r0, r4
 	bl func_ov42_0218c690
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov42_02189efc
 _0218a054: .word data_027e0764
@@ -1311,21 +1311,21 @@ _0218a624:
 	.global func_ov42_0218a63c
 	arm_func_start func_ov42_0218a63c
 func_ov42_0218a63c: ; 0x0218a63c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
-	mov sb, r0
-	ldr r0, [sb, #0x60]
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
+	mov r9, r0
+	ldr r0, [r9, #0x60]
 	mov r8, r1
 	cmp r0, #0
 	subgt r0, r0, #1
 	mov r7, r2
 	mov r6, r3
-	strgt r0, [sb, #0x60]
-	ldmgtia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	strgt r0, [r9, #0x60]
+	ldmgtia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	cmp r7, #0
 	mov r4, #0
 	ble _0218a6c8
 	ldr r10, _0218a730 ; =data_027e0fe4
-	add r5, sb, #0x28
+	add r5, r9, #0x28
 _0218a678:
 	ldr r0, [r10]
 	mov r1, r5
@@ -1343,8 +1343,8 @@ _0218a6a4:
 	bl func_ov42_0218c0ec
 _0218a6ac:
 	mov r0, #0xf
-	str r0, [sb, #0x60]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	str r0, [r9, #0x60]
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _0218a6b8:
 	add r4, r4, #1
 	cmp r4, r7
@@ -1353,9 +1353,9 @@ _0218a6b8:
 _0218a6c8:
 	mov r5, #0
 	cmp r8, #0
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	ldr r4, _0218a730 ; =data_027e0fe4
-	add r7, sb, #0x10
+	add r7, r9, #0x10
 _0218a6dc:
 	ldr r0, [r4]
 	mov r1, r7
@@ -1373,14 +1373,14 @@ _0218a708:
 	bl func_ov42_0218c0ec
 _0218a710:
 	mov r0, #0xf
-	str r0, [sb, #0x60]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	str r0, [r9, #0x60]
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _0218a71c:
 	add r5, r5, #1
 	cmp r5, r8
 	add r7, r7, #8
 	blt _0218a6dc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov42_0218a63c
 _0218a730: .word data_027e0fe4
@@ -1798,7 +1798,7 @@ _0218abfc:
 	.global func_ov42_0218ac10
 	arm_func_start func_ov42_0218ac10
 func_ov42_0218ac10: ; 0x0218ac10
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	mov r1, #4
 	ldr r2, _0218ad8c ; =data_027e0764
 	str r1, [r0, #0x474]
@@ -1813,28 +1813,28 @@ func_ov42_0218ac10: ; 0x0218ac10
 	adds r7, r5, r7
 	ldr r8, _0218ad90 ; =0x00005557
 	adc r6, r4, r6
-	umull r3, sb, r6, r8
+	umull r3, r9, r6, r8
 	mov r1, #0
 	str r7, [r2]
-	mla sb, r6, r1, sb
+	mla r9, r6, r1, r9
 	mov r3, r1
-	mla sb, r3, r8, sb
+	mla r9, r3, r8, r9
 	ldr r8, _0218ad94 ; =0xffffd555
 	str r6, [r2, #4]
-	add r8, sb, r8
+	add r8, r9, r8
 	mov r8, r8, lsl #0x10
 	movs r8, r8, asr #0x10
-	umull sb, r8, lr, r7
+	umull r9, r8, lr, r7
 	mla r8, lr, r6, r8
 	bmi _0218ad08
 	mla r8, ip, r7, r8
-	adds sb, r5, sb
+	adds r9, r5, r9
 	ldr r5, _0218ad98 ; =0x00001c73
 	adc r7, r4, r8
 	umull r4, r6, r7, r5
 	mla r6, r7, r1, r6
 	mla r6, r3, r5, r6
-	str sb, [r2]
+	str r9, [r2]
 	add r4, r6, #0x39
 	add r5, r4, #0xe00
 	str r7, [r2, #4]
@@ -1845,10 +1845,10 @@ func_ov42_0218ac10: ; 0x0218ac10
 	umull r8, r7, r6, r5
 	mla r7, r6, r0, r7
 	ldr r0, [r2, #0xc]
-	ldr sb, [r2, #0x10]
+	ldr r9, [r2, #0x10]
 	mla r7, r0, r5, r7
 	ldr r6, [r2, #0x14]
-	adds r8, sb, r8
+	adds r8, r9, r8
 	ldr r0, _0218ad9c ; =0x00001556
 	adc r7, r6, r7
 	umull r5, r6, r7, r0
@@ -1859,16 +1859,16 @@ func_ov42_0218ac10: ; 0x0218ac10
 	str r7, [r2, #4]
 	add r0, r0, #0xe00
 	strh r0, [r4, #0x8e]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _0218ad08:
 	mla r8, ip, r7, r8
-	adds sb, r5, sb
+	adds r9, r5, r9
 	ldr r5, _0218ad98 ; =0x00001c73
 	adc r7, r4, r8
 	umull r4, r6, r7, r5
 	mla r6, r7, r1, r6
 	mla r6, r3, r5, r6
-	str sb, [r2]
+	str r9, [r2]
 	add r4, r6, #0x39
 	add r5, r4, #0xe00
 	str r7, [r2, #4]
@@ -1893,7 +1893,7 @@ _0218ad08:
 	str r7, [r2, #4]
 	add r0, r6, r0
 	strh r0, [r4, #0x8e]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov42_0218ac10
 _0218ad8c: .word data_027e0764
@@ -2443,15 +2443,15 @@ _0218b43c: .word func_ov42_0218b440
 	.global func_ov42_0218b440
 	arm_func_start func_ov42_0218b440
 func_ov42_0218b440: ; 0x0218b440
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
-	mov sb, r0
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
+	mov r9, r0
 	mov r6, #0
 	mov r8, #0x1000
 	bl func_ov42_0218a794
 	cmp r0, #0
 	ldrne r8, [r0, #0x4a4]
-	cmp sb, #4
-	addls pc, pc, sb, lsl #2
+	cmp r9, #4
+	addls pc, pc, r9, lsl #2
 	b _0218b4f0
 _0218b468: ; jump table
 	b _0218b4dc ; case 0
@@ -2527,9 +2527,9 @@ _0218b4f0:
 	mov r7, r3, asr #0xc
 	str r2, [r1, #0x40]
 	bl func_ov05_0210e288
-	rsb sb, r7, #0x60
+	rsb r9, r7, #0x60
 	mov r5, r0
-	mov r0, sb
+	mov r0, r9
 	bl func_ov05_0210e2a4
 	mov r0, r0, lsl #0x10
 	mov r3, r0, lsr #0x10
@@ -2580,7 +2580,7 @@ _0218b4f0:
 	str r1, [r2, #0xc]
 	bl func_ov05_0210e288
 	mov r4, r0
-	mov r0, sb
+	mov r0, r9
 	bl func_ov05_0210e2a4
 	mov r0, r0, lsl #0x10
 	mov r1, r0, lsr #0x10
@@ -2592,7 +2592,7 @@ _0218b4f0:
 	str r0, [r2, #0xc]
 	mov r0, #0
 	str r0, [r2, #0x7c]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov42_0218b440
 _0218b67c: .word 0x0000ffff

--- a/asm/ov42.s
+++ b/asm/ov42.s
@@ -262,7 +262,7 @@ _02189830: .word data_ov09_0211f5b4
 	.global func_ov42_02189834
 	arm_func_start func_ov42_02189834
 func_ov42_02189834: ; 0x02189834
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #0x80
 	mov r7, r0
 	bl func_ov42_021897dc
@@ -365,14 +365,14 @@ _02189918:
 	add r4, sp, #4
 	ldmia r0, {r0, r1, r2}
 	stmia r4, {r0, r1, r2}
-	ldr sl, _02189b08 ; =0x4d544748
+	ldr r10, _02189b08 ; =0x4d544748
 	ldr r8, _02189b0c ; =data_027e0fe8
 	mov r5, #0
 	add r6, r7, #0x10
 	add sb, sp, #0x10
 _021899d4:
 	ldr r0, [sp, #0xc]
-	mov r1, sl
+	mov r1, r10
 	sub r0, r0, #0x1000
 	str r0, [sp, #0xc]
 	str r6, [sp]
@@ -388,7 +388,7 @@ _021899d4:
 	ldr r0, [sp, #0xc]
 	add r1, r1, #0x1000
 	add r0, r0, #0x3000
-	ldr sl, _02189b10 ; =0x4d544752
+	ldr r10, _02189b10 ; =0x4d544752
 	ldr r6, _02189b0c ; =data_027e0fe8
 	str r1, [sp, #4]
 	str r0, [sp, #0xc]
@@ -398,7 +398,7 @@ _021899d4:
 	add r8, sp, #0x10
 _02189a38:
 	ldr r0, [sp, #0xc]
-	mov r1, sl
+	mov r1, r10
 	sub r0, r0, #0x1000
 	str r0, [sp, #0xc]
 	str r5, [sp]
@@ -444,7 +444,7 @@ _02189a74:
 	mov r1, #1
 	strb r1, [r0, #0x24]
 	add sp, sp, #0x80
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov42_02189834
 _02189af4: .word data_027e0e60
@@ -758,18 +758,18 @@ _02189ef8: .word 0x000001c2
 	.global func_ov42_02189efc
 	arm_func_start func_ov42_02189efc
 func_ov42_02189efc: ; 0x02189efc
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x10
-	mov sl, r0
-	ldr r0, [sl, #0x60]
+	mov r10, r0
+	ldr r0, [r10, #0x60]
 	cmp r0, #0
 	addle sp, sp, #0x10
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	sub r0, r0, #1
 	cmp r0, #0
 	addgt sp, sp, #0x10
-	str r0, [sl, #0x60]
-	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	str r0, [r10, #0x60]
+	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	mov r1, #0
 	add r0, sp, #0
 _02189f34:
@@ -805,7 +805,7 @@ _02189f54:
 	blt _02189f54
 	mov r7, #0
 	ldr r4, _0218a058 ; =data_027e0fe4
-	add sb, sl, #0x28
+	add sb, r10, #0x28
 	mov r6, r7
 	mov r11, #3
 	add r5, sp, #0
@@ -831,7 +831,7 @@ _02189fe4:
 	add sb, sb, #8
 	blt _02189fc0
 	ldr r0, _0218a058 ; =data_027e0fe4
-	add r1, sl, #0x10
+	add r1, r10, #0x10
 	ldr r0, [r0]
 	bl _ZN12ActorManager8GetActorEP8ActorRef
 	mov r4, r0
@@ -848,7 +848,7 @@ _0218a034:
 	mov r0, r4
 	bl func_ov42_0218c690
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov42_02189efc
 _0218a054: .word data_027e0764
@@ -1311,7 +1311,7 @@ _0218a624:
 	.global func_ov42_0218a63c
 	arm_func_start func_ov42_0218a63c
 func_ov42_0218a63c: ; 0x0218a63c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	mov sb, r0
 	ldr r0, [sb, #0x60]
 	mov r8, r1
@@ -1320,14 +1320,14 @@ func_ov42_0218a63c: ; 0x0218a63c
 	mov r7, r2
 	mov r6, r3
 	strgt r0, [sb, #0x60]
-	ldmgtia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmgtia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	cmp r7, #0
 	mov r4, #0
 	ble _0218a6c8
-	ldr sl, _0218a730 ; =data_027e0fe4
+	ldr r10, _0218a730 ; =data_027e0fe4
 	add r5, sb, #0x28
 _0218a678:
-	ldr r0, [sl]
+	ldr r0, [r10]
 	mov r1, r5
 	bl _ZN12ActorManager8GetActorEP8ActorRef
 	ldr r1, [r0, #0x204]
@@ -1344,7 +1344,7 @@ _0218a6a4:
 _0218a6ac:
 	mov r0, #0xf
 	str r0, [sb, #0x60]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _0218a6b8:
 	add r4, r4, #1
 	cmp r4, r7
@@ -1353,7 +1353,7 @@ _0218a6b8:
 _0218a6c8:
 	mov r5, #0
 	cmp r8, #0
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	ldr r4, _0218a730 ; =data_027e0fe4
 	add r7, sb, #0x10
 _0218a6dc:
@@ -1374,13 +1374,13 @@ _0218a708:
 _0218a710:
 	mov r0, #0xf
 	str r0, [sb, #0x60]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _0218a71c:
 	add r5, r5, #1
 	cmp r5, r8
 	add r7, r7, #8
 	blt _0218a6dc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov42_0218a63c
 _0218a730: .word data_027e0fe4
@@ -2443,7 +2443,7 @@ _0218b43c: .word func_ov42_0218b440
 	.global func_ov42_0218b440
 	arm_func_start func_ov42_0218b440
 func_ov42_0218b440: ; 0x0218b440
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	mov sb, r0
 	mov r6, #0
 	mov r8, #0x1000
@@ -2461,35 +2461,35 @@ _0218b468: ; jump table
 	b _0218b47c ; case 4
 _0218b47c:
 	mov r6, #0x100
-	mov sl, #0x100000
+	mov r10, #0x100000
 	mov r4, #0x40000
 	mov r5, #0x4d
 	mov r7, #5
 	b _0218b4f0
 _0218b494:
-	mov sl, #0x40000
-	mov r4, sl
+	mov r10, #0x40000
+	mov r4, r10
 	mov r6, #0x40
 	mov r5, #0x4c
 	mov r7, #3
 	b _0218b4f0
 _0218b4ac:
-	mov sl, #0x40000
-	mov r4, sl
+	mov r10, #0x40000
+	mov r4, r10
 	mov r6, #0x40
 	mov r5, #0x4b
 	mov r7, #3
 	b _0218b4f0
 _0218b4c4:
-	mov sl, #0x40000
-	mov r4, sl
+	mov r10, #0x40000
+	mov r4, r10
 	mov r6, #0x40
 	mov r5, #0x4a
 	mov r7, #3
 	b _0218b4f0
 _0218b4dc:
 	mov r6, #0x100
-	mov sl, #0x100000
+	mov r10, #0x100000
 	mov r4, #0x40000
 	mov r5, #0x4e
 	mov r7, #5
@@ -2564,7 +2564,7 @@ _0218b4f0:
 	mov r4, r0
 	add r0, r7, #0x60
 	bl func_ov05_0210e2a4
-	mov r1, sl, lsl #0x8
+	mov r1, r10, lsl #0x8
 	mov r1, r1, asr #0x10
 	mov r1, r1, lsl #0x10
 	mov r5, r1, lsr #0x10
@@ -2592,7 +2592,7 @@ _0218b4f0:
 	str r0, [r2, #0xc]
 	mov r0, #0
 	str r0, [r2, #0x7c]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov42_0218b440
 _0218b67c: .word 0x0000ffff

--- a/asm/ov43.s
+++ b/asm/ov43.s
@@ -1293,7 +1293,7 @@ _0218a670: .word data_027e0764
 	.global func_ov43_0218a674
 	arm_func_start func_ov43_0218a674
 func_ov43_0218a674: ; 0x0218a674
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x24
 	ldr r1, _0218a84c ; =0x0000099a
 	mov r4, r0
@@ -1316,7 +1316,7 @@ func_ov43_0218a674: ; 0x0218a674
 	ldr r1, [r4, #0x4c]
 	adds r0, r0, #0x800
 	str r1, [sp, #0x18]
-	ldr sb, [r4, #0x50]
+	ldr r9, [r4, #0x50]
 	ldr r2, _0218a854 ; =data_027e0f90
 	mov r8, r0, lsr #0xc
 	ldr r0, [r2]
@@ -1341,8 +1341,8 @@ func_ov43_0218a674: ; 0x0218a674
 	adc r2, ip, #0
 	mov r3, r5, lsr #0xc
 	orr r3, r3, r2, lsl #20
-	str sb, [sp, #0x1c]
-	add r2, sb, r3
+	str r9, [sp, #0x1c]
+	add r2, r9, r3
 	str r2, [r1, #8]
 	bl _ZN10PlayerBase18func_ov00_020a7c1cEP8Cylinder
 	cmp r0, #0
@@ -1371,7 +1371,7 @@ _0218a784:
 	mov r3, #0
 	bl func_ov00_020c070c
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0218a7ac:
 	ldrh r0, [r4, #0x78]
 	mov r1, #0
@@ -1395,7 +1395,7 @@ _0218a7ac:
 	bl _ZN5Actor18func_ov00_020c1ef8EP8CylinderP5Vec3pii
 	cmp r0, #0
 	addeq sp, sp, #0x24
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r1, [r4, #4]
 	ldr r0, _0218a864 ; =0x50424c4e
 	mov r3, #0
@@ -1406,14 +1406,14 @@ _0218a7ac:
 	mov r1, #0x3b0
 	bl func_ov00_020ceacc
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0218a834:
 	ldr r0, _0218a868 ; =data_027e0ffc
 	add r2, r4, #0x48
 	mov r1, #0x3b8
 	bl func_ov00_020ceacc
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov43_0218a674
 _0218a84c: .word 0x0000099a
@@ -4126,7 +4126,7 @@ _0218cd64:
 	.global func_ov43_0218cd7c
 	arm_func_start func_ov43_0218cd7c
 func_ov43_0218cd7c: ; 0x0218cd7c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x18
 	mov r10, r0
 	ldrsh r4, [r10, #0x78]
@@ -4134,7 +4134,7 @@ func_ov43_0218cd7c: ; 0x0218cd7c
 	ldr r0, _0218cf84 ; =data_027e0fc8
 	strh r4, [r8]
 	ldr r0, [r0]
-	mov sb, r1
+	mov r9, r1
 	mov r7, r3
 	ldr r6, [sp, #0x40]
 	bl func_ov00_020bc46c
@@ -4153,7 +4153,7 @@ func_ov43_0218cd7c: ; 0x0218cd7c
 	ldmib r0, {r4, r5}
 	bne _0218cdfc
 	mvn r0, #0x80000000
-	str r0, [sb]
+	str r0, [r9]
 	mov r1, #0
 	mov r3, r0
 	strh r1, [r8]
@@ -4162,7 +4162,7 @@ _0218cdfc:
 	add r0, r10, #0x48
 	add r1, r1, #0x48
 	bl func_ov00_020ce2f0
-	str r0, [sb]
+	str r0, [r9]
 	ldr r1, [r10, #0x3c0]
 	mov r0, r10
 	add r1, r1, #0x48
@@ -4200,7 +4200,7 @@ _0218ce58:
 _0218ce8c:
 	mov r0, r10
 	bl _ZN5Actor16XzDistanceToLinkEv
-	str r0, [sb]
+	str r0, [r9]
 	mov r0, r10
 	bl _ZN5Actor14GetAngleToLinkEv
 	ldr r2, _0218cf88 ; =data_027e0f94
@@ -4228,7 +4228,7 @@ _0218ceac:
 	beq _0218cf40
 	add sp, sp, #0x18
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0218cf04:
 	ldr r2, _0218cf8c ; =data_027e0e60
 	str r0, [sp]
@@ -4244,27 +4244,27 @@ _0218cf04:
 	cmp r0, #0
 	addne sp, sp, #0x18
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0218cf40:
 	ldrb r0, [r10, #0x3e6]
 	cmp r0, #0
 	bne _0218cf64
-	ldr r0, [sb]
+	ldr r0, [r9]
 	cmp r0, #0xa800
 	ble _0218cf78
 	add sp, sp, #0x18
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0218cf64:
 	ldr r0, [r7]
 	cmp r0, #0x7000
 	addgt sp, sp, #0x18
 	movgt r0, #0
-	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0218cf78:
 	mov r0, #1
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov43_0218cd7c
 _0218cf84: .word data_027e0fc8

--- a/asm/ov43.s
+++ b/asm/ov43.s
@@ -1293,7 +1293,7 @@ _0218a670: .word data_027e0764
 	.global func_ov43_0218a674
 	arm_func_start func_ov43_0218a674
 func_ov43_0218a674: ; 0x0218a674
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x24
 	ldr r1, _0218a84c ; =0x0000099a
 	mov r4, r0
@@ -1311,7 +1311,7 @@ func_ov43_0218a674: ; 0x0218a674
 	add r0, r1, #0x800
 	str r0, [sp, #4]
 	umull r0, r7, r6, r0
-	add fp, r1, #0x800
+	add r11, r1, #0x800
 	str sl, [sp, #0x14]
 	ldr r1, [r4, #0x4c]
 	adds r0, r0, #0x800
@@ -1332,12 +1332,12 @@ func_ov43_0218a674: ; 0x0218a674
 	orr r8, r8, r2, lsl #20
 	add r2, sl, r8
 	str r2, [r1]
-	umull lr, ip, r3, fp
+	umull lr, ip, r3, r11
 	mov r2, #0
 	mla ip, r3, r2, ip
 	mov r2, r3, asr #0x1f
 	adds r5, lr, #0x800
-	mla ip, r2, fp, ip
+	mla ip, r2, r11, ip
 	adc r2, ip, #0
 	mov r3, r5, lsr #0xc
 	orr r3, r3, r2, lsl #20
@@ -1371,7 +1371,7 @@ _0218a784:
 	mov r3, #0
 	bl func_ov00_020c070c
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0218a7ac:
 	ldrh r0, [r4, #0x78]
 	mov r1, #0
@@ -1395,7 +1395,7 @@ _0218a7ac:
 	bl _ZN5Actor18func_ov00_020c1ef8EP8CylinderP5Vec3pii
 	cmp r0, #0
 	addeq sp, sp, #0x24
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r1, [r4, #4]
 	ldr r0, _0218a864 ; =0x50424c4e
 	mov r3, #0
@@ -1406,14 +1406,14 @@ _0218a7ac:
 	mov r1, #0x3b0
 	bl func_ov00_020ceacc
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0218a834:
 	ldr r0, _0218a868 ; =data_027e0ffc
 	add r2, r4, #0x48
 	mov r1, #0x3b8
 	bl func_ov00_020ceacc
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov43_0218a674
 _0218a84c: .word 0x0000099a
@@ -4126,7 +4126,7 @@ _0218cd64:
 	.global func_ov43_0218cd7c
 	arm_func_start func_ov43_0218cd7c
 func_ov43_0218cd7c: ; 0x0218cd7c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x18
 	mov sl, r0
 	ldrsh r4, [sl, #0x78]
@@ -4148,7 +4148,7 @@ func_ov43_0218cd7c: ; 0x0218cd7c
 	strh r0, [r6]
 	ldr r0, _0218cf88 ; =data_027e0f94
 	ldr r1, [sl, #0x3c0]
-	ldr fp, [r0]
+	ldr r11, [r0]
 	cmp r1, #0
 	ldmib r0, {r4, r5}
 	bne _0218cdfc
@@ -4177,10 +4177,10 @@ _0218ce34:
 	ldr r1, [sl, #0x3c0]
 	cmp r1, #0
 	bne _0218ce58
-	mvn fp, #0x80000000
-	str fp, [r7]
+	mvn r11, #0x80000000
+	str r11, [r7]
 	mov r4, #0
-	mov r5, fp
+	mov r5, r11
 	strh r4, [r6]
 	b _0218ce8c
 _0218ce58:
@@ -4194,7 +4194,7 @@ _0218ce58:
 	bl _ZN5Actor10GetAngleToEP5Vec3p
 	strh r0, [r6]
 	ldr r0, [sl, #0x3c0]
-	ldr fp, [r0, #0x48]
+	ldr r11, [r0, #0x48]
 	ldr r4, [r0, #0x4c]
 	ldr r5, [r0, #0x50]
 _0218ce8c:
@@ -4214,7 +4214,7 @@ _0218ceac:
 	cmp r2, #0
 	beq _0218cf04
 	ldr r0, _0218cf8c ; =data_027e0e60
-	str fp, [sp, #0xc]
+	str r11, [sp, #0xc]
 	str r4, [sp, #0x10]
 	str r5, [sp, #0x14]
 	ldrh r1, [sl, #0x26]
@@ -4228,7 +4228,7 @@ _0218ceac:
 	beq _0218cf40
 	add sp, sp, #0x18
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0218cf04:
 	ldr r2, _0218cf8c ; =data_027e0e60
 	str r0, [sp]
@@ -4244,7 +4244,7 @@ _0218cf04:
 	cmp r0, #0
 	addne sp, sp, #0x18
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0218cf40:
 	ldrb r0, [sl, #0x3e6]
 	cmp r0, #0
@@ -4254,17 +4254,17 @@ _0218cf40:
 	ble _0218cf78
 	add sp, sp, #0x18
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0218cf64:
 	ldr r0, [r7]
 	cmp r0, #0x7000
 	addgt sp, sp, #0x18
 	movgt r0, #0
-	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0218cf78:
 	mov r0, #1
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov43_0218cd7c
 _0218cf84: .word data_027e0fc8

--- a/asm/ov43.s
+++ b/asm/ov43.s
@@ -1293,13 +1293,13 @@ _0218a670: .word data_027e0764
 	.global func_ov43_0218a674
 	arm_func_start func_ov43_0218a674
 func_ov43_0218a674: ; 0x0218a674
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x24
 	ldr r1, _0218a84c ; =0x0000099a
 	mov r4, r0
 	str r1, [sp, #0x20]
 	ldrh r0, [r4, #0x78]
-	ldr sl, [r4, #0x48]
+	ldr r10, [r4, #0x48]
 	ldr r3, _0218a850 ; =data_02050f54
 	mov r0, r0, asr #0x4
 	mov r5, r0, lsl #0x1
@@ -1312,7 +1312,7 @@ func_ov43_0218a674: ; 0x0218a674
 	str r0, [sp, #4]
 	umull r0, r7, r6, r0
 	add r11, r1, #0x800
-	str sl, [sp, #0x14]
+	str r10, [sp, #0x14]
 	ldr r1, [r4, #0x4c]
 	adds r0, r0, #0x800
 	str r1, [sp, #0x18]
@@ -1330,7 +1330,7 @@ func_ov43_0218a674: ; 0x0218a674
 	mla r7, r5, r2, r7
 	adc r2, r7, #0
 	orr r8, r8, r2, lsl #20
-	add r2, sl, r8
+	add r2, r10, r8
 	str r2, [r1]
 	umull lr, ip, r3, r11
 	mov r2, #0
@@ -1371,7 +1371,7 @@ _0218a784:
 	mov r3, #0
 	bl func_ov00_020c070c
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0218a7ac:
 	ldrh r0, [r4, #0x78]
 	mov r1, #0
@@ -1395,7 +1395,7 @@ _0218a7ac:
 	bl _ZN5Actor18func_ov00_020c1ef8EP8CylinderP5Vec3pii
 	cmp r0, #0
 	addeq sp, sp, #0x24
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r1, [r4, #4]
 	ldr r0, _0218a864 ; =0x50424c4e
 	mov r3, #0
@@ -1406,14 +1406,14 @@ _0218a7ac:
 	mov r1, #0x3b0
 	bl func_ov00_020ceacc
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0218a834:
 	ldr r0, _0218a868 ; =data_027e0ffc
 	add r2, r4, #0x48
 	mov r1, #0x3b8
 	bl func_ov00_020ceacc
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov43_0218a674
 _0218a84c: .word 0x0000099a
@@ -4126,10 +4126,10 @@ _0218cd64:
 	.global func_ov43_0218cd7c
 	arm_func_start func_ov43_0218cd7c
 func_ov43_0218cd7c: ; 0x0218cd7c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x18
-	mov sl, r0
-	ldrsh r4, [sl, #0x78]
+	mov r10, r0
+	ldrsh r4, [r10, #0x78]
 	mov r8, r2
 	ldr r0, _0218cf84 ; =data_027e0fc8
 	strh r4, [r8]
@@ -4140,14 +4140,14 @@ func_ov43_0218cd7c: ; 0x0218cd7c
 	bl func_ov00_020bc46c
 	cmp r0, #1
 	bne _0218ce34
-	mov r0, sl
+	mov r0, r10
 	bl _ZN5Actor16XzDistanceToLinkEv
 	str r0, [r7]
-	mov r0, sl
+	mov r0, r10
 	bl _ZN5Actor14GetAngleToLinkEv
 	strh r0, [r6]
 	ldr r0, _0218cf88 ; =data_027e0f94
-	ldr r1, [sl, #0x3c0]
+	ldr r1, [r10, #0x3c0]
 	ldr r11, [r0]
 	cmp r1, #0
 	ldmib r0, {r4, r5}
@@ -4159,22 +4159,22 @@ func_ov43_0218cd7c: ; 0x0218cd7c
 	strh r1, [r8]
 	b _0218ceac
 _0218cdfc:
-	add r0, sl, #0x48
+	add r0, r10, #0x48
 	add r1, r1, #0x48
 	bl func_ov00_020ce2f0
 	str r0, [sb]
-	ldr r1, [sl, #0x3c0]
-	mov r0, sl
+	ldr r1, [r10, #0x3c0]
+	mov r0, r10
 	add r1, r1, #0x48
 	bl _ZN5Actor10GetAngleToEP5Vec3p
 	strh r0, [r8]
-	ldr r2, [sl, #0x3c0]
+	ldr r2, [r10, #0x3c0]
 	ldr r0, [r2, #0x48]
 	ldr r1, [r2, #0x4c]
 	ldr r3, [r2, #0x50]
 	b _0218ceac
 _0218ce34:
-	ldr r1, [sl, #0x3c0]
+	ldr r1, [r10, #0x3c0]
 	cmp r1, #0
 	bne _0218ce58
 	mvn r11, #0x80000000
@@ -4184,40 +4184,40 @@ _0218ce34:
 	strh r4, [r6]
 	b _0218ce8c
 _0218ce58:
-	add r0, sl, #0x48
+	add r0, r10, #0x48
 	add r1, r1, #0x48
 	bl func_ov00_020ce2f0
 	str r0, [r7]
-	ldr r1, [sl, #0x3c0]
-	mov r0, sl
+	ldr r1, [r10, #0x3c0]
+	mov r0, r10
 	add r1, r1, #0x48
 	bl _ZN5Actor10GetAngleToEP5Vec3p
 	strh r0, [r6]
-	ldr r0, [sl, #0x3c0]
+	ldr r0, [r10, #0x3c0]
 	ldr r11, [r0, #0x48]
 	ldr r4, [r0, #0x4c]
 	ldr r5, [r0, #0x50]
 _0218ce8c:
-	mov r0, sl
+	mov r0, r10
 	bl _ZN5Actor16XzDistanceToLinkEv
 	str r0, [sb]
-	mov r0, sl
+	mov r0, r10
 	bl _ZN5Actor14GetAngleToLinkEv
 	ldr r2, _0218cf88 ; =data_027e0f94
 	strh r0, [r8]
 	ldmia r2, {r0, r1, r3}
 _0218ceac:
-	ldrh r2, [sl, #0x26]
+	ldrh r2, [r10, #0x26]
 	cmp r2, #0
 	beq _0218cf40
-	ldrb r2, [sl, #0x3e6]
+	ldrb r2, [r10, #0x3e6]
 	cmp r2, #0
 	beq _0218cf04
 	ldr r0, _0218cf8c ; =data_027e0e60
 	str r11, [sp, #0xc]
 	str r4, [sp, #0x10]
 	str r5, [sp, #0x14]
-	ldrh r1, [sl, #0x26]
+	ldrh r1, [r10, #0x26]
 	ldr r0, [r0]
 	add r2, sp, #0xc
 	bl func_ov00_02083770
@@ -4228,14 +4228,14 @@ _0218ceac:
 	beq _0218cf40
 	add sp, sp, #0x18
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0218cf04:
 	ldr r2, _0218cf8c ; =data_027e0e60
 	str r0, [sp]
 	ldr r0, [r2]
 	str r3, [sp, #8]
 	str r1, [sp, #4]
-	ldrh r1, [sl, #0x26]
+	ldrh r1, [r10, #0x26]
 	add r2, sp, #0
 	bl func_ov00_02083770
 	cmp r0, #0
@@ -4244,9 +4244,9 @@ _0218cf04:
 	cmp r0, #0
 	addne sp, sp, #0x18
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0218cf40:
-	ldrb r0, [sl, #0x3e6]
+	ldrb r0, [r10, #0x3e6]
 	cmp r0, #0
 	bne _0218cf64
 	ldr r0, [sb]
@@ -4254,17 +4254,17 @@ _0218cf40:
 	ble _0218cf78
 	add sp, sp, #0x18
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0218cf64:
 	ldr r0, [r7]
 	cmp r0, #0x7000
 	addgt sp, sp, #0x18
 	movgt r0, #0
-	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0218cf78:
 	mov r0, #1
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov43_0218cd7c
 _0218cf84: .word data_027e0fc8

--- a/asm/ov46.s
+++ b/asm/ov46.s
@@ -1960,7 +1960,7 @@ _02191948: .word 0x53574f4e
 	.global func_ov46_0219194c
 	arm_func_start func_ov46_0219194c
 func_ov46_0219194c: ; 0x0219194c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x44
 	mov r7, r0
 	cmp r1, #0
@@ -1968,13 +1968,13 @@ func_ov46_0219194c: ; 0x0219194c
 	ldreqb r0, [r7, #0xa4]
 	cmp r0, #0
 	addeq sp, sp, #0x44
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r0, r7, #0x1d8
 	bl func_ov00_020c5f1c
 	ldr r3, [r7, #0x45c]
 	cmp r3, #0
 	addle sp, sp, #0x44
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldrb r0, [r7, #0x4d6]
 	cmp r0, #0
 	beq _02191b38
@@ -2100,7 +2100,7 @@ _02191b68:
 	ldrb r0, [r7, #0x4d7]
 	cmp r0, #0
 	addeq sp, sp, #0x44
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r1, _02191e44 ; =data_ov46_02194c2c
 	add r0, r7, #0x4a0
 	mov r2, #0xc
@@ -2131,12 +2131,12 @@ _02191b68:
 	ldr r0, _02191e4c ; =data_ov46_02194c20
 	str r8, [r7]
 	umull r8, r7, r6, r3
-	ldr fp, [r0]
+	ldr r11, [r0]
 	mla r7, r6, ip, r7
 	mov r5, r6, asr #0x1f
 	adds r6, r8, #0x800
 	mla r7, r5, r3, r7
-	mov r0, fp, asr #0x1f
+	mov r0, r11, asr #0x1f
 	str r0, [sp, #0x18]
 	ldr r0, _02191e4c ; =data_ov46_02194c20
 	adc r5, r7, #0
@@ -2159,9 +2159,9 @@ _02191b68:
 	ldr r4, _02191e48 ; =data_ov46_02194c14
 	str r0, [sp, #0x24]
 	str r5, [r4, #8]
-	umull r6, r5, fp, r3
+	umull r6, r5, r11, r3
 	ldr r0, [sp, #0x1c]
-	mla r5, fp, ip, r5
+	mla r5, r11, ip, r5
 	ldr r4, [sp, #0x18]
 	mov r0, r0, asr #0x1f
 	str r0, [sp, #0x20]
@@ -2271,7 +2271,7 @@ _02191b68:
 	ldr r1, _02191e48 ; =data_ov46_02194c14
 	bl func_ov18_0216941c
 	add sp, sp, #0x44
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov46_0219194c
 _02191e24: .word data_ov46_02194bf8
@@ -3427,7 +3427,7 @@ _02192c8c: .word data_ov46_02194c88
 	.global func_ov46_02192c90
 	arm_func_start func_ov46_02192c90
 func_ov46_02192c90: ; 0x02192c90
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0xc
 	mov r4, r0
 	ldrh r0, [r4, #0x20]
@@ -3485,9 +3485,9 @@ func_ov46_02192c90: ; 0x02192c90
 	str r2, [r0]
 	mla r3, r7, r2, r3
 	adc r2, sb, r3
-	umull ip, fp, r8, r5
-	mla fp, r8, r2, fp
-	mla fp, r7, r5, fp
+	umull ip, r11, r8, r5
+	mla r11, r8, r2, r11
+	mla r11, r7, r5, r11
 	mov r3, r6, lsr #0x10
 	mov r3, r3, lsl #0x10
 	str r6, [r0, #4]
@@ -3501,7 +3501,7 @@ func_ov46_02192c90: ; 0x02192c90
 	mov r3, r3, lsl #0x10
 	str r2, [r0, #4]
 	adds r7, sl, ip
-	adc r2, sb, fp
+	adc r2, sb, r11
 	mov r5, r2, lsr #0x10
 	mov r5, r5, lsl #0x10
 	mov r5, r5, lsr #0x10
@@ -3534,7 +3534,7 @@ func_ov46_02192c90: ; 0x02192c90
 	mov r5, r3, lsl #0x1
 	add r3, r2, #1
 	mov r6, r3, lsl #0x1
-	mov fp, r2, lsl #0x1
+	mov r11, r2, lsl #0x1
 	ldrsh sb, [r0, sb]
 	ldrsh r3, [r0, r8]
 	ldrsh r8, [r0, r7]
@@ -3547,18 +3547,18 @@ func_ov46_02192c90: ; 0x02192c90
 	mov r5, r5, lsr #0xc
 	ldrsh r6, [r0, r6]
 	orr r5, r5, ip, lsl #20
-	ldrsh r0, [r0, fp]
-	adc fp, r2, r1
+	ldrsh r0, [r0, r11]
+	adc r11, r2, r1
 	mov r2, sl, lsr #0xc
-	orr r2, r2, fp, lsl #20
-	smull ip, fp, r2, r0
+	orr r2, r2, r11, lsl #20
+	smull ip, r11, r2, r0
 	smull sl, sb, r7, sb
 	smull r8, r7, r3, r8
 	adds r3, ip, #0x800
-	adc fp, fp, r1
+	adc r11, r11, r1
 	mov r3, r3, lsr #0xc
-	orr r3, r3, fp, lsl #20
-	smull ip, fp, r2, r6
+	orr r3, r3, r11, lsl #20
+	smull ip, r11, r2, r6
 	smull r2, lr, r5, r6
 	adds r2, r2, #0x800
 	adc lr, lr, r1
@@ -3600,7 +3600,7 @@ func_ov46_02192c90: ; 0x02192c90
 	sub r0, r6, r5
 	str r0, [r4, #0x1d8]
 	adds r5, ip, #0x800
-	adc r0, fp, r1
+	adc r0, r11, r1
 	mov r5, r5, lsr #0xc
 	orr r5, r5, r0, lsl #20
 	adds r3, r3, #0x800
@@ -3625,7 +3625,7 @@ func_ov46_02192c90: ; 0x02192c90
 	bl func_ov46_021929b0
 	mov r0, #1
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov46_02192c90
 _02192fac: .word data_ov46_0219448c
@@ -3731,7 +3731,7 @@ func_ov46_021930a8: ; 0x021930a8
 	.global func_ov46_021930e0
 	arm_func_start func_ov46_021930e0
 func_ov46_021930e0: ; 0x021930e0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x40
 	ldr r1, _02193494 ; =data_ov46_0219449c
 	add r3, sp, #0x34
@@ -3760,18 +3760,18 @@ _02193130:
 _02193144:
 	ldr r3, _02193498 ; =data_027e0764
 	ldr r1, [r3]
-	ldmib r3, {r0, r7, fp}
+	ldmib r3, {r0, r7, r11}
 	umull r5, r2, r7, r1
 	mla r2, r7, r0, r2
 	ldr sb, [r3, #0x10]
-	mla r2, fp, r1, r2
+	mla r2, r11, r1, r2
 	adds r5, sb, r5
 	ldr r8, [r3, #0x14]
 	umull r1, r0, r7, r5
 	adc r2, r8, r2
 	mla r0, r7, r2, r0
 	str r5, [r3]
-	mla r0, fp, r5, r0
+	mla r0, r11, r5, r0
 	adds r6, sb, r1
 	adc r0, r8, r0
 	str r0, [sp, #0x2c]
@@ -3829,7 +3829,7 @@ _02193144:
 	str sl, [sp]
 	ldr sl, [sp, #0x2c]
 	mla r0, r7, sl, r0
-	mla r0, fp, r6, r0
+	mla r0, r11, r6, r0
 	str r0, [sp, #4]
 	ldr r0, [sp]
 	adds r6, sb, r0
@@ -3884,25 +3884,25 @@ _02193144:
 	str r0, [sp, #0x24]
 	umull r0, r3, r8, sl
 	adds r0, r0, r1
-	mov fp, r0, lsr #0xc
+	mov r11, r0, lsr #0xc
 	mla r3, r8, sb, r3
 	ldr r0, [sp, #0x18]
 	mla r3, r0, sl, r3
 	adc r0, r3, r2
-	orr fp, fp, r0, lsl #20
+	orr r11, r11, r0, lsl #20
 	ldr r0, [sp, #0x24]
-	sub r0, r0, fp
+	sub r0, r0, r11
 	str r0, [r4, #0x1e0]
 	ldr r0, [sp, #8]
-	umull fp, r3, ip, r5
+	umull r11, r3, ip, r5
 	mla r3, ip, r0, r3
 	ldr r0, [sp, #0x14]
 	mla r3, r0, r5, r3
-	adds r5, fp, r1
+	adds r5, r11, r1
 	adc r0, r3, r2
-	mov fp, r5, lsr #0xc
-	orr fp, fp, r0, lsl #20
-	mov r0, fp, asr #0x1f
+	mov r11, r5, lsr #0xc
+	orr r11, r11, r0, lsl #20
+	mov r0, r11, asr #0x1f
 	str r0, [sp, #0x28]
 	ldr r0, [sp, #0x30]
 	ldr r3, [sp, #0x10]
@@ -3923,20 +3923,20 @@ _02193144:
 	adc r5, ip, r2
 	orr r3, r3, r5, lsl #20
 	smull r5, lr, r0, r7
-	smull r0, ip, fp, r7
+	smull r0, ip, r11, r7
 	adds r0, r0, r1
 	adc ip, ip, r2
 	mov r0, r0, lsr #0xc
 	orr r0, r0, ip, lsl #20
 	add r0, r3, r0
 	str r0, [r4, #0x1e4]
-	umull r3, r0, fp, sl
-	mla r0, fp, sb, r0
-	ldr fp, [sp, #0x28]
-	mla r0, fp, sl, r0
-	adds fp, r3, r1
+	umull r3, r0, r11, sl
+	mla r0, r11, sb, r0
+	ldr r11, [sp, #0x28]
+	mla r0, r11, sl, r0
+	adds r11, r3, r1
 	adc r3, r0, r2
-	mov r0, fp, lsr #0xc
+	mov r0, r11, lsr #0xc
 	adds r5, r5, r1
 	orr r0, r0, r3, lsl #20
 	adc r3, lr, r2
@@ -3969,7 +3969,7 @@ _02193144:
 	mov r0, #2
 	str r0, [r4, #0x12c]
 	add sp, sp, #0x40
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov46_021930e0
 _02193494: .word data_ov46_0219449c
@@ -4043,7 +4043,7 @@ _02193570: .word data_027e0764
 	.global func_ov46_02193574
 	arm_func_start func_ov46_02193574
 func_ov46_02193574: ; 0x02193574
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x78
 	mov r4, r0
 	ldr r1, _02193b14 ; =0x0000019a
@@ -4183,7 +4183,7 @@ _02193710:
 	mla r7, r0, r3, r7
 	str r0, [sp, #0x38]
 	ldr r6, [r1, #0x14]
-	adds fp, lr, r8
+	adds r11, lr, r8
 	ldr r0, _02193b24 ; =0x00004001
 	adc r7, r6, r7
 	umull r0, r8, r7, r0
@@ -4208,7 +4208,7 @@ _02193710:
 	mov r0, sl, asr #0x1f
 	str r0, [sp, #8]
 	ldrsh r0, [r2]
-	str fp, [r1]
+	str r11, [r1]
 	ldrsh r8, [r2, #2]
 	str r0, [sp, #0xc]
 	mov r0, sb, asr #0x1f
@@ -4219,11 +4219,11 @@ _02193710:
 	str r0, [sp, #0x10]
 	mov r0, r8, asr #0x1f
 	str r0, [sp, #0x18]
-	umull r0, r3, r5, fp
+	umull r0, r3, r5, r11
 	str r0, [sp, #4]
 	mla r3, r5, r7, r3
 	ldr r0, [sp, #0x38]
-	mla r3, r0, fp, r3
+	mla r3, r0, r11, r3
 	ldr r0, [sp, #4]
 	adds r0, lr, r0
 	adc r5, r6, r3
@@ -4259,8 +4259,8 @@ _02193710:
 	str r0, [sp, #0x20]
 	mov r0, r5, asr #0x1f
 	str r0, [sp, #0x3c]
-	umull fp, r2, r8, sb
-	adds r3, fp, #0x800
+	umull r11, r2, r8, sb
+	adds r3, r11, #0x800
 	mov r3, r3, lsr #0xc
 	str r3, [sp, #0x24]
 	ldr r3, [sp, #0x14]
@@ -4276,33 +4276,33 @@ _02193710:
 	mov r2, r2, asr #0x1f
 	ldr r3, [sp, #0x24]
 	str r2, [sp, #0x28]
-	umull r2, fp, r3, r5
+	umull r2, r11, r3, r5
 	adds r2, r2, #0x800
 	mov lr, r2, lsr #0xc
 	ldr r2, [sp, #0x3c]
-	mla fp, r3, r2, fp
+	mla r11, r3, r2, r11
 	ldr r2, [sp, #0x28]
 	ldr r3, [sp, #0x1c]
-	mla fp, r2, r5, fp
-	adc r2, fp, ip
+	mla r11, r2, r5, r11
+	adc r2, r11, ip
 	orr lr, lr, r2, lsl #20
-	umull r2, fp, r3, r7
+	umull r2, r11, r3, r7
 	adds r2, r2, #0x800
 	mov r2, r2, lsr #0xc
 	str r2, [sp, #0x2c]
 	mov r2, r3
-	mla fp, r2, r6, fp
+	mla r11, r2, r6, r11
 	ldr r2, [sp, #0x20]
-	mla fp, r2, r7, fp
-	adc r3, fp, ip
+	mla r11, r2, r7, r11
+	adc r3, r11, ip
 	ldr r2, [sp, #0x2c]
-	ldr fp, [sp, #8]
+	ldr r11, [sp, #8]
 	orr r2, r2, r3, lsl #20
 	str r2, [sp, #0x2c]
 	sub r2, lr, r2
 	str r2, [sp, #0x40]
 	umull r3, r2, r8, sl
-	mla r2, r8, fp, r2
+	mla r2, r8, r11, r2
 	ldr r8, [sp, #0x18]
 	mla r2, r8, sl, r2
 	adds r8, r3, #0x800
@@ -4313,19 +4313,19 @@ _02193710:
 	mov r3, r2, asr #0x1f
 	str r3, [sp, #0x30]
 	umull r8, r3, sl, sb
-	mov fp, sl
+	mov r11, sl
 	ldr sl, [sp, #0x14]
 	adds r8, r8, #0x800
-	mla r3, fp, sl, r3
+	mla r3, r11, sl, r3
 	ldr sl, [sp, #0x10]
-	mov fp, r8, lsr #0xc
+	mov r11, r8, lsr #0xc
 	mla r3, sl, sb, r3
 	adc r3, r3, ip
-	orr fp, fp, r3, lsl #20
-	umull sb, r8, fp, r7
+	orr r11, r11, r3, lsl #20
+	umull sb, r8, r11, r7
 	adds r3, sb, #0x800
-	mla r8, fp, r6, r8
-	mov sl, fp, asr #0x1f
+	mla r8, r11, r6, r8
+	mov sl, r11, asr #0x1f
 	mla r8, sl, r7, r8
 	mov sb, r3, lsr #0xc
 	adc r3, r8, ip
@@ -4353,8 +4353,8 @@ _02193710:
 	adc r2, r3, ip
 	mov r8, r8, lsr #0xc
 	orr r8, r8, r2, lsl #20
-	umull r3, r2, fp, r5
-	mla r2, fp, sb, r2
+	umull r3, r2, r11, r5
+	mla r2, r11, sb, r2
 	adds r3, r3, #0x800
 	mla r2, sl, r5, r2
 	adc r2, r2, ip
@@ -4401,12 +4401,12 @@ _02193ad4:
 	add r0, r0, #0x14000
 	cmp r1, r0
 	addlt sp, sp, #0x78
-	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r0, r4, #0x15c
 	mov r1, #4
 	bl func_ov46_02192a0c
 	add sp, sp, #0x78
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov46_02193574
 _02193b14: .word 0x0000019a
@@ -4884,9 +4884,9 @@ _021940d8:
 	.global func_ov46_0219416c
 	arm_func_start func_ov46_0219416c
 func_ov46_0219416c: ; 0x0219416c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x34
-	ldr fp, _021942ec ; =data_027e0764
+	ldr r11, _021942ec ; =data_027e0764
 	mov r6, r0
 	mov r5, #0
 	add r4, sp, #0x10
@@ -4926,17 +4926,17 @@ _02194184:
 	ldr sl, [sp, #0x10]
 	cmp sl, #0
 	bne _02194264
-	ldr r2, [fp]
-	ldmib fp, {r0, ip}
+	ldr r2, [r11]
+	ldmib r11, {r0, ip}
 	umull r7, lr, ip, r2
 	mla lr, ip, r0, lr
-	ldr r3, [fp, #0xc]
-	ldr sb, [fp, #0x10]
+	ldr r3, [r11, #0xc]
+	ldr sb, [r11, #0x10]
 	mla lr, r3, r2, lr
-	ldr r8, [fp, #0x14]
+	ldr r8, [r11, #0x14]
 	adds r0, sb, r7
 	adc r2, r8, lr
-	stmia fp, {r0, r2}
+	stmia r11, {r0, r2}
 	mov r0, #0x53
 	umull r0, r3, r2, r0
 	mov r0, #0
@@ -4982,7 +4982,7 @@ _021942d8:
 	cmp r5, #4
 	blt _02194184
 	add sp, sp, #0x34
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov46_0219416c
 _021942ec: .word data_027e0764

--- a/asm/ov46.s
+++ b/asm/ov46.s
@@ -1960,7 +1960,7 @@ _02191948: .word 0x53574f4e
 	.global func_ov46_0219194c
 	arm_func_start func_ov46_0219194c
 func_ov46_0219194c: ; 0x0219194c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x44
 	mov r7, r0
 	cmp r1, #0
@@ -1968,13 +1968,13 @@ func_ov46_0219194c: ; 0x0219194c
 	ldreqb r0, [r7, #0xa4]
 	cmp r0, #0
 	addeq sp, sp, #0x44
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r0, r7, #0x1d8
 	bl func_ov00_020c5f1c
 	ldr r3, [r7, #0x45c]
 	cmp r3, #0
 	addle sp, sp, #0x44
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldrb r0, [r7, #0x4d6]
 	cmp r0, #0
 	beq _02191b38
@@ -2100,7 +2100,7 @@ _02191b68:
 	ldrb r0, [r7, #0x4d7]
 	cmp r0, #0
 	addeq sp, sp, #0x44
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r1, _02191e44 ; =data_ov46_02194c2c
 	add r0, r7, #0x4a0
 	mov r2, #0xc
@@ -2118,13 +2118,13 @@ _02191b68:
 	ldr r8, [r0]
 	ldr r6, [r0, #4]
 	mov ip, #0
-	umull r10, sb, r8, r3
-	mla sb, r8, ip, sb
+	umull r10, r9, r8, r3
+	mla r9, r8, ip, r9
 	mov r7, r8, asr #0x1f
 	ldr r4, [r0, #8]
 	adds r8, r10, #0x800
-	mla sb, r7, r3, sb
-	adc r7, sb, #0
+	mla r9, r7, r3, r9
+	adc r7, r9, #0
 	mov r8, r8, lsr #0xc
 	orr r8, r8, r7, lsl #20
 	ldr r7, _02191e48 ; =data_ov46_02194c14
@@ -2271,7 +2271,7 @@ _02191b68:
 	ldr r1, _02191e48 ; =data_ov46_02194c14
 	bl func_ov18_0216941c
 	add sp, sp, #0x44
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov46_0219194c
 _02191e24: .word data_ov46_02194bf8
@@ -3427,7 +3427,7 @@ _02192c8c: .word data_ov46_02194c88
 	.global func_ov46_02192c90
 	arm_func_start func_ov46_02192c90
 func_ov46_02192c90: ; 0x02192c90
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0xc
 	mov r4, r0
 	ldrh r0, [r4, #0x20]
@@ -3476,15 +3476,15 @@ func_ov46_02192c90: ; 0x02192c90
 	ldr r7, [r0, #0xc]
 	ldr r10, [r0, #0x10]
 	mla r5, r7, r3, r5
-	ldr sb, [r0, #0x14]
+	ldr r9, [r0, #0x14]
 	adds r2, r10, r6
-	adc r6, sb, r5
+	adc r6, r9, r5
 	umull r5, r3, r8, r2
 	mla r3, r8, r6, r3
 	adds r5, r10, r5
 	str r2, [r0]
 	mla r3, r7, r2, r3
-	adc r2, sb, r3
+	adc r2, r9, r3
 	umull ip, r11, r8, r5
 	mla r11, r8, r2, r11
 	mla r11, r7, r5, r11
@@ -3501,7 +3501,7 @@ func_ov46_02192c90: ; 0x02192c90
 	mov r3, r3, lsl #0x10
 	str r2, [r0, #4]
 	adds r7, r10, ip
-	adc r2, sb, r11
+	adc r2, r9, r11
 	mov r5, r2, lsr #0x10
 	mov r5, r5, lsl #0x10
 	mov r5, r5, lsr #0x10
@@ -3528,18 +3528,18 @@ func_ov46_02192c90: ; 0x02192c90
 	add r5, r6, #1
 	add r3, r7, #1
 	ldr r0, _02192fbc ; =data_02050f54
-	mov sb, r6, lsl #0x1
+	mov r9, r6, lsl #0x1
 	mov r8, r7, lsl #0x1
 	mov r7, r5, lsl #0x1
 	mov r5, r3, lsl #0x1
 	add r3, r2, #1
 	mov r6, r3, lsl #0x1
 	mov r11, r2, lsl #0x1
-	ldrsh sb, [r0, sb]
+	ldrsh r9, [r0, r9]
 	ldrsh r3, [r0, r8]
 	ldrsh r8, [r0, r7]
 	ldrsh r7, [r0, r5]
-	smull r2, ip, r3, sb
+	smull r2, ip, r3, r9
 	adds r5, r2, #0x800
 	smull r10, r2, r7, r8
 	adc ip, ip, r1
@@ -3552,7 +3552,7 @@ func_ov46_02192c90: ; 0x02192c90
 	mov r2, r10, lsr #0xc
 	orr r2, r2, r11, lsl #20
 	smull ip, r11, r2, r0
-	smull r10, sb, r7, sb
+	smull r10, r9, r7, r9
 	smull r8, r7, r3, r8
 	adds r3, ip, #0x800
 	adc r11, r11, r1
@@ -3567,22 +3567,22 @@ func_ov46_02192c90: ; 0x02192c90
 	sub r2, r3, r2
 	str r2, [r4, #0x1d0]
 	adds r3, r10, #0x800
-	adc r2, sb, r1
+	adc r2, r9, r1
 	mov r10, r3, lsr #0xc
 	orr r10, r10, r2, lsl #20
 	adds r3, r8, #0x800
 	adc r2, r7, r1
-	mov sb, r3, lsr #0xc
-	orr sb, sb, r2, lsl #20
+	mov r9, r3, lsr #0xc
+	orr r9, r9, r2, lsl #20
 	smull r3, r2, r5, r0
-	smull r7, r5, sb, r6
+	smull r7, r5, r9, r6
 	adds r7, r7, #0x800
 	adc r5, r5, r1
 	mov r8, r7, lsr #0xc
 	orr r8, r8, r5, lsl #20
 	smull r5, lr, r10, r6
 	smull r7, r6, r10, r0
-	smull r10, r0, sb, r0
+	smull r10, r0, r9, r0
 	adds r7, r7, #0x800
 	adc r6, r6, r1
 	mov r7, r7, lsr #0xc
@@ -3625,7 +3625,7 @@ func_ov46_02192c90: ; 0x02192c90
 	bl func_ov46_021929b0
 	mov r0, #1
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov46_02192c90
 _02192fac: .word data_ov46_0219448c
@@ -3731,7 +3731,7 @@ func_ov46_021930a8: ; 0x021930a8
 	.global func_ov46_021930e0
 	arm_func_start func_ov46_021930e0
 func_ov46_021930e0: ; 0x021930e0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x40
 	ldr r1, _02193494 ; =data_ov46_0219449c
 	add r3, sp, #0x34
@@ -3763,16 +3763,16 @@ _02193144:
 	ldmib r3, {r0, r7, r11}
 	umull r5, r2, r7, r1
 	mla r2, r7, r0, r2
-	ldr sb, [r3, #0x10]
+	ldr r9, [r3, #0x10]
 	mla r2, r11, r1, r2
-	adds r5, sb, r5
+	adds r5, r9, r5
 	ldr r8, [r3, #0x14]
 	umull r1, r0, r7, r5
 	adc r2, r8, r2
 	mla r0, r7, r2, r0
 	str r5, [r3]
 	mla r0, r11, r5, r0
-	adds r6, sb, r1
+	adds r6, r9, r1
 	adc r0, r8, r0
 	str r0, [sp, #0x2c]
 	mov r0, r2, lsr #0x10
@@ -3832,7 +3832,7 @@ _02193144:
 	mla r0, r11, r6, r0
 	str r0, [sp, #4]
 	ldr r0, [sp]
-	adds r6, sb, r0
+	adds r6, r9, r0
 	ldr r0, [sp, #4]
 	str r6, [r3]
 	adc r0, r8, r0
@@ -3858,7 +3858,7 @@ _02193144:
 	mov r8, r7, lsr #0xc
 	orr r8, r8, r3, lsl #20
 	mov r3, r8, asr #0x1f
-	mov sb, r10, asr #0x1f
+	mov r9, r10, asr #0x1f
 	str r3, [sp, #0x18]
 	mov r3, r0, lsl #0x1
 	ldr r0, _0219349c ; =data_02050f54
@@ -3885,7 +3885,7 @@ _02193144:
 	umull r0, r3, r8, r10
 	adds r0, r0, r1
 	mov r11, r0, lsr #0xc
-	mla r3, r8, sb, r3
+	mla r3, r8, r9, r3
 	ldr r0, [sp, #0x18]
 	mla r3, r0, r10, r3
 	adc r0, r3, r2
@@ -3916,7 +3916,7 @@ _02193144:
 	orr r0, r0, r3, lsl #20
 	umull r3, ip, r0, r10
 	adds r3, r3, r1
-	mla ip, r0, sb, ip
+	mla ip, r0, r9, ip
 	mov r5, r0, asr #0x1f
 	mla ip, r5, r10, ip
 	mov r3, r3, lsr #0xc
@@ -3931,7 +3931,7 @@ _02193144:
 	add r0, r3, r0
 	str r0, [r4, #0x1e4]
 	umull r3, r0, r11, r10
-	mla r0, r11, sb, r0
+	mla r0, r11, r9, r0
 	ldr r11, [sp, #0x28]
 	mla r0, r11, r10, r0
 	adds r11, r3, r1
@@ -3945,7 +3945,7 @@ _02193144:
 	sub r0, r0, r5
 	umull r5, r3, r6, r10
 	str r0, [r4, #0x1e8]
-	mla r3, r6, sb, r3
+	mla r3, r6, r9, r3
 	ldr r0, [sp, #0x20]
 	mla r3, r0, r10, r3
 	adds r0, r5, r1
@@ -3969,7 +3969,7 @@ _02193144:
 	mov r0, #2
 	str r0, [r4, #0x12c]
 	add sp, sp, #0x40
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov46_021930e0
 _02193494: .word data_ov46_0219449c
@@ -4043,7 +4043,7 @@ _02193570: .word data_027e0764
 	.global func_ov46_02193574
 	arm_func_start func_ov46_02193574
 func_ov46_02193574: ; 0x02193574
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x78
 	mov r4, r0
 	ldr r1, _02193b14 ; =0x0000019a
@@ -4204,14 +4204,14 @@ _02193710:
 	ldrsh r10, [r2, r0]
 	add r0, r3, #1
 	mov r0, r0, lsl #0x1
-	ldrsh sb, [r2, r0]
+	ldrsh r9, [r2, r0]
 	mov r0, r10, asr #0x1f
 	str r0, [sp, #8]
 	ldrsh r0, [r2]
 	str r11, [r1]
 	ldrsh r8, [r2, #2]
 	str r0, [sp, #0xc]
-	mov r0, sb, asr #0x1f
+	mov r0, r9, asr #0x1f
 	str r0, [sp, #0x14]
 	ldr r0, [sp, #0xc]
 	str r7, [r1, #4]
@@ -4259,7 +4259,7 @@ _02193710:
 	str r0, [sp, #0x20]
 	mov r0, r5, asr #0x1f
 	str r0, [sp, #0x3c]
-	umull r11, r2, r8, sb
+	umull r11, r2, r8, r9
 	adds r3, r11, #0x800
 	mov r3, r3, lsr #0xc
 	str r3, [sp, #0x24]
@@ -4268,7 +4268,7 @@ _02193710:
 	mla r2, r8, r3, r2
 	ldr r3, [sp, #0x18]
 	add r1, sp, #0x40
-	mla r2, r3, sb, r2
+	mla r2, r3, r9, r2
 	adc r3, r2, ip
 	ldr r2, [sp, #0x24]
 	orr r2, r2, r3, lsl #20
@@ -4312,25 +4312,25 @@ _02193710:
 	ldr r10, [sp, #0xc]
 	mov r3, r2, asr #0x1f
 	str r3, [sp, #0x30]
-	umull r8, r3, r10, sb
+	umull r8, r3, r10, r9
 	mov r11, r10
 	ldr r10, [sp, #0x14]
 	adds r8, r8, #0x800
 	mla r3, r11, r10, r3
 	ldr r10, [sp, #0x10]
 	mov r11, r8, lsr #0xc
-	mla r3, r10, sb, r3
+	mla r3, r10, r9, r3
 	adc r3, r3, ip
 	orr r11, r11, r3, lsl #20
-	umull sb, r8, r11, r7
-	adds r3, sb, #0x800
+	umull r9, r8, r11, r7
+	adds r3, r9, #0x800
 	mla r8, r11, r6, r8
 	mov r10, r11, asr #0x1f
 	mla r8, r10, r7, r8
-	mov sb, r3, lsr #0xc
+	mov r9, r3, lsr #0xc
 	adc r3, r8, ip
 	umull r8, lr, r2, r5
-	orr sb, sb, r3, lsl #20
+	orr r9, r9, r3, lsl #20
 	adds r3, r8, #0x800
 	mov r3, r3, lsr #0xc
 	str r3, [sp, #0x34]
@@ -4342,19 +4342,19 @@ _02193710:
 	adc r8, lr, ip
 	orr r3, r3, r8, lsl #20
 	str r3, [sp, #0x34]
-	add r3, sb, r3
+	add r3, r9, r3
 	str r3, [sp, #0x44]
 	umull r8, r3, r2, r7
 	mla r3, r2, r6, r3
 	ldr r2, [sp, #0x30]
 	adds r8, r8, #0x800
 	mla r3, r2, r7, r3
-	ldr sb, [sp, #0x3c]
+	ldr r9, [sp, #0x3c]
 	adc r2, r3, ip
 	mov r8, r8, lsr #0xc
 	orr r8, r8, r2, lsl #20
 	umull r3, r2, r11, r5
-	mla r2, r11, sb, r2
+	mla r2, r11, r9, r2
 	adds r3, r3, #0x800
 	mla r2, r10, r5, r2
 	adc r2, r2, ip
@@ -4363,12 +4363,12 @@ _02193710:
 	sub r2, r8, r3
 	str r2, [sp, #0x48]
 	ldr r2, [sp, #0x24]
-	mov sb, #0x800
+	mov r9, #0x800
 	umull r8, r3, r2, r7
 	mla r3, r2, r6, r3
 	ldr r2, [sp, #0x28]
 	mla r3, r2, r7, r3
-	mov r2, sb
+	mov r2, r9
 	adds r2, r8, r2
 	adc r3, r3, ip
 	mov r2, r2, lsr #0xc
@@ -4380,7 +4380,7 @@ _02193710:
 	mla r7, r6, r3, r7
 	ldr r3, [sp, #0x20]
 	mla r7, r3, r5, r7
-	mov r3, sb
+	mov r3, r9
 	adds r5, r8, r3
 	adc r3, r7, ip
 	mov r5, r5, lsr #0xc
@@ -4401,12 +4401,12 @@ _02193ad4:
 	add r0, r0, #0x14000
 	cmp r1, r0
 	addlt sp, sp, #0x78
-	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmltia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r0, r4, #0x15c
 	mov r1, #4
 	bl func_ov46_02192a0c
 	add sp, sp, #0x78
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov46_02193574
 _02193b14: .word 0x0000019a
@@ -4884,7 +4884,7 @@ _021940d8:
 	.global func_ov46_0219416c
 	arm_func_start func_ov46_0219416c
 func_ov46_0219416c: ; 0x0219416c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x34
 	ldr r11, _021942ec ; =data_027e0764
 	mov r6, r0
@@ -4931,10 +4931,10 @@ _02194184:
 	umull r7, lr, ip, r2
 	mla lr, ip, r0, lr
 	ldr r3, [r11, #0xc]
-	ldr sb, [r11, #0x10]
+	ldr r9, [r11, #0x10]
 	mla lr, r3, r2, lr
 	ldr r8, [r11, #0x14]
-	adds r0, sb, r7
+	adds r0, r9, r7
 	adc r2, r8, lr
 	stmia r11, {r0, r2}
 	mov r0, #0x53
@@ -4982,7 +4982,7 @@ _021942d8:
 	cmp r5, #4
 	blt _02194184
 	add sp, sp, #0x34
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov46_0219416c
 _021942ec: .word data_027e0764

--- a/asm/ov46.s
+++ b/asm/ov46.s
@@ -1960,7 +1960,7 @@ _02191948: .word 0x53574f4e
 	.global func_ov46_0219194c
 	arm_func_start func_ov46_0219194c
 func_ov46_0219194c: ; 0x0219194c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x44
 	mov r7, r0
 	cmp r1, #0
@@ -1968,13 +1968,13 @@ func_ov46_0219194c: ; 0x0219194c
 	ldreqb r0, [r7, #0xa4]
 	cmp r0, #0
 	addeq sp, sp, #0x44
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	add r0, r7, #0x1d8
 	bl func_ov00_020c5f1c
 	ldr r3, [r7, #0x45c]
 	cmp r3, #0
 	addle sp, sp, #0x44
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldrb r0, [r7, #0x4d6]
 	cmp r0, #0
 	beq _02191b38
@@ -2100,7 +2100,7 @@ _02191b68:
 	ldrb r0, [r7, #0x4d7]
 	cmp r0, #0
 	addeq sp, sp, #0x44
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r1, _02191e44 ; =data_ov46_02194c2c
 	add r0, r7, #0x4a0
 	mov r2, #0xc
@@ -2118,11 +2118,11 @@ _02191b68:
 	ldr r8, [r0]
 	ldr r6, [r0, #4]
 	mov ip, #0
-	umull sl, sb, r8, r3
+	umull r10, sb, r8, r3
 	mla sb, r8, ip, sb
 	mov r7, r8, asr #0x1f
 	ldr r4, [r0, #8]
-	adds r8, sl, #0x800
+	adds r8, r10, #0x800
 	mla sb, r7, r3, sb
 	adc r7, sb, #0
 	mov r8, r8, lsr #0xc
@@ -2271,7 +2271,7 @@ _02191b68:
 	ldr r1, _02191e48 ; =data_ov46_02194c14
 	bl func_ov18_0216941c
 	add sp, sp, #0x44
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov46_0219194c
 _02191e24: .word data_ov46_02194bf8
@@ -3427,7 +3427,7 @@ _02192c8c: .word data_ov46_02194c88
 	.global func_ov46_02192c90
 	arm_func_start func_ov46_02192c90
 func_ov46_02192c90: ; 0x02192c90
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0xc
 	mov r4, r0
 	ldrh r0, [r4, #0x20]
@@ -3474,14 +3474,14 @@ func_ov46_02192c90: ; 0x02192c90
 	umull r6, r5, r8, r3
 	mla r5, r8, r2, r5
 	ldr r7, [r0, #0xc]
-	ldr sl, [r0, #0x10]
+	ldr r10, [r0, #0x10]
 	mla r5, r7, r3, r5
 	ldr sb, [r0, #0x14]
-	adds r2, sl, r6
+	adds r2, r10, r6
 	adc r6, sb, r5
 	umull r5, r3, r8, r2
 	mla r3, r8, r6, r3
-	adds r5, sl, r5
+	adds r5, r10, r5
 	str r2, [r0]
 	mla r3, r7, r2, r3
 	adc r2, sb, r3
@@ -3500,7 +3500,7 @@ func_ov46_02192c90: ; 0x02192c90
 	mov r3, r3, lsr #0x10
 	mov r3, r3, lsl #0x10
 	str r2, [r0, #4]
-	adds r7, sl, ip
+	adds r7, r10, ip
 	adc r2, sb, r11
 	mov r5, r2, lsr #0x10
 	mov r5, r5, lsl #0x10
@@ -3541,18 +3541,18 @@ func_ov46_02192c90: ; 0x02192c90
 	ldrsh r7, [r0, r5]
 	smull r2, ip, r3, sb
 	adds r5, r2, #0x800
-	smull sl, r2, r7, r8
+	smull r10, r2, r7, r8
 	adc ip, ip, r1
-	adds sl, sl, #0x800
+	adds r10, r10, #0x800
 	mov r5, r5, lsr #0xc
 	ldrsh r6, [r0, r6]
 	orr r5, r5, ip, lsl #20
 	ldrsh r0, [r0, r11]
 	adc r11, r2, r1
-	mov r2, sl, lsr #0xc
+	mov r2, r10, lsr #0xc
 	orr r2, r2, r11, lsl #20
 	smull ip, r11, r2, r0
-	smull sl, sb, r7, sb
+	smull r10, sb, r7, sb
 	smull r8, r7, r3, r8
 	adds r3, ip, #0x800
 	adc r11, r11, r1
@@ -3566,10 +3566,10 @@ func_ov46_02192c90: ; 0x02192c90
 	orr r2, r2, lr, lsl #20
 	sub r2, r3, r2
 	str r2, [r4, #0x1d0]
-	adds r3, sl, #0x800
+	adds r3, r10, #0x800
 	adc r2, sb, r1
-	mov sl, r3, lsr #0xc
-	orr sl, sl, r2, lsl #20
+	mov r10, r3, lsr #0xc
+	orr r10, r10, r2, lsl #20
 	adds r3, r8, #0x800
 	adc r2, r7, r1
 	mov sb, r3, lsr #0xc
@@ -3580,9 +3580,9 @@ func_ov46_02192c90: ; 0x02192c90
 	adc r5, r5, r1
 	mov r8, r7, lsr #0xc
 	orr r8, r8, r5, lsl #20
-	smull r5, lr, sl, r6
-	smull r7, r6, sl, r0
-	smull sl, r0, sb, r0
+	smull r5, lr, r10, r6
+	smull r7, r6, r10, r0
+	smull r10, r0, sb, r0
 	adds r7, r7, #0x800
 	adc r6, r6, r1
 	mov r7, r7, lsr #0xc
@@ -3593,7 +3593,7 @@ func_ov46_02192c90: ; 0x02192c90
 	adc r5, lr, r1
 	mov r6, r6, lsr #0xc
 	orr r6, r6, r5, lsl #20
-	adds r5, sl, #0x800
+	adds r5, r10, #0x800
 	adc r0, r0, r1
 	mov r5, r5, lsr #0xc
 	orr r5, r5, r0, lsl #20
@@ -3625,7 +3625,7 @@ func_ov46_02192c90: ; 0x02192c90
 	bl func_ov46_021929b0
 	mov r0, #1
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov46_02192c90
 _02192fac: .word data_ov46_0219448c
@@ -3731,7 +3731,7 @@ func_ov46_021930a8: ; 0x021930a8
 	.global func_ov46_021930e0
 	arm_func_start func_ov46_021930e0
 func_ov46_021930e0: ; 0x021930e0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x40
 	ldr r1, _02193494 ; =data_ov46_0219449c
 	add r3, sp, #0x34
@@ -3825,10 +3825,10 @@ _02193144:
 	str r0, [sp, #0x10]
 	mov r0, ip, asr #0x1f
 	str r0, [sp, #0x14]
-	umull sl, r0, r7, r6
-	str sl, [sp]
-	ldr sl, [sp, #0x2c]
-	mla r0, r7, sl, r0
+	umull r10, r0, r7, r6
+	str r10, [sp]
+	ldr r10, [sp, #0x2c]
+	mla r0, r7, r10, r0
 	mla r0, r11, r6, r0
 	str r0, [sp, #4]
 	ldr r0, [sp]
@@ -3850,7 +3850,7 @@ _02193144:
 	add r3, r0, #1
 	mov r6, r3, lsl #0x1
 	ldr r3, _0219349c ; =data_02050f54
-	ldrsh sl, [r3, r6]
+	ldrsh r10, [r3, r6]
 	ldr r3, [sp, #0x30]
 	smull r7, r6, r3, r5
 	adds r7, r7, #0x800
@@ -3858,7 +3858,7 @@ _02193144:
 	mov r8, r7, lsr #0xc
 	orr r8, r8, r3, lsl #20
 	mov r3, r8, asr #0x1f
-	mov sb, sl, asr #0x1f
+	mov sb, r10, asr #0x1f
 	str r3, [sp, #0x18]
 	mov r3, r0, lsl #0x1
 	ldr r0, _0219349c ; =data_02050f54
@@ -3882,12 +3882,12 @@ _02193144:
 	mov r3, r3, lsr #0xc
 	orr r0, r3, r0, lsl #20
 	str r0, [sp, #0x24]
-	umull r0, r3, r8, sl
+	umull r0, r3, r8, r10
 	adds r0, r0, r1
 	mov r11, r0, lsr #0xc
 	mla r3, r8, sb, r3
 	ldr r0, [sp, #0x18]
-	mla r3, r0, sl, r3
+	mla r3, r0, r10, r3
 	adc r0, r3, r2
 	orr r11, r11, r0, lsl #20
 	ldr r0, [sp, #0x24]
@@ -3914,11 +3914,11 @@ _02193144:
 	adc r3, r5, r2
 	mov r0, r0, lsr #0xc
 	orr r0, r0, r3, lsl #20
-	umull r3, ip, r0, sl
+	umull r3, ip, r0, r10
 	adds r3, r3, r1
 	mla ip, r0, sb, ip
 	mov r5, r0, asr #0x1f
-	mla ip, r5, sl, ip
+	mla ip, r5, r10, ip
 	mov r3, r3, lsr #0xc
 	adc r5, ip, r2
 	orr r3, r3, r5, lsl #20
@@ -3930,10 +3930,10 @@ _02193144:
 	orr r0, r0, ip, lsl #20
 	add r0, r3, r0
 	str r0, [r4, #0x1e4]
-	umull r3, r0, r11, sl
+	umull r3, r0, r11, r10
 	mla r0, r11, sb, r0
 	ldr r11, [sp, #0x28]
-	mla r0, r11, sl, r0
+	mla r0, r11, r10, r0
 	adds r11, r3, r1
 	adc r3, r0, r2
 	mov r0, r11, lsr #0xc
@@ -3943,11 +3943,11 @@ _02193144:
 	mov r5, r5, lsr #0xc
 	orr r5, r5, r3, lsl #20
 	sub r0, r0, r5
-	umull r5, r3, r6, sl
+	umull r5, r3, r6, r10
 	str r0, [r4, #0x1e8]
 	mla r3, r6, sb, r3
 	ldr r0, [sp, #0x20]
-	mla r3, r0, sl, r3
+	mla r3, r0, r10, r3
 	adds r0, r5, r1
 	adc r3, r3, r2
 	mov r0, r0, lsr #0xc
@@ -3969,7 +3969,7 @@ _02193144:
 	mov r0, #2
 	str r0, [r4, #0x12c]
 	add sp, sp, #0x40
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov46_021930e0
 _02193494: .word data_ov46_0219449c
@@ -4043,7 +4043,7 @@ _02193570: .word data_027e0764
 	.global func_ov46_02193574
 	arm_func_start func_ov46_02193574
 func_ov46_02193574: ; 0x02193574
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x78
 	mov r4, r0
 	ldr r1, _02193b14 ; =0x0000019a
@@ -4201,11 +4201,11 @@ _02193710:
 	ldr r2, _02193b28 ; =data_02050f54
 	mov r3, r0, lsl #0x1
 	mov r0, r3, lsl #0x1
-	ldrsh sl, [r2, r0]
+	ldrsh r10, [r2, r0]
 	add r0, r3, #1
 	mov r0, r0, lsl #0x1
 	ldrsh sb, [r2, r0]
-	mov r0, sl, asr #0x1f
+	mov r0, r10, asr #0x1f
 	str r0, [sp, #8]
 	ldrsh r0, [r2]
 	str r11, [r1]
@@ -4249,7 +4249,7 @@ _02193710:
 	ldrsh r5, [r2, r0]
 	ldr r0, [sp, #0xc]
 	mov r6, r7, asr #0x1f
-	smull r2, r1, r0, sl
+	smull r2, r1, r0, r10
 	adds r0, r2, #0x800
 	adc r1, r1, #0
 	mov r0, r0, lsr #0xc
@@ -4301,32 +4301,32 @@ _02193710:
 	str r2, [sp, #0x2c]
 	sub r2, lr, r2
 	str r2, [sp, #0x40]
-	umull r3, r2, r8, sl
+	umull r3, r2, r8, r10
 	mla r2, r8, r11, r2
 	ldr r8, [sp, #0x18]
-	mla r2, r8, sl, r2
+	mla r2, r8, r10, r2
 	adds r8, r3, #0x800
 	adc r3, r2, ip
 	mov r2, r8, lsr #0xc
 	orr r2, r2, r3, lsl #20
-	ldr sl, [sp, #0xc]
+	ldr r10, [sp, #0xc]
 	mov r3, r2, asr #0x1f
 	str r3, [sp, #0x30]
-	umull r8, r3, sl, sb
-	mov r11, sl
-	ldr sl, [sp, #0x14]
+	umull r8, r3, r10, sb
+	mov r11, r10
+	ldr r10, [sp, #0x14]
 	adds r8, r8, #0x800
-	mla r3, r11, sl, r3
-	ldr sl, [sp, #0x10]
+	mla r3, r11, r10, r3
+	ldr r10, [sp, #0x10]
 	mov r11, r8, lsr #0xc
-	mla r3, sl, sb, r3
+	mla r3, r10, sb, r3
 	adc r3, r3, ip
 	orr r11, r11, r3, lsl #20
 	umull sb, r8, r11, r7
 	adds r3, sb, #0x800
 	mla r8, r11, r6, r8
-	mov sl, r11, asr #0x1f
-	mla r8, sl, r7, r8
+	mov r10, r11, asr #0x1f
+	mla r8, r10, r7, r8
 	mov sb, r3, lsr #0xc
 	adc r3, r8, ip
 	umull r8, lr, r2, r5
@@ -4356,7 +4356,7 @@ _02193710:
 	umull r3, r2, r11, r5
 	mla r2, r11, sb, r2
 	adds r3, r3, #0x800
-	mla r2, sl, r5, r2
+	mla r2, r10, r5, r2
 	adc r2, r2, ip
 	mov r3, r3, lsr #0xc
 	orr r3, r3, r2, lsl #20
@@ -4401,12 +4401,12 @@ _02193ad4:
 	add r0, r0, #0x14000
 	cmp r1, r0
 	addlt sp, sp, #0x78
-	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	add r0, r4, #0x15c
 	mov r1, #4
 	bl func_ov46_02192a0c
 	add sp, sp, #0x78
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov46_02193574
 _02193b14: .word 0x0000019a
@@ -4884,7 +4884,7 @@ _021940d8:
 	.global func_ov46_0219416c
 	arm_func_start func_ov46_0219416c
 func_ov46_0219416c: ; 0x0219416c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x34
 	ldr r11, _021942ec ; =data_027e0764
 	mov r6, r0
@@ -4923,8 +4923,8 @@ _02194184:
 	cmp r0, #0
 	beq _021942d8
 	sub r1, r8, r7
-	ldr sl, [sp, #0x10]
-	cmp sl, #0
+	ldr r10, [sp, #0x10]
+	cmp r10, #0
 	bne _02194264
 	ldr r2, [r11]
 	ldmib r11, {r0, ip}
@@ -4945,7 +4945,7 @@ _02194184:
 	mov r0, #0x53
 	mla r3, r2, r0, r3
 	sub r0, r3, #0x29
-	add r0, sl, r0
+	add r0, r10, r0
 	str r0, [sp, #0x10]
 _02194264:
 	mov r0, r4
@@ -4982,7 +4982,7 @@ _021942d8:
 	cmp r5, #4
 	blt _02194184
 	add sp, sp, #0x34
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov46_0219416c
 _021942ec: .word data_027e0764

--- a/asm/ov47.s
+++ b/asm/ov47.s
@@ -697,7 +697,7 @@ _02190910: .word func_ov47_02190914
 	.global func_ov47_02190914
 	arm_func_start func_ov47_02190914
 func_ov47_02190914: ; 0x02190914
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x90
 	mov r4, r0
 	ldrb r1, [r4, #0x17c]
@@ -778,15 +778,15 @@ _02190964:
 	str r7, [r8, #0x60]
 	str r6, [r8, #0x64]
 	str r5, [r8, #0x68]
-	ldrh sl, [r3, #0x76]
+	ldrh r10, [r3, #0x76]
 	add r2, r4, #0x48
 	mov r1, #0x394
-	add sl, sl, #1
-	strh sl, [r3, #0x76]
-	ldrh sl, [sb, #0x76]
+	add r10, r10, #1
+	strh r10, [r3, #0x76]
+	ldrh r10, [sb, #0x76]
 	mov r3, #0
 	str r7, [sp, #0x6c]
-	add r7, sl, #1
+	add r7, r10, #1
 	str r6, [sp, #0x70]
 	str r5, [sp, #0x74]
 	strh r7, [sb, #0x76]
@@ -804,7 +804,7 @@ _02190a84:
 	bl func_ov47_02190e00
 	add sp, sp, #0x90
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02190ab8:
 	ldr r1, [r4, #0x60]
 	add r0, r4, #0x48
@@ -890,7 +890,7 @@ _02190be4:
 	bl func_ov47_02190e00
 	add sp, sp, #0x90
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02190bf8:
 	cmp r2, #0
 	beq _02190dc0
@@ -927,7 +927,7 @@ _02190bf8:
 	bl func_ov47_02190e00
 	add sp, sp, #0x90
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02190c88:
 	add r0, sp, #0x54
 	add r1, sp, #0x60
@@ -962,10 +962,10 @@ _02190c88:
 	umull r8, r7, r2, r6
 	mla r7, r2, r5, r7
 	ldr r1, [ip, #0xc]
-	ldr sl, [ip, #0x10]
+	ldr r10, [ip, #0x10]
 	mla r7, r1, r6, r7
 	ldr sb, [ip, #0x14]
-	adds r1, sl, r8
+	adds r1, r10, r8
 	adc r2, sb, r7
 	ldr r3, _02190df8 ; =0x00001001
 	stmia ip, {r1, r2}
@@ -1010,11 +1010,11 @@ _02190c88:
 _02190dc0:
 	add sp, sp, #0x90
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02190dcc:
 	mov r0, #0
 	add sp, sp, #0x90
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov47_02190914
 _02190dd8: .word 0x42494752
@@ -3627,7 +3627,7 @@ _02193058: .word 0x00000ee1
 	.global func_ov47_0219305c
 	arm_func_start func_ov47_0219305c
 func_ov47_0219305c: ; 0x0219305c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x44
 	mov r4, r0
 	add r0, sp, #0x18
@@ -3650,13 +3650,13 @@ func_ov47_0219305c: ; 0x0219305c
 	mov r0, r0, asr #0x4
 	mov r2, r0, lsl #0x1
 	mov r0, r2, lsl #0x1
-	ldrsh sl, [r1, r0]
+	ldrsh r10, [r1, r0]
 	add r0, r2, #1
 	mov r0, r0, lsl #0x1
 	ldrsh r5, [r1, r0]
 	str sb, [sp, #0xc]
 	ldr r0, [r4, #0x4c]
-	rsb ip, sl, #0
+	rsb ip, r10, #0
 	str r0, [sp, #0x10]
 	add r0, r0, #0xae
 	ldr r8, [r4, #0x50]
@@ -3665,10 +3665,10 @@ func_ov47_0219305c: ; 0x0219305c
 	mov r0, ip, asr #0x1f
 	str r0, [sp, #8]
 	ldr r0, _0219320c ; =0x00000e3d
-	mov r11, sl, asr #0x1f
-	umull r7, r6, sl, r0
+	mov r11, r10, asr #0x1f
+	umull r7, r6, r10, r0
 	mov r0, #0
-	mla r6, sl, r0, r6
+	mla r6, r10, r0, r6
 	ldr r0, _0219320c ; =0x00000e3d
 	adds r7, r7, #0x800
 	mla r6, r11, r0, r6
@@ -3733,7 +3733,7 @@ func_ov47_0219305c: ; 0x0219305c
 	movge r0, #1
 	movlt r0, #0
 	add sp, sp, #0x44
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov47_0219305c
 _02193208: .word data_02050f54

--- a/asm/ov47.s
+++ b/asm/ov47.s
@@ -697,7 +697,7 @@ _02190910: .word func_ov47_02190914
 	.global func_ov47_02190914
 	arm_func_start func_ov47_02190914
 func_ov47_02190914: ; 0x02190914
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x90
 	mov r4, r0
 	ldrb r1, [r4, #0x17c]
@@ -804,7 +804,7 @@ _02190a84:
 	bl func_ov47_02190e00
 	add sp, sp, #0x90
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02190ab8:
 	ldr r1, [r4, #0x60]
 	add r0, r4, #0x48
@@ -890,7 +890,7 @@ _02190be4:
 	bl func_ov47_02190e00
 	add sp, sp, #0x90
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02190bf8:
 	cmp r2, #0
 	beq _02190dc0
@@ -927,7 +927,7 @@ _02190bf8:
 	bl func_ov47_02190e00
 	add sp, sp, #0x90
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02190c88:
 	add r0, sp, #0x54
 	add r1, sp, #0x60
@@ -969,9 +969,9 @@ _02190c88:
 	adc r2, sb, r7
 	ldr r3, _02190df8 ; =0x00001001
 	stmia ip, {r1, r2}
-	mov fp, lr
+	mov r11, lr
 	umull r1, r5, r2, r3
-	mla r5, r2, fp, r5
+	mla r5, r2, r11, r5
 	mla r5, lr, r3, r5
 	add r0, sp, #0x3c
 	bl func_01fffb4c
@@ -1005,16 +1005,16 @@ _02190c88:
 	mov r1, #0x394
 	str r2, [r4, #0x68]
 	add r2, r4, #0x48
-	mov r3, fp
+	mov r3, r11
 	bl func_ov00_020ceacc
 _02190dc0:
 	add sp, sp, #0x90
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02190dcc:
 	mov r0, #0
 	add sp, sp, #0x90
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov47_02190914
 _02190dd8: .word 0x42494752
@@ -3627,7 +3627,7 @@ _02193058: .word 0x00000ee1
 	.global func_ov47_0219305c
 	arm_func_start func_ov47_0219305c
 func_ov47_0219305c: ; 0x0219305c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x44
 	mov r4, r0
 	add r0, sp, #0x18
@@ -3665,13 +3665,13 @@ func_ov47_0219305c: ; 0x0219305c
 	mov r0, ip, asr #0x1f
 	str r0, [sp, #8]
 	ldr r0, _0219320c ; =0x00000e3d
-	mov fp, sl, asr #0x1f
+	mov r11, sl, asr #0x1f
 	umull r7, r6, sl, r0
 	mov r0, #0
 	mla r6, sl, r0, r6
 	ldr r0, _0219320c ; =0x00000e3d
 	adds r7, r7, #0x800
-	mla r6, fp, r0, r6
+	mla r6, r11, r0, r6
 	adc r0, r6, #0
 	mov r6, r7, lsr #0xc
 	orr r6, r6, r0, lsl #20
@@ -3733,7 +3733,7 @@ func_ov47_0219305c: ; 0x0219305c
 	movge r0, #1
 	movlt r0, #0
 	add sp, sp, #0x44
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov47_0219305c
 _02193208: .word data_02050f54

--- a/asm/ov47.s
+++ b/asm/ov47.s
@@ -697,7 +697,7 @@ _02190910: .word func_ov47_02190914
 	.global func_ov47_02190914
 	arm_func_start func_ov47_02190914
 func_ov47_02190914: ; 0x02190914
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x90
 	mov r4, r0
 	ldrb r1, [r4, #0x17c]
@@ -770,7 +770,7 @@ _02190964:
 	add r3, r4, #0x100
 	str r0, [r4, #0x60]
 	ldr r0, [r8, #0x64]
-	add sb, r8, #0x100
+	add r9, r8, #0x100
 	str r0, [r4, #0x64]
 	ldr r1, [r8, #0x68]
 	ldr r0, _02190de0 ; =data_027e0ffc
@@ -783,13 +783,13 @@ _02190964:
 	mov r1, #0x394
 	add r10, r10, #1
 	strh r10, [r3, #0x76]
-	ldrh r10, [sb, #0x76]
+	ldrh r10, [r9, #0x76]
 	mov r3, #0
 	str r7, [sp, #0x6c]
 	add r7, r10, #1
 	str r6, [sp, #0x70]
 	str r5, [sp, #0x74]
-	strh r7, [sb, #0x76]
+	strh r7, [r9, #0x76]
 	bl func_ov00_020ceacc
 _02190a84:
 	ldrb r0, [r4, #0x17c]
@@ -804,7 +804,7 @@ _02190a84:
 	bl func_ov47_02190e00
 	add sp, sp, #0x90
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02190ab8:
 	ldr r1, [r4, #0x60]
 	add r0, r4, #0x48
@@ -890,7 +890,7 @@ _02190be4:
 	bl func_ov47_02190e00
 	add sp, sp, #0x90
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02190bf8:
 	cmp r2, #0
 	beq _02190dc0
@@ -927,7 +927,7 @@ _02190bf8:
 	bl func_ov47_02190e00
 	add sp, sp, #0x90
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02190c88:
 	add r0, sp, #0x54
 	add r1, sp, #0x60
@@ -964,9 +964,9 @@ _02190c88:
 	ldr r1, [ip, #0xc]
 	ldr r10, [ip, #0x10]
 	mla r7, r1, r6, r7
-	ldr sb, [ip, #0x14]
+	ldr r9, [ip, #0x14]
 	adds r1, r10, r8
-	adc r2, sb, r7
+	adc r2, r9, r7
 	ldr r3, _02190df8 ; =0x00001001
 	stmia ip, {r1, r2}
 	mov r11, lr
@@ -1010,11 +1010,11 @@ _02190c88:
 _02190dc0:
 	add sp, sp, #0x90
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02190dcc:
 	mov r0, #0
 	add sp, sp, #0x90
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov47_02190914
 _02190dd8: .word 0x42494752
@@ -3627,7 +3627,7 @@ _02193058: .word 0x00000ee1
 	.global func_ov47_0219305c
 	arm_func_start func_ov47_0219305c
 func_ov47_0219305c: ; 0x0219305c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x44
 	mov r4, r0
 	add r0, sp, #0x18
@@ -3646,7 +3646,7 @@ func_ov47_0219305c: ; 0x0219305c
 	ldrsh r0, [r4, #0x78]
 	strh r0, [sp, #0x2c]
 	ldrh r0, [r4, #0x78]
-	ldr sb, [r4, #0x48]
+	ldr r9, [r4, #0x48]
 	mov r0, r0, asr #0x4
 	mov r2, r0, lsl #0x1
 	mov r0, r2, lsl #0x1
@@ -3654,7 +3654,7 @@ func_ov47_0219305c: ; 0x0219305c
 	add r0, r2, #1
 	mov r0, r0, lsl #0x1
 	ldrsh r5, [r1, r0]
-	str sb, [sp, #0xc]
+	str r9, [sp, #0xc]
 	ldr r0, [r4, #0x4c]
 	rsb ip, r10, #0
 	str r0, [sp, #0x10]
@@ -3676,24 +3676,24 @@ func_ov47_0219305c: ; 0x0219305c
 	mov r6, r7, lsr #0xc
 	orr r6, r6, r0, lsl #20
 	ldr r0, _0219320c ; =0x00000e3d
-	add r6, sb, r6
-	umull r0, sb, r5, r0
+	add r6, r9, r6
+	umull r0, r9, r5, r0
 	mov r7, #0
-	mla sb, r5, r7, sb
+	mla r9, r5, r7, r9
 	adds r0, r0, #0x800
 	ldr r7, _0219320c ; =0x00000e3d
 	mov lr, r5, asr #0x1f
-	mla sb, lr, r7, sb
+	mla r9, lr, r7, r9
 	mov r0, r0, lsr #0xc
-	adc r7, sb, #0
+	adc r7, r9, #0
 	orr r0, r0, r7, lsl #20
 	mov r7, #0x69
 	add r0, r8, r0
-	umull sb, r8, r5, r7
+	umull r9, r8, r5, r7
 	mov r7, #0
 	mla r8, r5, r7, r8
 	mov r5, #0x69
-	adds r7, sb, #0x800
+	adds r7, r9, #0x800
 	mla r8, lr, r5, r8
 	adc r5, r8, #0
 	mov r7, r7, lsr #0xc
@@ -3733,7 +3733,7 @@ func_ov47_0219305c: ; 0x0219305c
 	movge r0, #1
 	movlt r0, #0
 	add sp, sp, #0x44
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov47_0219305c
 _02193208: .word data_02050f54

--- a/asm/ov48.s
+++ b/asm/ov48.s
@@ -169,7 +169,7 @@ func_ov48_02190224: ; 0x02190224
 	.global func_ov48_0219022c
 	arm_func_start func_ov48_0219022c
 func_ov48_0219022c: ; 0x0219022c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #0x1c
 	mov r4, r0
 	ldr r2, [r4, #0x1c]
@@ -216,23 +216,23 @@ _021902c4:
 	add r0, r0, #0x60
 	ldmia r0, {r0, r1, r2}
 	stmia r5, {r0, r1, r2}
-	ldr sl, [sp, #0x10]
+	ldr r10, [sp, #0x10]
 	ldr r2, _02190444 ; =0x00000ccd
 	ldr r7, [sp, #0x14]
-	umull r1, r0, sl, r2
+	umull r1, r0, r10, r2
 	mov ip, #0
-	mla r0, sl, ip, r0
+	mla r0, r10, ip, r0
 	umull sb, r8, r7, r2
-	mov sl, sl, asr #0x1f
+	mov r10, r10, asr #0x1f
 	ldr r5, [sp, #0x18]
-	mla r0, sl, r2, r0
+	mla r0, r10, r2, r0
 	adds r1, r1, #0x800
-	adc sl, r0, #0
+	adc r10, r0, #0
 	mov r0, r1, lsr #0xc
 	adds r1, sb, #0x800
 	mov sb, r1, lsr #0xc
 	umull r6, lr, r5, r2
-	orr r0, r0, sl, lsl #20
+	orr r0, r0, r10, lsl #20
 	mla r8, r7, ip, r8
 	mov r1, r7, asr #0x1f
 	mla r8, r1, r2, r8
@@ -263,12 +263,12 @@ _02190378:
 	add r2, r2, #0x48
 	bl func_ov00_020cec60
 	add sp, sp, #0x1c
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 _021903a0:
 	add r0, r4, #0x17c
 	bl func_ov00_020b7e6c
 	add sp, sp, #0x1c
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 _021903b0:
 	cmp r0, #0
 	beq _02190410
@@ -294,13 +294,13 @@ _021903e8:
 	add r7, r7, #0xc
 	blo _021903e8
 	add sp, sp, #0x1c
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 _02190410:
 	add r5, r4, #0x188
 	add r4, r4, #0x1a0
 	cmp r5, r4
 	addeq sp, sp, #0x1c
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 _02190424:
 	mov r0, r5
 	bl func_ov00_020b7e6c
@@ -308,7 +308,7 @@ _02190424:
 	cmp r5, r4
 	bne _02190424
 	add sp, sp, #0x1c
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov48_0219022c
 _02190440: .word data_027e0e58
@@ -3191,7 +3191,7 @@ _02192600: .word 0x0000013f
 	.global func_ov48_02192604
 	arm_func_start func_ov48_02192604
 func_ov48_02192604: ; 0x02192604
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x88
 	mov sb, r0
 	ldr r0, [sb, #0x130]
@@ -3323,7 +3323,7 @@ _021927dc:
 	str r7, [r3, r5, lsl #2]
 	cmp r8, #3
 	blt _021927a4
-	ldr sl, _02193170 ; =data_027e0f90
+	ldr r10, _02193170 ; =data_027e0f90
 	mov r6, #0
 	add r4, sp, #0x44
 	add r5, sp, #0x60
@@ -3566,7 +3566,7 @@ _02192b5c:
 	mov r0, r8
 	mov r1, r4
 	bl _ZN5Actor9GetHitboxEP8Cylinder
-	ldr r0, [sl]
+	ldr r0, [r10]
 	mov r1, r4
 	bl _ZN10PlayerBase18func_ov00_020a7c1cEP8Cylinder
 	cmp r0, #0
@@ -3614,11 +3614,11 @@ _02192bd0:
 	mov r8, #0
 	cmp r0, #0
 	ble _02192ccc
-	mov sl, #0xc
+	mov r10, #0xc
 	ldr r11, _02193190 ; =0x00000e66
 	add r6, sp, #0x20
 	add r5, sp, #0x14
-	mov r4, sl
+	mov r4, r10
 _02192c34:
 	ldr r1, [sb, #0x340]
 	ldr r0, [sb, #0x338]
@@ -3626,7 +3626,7 @@ _02192c34:
 	sub r0, r0, r8
 	bl func_02002c14
 	ldr r0, [sb, #0x33c]
-	mla r0, r1, sl, r0
+	mla r0, r1, r10, r0
 	ldmia r0, {r0, r1, r2}
 	stmia r6, {r0, r1, r2}
 	mov r0, r6
@@ -3686,7 +3686,7 @@ _02192d10:
 	add r7, r1, #0x400
 	mov r8, #0
 	mov r11, r6
-	add sl, sb, #0xdc
+	add r10, sb, #0xdc
 	add r4, sp, #8
 _02192d38:
 	ldr r1, [sb, #0x138]
@@ -3721,7 +3721,7 @@ _02192da4:
 	cmp r8, #4
 	bne _02192de0
 	mov r2, r4
-	add r0, sl, #0x400
+	add r0, r10, #0x400
 	add r1, sb, #0x4d0
 	bl func_01ff9bf8
 	ldr r0, [sp, #8]
@@ -3979,7 +3979,7 @@ _02193144:
 _02193154:
 	mov r0, #1
 	add sp, sp, #0x88
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov48_02192604
 _02193160: .word gItemManager
@@ -4001,13 +4001,13 @@ _02193198: .word data_027e0e58
 	.global func_ov48_0219319c
 	arm_func_start func_ov48_0219319c
 func_ov48_0219319c: ; 0x0219319c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x90
-	mov sl, r0
-	add r0, sl, #0xe8
+	mov r10, r0
+	add r0, r10, #0xe8
 	mov r1, #0x1800
 	add r8, r0, #0x400
-	add r0, sl, #0xac
+	add r0, r10, #0xac
 	ldr r6, _02193358 ; =data_02050f54
 	mov sb, r8
 	str r1, [sp, #0x84]
@@ -4018,13 +4018,13 @@ func_ov48_0219319c: ; 0x0219319c
 	add r5, sp, #0x84
 	add r11, sp, #0x60
 _021931dc:
-	add r0, sl, r7
+	add r0, r10, r7
 	ldrb r0, [r0, #0x524]
 	cmp r0, #0
 	beq _02193330
 	cmp r7, #0
 	bne _02193240
-	ldrh r1, [sl, #0x78]
+	ldrh r1, [r10, #0x78]
 	mov r0, r11
 	mov r1, r1, asr #0x4
 	mov r2, r1, lsl #0x1
@@ -4033,9 +4033,9 @@ _021931dc:
 	add r2, r6, r2, lsl #1
 	ldrsh r2, [r2, #2]
 	blx func_01ff8214
-	add r0, sl, #0x21c
+	add r0, r10, #0x21c
 	bl func_ov00_020b41ec
-	add r0, sl, #0x21c
+	add r0, r10, #0x21c
 	mov r1, r5
 	mov r2, r11
 	mov r3, r8
@@ -4067,9 +4067,9 @@ _02193240:
 	ldrsh r2, [r2, #2]
 	add r0, sp, #0x30
 	blx func_01ff8214
-	add r0, sl, #0x2d4
+	add r0, r10, #0x2d4
 	bl func_ov00_020b41ec
-	add r0, sl, #0x2d4
+	add r0, r10, #0x2d4
 	ldr ip, [r0]
 	mov r1, r5
 	ldr ip, [ip, #0x10]
@@ -4096,9 +4096,9 @@ _021932c4:
 	ldrsh r2, [r2, #2]
 	add r0, sp, #0
 	blx func_01ff8214
-	add r0, sl, #0x278
+	add r0, r10, #0x278
 	bl func_ov00_020b41ec
-	add r0, sl, #0x278
+	add r0, r10, #0x278
 	ldr ip, [r0]
 	mov r1, r5
 	ldr ip, [ip, #0x10]
@@ -4115,7 +4115,7 @@ _02193330:
 	blt _021931dc
 	mov r0, #1
 	add sp, sp, #0x90
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov48_0219319c
 _02193358: .word data_02050f54
@@ -4477,33 +4477,33 @@ func_ov48_02193644: ; 0x02193644
 	.global func_ov48_02193658
 	arm_func_start func_ov48_02193658
 func_ov48_02193658: ; 0x02193658
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x26c
-	mov sl, r0
+	mov r10, r0
 	str r1, [sp, #0xc]
 	bl _ZN5Actor18func_ov00_020c313cEj
 	cmp r0, #0
 	beq _02193f10
-	ldr r1, [sl, #0x48]
-	mov r0, sl
-	str r1, [sl, #0x54]
-	ldr r1, [sl, #0x4c]
-	str r1, [sl, #0x58]
-	ldr r1, [sl, #0x50]
-	str r1, [sl, #0x5c]
+	ldr r1, [r10, #0x48]
+	mov r0, r10
+	str r1, [r10, #0x54]
+	ldr r1, [r10, #0x4c]
+	str r1, [r10, #0x58]
+	ldr r1, [r10, #0x50]
+	str r1, [r10, #0x5c]
 	bl _ZN5Actor20IncreaseActiveFramesEv
-	mov r0, sl
+	mov r0, r10
 	bl _ZN5Actor18func_ov00_020c1cf8Ev
-	ldrb r0, [sl, #0xa4]
+	ldrb r0, [r10, #0xa4]
 	mov r4, #0
 	cmp r0, #0
-	ldreqb r0, [sl, #0xa5]
+	ldreqb r0, [r10, #0xa5]
 	cmpeq r0, #0
 	beq _0219389c
-	add r0, sl, #0x100
+	add r0, r10, #0x100
 	ldrh r0, [r0, #0x5c]
 	ldr r2, _02193f28 ; =data_02050f54
-	add r5, sl, #0x16c
+	add r5, r10, #0x16c
 	mov r0, r0, asr #0x4
 	mov r1, r0, lsl #0x1
 	add r0, r1, #1
@@ -4514,7 +4514,7 @@ func_ov48_02193658: ; 0x02193658
 	str r4, [sp, #0xbc]
 	str r1, [sp, #0xb8]
 	str r0, [sp, #0xc0]
-	ldr r0, [sl, #0x138]
+	ldr r0, [r10, #0x138]
 	mov r1, r0, lsr #0x1f
 	rsb r0, r1, r0, lsl #28
 	add r0, r1, r0, ror #28
@@ -4532,7 +4532,7 @@ _02193714:
 	cmp r4, #8
 	add r5, r5, #0xc
 	blt _02193704
-	add r4, sl, #0x100
+	add r4, r10, #0x100
 	ldrh r0, [r4, #0x5e]
 	mov sb, #0
 	mov r1, r0, lsl #0x1
@@ -4541,20 +4541,20 @@ _02193714:
 	mov r0, #0xc
 	mul r6, r8, r0
 	ldr r11, _02193f2c ; =data_027e0e58
-	add r7, sl, #0x16c
+	add r7, r10, #0x16c
 	add r5, sp, #0xac
 _02193758:
 	add r0, sb, #1
 	add r1, sp, #0xb8
 	mov r3, r5
 	mov r0, r0, lsl #0xb
-	add r2, sl, #0x48
+	add r2, r10, #0x48
 	bl func_01ff9e64
 	ldr r1, [sp, #0xb0]
 	ldr r0, [r11]
 	add r1, r1, #0x800
 	str r1, [sp, #0xb0]
-	add r1, sl, #0x160
+	add r1, r10, #0x160
 	mov r2, r5
 	bl func_ov00_0207c518
 	ldr r0, [r11]
@@ -4569,7 +4569,7 @@ _02193758:
 	mov r1, r0, lsl #0x1
 	blt _02193758
 _021937b8:
-	ldr r0, [sl, #0x158]
+	ldr r0, [r10, #0x158]
 	cmp r0, #1
 	bne _02193848
 	cmp r1, #0
@@ -4578,8 +4578,8 @@ _021937b8:
 	mov r0, #0xc
 	mul r6, r8, r0
 	ldr r11, _02193f2c ; =data_027e0e58
-	add r7, sl, #0x16c
-	add r4, sl, #0x100
+	add r7, r10, #0x16c
+	add r4, r10, #0x100
 	add r5, sp, #0xac
 _021937e8:
 	add r0, sb, #1
@@ -4587,13 +4587,13 @@ _021937e8:
 	add r1, sp, #0xb8
 	mov r3, r5
 	rsb r0, r0, #0
-	add r2, sl, #0x48
+	add r2, r10, #0x48
 	bl func_01ff9e64
 	ldr r1, [sp, #0xb0]
 	ldr r0, [r11]
 	add r1, r1, #0x800
 	str r1, [sp, #0xb0]
-	add r1, sl, #0x160
+	add r1, r10, #0x160
 	mov r2, r5
 	bl func_ov00_0207c518
 	ldr r0, [r11]
@@ -4607,20 +4607,20 @@ _021937e8:
 	cmp sb, r0, lsl #1
 	blt _021937e8
 _02193848:
-	ldr r1, [sl, #0x48]
+	ldr r1, [r10, #0x48]
 	ldr r0, _02193f2c ; =data_027e0e58
 	str r1, [sp, #0xac]
-	ldr r1, [sl, #0x4c]
+	ldr r1, [r10, #0x4c]
 	ldr r0, [r0]
 	str r1, [sp, #0xb0]
-	ldr r4, [sl, #0x50]
+	ldr r4, [r10, #0x50]
 	add r3, r1, #0x800
 	add r2, sp, #0xac
-	add r1, sl, #0x160
+	add r1, r10, #0x160
 	str r4, [sp, #0xb4]
 	str r3, [sp, #0xb0]
 	bl func_ov00_0207c518
-	add r1, sl, #0x16c
+	add r1, r10, #0x16c
 	mov r0, #0xc
 	mla r1, r8, r0, r1
 	ldr r2, _02193f2c ; =data_027e0e58
@@ -4629,9 +4629,9 @@ _02193848:
 	bl func_ov00_0207c518
 	b _021938c8
 _0219389c:
-	add r0, sl, #0x160
+	add r0, r10, #0x160
 	bl func_ov00_020b7e6c
-	add r5, sl, #0x16c
+	add r5, r10, #0x16c
 _021938a8:
 	mov r0, r5
 	bl func_ov00_020b7e6c
@@ -4642,12 +4642,12 @@ _021938a8:
 	add r5, r5, #0xc
 	blt _021938a8
 _021938c8:
-	ldr r0, [sl, #0x154]
+	ldr r0, [r10, #0x154]
 	cmp r0, #0
 	bne _02193ea0
-	add r0, sl, #0x100
+	add r0, r10, #0x100
 	ldrh r2, [r0, #0x5e]
-	ldrh r1, [sl, #0x20]
+	ldrh r1, [r10, #0x20]
 	mov r4, r2, lsl #0xc
 	cmp r1, #0
 	beq _021938f8
@@ -4683,17 +4683,17 @@ _02193924:
 	str r3, [sp, #0xa0]
 	str r0, [sp, #0xa8]
 	str r2, [sp, #0xa4]
-	ldr r2, [sl, #0x48]
-	add r0, sl, #0x100
-	str r2, [sl, #0x1cc]
-	ldr r2, [sl, #0x4c]
+	ldr r2, [r10, #0x48]
+	add r0, r10, #0x100
+	str r2, [r10, #0x1cc]
+	ldr r2, [r10, #0x4c]
 	add r5, sp, #0xa0
-	str r2, [sl, #0x1d0]
-	ldr r3, [sl, #0x50]
+	str r2, [r10, #0x1d0]
+	ldr r3, [r10, #0x50]
 	mov r2, #4
-	str r3, [sl, #0x1d4]
+	str r3, [r10, #0x1d4]
 	ldrh r6, [r0, #0x5c]
-	ldr r0, [sl, #0x1cc]
+	ldr r0, [r10, #0x1cc]
 	ldr r3, _02193f30 ; =0x000004cd
 	mov r6, r6, asr #0x4
 	mov r8, r6, lsl #0x1
@@ -4710,33 +4710,33 @@ _02193924:
 	orr sb, sb, r8, lsl #20
 	add r0, r0, sb
 	adds r1, r7, #0x800
-	str r0, [sl, #0x1cc]
+	str r0, [r10, #0x1cc]
 	adc r0, r6, #0
 	mov r1, r1, lsr #0xc
-	ldr r6, [sl, #0x1d4]
+	ldr r6, [r10, #0x1d4]
 	orr r1, r1, r0, lsl #20
 	add r0, r6, r1
-	str r0, [sl, #0x1d4]
+	str r0, [r10, #0x1d4]
 	str r5, [sp]
-	ldrb r5, [sl, #0x124]
-	mov r0, sl
-	add r1, sl, #0x48
+	ldrb r5, [r10, #0x124]
+	mov r0, r10
+	add r1, r10, #0x48
 	str r5, [sp, #4]
 	str r2, [sp, #8]
-	add r2, sl, #0x1cc
+	add r2, r10, #0x1cc
 	bl _ZN5Actor18func_ov00_020c1f5cEP5Vec3pS1_iS1_ii
-	ldr r0, [sl, #0x158]
+	ldr r0, [r10, #0x158]
 	cmp r0, #1
 	bne _02193b5c
-	ldr r0, [sl, #0x48]
+	ldr r0, [r10, #0x48]
 	ldr r6, _02193f28 ; =data_02050f54
-	str r0, [sl, #0x1d8]
-	ldr r0, [sl, #0x4c]
+	str r0, [r10, #0x1d8]
+	ldr r0, [r10, #0x4c]
 	mov r5, #0
-	str r0, [sl, #0x1dc]
-	ldr r1, [sl, #0x50]
-	add r0, sl, #0x100
-	str r1, [sl, #0x1e0]
+	str r0, [r10, #0x1dc]
+	ldr r1, [r10, #0x50]
+	add r0, r10, #0x100
+	str r1, [r10, #0x1e0]
 	ldrh r1, [r0, #0x5c]
 	rsb r0, r4, #0
 	mov r3, #0x800
@@ -4753,16 +4753,16 @@ _02193924:
 	adc r4, r4, #0
 	smull r2, r0, r1, r0
 	adds r1, r2, #0x800
-	ldr r2, [sl, #0x1d8]
+	ldr r2, [r10, #0x1d8]
 	orr r6, r6, r4, lsl #20
 	add r2, r2, r6
-	str r2, [sl, #0x1d8]
+	str r2, [r10, #0x1d8]
 	adc r0, r0, #0
 	mov r1, r1, lsr #0xc
-	ldr r2, [sl, #0x1e0]
+	ldr r2, [r10, #0x1e0]
 	orr r1, r1, r0, lsl #20
 	add r0, r2, r1
-	str r0, [sl, #0x1e0]
+	str r0, [r10, #0x1e0]
 	sub r0, r3, #0x1800
 	ldr r7, [sp, #0xa0]
 	sub r1, r5, #1
@@ -4801,21 +4801,21 @@ _02193924:
 	str r1, [sp, #0xa8]
 	add r0, sp, #0xa0
 	str r0, [sp]
-	ldrb r3, [sl, #0x124]
+	ldrb r3, [r10, #0x124]
 	mov r2, #4
-	mov r0, sl
+	mov r0, r10
 	str r3, [sp, #4]
 	str r2, [sp, #8]
 	ldr r3, _02193f30 ; =0x000004cd
-	add r1, sl, #0x48
-	add r2, sl, #0x1d8
+	add r1, r10, #0x48
+	add r2, r10, #0x1d8
 	bl _ZN5Actor18func_ov00_020c1f5cEP5Vec3pS1_iS1_ii
 _02193b5c:
 	ldr r0, _02193f34 ; =data_ov48_02194688
 	add r3, sp, #0x94
 	ldmia r0, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
-	mov r0, sl
+	mov r0, r10
 	mov r1, r3
 	mov r2, #0
 	bl _ZN5Actor18func_ov00_020c243cEiPi
@@ -4868,46 +4868,46 @@ _02193c18:
 	beq _02193cfc
 	mov r1, r4
 	bl _ZN5Actor9GetHitboxEP8Cylinder
-	ldr r0, [sl, #0x48]
+	ldr r0, [r10, #0x48]
 	mov r7, #1
 	str r0, [sp, #0x68]
-	ldr r1, [sl, #0x4c]
+	ldr r1, [r10, #0x4c]
 	mov r0, r4
 	str r1, [sp, #0x6c]
-	ldr r2, [sl, #0x50]
+	ldr r2, [r10, #0x50]
 	add r1, sp, #0x68
 	str r2, [sp, #0x70]
-	ldr r3, [sl, #0x1cc]
+	ldr r3, [r10, #0x1cc]
 	add r2, sp, #0x5c
 	str r3, [sp, #0x5c]
-	ldr r3, [sl, #0x1d0]
+	ldr r3, [r10, #0x1d0]
 	str r3, [sp, #0x60]
-	ldr r3, [sl, #0x1d4]
+	ldr r3, [r10, #0x1d4]
 	str r3, [sp, #0x64]
-	ldr r3, [sl, #0x88]
+	ldr r3, [r10, #0x88]
 	bl func_ov00_0208f030
 	cmp r0, #0
 	bne _02193cec
-	ldr r0, [sl, #0x158]
+	ldr r0, [r10, #0x158]
 	mov r8, #0
 	cmp r0, #1
 	bne _02193ce4
-	ldr r1, [sl, #0x1d8]
+	ldr r1, [r10, #0x1d8]
 	mov r0, r4
 	str r1, [sp, #0x50]
-	ldr r2, [sl, #0x1dc]
+	ldr r2, [r10, #0x1dc]
 	add r1, sp, #0x44
 	str r2, [sp, #0x54]
-	ldr r3, [sl, #0x1e0]
+	ldr r3, [r10, #0x1e0]
 	add r2, sp, #0x50
 	str r3, [sp, #0x58]
-	ldr r3, [sl, #0x48]
+	ldr r3, [r10, #0x48]
 	str r3, [sp, #0x44]
-	ldr r3, [sl, #0x4c]
+	ldr r3, [r10, #0x4c]
 	str r3, [sp, #0x48]
-	ldr r3, [sl, #0x50]
+	ldr r3, [r10, #0x50]
 	str r3, [sp, #0x4c]
-	ldr r3, [sl, #0x88]
+	ldr r3, [r10, #0x88]
 	bl func_ov00_0208f030
 	cmp r0, #0
 	movne r8, r7
@@ -4976,46 +4976,46 @@ _02193dac:
 	beq _02193e8c
 	mov r1, r4
 	bl _ZN5Actor9GetHitboxEP8Cylinder
-	ldr r0, [sl, #0x48]
+	ldr r0, [r10, #0x48]
 	mov r7, #1
 	str r0, [sp, #0x38]
-	ldr r1, [sl, #0x4c]
+	ldr r1, [r10, #0x4c]
 	mov r0, r4
 	str r1, [sp, #0x3c]
-	ldr r2, [sl, #0x50]
+	ldr r2, [r10, #0x50]
 	add r1, sp, #0x38
 	str r2, [sp, #0x40]
-	ldr r3, [sl, #0x1cc]
+	ldr r3, [r10, #0x1cc]
 	add r2, sp, #0x2c
 	str r3, [sp, #0x2c]
-	ldr r3, [sl, #0x1d0]
+	ldr r3, [r10, #0x1d0]
 	str r3, [sp, #0x30]
-	ldr r3, [sl, #0x1d4]
+	ldr r3, [r10, #0x1d4]
 	str r3, [sp, #0x34]
-	ldr r3, [sl, #0x88]
+	ldr r3, [r10, #0x88]
 	bl func_ov00_0208f030
 	cmp r0, #0
 	bne _02193e84
-	ldr r0, [sl, #0x158]
+	ldr r0, [r10, #0x158]
 	mov r8, #0
 	cmp r0, #1
 	bne _02193e7c
-	ldr r1, [sl, #0x1d8]
+	ldr r1, [r10, #0x1d8]
 	mov r0, r4
 	str r1, [sp, #0x20]
-	ldr r2, [sl, #0x1dc]
+	ldr r2, [r10, #0x1dc]
 	add r1, sp, #0x14
 	str r2, [sp, #0x24]
-	ldr r3, [sl, #0x1e0]
+	ldr r3, [r10, #0x1e0]
 	add r2, sp, #0x20
 	str r3, [sp, #0x28]
-	ldr r3, [sl, #0x48]
+	ldr r3, [r10, #0x48]
 	str r3, [sp, #0x14]
-	ldr r3, [sl, #0x4c]
+	ldr r3, [r10, #0x4c]
 	str r3, [sp, #0x18]
-	ldr r3, [sl, #0x50]
+	ldr r3, [r10, #0x50]
 	str r3, [sp, #0x1c]
-	ldr r3, [sl, #0x88]
+	ldr r3, [r10, #0x88]
 	bl func_ov00_0208f030
 	cmp r0, #0
 	movne r8, r7
@@ -5032,10 +5032,10 @@ _02193e8c:
 	cmp r5, r0
 	blt _02193dac
 _02193ea0:
-	ldr r0, [sl, #0x130]
+	ldr r0, [r10, #0x130]
 	cmp r0, #0
 	bne _02193f10
-	ldrh r0, [sl, #0x22]
+	ldrh r0, [r10, #0x22]
 	mov r2, #0x12c
 	cmp r0, #0
 	beq _02193ed4
@@ -5047,30 +5047,30 @@ _02193ea0:
 _02193ed0:
 	mov r2, #0x258
 _02193ed4:
-	ldrh r0, [sl, #0x20]
+	ldrh r0, [r10, #0x20]
 	cmp r0, #0
 	beq _02193eec
 	cmp r0, #1
 	beq _02193f00
 	b _02193f10
 _02193eec:
-	add r0, sl, #0x100
+	add r0, r10, #0x100
 	ldrsh r1, [r0, #0x5c]
 	add r1, r1, r2
 	strh r1, [r0, #0x5c]
 	b _02193f10
 _02193f00:
-	add r0, sl, #0x100
+	add r0, r10, #0x100
 	ldrsh r1, [r0, #0x5c]
 	sub r1, r1, r2
 	strh r1, [r0, #0x5c]
 _02193f10:
 	ldr r1, [sp, #0xc]
-	add r0, sl, #0xa4
-	add r2, sl, #0x48
+	add r0, r10, #0xa4
+	add r2, r10, #0x48
 	bl func_ov00_0207a1c8
 	add sp, sp, #0x26c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov48_02193658
 _02193f28: .word data_02050f54

--- a/asm/ov48.s
+++ b/asm/ov48.s
@@ -3191,7 +3191,7 @@ _02192600: .word 0x0000013f
 	.global func_ov48_02192604
 	arm_func_start func_ov48_02192604
 func_ov48_02192604: ; 0x02192604
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x88
 	mov sb, r0
 	ldr r0, [sb, #0x130]
@@ -3327,10 +3327,10 @@ _021927dc:
 	mov r6, #0
 	add r4, sp, #0x44
 	add r5, sp, #0x60
-	mov fp, #0x1a
+	mov r11, #0x1a
 _02192804:
 	ldr r7, [r5, r6, lsl #2]
-	mov r1, fp
+	mov r1, r11
 	add r0, sb, r7, lsl #2
 	ldr r8, [r0, #0x52c]
 	mov r0, r8
@@ -3615,7 +3615,7 @@ _02192bd0:
 	cmp r0, #0
 	ble _02192ccc
 	mov sl, #0xc
-	ldr fp, _02193190 ; =0x00000e66
+	ldr r11, _02193190 ; =0x00000e66
 	add r6, sp, #0x20
 	add r5, sp, #0x14
 	mov r4, sl
@@ -3633,7 +3633,7 @@ _02192c34:
 	mov r1, r7
 	mov r2, r5
 	bl func_01ff9bf8
-	mov r0, fp
+	mov r0, r11
 	mov r1, r5
 	mov r2, r7
 	mov r3, r6
@@ -3685,7 +3685,7 @@ _02192d10:
 	add r6, r0, #0x400
 	add r7, r1, #0x400
 	mov r8, #0
-	mov fp, r6
+	mov r11, r6
 	add sl, sb, #0xdc
 	add r4, sp, #8
 _02192d38:
@@ -3736,7 +3736,7 @@ _02192da4:
 _02192de0:
 	add r1, r8, #1
 	mov r0, #0xc
-	mla r0, r1, r0, fp
+	mla r0, r1, r0, r11
 	mov r1, r6
 	mov r2, r4
 	bl func_01ff9bf8
@@ -3979,7 +3979,7 @@ _02193144:
 _02193154:
 	mov r0, #1
 	add sp, sp, #0x88
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov48_02192604
 _02193160: .word gItemManager
@@ -4001,7 +4001,7 @@ _02193198: .word data_027e0e58
 	.global func_ov48_0219319c
 	arm_func_start func_ov48_0219319c
 func_ov48_0219319c: ; 0x0219319c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x90
 	mov sl, r0
 	add r0, sl, #0xe8
@@ -4016,7 +4016,7 @@ func_ov48_0219319c: ; 0x0219319c
 	mov r7, #0
 	add r4, r0, #0x400
 	add r5, sp, #0x84
-	add fp, sp, #0x60
+	add r11, sp, #0x60
 _021931dc:
 	add r0, sl, r7
 	ldrb r0, [r0, #0x524]
@@ -4025,7 +4025,7 @@ _021931dc:
 	cmp r7, #0
 	bne _02193240
 	ldrh r1, [sl, #0x78]
-	mov r0, fp
+	mov r0, r11
 	mov r1, r1, asr #0x4
 	mov r2, r1, lsl #0x1
 	mov r1, r2, lsl #0x1
@@ -4037,7 +4037,7 @@ _021931dc:
 	bl func_ov00_020b41ec
 	add r0, sl, #0x21c
 	mov r1, r5
-	mov r2, fp
+	mov r2, r11
 	mov r3, r8
 	ldr ip, [r0]
 	ldr ip, [ip, #0x10]
@@ -4115,7 +4115,7 @@ _02193330:
 	blt _021931dc
 	mov r0, #1
 	add sp, sp, #0x90
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov48_0219319c
 _02193358: .word data_02050f54
@@ -4477,7 +4477,7 @@ func_ov48_02193644: ; 0x02193644
 	.global func_ov48_02193658
 	arm_func_start func_ov48_02193658
 func_ov48_02193658: ; 0x02193658
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x26c
 	mov sl, r0
 	str r1, [sp, #0xc]
@@ -4540,7 +4540,7 @@ _02193714:
 	ble _021937b8
 	mov r0, #0xc
 	mul r6, r8, r0
-	ldr fp, _02193f2c ; =data_027e0e58
+	ldr r11, _02193f2c ; =data_027e0e58
 	add r7, sl, #0x16c
 	add r5, sp, #0xac
 _02193758:
@@ -4551,13 +4551,13 @@ _02193758:
 	add r2, sl, #0x48
 	bl func_01ff9e64
 	ldr r1, [sp, #0xb0]
-	ldr r0, [fp]
+	ldr r0, [r11]
 	add r1, r1, #0x800
 	str r1, [sp, #0xb0]
 	add r1, sl, #0x160
 	mov r2, r5
 	bl func_ov00_0207c518
-	ldr r0, [fp]
+	ldr r0, [r11]
 	add r1, r7, r6
 	mov r2, r5
 	bl func_ov00_0207c518
@@ -4577,7 +4577,7 @@ _021937b8:
 	ble _02193848
 	mov r0, #0xc
 	mul r6, r8, r0
-	ldr fp, _02193f2c ; =data_027e0e58
+	ldr r11, _02193f2c ; =data_027e0e58
 	add r7, sl, #0x16c
 	add r4, sl, #0x100
 	add r5, sp, #0xac
@@ -4590,13 +4590,13 @@ _021937e8:
 	add r2, sl, #0x48
 	bl func_01ff9e64
 	ldr r1, [sp, #0xb0]
-	ldr r0, [fp]
+	ldr r0, [r11]
 	add r1, r1, #0x800
 	str r1, [sp, #0xb0]
 	add r1, sl, #0x160
 	mov r2, r5
 	bl func_ov00_0207c518
-	ldr r0, [fp]
+	ldr r0, [r11]
 	add r1, r7, r6
 	mov r2, r5
 	bl func_ov00_0207c518
@@ -4856,12 +4856,12 @@ _02193bd4:
 	mov r5, #0
 	cmp r0, #0
 	ble _02193d10
-	ldr fp, _02193f40 ; =data_027e0fe4
+	ldr r11, _02193f40 ; =data_027e0fe4
 	mov sb, r5
 	add r4, sp, #0x84
 _02193c18:
 	ldr r1, [sp, #0x198]
-	ldr r0, [fp]
+	ldr r0, [r11]
 	add r1, r1, sb
 	bl _ZN12ActorManager8GetActorEP8ActorRef
 	movs r6, r0
@@ -4965,7 +4965,7 @@ _02193d68:
 	ble _02193ea0
 	mov sb, r5
 	add r4, sp, #0x74
-	mov fp, #1
+	mov r11, #1
 _02193dac:
 	ldr r0, _02193f40 ; =data_027e0fe4
 	ldr r1, [sp, #0xc4]
@@ -5024,7 +5024,7 @@ _02193e7c:
 	moveq r7, #0
 _02193e84:
 	cmp r7, #0
-	strneb fp, [r6, #0x180]
+	strneb r11, [r6, #0x180]
 _02193e8c:
 	add sb, sb, #8
 	add r5, r5, #1
@@ -5070,7 +5070,7 @@ _02193f10:
 	add r2, sl, #0x48
 	bl func_ov00_0207a1c8
 	add sp, sp, #0x26c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov48_02193658
 _02193f28: .word data_02050f54

--- a/asm/ov48.s
+++ b/asm/ov48.s
@@ -169,7 +169,7 @@ func_ov48_02190224: ; 0x02190224
 	.global func_ov48_0219022c
 	arm_func_start func_ov48_0219022c
 func_ov48_0219022c: ; 0x0219022c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #0x1c
 	mov r4, r0
 	ldr r2, [r4, #0x1c]
@@ -222,22 +222,22 @@ _021902c4:
 	umull r1, r0, r10, r2
 	mov ip, #0
 	mla r0, r10, ip, r0
-	umull sb, r8, r7, r2
+	umull r9, r8, r7, r2
 	mov r10, r10, asr #0x1f
 	ldr r5, [sp, #0x18]
 	mla r0, r10, r2, r0
 	adds r1, r1, #0x800
 	adc r10, r0, #0
 	mov r0, r1, lsr #0xc
-	adds r1, sb, #0x800
-	mov sb, r1, lsr #0xc
+	adds r1, r9, #0x800
+	mov r9, r1, lsr #0xc
 	umull r6, lr, r5, r2
 	orr r0, r0, r10, lsl #20
 	mla r8, r7, ip, r8
 	mov r1, r7, asr #0x1f
 	mla r8, r1, r2, r8
 	adc r1, r8, #0
-	orr sb, sb, r1, lsl #20
+	orr r9, r9, r1, lsl #20
 	mla lr, r5, ip, lr
 	mov r1, r5, asr #0x1f
 	mla lr, r1, r2, lr
@@ -246,7 +246,7 @@ _021902c4:
 	mov r2, r2, lsr #0xc
 	orr r2, r2, r1, lsl #20
 	str r0, [sp, #0x10]
-	str sb, [sp, #0x14]
+	str r9, [sp, #0x14]
 	str r2, [sp, #0x18]
 	str r0, [r3, #0x40]
 	ldr r0, [sp, #0x14]
@@ -263,12 +263,12 @@ _02190378:
 	add r2, r2, #0x48
 	bl func_ov00_020cec60
 	add sp, sp, #0x1c
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 _021903a0:
 	add r0, r4, #0x17c
 	bl func_ov00_020b7e6c
 	add sp, sp, #0x1c
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 _021903b0:
 	cmp r0, #0
 	beq _02190410
@@ -294,13 +294,13 @@ _021903e8:
 	add r7, r7, #0xc
 	blo _021903e8
 	add sp, sp, #0x1c
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 _02190410:
 	add r5, r4, #0x188
 	add r4, r4, #0x1a0
 	cmp r5, r4
 	addeq sp, sp, #0x1c
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 _02190424:
 	mov r0, r5
 	bl func_ov00_020b7e6c
@@ -308,7 +308,7 @@ _02190424:
 	cmp r5, r4
 	bne _02190424
 	add sp, sp, #0x1c
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov48_0219022c
 _02190440: .word data_027e0e58
@@ -3088,7 +3088,7 @@ _02192480: .word data_027e0e5c
 	.global func_ov48_02192484
 	arm_func_start func_ov48_02192484
 func_ov48_02192484: ; 0x02192484
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x24
 	mov r4, r0
 	ldr r0, _021925fc ; =0x000025c3
@@ -3101,7 +3101,7 @@ func_ov48_02192484: ; 0x02192484
 	cmp r1, r0, asr #12
 	movlt r6, r1
 	mov r8, r7
-	mov sb, r4
+	mov r9, r4
 	mov r5, #0xc
 _021924c0:
 	ldr r1, [r4, #0x340]
@@ -3117,15 +3117,15 @@ _021924c0:
 	ldr r1, [r3, r2]
 	mov r0, r0, lsl #0x10
 	mov r7, r0, asr #0x10
-	str r1, [sb, #0x4ac]
+	str r1, [r9, #0x4ac]
 	add r1, r3, r2
 	ldr r0, [r1, #4]
 	cmp r7, #5
-	str r0, [sb, #0x4b0]
+	str r0, [r9, #0x4b0]
 	ldr r0, [r1, #8]
 	add r8, r8, r6
-	str r0, [sb, #0x4b4]
-	add sb, sb, #0xc
+	str r0, [r9, #0x4b4]
+	add r9, r9, #0xc
 	blt _021924c0
 	ldr r5, [r4, #0x52c]
 	add r0, r4, #0xac
@@ -3182,7 +3182,7 @@ _021924c0:
 	ldr r0, [sp, #8]
 	str r0, [r5, #0x68]
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov48_02192484
 _021925fc: .word 0x000025c3
@@ -3191,34 +3191,34 @@ _02192600: .word 0x0000013f
 	.global func_ov48_02192604
 	arm_func_start func_ov48_02192604
 func_ov48_02192604: ; 0x02192604
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x88
-	mov sb, r0
-	ldr r0, [sb, #0x130]
+	mov r9, r0
+	ldr r0, [r9, #0x130]
 	cmp r0, #3
 	cmpne r0, #4
 	cmpne r0, #5
 	beq _0219266c
-	ldr r0, [sb, #0x338]
+	ldr r0, [r9, #0x338]
 	add r0, r0, #1
-	str r0, [sb, #0x338]
-	ldr r1, [sb, #0x340]
+	str r0, [r9, #0x338]
+	ldr r1, [r9, #0x340]
 	bl func_02002c14
 	mov r0, #0xc
 	mul r2, r1, r0
-	str r1, [sb, #0x338]
-	ldr r1, [sb, #0x33c]
-	ldr r0, [sb, #0x48]
+	str r1, [r9, #0x338]
+	ldr r1, [r9, #0x33c]
+	ldr r0, [r9, #0x48]
 	add r3, r1, r2
 	str r0, [r1, r2]
-	ldr r1, [sb, #0x4c]
-	mov r0, sb
+	ldr r1, [r9, #0x4c]
+	mov r0, r9
 	str r1, [r3, #4]
-	ldr r1, [sb, #0x50]
+	ldr r1, [r9, #0x50]
 	str r1, [r3, #8]
 	bl func_ov48_02192484
 _0219266c:
-	ldr r0, [sb, #0x130]
+	ldr r0, [r9, #0x130]
 	mov r5, #0
 	cmp r0, #3
 	cmpne r0, #4
@@ -3233,12 +3233,12 @@ _0219266c:
 	mov r6, r5
 	add r4, sp, #0x78
 _021926a4:
-	add r0, sb, r6, lsl #2
+	add r0, r9, r6, lsl #2
 	ldr r0, [r0, #0x52c]
 	mov r1, r4
 	bl _ZN5Actor9GetHitboxEP8Cylinder
 	ldr r1, [sp, #0x84]
-	mov r0, sb
+	mov r0, r9
 	add r1, r1, #0x9a
 	add r2, r1, #0x100
 	mov r1, r4
@@ -3247,14 +3247,14 @@ _021926a4:
 	cmp r0, #0
 	beq _02192708
 	bl func_ov48_02191c50
-	add r2, sb, #0x48
+	add r2, r9, #0x48
 	mov r1, #0xf9
 	mov r3, #0
 	bl func_ov00_020c070c
 	cmp r6, #0
 	mov r5, #1
 	bne _02192714
-	mov r0, sb
+	mov r0, r9
 	mov r1, #2
 	bl func_ov48_021923f8
 	b _02192714
@@ -3263,7 +3263,7 @@ _02192708:
 	cmp r6, #3
 	blt _021926a4
 _02192714:
-	ldr r0, [sb, #0x130]
+	ldr r0, [r9, #0x130]
 	cmp r0, #3
 	cmpne r0, #4
 	cmpne r0, #5
@@ -3272,10 +3272,10 @@ _02192714:
 	bne _02192bd0
 	mov r0, #0
 	str r0, [sp]
-	ldr r3, [sb, #8]
+	ldr r3, [r9, #8]
 	ldr r0, _02193164 ; =data_027e0ffc
 	ldr r1, _02193168 ; =0x00000247
-	add r2, sb, #0x48
+	add r2, r9, #0x48
 	bl func_ov00_020cec60
 	ldr r0, _0219316c ; =data_027e0f94
 	add r3, sp, #0x6c
@@ -3284,7 +3284,7 @@ _02192714:
 	mov r5, #0
 	add r4, sp, #0x54
 _02192764:
-	add r0, sb, r5, lsl #2
+	add r0, r9, r5, lsl #2
 	ldr r0, [r0, #0x52c]
 	bl _ZN5Actor16XzDistanceToLinkEv
 	str r0, [r4, r5, lsl #2]
@@ -3331,7 +3331,7 @@ _021927dc:
 _02192804:
 	ldr r7, [r5, r6, lsl #2]
 	mov r1, r11
-	add r0, sb, r7, lsl #2
+	add r0, r9, r7, lsl #2
 	ldr r8, [r0, #0x52c]
 	mov r0, r8
 	bl _ZN5Actor18func_ov00_020c1fc8Ej
@@ -3346,7 +3346,7 @@ _02192804:
 _0219283c:
 	cmp r7, #2
 	bne _021928c0
-	add r1, sb, #0x100
+	add r1, r9, #0x100
 	ldr r0, [r8, #0x168]
 	ldrb r3, [r8, #0x158]
 	cmp r0, #7
@@ -3356,16 +3356,16 @@ _0219283c:
 	sub r2, r2, r3
 	strh r2, [r1, #0x20]
 	bl func_ov00_020c71fc
-	add r0, sb, #0x100
+	add r0, r9, #0x100
 	ldrsh r0, [r0, #0x20]
 	mov r3, #0
 	cmp r0, #0
 	bgt _021928a0
 	ldr r0, _02193164 ; =data_027e0ffc
 	ldr r1, _02193174 ; =0x00000191
-	add r2, sb, #0x48
+	add r2, r9, #0x48
 	bl func_ov00_020ceacc
-	mov r0, sb
+	mov r0, r9
 	mov r1, #5
 	bl func_ov48_021923f8
 	b _02192bd0
@@ -3374,7 +3374,7 @@ _021928a0:
 	add r2, r8, #0x48
 	mov r1, #0x190
 	bl func_ov00_020ceacc
-	mov r0, sb
+	mov r0, r9
 	mov r1, #3
 	bl func_ov48_021923f8
 	b _02192bd0
@@ -3406,7 +3406,7 @@ _02192900:
 	bne _02192a00
 	ldr r0, _02193164 ; =data_027e0ffc
 	mov r3, r4
-	add r2, sb, #0x48
+	add r2, r9, #0x48
 	mov r1, #0xf6
 	bl func_ov00_020ceacc
 	mov r0, r5
@@ -3424,7 +3424,7 @@ _02192940:
 	ldr r0, _02193164 ; =data_027e0ffc
 	ldr r1, _02193180 ; =0x0000019d
 	mov r3, r4
-	add r2, sb, #0x48
+	add r2, r9, #0x48
 	bl func_ov00_020ceacc
 	mov r0, r5
 	bl func_ov14_021231d4
@@ -3438,7 +3438,7 @@ _02192980:
 	ldr r1, _02193184 ; =0x41525257
 	cmp r2, r1
 	bne _02192a00
-	ldrsh r1, [sb, #0x78]
+	ldrsh r1, [r9, #0x78]
 	mov r2, #1
 	bl func_ov14_02120ac4
 	mov r4, #1
@@ -3453,7 +3453,7 @@ _021929b0:
 	bne _02192a00
 	bl func_ov14_02123904
 	ldr r0, _02193164 ; =data_027e0ffc
-	add r2, sb, #0x48
+	add r2, r9, #0x48
 	mov r1, #0xf6
 	mov r3, r4
 	bl func_ov00_020ceacc
@@ -3462,13 +3462,13 @@ _021929b0:
 _021929ec:
 	ldr r0, _02193164 ; =data_027e0ffc
 	ldr r1, _0219318c ; =0x00000193
-	add r2, sb, #0x48
+	add r2, r9, #0x48
 	mov r3, #0
 	bl func_ov00_020ceacc
 _02192a00:
 	cmp r4, #0
 	beq _02192bd0
-	mov r0, sb
+	mov r0, r9
 	mov r1, #4
 	bl func_ov48_021923f8
 	b _02192bd0
@@ -3501,7 +3501,7 @@ _02192a5c:
 	cmp r1, r0
 	bne _02192b4c
 	ldr r0, _02193164 ; =data_027e0ffc
-	add r2, sb, #0x48
+	add r2, r9, #0x48
 	mov r1, #0xf6
 	mov r3, #0
 	bl func_ov00_020ceacc
@@ -3518,7 +3518,7 @@ _02192a98:
 	bne _02192b4c
 	ldr r0, _02193164 ; =data_027e0ffc
 	ldr r1, _02193180 ; =0x0000019d
-	add r2, sb, #0x48
+	add r2, r9, #0x48
 	mov r3, #0
 	bl func_ov00_020ceacc
 	mov r0, r4
@@ -3532,7 +3532,7 @@ _02192ad4:
 	ldr r1, _02193184 ; =0x41525257
 	cmp r2, r1
 	bne _02192b4c
-	ldrsh r1, [sb, #0x78]
+	ldrsh r1, [r9, #0x78]
 	mov r2, #1
 	bl func_ov14_02120ac4
 	b _02192b4c
@@ -3546,7 +3546,7 @@ _02192b00:
 	bne _02192b4c
 	bl func_ov14_02123904
 	ldr r0, _02193164 ; =data_027e0ffc
-	add r2, sb, #0x48
+	add r2, r9, #0x48
 	mov r1, #0xf6
 	mov r3, #0
 	bl func_ov00_020ceacc
@@ -3554,11 +3554,11 @@ _02192b00:
 _02192b38:
 	ldr r0, _02193164 ; =data_027e0ffc
 	ldr r1, _0219318c ; =0x00000193
-	add r2, sb, #0x48
+	add r2, r9, #0x48
 	mov r3, #0
 	bl func_ov00_020ceacc
 _02192b4c:
-	mov r0, sb
+	mov r0, r9
 	mov r1, #4
 	bl func_ov48_021923f8
 	b _02192bd0
@@ -3576,7 +3576,7 @@ _02192b5c:
 	add r1, r8, #0x48
 	bl func_01ff9bf8
 	ldr r0, _02193170 ; =data_027e0f90
-	ldrb r1, [sb, #0x124]
+	ldrb r1, [r9, #0x124]
 	ldr r0, [r0]
 	add r2, sp, #0x38
 	ldr r4, [r0]
@@ -3585,7 +3585,7 @@ _02192b5c:
 	blx r4
 	cmp r0, #0
 	beq _02192bd0
-	mov r0, sb
+	mov r0, r9
 	mov r1, #0
 	bl func_ov48_021923f8
 	b _02192bd0
@@ -3594,23 +3594,23 @@ _02192bc4:
 	cmp r6, #3
 	blt _02192804
 _02192bd0:
-	ldr r0, [sb, #0x130]
+	ldr r0, [r9, #0x130]
 	cmp r0, #3
 	bne _02192d10
-	ldr r0, [sb, #0x138]
+	ldr r0, [r9, #0x138]
 	cmp r0, #0xa
 	bge _02192ccc
-	ldr r1, [sb, #0x340]
-	ldr r0, [sb, #0x338]
+	ldr r1, [r9, #0x340]
+	ldr r0, [r9, #0x338]
 	add r0, r1, r0
 	bl func_02002c14
-	ldr r2, [sb, #0x33c]
+	ldr r2, [r9, #0x33c]
 	mov r0, #0xc
 	mla r0, r1, r0, r2
 	add r7, sp, #0x2c
 	ldmia r0, {r0, r1, r2}
 	stmia r7, {r0, r1, r2}
-	ldr r0, [sb, #0x340]
+	ldr r0, [r9, #0x340]
 	mov r8, #0
 	cmp r0, #0
 	ble _02192ccc
@@ -3620,12 +3620,12 @@ _02192bd0:
 	add r5, sp, #0x14
 	mov r4, r10
 _02192c34:
-	ldr r1, [sb, #0x340]
-	ldr r0, [sb, #0x338]
+	ldr r1, [r9, #0x340]
+	ldr r0, [r9, #0x338]
 	add r0, r1, r0
 	sub r0, r0, r8
 	bl func_02002c14
-	ldr r0, [sb, #0x33c]
+	ldr r0, [r9, #0x33c]
 	mla r0, r1, r10, r0
 	ldmia r0, {r0, r1, r2}
 	stmia r6, {r0, r1, r2}
@@ -3638,13 +3638,13 @@ _02192c34:
 	mov r2, r7
 	mov r3, r6
 	bl func_01ff9e64
-	ldr r1, [sb, #0x340]
-	ldr r0, [sb, #0x338]
+	ldr r1, [r9, #0x340]
+	ldr r0, [r9, #0x338]
 	add r0, r1, r0
 	sub r0, r0, r8
 	bl func_02002c14
 	mul r2, r1, r4
-	ldr r3, [sb, #0x33c]
+	ldr r3, [r9, #0x33c]
 	ldr r1, [sp, #0x20]
 	add r0, r3, r2
 	str r1, [r3, r2]
@@ -3655,13 +3655,13 @@ _02192c34:
 	ldr r2, [sp, #0x28]
 	mov r8, r1, asr #0x10
 	str r2, [r0, #8]
-	ldr r0, [sb, #0x340]
+	ldr r0, [r9, #0x340]
 	cmp r0, r1, asr #16
 	bgt _02192c34
 _02192ccc:
-	mov r0, sb
+	mov r0, r9
 	bl func_ov48_02192484
-	mov r2, sb
+	mov r2, r9
 	mov r0, #0
 _02192cdc:
 	ldr r1, [r2, #0x4ac]
@@ -3680,16 +3680,16 @@ _02192cdc:
 _02192d10:
 	cmp r0, #4
 	bne _02192e4c
-	add r0, sb, #0xac
-	add r1, sb, #0xe8
+	add r0, r9, #0xac
+	add r1, r9, #0xe8
 	add r6, r0, #0x400
 	add r7, r1, #0x400
 	mov r8, #0
 	mov r11, r6
-	add r10, sb, #0xdc
+	add r10, r9, #0xdc
 	add r4, sp, #8
 _02192d38:
-	ldr r1, [sb, #0x138]
+	ldr r1, [r9, #0x138]
 	mov r0, r8, lsl #0x10
 	cmp r1, r0, asr #16
 	mov r2, r0, asr #0x10
@@ -3722,7 +3722,7 @@ _02192da4:
 	bne _02192de0
 	mov r2, r4
 	add r0, r10, #0x400
-	add r1, sb, #0x4d0
+	add r1, r9, #0x4d0
 	bl func_01ff9bf8
 	ldr r0, [sp, #8]
 	cmp r0, #0
@@ -3763,7 +3763,7 @@ _02192e18:
 	blt _02192d38
 	b _02192e84
 _02192e4c:
-	mov r2, sb
+	mov r2, r9
 	mov r0, #0
 _02192e54:
 	ldr r1, [r2, #0x4ac]
@@ -3779,7 +3779,7 @@ _02192e54:
 	add r2, r2, #0xc
 	blt _02192e54
 _02192e84:
-	ldr r0, [sb, #0x130]
+	ldr r0, [r9, #0x130]
 	cmp r0, #5
 	addls pc, pc, r0, lsl #2
 	b _02193154
@@ -3791,92 +3791,92 @@ _02192e94: ; jump table
 	b _02192fc4 ; case 4
 	b _02192fe0 ; case 5
 _02192eac:
-	mov r0, sb
+	mov r0, r9
 	bl func_ov48_021920f8
-	ldr r0, [sb, #0x138]
+	ldr r0, [r9, #0x138]
 	cmp r0, #0x14
 	ble _02193154
-	mov r0, sb
+	mov r0, r9
 	bl func_ov48_021923e8
 	cmp r0, #0
 	beq _02193154
-	mov r0, sb
+	mov r0, r9
 	mov r1, #1
 	bl func_ov48_021923f8
 	b _02193154
 _02192ee0:
-	mov r0, sb
+	mov r0, r9
 	bl func_ov48_02192328
-	ldrb r0, [sb, #0x110]
+	ldrb r0, [r9, #0x110]
 	cmp r0, #0
-	ldreqb r0, [sb, #0x112]
+	ldreqb r0, [r9, #0x112]
 	cmpeq r0, #0
-	ldreqb r0, [sb, #0x113]
+	ldreqb r0, [r9, #0x113]
 	cmpeq r0, #0
 	beq _02192f14
-	mov r0, sb
+	mov r0, r9
 	mov r1, #0
 	bl func_ov48_021923f8
 	b _02193154
 _02192f14:
-	ldr r0, [sb, #0x138]
+	ldr r0, [r9, #0x138]
 	cmp r0, #0x5a
 	ble _02192f30
-	mov r0, sb
+	mov r0, r9
 	mov r1, #0
 	bl func_ov48_021923f8
 	b _02193154
 _02192f30:
 	cmp r0, #0x1e
 	ble _02193154
-	mov r0, sb
+	mov r0, r9
 	bl func_ov48_021923e8
 	cmp r0, #0
 	bne _02193154
-	mov r0, sb
+	mov r0, r9
 	mov r1, #0
 	bl func_ov48_021923f8
 	b _02193154
 _02192f58:
-	mov r0, sb
+	mov r0, r9
 	bl func_ov48_02192354
-	ldrb r0, [sb, #0x110]
+	ldrb r0, [r9, #0x110]
 	cmp r0, #0
-	ldreqb r0, [sb, #0x112]
+	ldreqb r0, [r9, #0x112]
 	cmpeq r0, #0
-	ldreqb r0, [sb, #0x113]
+	ldreqb r0, [r9, #0x113]
 	cmpeq r0, #0
 	beq _02192f8c
-	mov r0, sb
+	mov r0, r9
 	mov r1, #0
 	bl func_ov48_021923f8
 	b _02193154
 _02192f8c:
-	ldr r0, [sb, #0x138]
+	ldr r0, [r9, #0x138]
 	cmp r0, #0x5a
 	ble _02193154
-	mov r0, sb
+	mov r0, r9
 	mov r1, #0
 	bl func_ov48_021923f8
 	b _02193154
 _02192fa8:
-	ldr r0, [sb, #0x138]
+	ldr r0, [r9, #0x138]
 	cmp r0, #0xa
 	ble _02193154
-	mov r0, sb
+	mov r0, r9
 	mov r1, #1
 	bl func_ov48_021923f8
 	b _02193154
 _02192fc4:
-	ldr r0, [sb, #0x138]
+	ldr r0, [r9, #0x138]
 	cmp r0, #0xa
 	ble _02193154
-	mov r0, sb
+	mov r0, r9
 	mov r1, #0
 	bl func_ov48_021923f8
 	b _02193154
 _02192fe0:
-	ldr r0, [sb, #0x138]
+	ldr r0, [r9, #0x138]
 	cmp r0, #0xa
 	bgt _02193010
 	bge _021930b4
@@ -3899,17 +3899,17 @@ _02193020:
 	b _02193154
 _0219302c:
 	mov r1, #0
-	strb r1, [sb, #0x528]
+	strb r1, [r9, #0x528]
 	str r1, [sp]
 	ldr r0, _02193198 ; =data_027e0e58
 	str r1, [sp, #4]
-	add r1, sb, #0xdc
+	add r1, r9, #0xdc
 	ldr r0, [r0]
 	add r2, r1, #0x400
 	mov r1, #0x20c
 	mov r3, #2
 	bl func_ov00_0207c1b0
-	add r1, sb, #0xdc
+	add r1, r9, #0xdc
 	ldr r0, _02193164 ; =data_027e0ffc
 	add r2, r1, #0x400
 	mov r1, #0x248
@@ -3918,34 +3918,34 @@ _0219302c:
 	b _02193154
 _02193074:
 	mov r1, #0
-	strb r1, [sb, #0x527]
+	strb r1, [r9, #0x527]
 	str r1, [sp]
 	ldr r0, _02193198 ; =data_027e0e58
 	str r1, [sp, #4]
 	ldr r0, [r0]
-	add r2, sb, #0x4d0
+	add r2, r9, #0x4d0
 	mov r1, #0x20c
 	mov r3, #2
 	bl func_ov00_0207c1b0
 	ldr r0, _02193164 ; =data_027e0ffc
-	add r2, sb, #0x4d0
+	add r2, r9, #0x4d0
 	mov r1, #0x248
 	mov r3, #0
 	bl func_ov00_020ceacc
 	b _02193154
 _021930b4:
 	mov r1, #0
-	strb r1, [sb, #0x526]
+	strb r1, [r9, #0x526]
 	str r1, [sp]
 	ldr r0, _02193198 ; =data_027e0e58
 	str r1, [sp, #4]
-	add r1, sb, #0xc4
+	add r1, r9, #0xc4
 	ldr r0, [r0]
 	add r2, r1, #0x400
 	mov r1, #0x20c
 	mov r3, #2
 	bl func_ov00_0207c1b0
-	add r1, sb, #0xc4
+	add r1, r9, #0xc4
 	ldr r0, _02193164 ; =data_027e0ffc
 	add r2, r1, #0x400
 	mov r1, #0x248
@@ -3954,17 +3954,17 @@ _021930b4:
 	b _02193154
 _021930fc:
 	mov r1, #0
-	strb r1, [sb, #0x525]
+	strb r1, [r9, #0x525]
 	str r1, [sp]
 	ldr r0, _02193198 ; =data_027e0e58
 	str r1, [sp, #4]
-	add r1, sb, #0xb8
+	add r1, r9, #0xb8
 	ldr r0, [r0]
 	add r2, r1, #0x400
 	mov r1, #0x20c
 	mov r3, #2
 	bl func_ov00_0207c1b0
-	add r1, sb, #0xb8
+	add r1, r9, #0xb8
 	ldr r0, _02193164 ; =data_027e0ffc
 	add r2, r1, #0x400
 	mov r1, #0x248
@@ -3973,13 +3973,13 @@ _021930fc:
 	b _02193154
 _02193144:
 	mov r1, #0
-	mov r0, sb
-	strb r1, [sb, #0x524]
+	mov r0, r9
+	strb r1, [r9, #0x524]
 	bl func_ov00_020cc180
 _02193154:
 	mov r0, #1
 	add sp, sp, #0x88
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov48_02192604
 _02193160: .word gItemManager
@@ -4001,7 +4001,7 @@ _02193198: .word data_027e0e58
 	.global func_ov48_0219319c
 	arm_func_start func_ov48_0219319c
 func_ov48_0219319c: ; 0x0219319c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x90
 	mov r10, r0
 	add r0, r10, #0xe8
@@ -4009,7 +4009,7 @@ func_ov48_0219319c: ; 0x0219319c
 	add r8, r0, #0x400
 	add r0, r10, #0xac
 	ldr r6, _02193358 ; =data_02050f54
-	mov sb, r8
+	mov r9, r8
 	str r1, [sp, #0x84]
 	str r1, [sp, #0x88]
 	str r1, [sp, #0x8c]
@@ -4049,7 +4049,7 @@ _02193240:
 	mla r0, r1, r0, r4
 	cmp r7, #4
 	bne _021932c4
-	mov r1, sb
+	mov r1, r9
 	add r2, sp, #0x54
 	bl func_01ff9bf8
 	ldr r0, [sp, #0x54]
@@ -4078,7 +4078,7 @@ _02193240:
 	blx ip
 	b _02193330
 _021932c4:
-	mov r1, sb
+	mov r1, r9
 	add r2, sp, #0x24
 	bl func_01ff9bf8
 	ldr r0, [sp, #0x24]
@@ -4107,7 +4107,7 @@ _021932c4:
 	blx ip
 _02193330:
 	add r8, r8, #0xc
-	add sb, sb, #0xc
+	add r9, r9, #0xc
 	add r0, r7, #1
 	mov r0, r0, lsl #0x10
 	mov r7, r0, asr #0x10
@@ -4115,7 +4115,7 @@ _02193330:
 	blt _021931dc
 	mov r0, #1
 	add sp, sp, #0x90
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov48_0219319c
 _02193358: .word data_02050f54
@@ -4477,7 +4477,7 @@ func_ov48_02193644: ; 0x02193644
 	.global func_ov48_02193658
 	arm_func_start func_ov48_02193658
 func_ov48_02193658: ; 0x02193658
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x26c
 	mov r10, r0
 	str r1, [sp, #0xc]
@@ -4534,7 +4534,7 @@ _02193714:
 	blt _02193704
 	add r4, r10, #0x100
 	ldrh r0, [r4, #0x5e]
-	mov sb, #0
+	mov r9, #0
 	mov r1, r0, lsl #0x1
 	cmp r1, #0
 	ble _021937b8
@@ -4544,7 +4544,7 @@ _02193714:
 	add r7, r10, #0x16c
 	add r5, sp, #0xac
 _02193758:
-	add r0, sb, #1
+	add r0, r9, #1
 	add r1, sp, #0xb8
 	mov r3, r5
 	mov r0, r0, lsl #0xb
@@ -4561,11 +4561,11 @@ _02193758:
 	add r1, r7, r6
 	mov r2, r5
 	bl func_ov00_0207c518
-	add r0, sb, #1
+	add r0, r9, #1
 	mov r0, r0, lsl #0x10
-	mov sb, r0, asr #0x10
+	mov r9, r0, asr #0x10
 	ldrh r0, [r4, #0x5e]
-	cmp sb, r0, lsl #1
+	cmp r9, r0, lsl #1
 	mov r1, r0, lsl #0x1
 	blt _02193758
 _021937b8:
@@ -4573,7 +4573,7 @@ _021937b8:
 	cmp r0, #1
 	bne _02193848
 	cmp r1, #0
-	mov sb, #0
+	mov r9, #0
 	ble _02193848
 	mov r0, #0xc
 	mul r6, r8, r0
@@ -4582,7 +4582,7 @@ _021937b8:
 	add r4, r10, #0x100
 	add r5, sp, #0xac
 _021937e8:
-	add r0, sb, #1
+	add r0, r9, #1
 	mov r0, r0, lsl #0xb
 	add r1, sp, #0xb8
 	mov r3, r5
@@ -4600,11 +4600,11 @@ _021937e8:
 	add r1, r7, r6
 	mov r2, r5
 	bl func_ov00_0207c518
-	add r0, sb, #1
+	add r0, r9, #1
 	mov r0, r0, lsl #0x10
-	mov sb, r0, asr #0x10
+	mov r9, r0, asr #0x10
 	ldrh r0, [r4, #0x5e]
-	cmp sb, r0, lsl #1
+	cmp r9, r0, lsl #1
 	blt _021937e8
 _02193848:
 	ldr r1, [r10, #0x48]
@@ -4701,14 +4701,14 @@ _02193924:
 	ldrsh r7, [r1, r6]
 	add r6, r8, #1
 	mov r6, r6, lsl #0x1
-	smull sb, r8, r7, r4
-	adds r7, sb, #0x800
+	smull r9, r8, r7, r4
+	adds r7, r9, #0x800
 	ldrsh r1, [r1, r6]
-	mov sb, r7, lsr #0xc
+	mov r9, r7, lsr #0xc
 	adc r8, r8, #0
 	smull r7, r6, r1, r4
-	orr sb, sb, r8, lsl #20
-	add r0, r0, sb
+	orr r9, r9, r8, lsl #20
+	add r0, r0, r9
 	adds r1, r7, #0x800
 	str r0, [r10, #0x1cc]
 	adc r0, r6, #0
@@ -4766,11 +4766,11 @@ _02193924:
 	sub r0, r3, #0x1800
 	ldr r7, [sp, #0xa0]
 	sub r1, r5, #1
-	umull sb, r8, r7, r0
+	umull r9, r8, r7, r0
 	mla r8, r7, r1, r8
 	mov r1, r7, asr #0x1f
 	mla r8, r1, r0, r8
-	adds r7, sb, #0x800
+	adds r7, r9, #0x800
 	ldr r6, [sp, #0xa4]
 	adc r3, r8, #0
 	mov r7, r7, lsr #0xc
@@ -4857,12 +4857,12 @@ _02193bd4:
 	cmp r0, #0
 	ble _02193d10
 	ldr r11, _02193f40 ; =data_027e0fe4
-	mov sb, r5
+	mov r9, r5
 	add r4, sp, #0x84
 _02193c18:
 	ldr r1, [sp, #0x198]
 	ldr r0, [r11]
-	add r1, r1, sb
+	add r1, r1, r9
 	bl _ZN12ActorManager8GetActorEP8ActorRef
 	movs r6, r0
 	beq _02193cfc
@@ -4920,7 +4920,7 @@ _02193cec:
 	mov r0, r6
 	bl func_ov14_02122e98
 _02193cfc:
-	add sb, sb, #8
+	add r9, r9, #8
 	add r5, r5, #1
 	ldr r0, [sp, #0x1a0]
 	cmp r5, r0
@@ -4963,14 +4963,14 @@ _02193d68:
 	mov r5, #0
 	cmp r0, #0
 	ble _02193ea0
-	mov sb, r5
+	mov r9, r5
 	add r4, sp, #0x74
 	mov r11, #1
 _02193dac:
 	ldr r0, _02193f40 ; =data_027e0fe4
 	ldr r1, [sp, #0xc4]
 	ldr r0, [r0]
-	add r1, r1, sb
+	add r1, r1, r9
 	bl _ZN12ActorManager8GetActorEP8ActorRef
 	movs r6, r0
 	beq _02193e8c
@@ -5026,7 +5026,7 @@ _02193e84:
 	cmp r7, #0
 	strneb r11, [r6, #0x180]
 _02193e8c:
-	add sb, sb, #8
+	add r9, r9, #8
 	add r5, r5, #1
 	ldr r0, [sp, #0xcc]
 	cmp r5, r0
@@ -5070,7 +5070,7 @@ _02193f10:
 	add r2, r10, #0x48
 	bl func_ov00_0207a1c8
 	add sp, sp, #0x26c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov48_02193658
 _02193f28: .word data_02050f54

--- a/asm/ov50.s
+++ b/asm/ov50.s
@@ -1814,19 +1814,19 @@ _02196d90: .word data_027e0fc8
 	.global func_ov50_02196d94
 	arm_func_start func_ov50_02196d94
 func_ov50_02196d94: ; 0x02196d94
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x8c
 	mov r5, #0xff
 	sub r4, r5, #0x100
 	add r3, sp, #0x34
-	mov fp, r0
+	mov r11, r0
 	mov r7, #0
 	mov r6, #0xb
 	mov r2, #8
 	add r1, sp, #0x18
 	strb r5, [sp, #0x74]
 	str r6, [sp, #0x84]
-	str fp, [sp, #0x88]
+	str r11, [sp, #0x88]
 	str r4, [sp, #0x34]
 	str r4, [sp, #0x38]
 	str r4, [sp, #0x3c]
@@ -1859,13 +1859,13 @@ func_ov50_02196d94: ; 0x02196d94
 	add r1, sp, #0
 	add r2, sp, #0x28
 	str r3, [r4, #0xc]
-	str fp, [sp, #0x14]
+	str r11, [sp, #0x14]
 	bl _ZN12ActorManager12FilterActorsEP15ActorFilterBaseP9ActorList
 	mov r8, r0
 	cmp r8, #0
 	mov sb, r7
 	addle sp, sp, #0x8c
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r4, _02196edc ; =0x42494752
 	ldr r5, _02196ed8 ; =data_027e0fe4
 	add sl, sp, #0x34
@@ -1883,19 +1883,19 @@ _02196e74:
 	ldr r0, [r7, #4]
 	cmp r0, r4
 	bne _02196ebc
-	mov r0, fp
+	mov r0, r11
 	mov r1, #4
 	mov r2, #0
 	bl func_ov50_021960c8
 	add sp, sp, #0x8c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02196ebc:
 	add sb, sb, #1
 	cmp sb, r8
 	add sl, sl, #8
 	blt _02196e74
 	add sp, sp, #0x8c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov50_02196d94
 _02196ed4: .word data_ov50_021989f0

--- a/asm/ov50.s
+++ b/asm/ov50.s
@@ -1814,7 +1814,7 @@ _02196d90: .word data_027e0fc8
 	.global func_ov50_02196d94
 	arm_func_start func_ov50_02196d94
 func_ov50_02196d94: ; 0x02196d94
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x8c
 	mov r5, #0xff
 	sub r4, r5, #0x100
@@ -1865,14 +1865,14 @@ func_ov50_02196d94: ; 0x02196d94
 	cmp r8, #0
 	mov sb, r7
 	addle sp, sp, #0x8c
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r4, _02196edc ; =0x42494752
 	ldr r5, _02196ed8 ; =data_027e0fe4
-	add sl, sp, #0x34
+	add r10, sp, #0x34
 	add r6, sp, #0x74
 _02196e74:
 	ldr r0, [r5]
-	mov r1, sl
+	mov r1, r10
 	bl _ZN12ActorManager8GetActorEP8ActorRef
 	movs r7, r0
 	beq _02196ebc
@@ -1888,14 +1888,14 @@ _02196e74:
 	mov r2, #0
 	bl func_ov50_021960c8
 	add sp, sp, #0x8c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02196ebc:
 	add sb, sb, #1
 	cmp sb, r8
-	add sl, sl, #8
+	add r10, r10, #8
 	blt _02196e74
 	add sp, sp, #0x8c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov50_02196d94
 _02196ed4: .word data_ov50_021989f0

--- a/asm/ov50.s
+++ b/asm/ov50.s
@@ -1814,7 +1814,7 @@ _02196d90: .word data_027e0fc8
 	.global func_ov50_02196d94
 	arm_func_start func_ov50_02196d94
 func_ov50_02196d94: ; 0x02196d94
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x8c
 	mov r5, #0xff
 	sub r4, r5, #0x100
@@ -1863,9 +1863,9 @@ func_ov50_02196d94: ; 0x02196d94
 	bl _ZN12ActorManager12FilterActorsEP15ActorFilterBaseP9ActorList
 	mov r8, r0
 	cmp r8, #0
-	mov sb, r7
+	mov r9, r7
 	addle sp, sp, #0x8c
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r4, _02196edc ; =0x42494752
 	ldr r5, _02196ed8 ; =data_027e0fe4
 	add r10, sp, #0x34
@@ -1888,14 +1888,14 @@ _02196e74:
 	mov r2, #0
 	bl func_ov50_021960c8
 	add sp, sp, #0x8c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02196ebc:
-	add sb, sb, #1
-	cmp sb, r8
+	add r9, r9, #1
+	cmp r9, r8
 	add r10, r10, #8
 	blt _02196e74
 	add sp, sp, #0x8c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov50_02196d94
 _02196ed4: .word data_ov50_021989f0

--- a/asm/ov51.s
+++ b/asm/ov51.s
@@ -1114,37 +1114,37 @@ _021962ac:
 	.global func_ov51_021962b4
 	arm_func_start func_ov51_021962b4
 func_ov51_021962b4: ; 0x021962b4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x2c
-	mov sl, r0
-	ldr r0, [sl, #0x2f8]
+	mov r10, r0
+	ldr r0, [r10, #0x2f8]
 	add r0, r0, #1
-	str r0, [sl, #0x2f8]
-	ldr r1, [sl, #0x300]
+	str r0, [r10, #0x2f8]
+	ldr r1, [r10, #0x300]
 	bl func_02002c14
 	mov r0, #0xc
 	mul r2, r1, r0
-	str r1, [sl, #0x2f8]
-	ldr r1, [sl, #0x2fc]
-	ldr r0, [sl, #0x48]
+	str r1, [r10, #0x2f8]
+	ldr r1, [r10, #0x2fc]
+	ldr r0, [r10, #0x48]
 	add r3, r1, r2
 	str r0, [r1, r2]
-	ldr r0, [sl, #0x4c]
+	ldr r0, [r10, #0x4c]
 	str r0, [r3, #4]
-	ldr r0, [sl, #0x50]
+	ldr r0, [r10, #0x50]
 	str r0, [r3, #8]
-	ldr r0, [sl, #0x154]
+	ldr r0, [r10, #0x154]
 	cmp r0, #1
 	bgt _02196470
 	ldr r5, _021964f4 ; =data_027e0e58
-	mov r8, sl
-	add sb, sl, #0x490
+	mov r8, r10
+	add sb, r10, #0x490
 	mov r7, #0
 	add r6, sp, #0x20
 	mov r4, #0xc
 _02196324:
-	ldr r1, [sl, #0x300]
-	ldr r2, [sl, #0x2f8]
+	ldr r1, [r10, #0x300]
+	ldr r2, [r10, #0x2f8]
 	sub r0, r1, #1
 	mul r0, r7, r0
 	add r2, r1, r2
@@ -1152,7 +1152,7 @@ _02196324:
 	sub r0, r2, r0, asr #1
 	bl func_02002c14
 	mul r2, r1, r4
-	ldr r3, [sl, #0x2fc]
+	ldr r3, [r10, #0x2fc]
 	add r0, r8, #0x6c
 	ldr r1, [r3, r2]
 	add r2, r3, r2
@@ -1179,10 +1179,10 @@ _02196324:
 	add r8, r8, #0xc
 	add sb, sb, #0xc
 	blt _02196324
-	add r0, sl, #0x6c
+	add r0, r10, #0x6c
 	ldr r11, _021964f8 ; =0x000004cd
 	ldr r4, _021964fc ; =data_027e0f90
-	mov r8, sl
+	mov r8, r10
 	add sb, r0, #0x400
 	mov r7, #0
 	add r6, sp, #0x14
@@ -1201,8 +1201,8 @@ _021963d4:
 	bl func_01ff9bf8
 	mov r0, #5
 	str r0, [sp]
-	ldrb r3, [sl, #0x124]
-	mov r0, sl
+	ldrb r3, [r10, #0x124]
+	mov r0, r10
 	mov r1, r5
 	mov r2, r6
 	bl _ZN5Actor18func_ov00_020c1ef8EP8CylinderP5Vec3pii
@@ -1213,7 +1213,7 @@ _021963d4:
 	cmp r0, #0
 	beq _02196450
 	ldr r0, [r4]
-	ldrb r1, [sl, #0x124]
+	ldrb r1, [r10, #0x124]
 	ldr ip, [r0]
 	mov r2, r6
 	ldr ip, [ip, #0x30]
@@ -1229,7 +1229,7 @@ _02196450:
 	blt _021963d4
 	b _02196498
 _02196470:
-	add r5, sl, #0x490
+	add r5, r10, #0x490
 	mov r4, #0
 _02196478:
 	mov r0, r5
@@ -1243,30 +1243,30 @@ _02196478:
 _02196498:
 	mov r0, #0
 	str r0, [sp]
-	ldr r3, [sl, #8]
+	ldr r3, [r10, #8]
 	ldr r0, _02196504 ; =data_027e0ffc
 	ldr r1, _02196508 ; =0x00000262
-	add r2, sl, #0x48
+	add r2, r10, #0x48
 	bl func_ov00_020cec60
-	ldr r0, [sl, #0x130]
+	ldr r0, [r10, #0x130]
 	cmp r0, #0
 	beq _021964cc
 	cmp r0, #1
 	beq _021964d8
 	b _021964e0
 _021964cc:
-	mov r0, sl
+	mov r0, r10
 	bl func_ov51_02196220
 	b _021964e0
 _021964d8:
-	mov r0, sl
+	mov r0, r10
 	bl func_ov51_02196254
 _021964e0:
-	add r0, sl, #0x21c
+	add r0, r10, #0x21c
 	bl func_ov51_02196004
 	mov r0, #1
 	add sp, sp, #0x2c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov51_021962b4
 _021964f4: .word data_027e0e58
@@ -1279,13 +1279,13 @@ _02196508: .word 0x00000262
 	.global func_ov51_0219650c
 	arm_func_start func_ov51_0219650c
 func_ov51_0219650c: ; 0x0219650c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x24
-	mov sl, r0
-	add r0, sl, #0x6c
+	mov r10, r0
+	add r0, r10, #0x6c
 	add r0, r0, #0x400
 	ldr r5, _021965b8 ; =0x000004cd
-	add r8, sl, #0x18
+	add r8, r10, #0x18
 	add sb, r0, #0x18
 	mov r7, #2
 	add r6, sp, #0x18
@@ -1297,7 +1297,7 @@ _0219653c:
 	ldmia r0, {r0, r1, r2}
 	stmia r6, {r0, r1, r2}
 	ldr r1, [sp, #0x1c]
-	add r0, sl, #0x21c
+	add r0, r10, #0x21c
 	add r1, r1, #0x85
 	add r1, r1, #0x300
 	str r1, [sp, #0x1c]
@@ -1322,7 +1322,7 @@ _0219653c:
 	bpl _0219653c
 	mov r0, #1
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov51_0219650c
 _021965b8: .word 0x000004cd
@@ -1599,7 +1599,7 @@ _02196920: .word data_ov51_02198918
 	.global func_ov51_02196924
 	arm_func_start func_ov51_02196924
 func_ov51_02196924: ; 0x02196924
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x68
 	ldr r2, _02196b38 ; =func_ov51_02196b4c
 	ldr r3, _02196b3c ; =func_ov51_02196b50
@@ -1689,30 +1689,30 @@ func_ov51_02196924: ; 0x02196924
 	adds r8, r2, #0x800
 	mov r1, r1, lsl #0x1
 	ldrsh r6, [r5, r1]
-	ldr sl, [sp, #8]
+	ldr r10, [sp, #8]
 	ldr r1, [sp, #4]
-	add r3, r3, sl
+	add r3, r3, r10
 	smull r5, r2, sb, r6
 	adc r7, r7, #0
 	adds r5, r5, #0x800
 	mov r8, r8, lsr #0xc
 	orr r8, r8, r7, lsl #20
-	smull sl, r6, r1, r6
+	smull r10, r6, r1, r6
 	adc sb, r2, #0
 	mov r5, r5, lsr #0xc
 	sub r7, lr, #0x8000
 	rsb r0, r0, #0
-	adds r2, sl, #0x800
+	adds r2, r10, #0x800
 	orr r5, r5, sb, lsl #20
-	smull sl, sb, r1, r0
+	smull r10, sb, r1, r0
 	adc r0, r6, #0
-	adds r6, sl, #0x800
-	mov sl, r2, lsr #0xc
+	adds r6, r10, #0x800
+	mov r10, r2, lsr #0xc
 	mov r2, r6, lsr #0xc
 	adc r1, sb, #0
-	orr sl, sl, r0, lsl #20
+	orr r10, r10, r0, lsl #20
 	add r6, r11, r8
-	add r6, r6, sl
+	add r6, r6, r10
 	orr r2, r2, r1, lsl #20
 	add r0, ip, r5
 	add r0, r0, r2
@@ -1731,7 +1731,7 @@ func_ov51_02196924: ; 0x02196924
 	bl func_0204f754
 	mov r0, #1
 	add sp, sp, #0x68
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov51_02196924
 _02196b38: .word func_ov51_02196b4c
@@ -1985,11 +1985,11 @@ func_ov51_02196dec: ; 0x02196dec
 	.global func_ov51_02196e18
 	arm_func_start func_ov51_02196e18
 func_ov51_02196e18: ; 0x02196e18
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x30
 	ldr r1, _02196f00 ; =data_027e0f94
 	add r8, sp, #0x24
-	mov sl, r0
+	mov r10, r0
 	ldmia r1, {r0, r1, r2}
 	mov sb, #0
 	stmia r8, {r0, r1, r2}
@@ -2001,7 +2001,7 @@ func_ov51_02196e18: ; 0x02196e18
 _02196e4c:
 	mov r1, sb
 	mov r2, r6
-	add r0, sl, #0x48
+	add r0, r10, #0x48
 	mov r3, r11
 	stmia sp, {r7, r8}
 	bl func_ov00_020c57fc
@@ -2013,29 +2013,29 @@ _02196e4c:
 	ldr r0, [sp, #0x2c]
 	str r1, [sp, #0x1c]
 	str r0, [sp, #0x20]
-	ldr r0, [sl, #0x48]
+	ldr r0, [r10, #0x48]
 	add r1, sp, #0x18
 	str r0, [sp, #0xc]
-	ldr r0, [sl, #0x4c]
+	ldr r0, [r10, #0x4c]
 	add r2, sp, #0xc
 	str r0, [sp, #0x10]
-	ldr r0, [sl, #0x50]
+	ldr r0, [r10, #0x50]
 	str r0, [sp, #0x14]
-	ldr r0, [sl, #8]
+	ldr r0, [r10, #8]
 	str r0, [sp]
-	ldrh r0, [sl, #0x9c]
+	ldrh r0, [r10, #0x9c]
 	stmib sp, {r0, r5}
 	ldr r0, [r4]
-	ldr r3, [sl, #0x88]
+	ldr r3, [r10, #0x88]
 	bl func_01ffe1cc
 	cmp r0, #0
 	moveq r0, #1
 	movne r0, #0
 	cmp r0, #0
 	addne sp, sp, #0x30
-	strne sb, [sl, #0x74]
+	strne sb, [r10, #0x74]
 	movne r0, #1
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02196ee0:
 	add r0, sb, #1
 	mov r0, r0, lsl #0x10
@@ -2044,7 +2044,7 @@ _02196ee0:
 	blt _02196e4c
 	mov r0, #0
 	add sp, sp, #0x30
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov51_02196e18
 _02196f00: .word data_027e0f94
@@ -3187,7 +3187,7 @@ _02197df4:
 	.global func_ov51_02197e08
 	arm_func_start func_ov51_02197e08
 func_ov51_02197e08: ; 0x02197e08
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x90
 	mov r4, r0
 	cmp r1, #0
@@ -3195,7 +3195,7 @@ func_ov51_02197e08: ; 0x02197e08
 	ldreqb r0, [r4, #0xa4]
 	cmp r0, #0
 	addeq sp, sp, #0x90
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	mov r0, #0x1000
 	str r0, [sp, #0x84]
 	str r0, [sp, #0x88]
@@ -3268,7 +3268,7 @@ _02197f1c:
 	ldrh r0, [r5, #0xe6]
 	cmp r0, #0
 	ble _02197f94
-	mov sl, sb
+	mov r10, sb
 	add r8, r4, #0x48
 	add r7, sp, #0x48
 	add r6, sp, #0x54
@@ -3276,7 +3276,7 @@ _02197f1c:
 _02197f48:
 	ldmia r8, {r0, r1, r2}
 	stmia r7, {r0, r1, r2}
-	mov r0, sl
+	mov r0, r10
 	mov r1, r6
 	mov r2, r7
 	mov r3, r7
@@ -3290,7 +3290,7 @@ _02197f48:
 	blx ip
 	ldrh r0, [r5, #0xe6]
 	add sb, sb, #1
-	add sl, sl, #0x1000
+	add r10, r10, #0x1000
 	cmp sb, r0
 	blt _02197f48
 _02197f94:
@@ -3326,7 +3326,7 @@ _02197f94:
 	mov r3, r3, lsl #0xb
 	bl func_ov05_02102c2c
 	add sp, sp, #0x90
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov51_02197e08
 _02198018: .word data_02050f54
@@ -3336,7 +3336,7 @@ _02198020: .word data_ov00_020e9370
 	.global func_ov51_02198024
 	arm_func_start func_ov51_02198024
 func_ov51_02198024: ; 0x02198024
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	mov sb, r0
 	ldr r4, [sb, #0x48]
 	ldr r5, [sb, #0x50]
@@ -3344,7 +3344,7 @@ func_ov51_02198024: ; 0x02198024
 	mov r8, r1
 	mov r6, r4
 	mov r7, r5
-	ldr sl, [sb, #0x4c]
+	ldr r10, [sb, #0x4c]
 	bl func_0202bb98
 	cmp r0, #3
 	addls pc, pc, r0, lsl #2
@@ -3423,12 +3423,12 @@ _02198128:
 	sub r7, r7, #0x400
 _02198164:
 	str r4, [r8]
-	sub r0, sl, #0x800
+	sub r0, r10, #0x800
 	stmib r8, {r0, r5, r6}
-	add r0, sl, #0x800
+	add r0, r10, #0x800
 	str r0, [r8, #0x10]
 	str r7, [r8, #0x14]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov51_02198024
 _02198180: .word 0x000004cd

--- a/asm/ov51.s
+++ b/asm/ov51.s
@@ -1114,7 +1114,7 @@ _021962ac:
 	.global func_ov51_021962b4
 	arm_func_start func_ov51_021962b4
 func_ov51_021962b4: ; 0x021962b4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x2c
 	mov sl, r0
 	ldr r0, [sl, #0x2f8]
@@ -1180,7 +1180,7 @@ _02196324:
 	add sb, sb, #0xc
 	blt _02196324
 	add r0, sl, #0x6c
-	ldr fp, _021964f8 ; =0x000004cd
+	ldr r11, _021964f8 ; =0x000004cd
 	ldr r4, _021964fc ; =data_027e0f90
 	mov r8, sl
 	add sb, r0, #0x400
@@ -1197,7 +1197,7 @@ _021963d4:
 	ldr r3, [r8, #0x474]
 	mov r2, r6
 	str r3, [sp, #0xc]
-	str fp, [sp, #0x10]
+	str r11, [sp, #0x10]
 	bl func_01ff9bf8
 	mov r0, #5
 	str r0, [sp]
@@ -1266,7 +1266,7 @@ _021964e0:
 	bl func_ov51_02196004
 	mov r0, #1
 	add sp, sp, #0x2c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov51_021962b4
 _021964f4: .word data_027e0e58
@@ -1279,7 +1279,7 @@ _02196508: .word 0x00000262
 	.global func_ov51_0219650c
 	arm_func_start func_ov51_0219650c
 func_ov51_0219650c: ; 0x0219650c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x24
 	mov sl, r0
 	add r0, sl, #0x6c
@@ -1290,7 +1290,7 @@ func_ov51_0219650c: ; 0x0219650c
 	mov r7, #2
 	add r6, sp, #0x18
 	mov r4, #0x1f
-	mov fp, #1
+	mov r11, #1
 _0219653c:
 	add r0, r8, #0x6c
 	add r0, r0, #0x400
@@ -1307,12 +1307,12 @@ _0219653c:
 	mov r0, #0
 	stmib sp, {r0, r4}
 	str r0, [sp, #0xc]
-	str fp, [sp, #0x10]
+	str r11, [sp, #0x10]
 	ldr r0, _021965bc ; =data_ov00_020e9370
 	mov r1, #0
 	mov r2, sb
 	mov r3, r5
-	str fp, [sp, #0x14]
+	str r11, [sp, #0x14]
 	bl func_ov05_02102c2c
 	sub r0, r7, #1
 	mov r0, r0, lsl #0x10
@@ -1322,7 +1322,7 @@ _0219653c:
 	bpl _0219653c
 	mov r0, #1
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov51_0219650c
 _021965b8: .word 0x000004cd
@@ -1599,7 +1599,7 @@ _02196920: .word data_ov51_02198918
 	.global func_ov51_02196924
 	arm_func_start func_ov51_02196924
 func_ov51_02196924: ; 0x02196924
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x68
 	ldr r2, _02196b38 ; =func_ov51_02196b4c
 	ldr r3, _02196b3c ; =func_ov51_02196b50
@@ -1673,7 +1673,7 @@ func_ov51_02196924: ; 0x02196924
 	ldr r0, _02196b44 ; =data_ov51_02198274
 	ldr r3, [r1, #0x4c]
 	ldr ip, [r5, #0xc]
-	ldr fp, [r5, #4]
+	ldr r11, [r5, #4]
 	ldr r5, _02196b48 ; =data_02050f54
 	add r8, sp, #4
 	ldmia r0, {r0, r1, r2}
@@ -1682,7 +1682,7 @@ func_ov51_02196924: ; 0x02196924
 	ldrsh r0, [r5, r6]
 	str r3, [sp, #0x14]
 	str ip, [sp, #0x18]
-	str fp, [sp, #0x10]
+	str r11, [sp, #0x10]
 	ldr sb, [sp, #0xc]
 	add r1, r7, #1
 	smull r2, r7, sb, r0
@@ -1711,7 +1711,7 @@ func_ov51_02196924: ; 0x02196924
 	mov r2, r6, lsr #0xc
 	adc r1, sb, #0
 	orr sl, sl, r0, lsl #20
-	add r6, fp, r8
+	add r6, r11, r8
 	add r6, r6, sl
 	orr r2, r2, r1, lsl #20
 	add r0, ip, r5
@@ -1731,7 +1731,7 @@ func_ov51_02196924: ; 0x02196924
 	bl func_0204f754
 	mov r0, #1
 	add sp, sp, #0x68
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov51_02196924
 _02196b38: .word func_ov51_02196b4c
@@ -1985,7 +1985,7 @@ func_ov51_02196dec: ; 0x02196dec
 	.global func_ov51_02196e18
 	arm_func_start func_ov51_02196e18
 func_ov51_02196e18: ; 0x02196e18
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x30
 	ldr r1, _02196f00 ; =data_027e0f94
 	add r8, sp, #0x24
@@ -1997,12 +1997,12 @@ func_ov51_02196e18: ; 0x02196e18
 	mov r5, sb
 	mov r7, #0xa000
 	mov r6, #0x800
-	mov fp, #0x2000
+	mov r11, #0x2000
 _02196e4c:
 	mov r1, sb
 	mov r2, r6
 	add r0, sl, #0x48
-	mov r3, fp
+	mov r3, r11
 	stmia sp, {r7, r8}
 	bl func_ov00_020c57fc
 	cmp r0, #0
@@ -2035,7 +2035,7 @@ _02196e4c:
 	addne sp, sp, #0x30
 	strne sb, [sl, #0x74]
 	movne r0, #1
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02196ee0:
 	add r0, sb, #1
 	mov r0, r0, lsl #0x10
@@ -2044,7 +2044,7 @@ _02196ee0:
 	blt _02196e4c
 	mov r0, #0
 	add sp, sp, #0x30
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov51_02196e18
 _02196f00: .word data_027e0f94
@@ -3187,7 +3187,7 @@ _02197df4:
 	.global func_ov51_02197e08
 	arm_func_start func_ov51_02197e08
 func_ov51_02197e08: ; 0x02197e08
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x90
 	mov r4, r0
 	cmp r1, #0
@@ -3195,7 +3195,7 @@ func_ov51_02197e08: ; 0x02197e08
 	ldreqb r0, [r4, #0xa4]
 	cmp r0, #0
 	addeq sp, sp, #0x90
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	mov r0, #0x1000
 	str r0, [sp, #0x84]
 	str r0, [sp, #0x88]
@@ -3272,7 +3272,7 @@ _02197f1c:
 	add r8, r4, #0x48
 	add r7, sp, #0x48
 	add r6, sp, #0x54
-	add fp, sp, #0x84
+	add r11, sp, #0x84
 _02197f48:
 	ldmia r8, {r0, r1, r2}
 	stmia r7, {r0, r1, r2}
@@ -3283,7 +3283,7 @@ _02197f48:
 	bl func_01ff9e64
 	add r0, r4, #0x158
 	ldr ip, [r0]
-	mov r1, fp
+	mov r1, r11
 	ldr ip, [ip, #0x10]
 	add r2, sp, #0x60
 	mov r3, r7
@@ -3326,7 +3326,7 @@ _02197f94:
 	mov r3, r3, lsl #0xb
 	bl func_ov05_02102c2c
 	add sp, sp, #0x90
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov51_02197e08
 _02198018: .word data_02050f54

--- a/asm/ov51.s
+++ b/asm/ov51.s
@@ -1114,7 +1114,7 @@ _021962ac:
 	.global func_ov51_021962b4
 	arm_func_start func_ov51_021962b4
 func_ov51_021962b4: ; 0x021962b4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x2c
 	mov r10, r0
 	ldr r0, [r10, #0x2f8]
@@ -1138,7 +1138,7 @@ func_ov51_021962b4: ; 0x021962b4
 	bgt _02196470
 	ldr r5, _021964f4 ; =data_027e0e58
 	mov r8, r10
-	add sb, r10, #0x490
+	add r9, r10, #0x490
 	mov r7, #0
 	add r6, sp, #0x20
 	mov r4, #0xc
@@ -1169,7 +1169,7 @@ _02196324:
 	add r1, r1, #0x85
 	add r1, r1, #0x300
 	str r1, [sp, #0x24]
-	mov r1, sb
+	mov r1, r9
 	mov r2, r6
 	bl func_ov00_0207c474
 	add r0, r7, #1
@@ -1177,13 +1177,13 @@ _02196324:
 	mov r7, r0, asr #0x10
 	cmp r7, #3
 	add r8, r8, #0xc
-	add sb, sb, #0xc
+	add r9, r9, #0xc
 	blt _02196324
 	add r0, r10, #0x6c
 	ldr r11, _021964f8 ; =0x000004cd
 	ldr r4, _021964fc ; =data_027e0f90
 	mov r8, r10
-	add sb, r0, #0x400
+	add r9, r0, #0x400
 	mov r7, #0
 	add r6, sp, #0x14
 	add r5, sp, #4
@@ -1192,7 +1192,7 @@ _021963d4:
 	ldr r0, _02196500 ; =data_027e0f94
 	str r1, [sp, #4]
 	ldr r2, [r8, #0x470]
-	mov r1, sb
+	mov r1, r9
 	str r2, [sp, #8]
 	ldr r3, [r8, #0x474]
 	mov r2, r6
@@ -1225,7 +1225,7 @@ _02196450:
 	mov r7, r0, asr #0x10
 	cmp r7, #3
 	add r8, r8, #0xc
-	add sb, sb, #0xc
+	add r9, r9, #0xc
 	blt _021963d4
 	b _02196498
 _02196470:
@@ -1266,7 +1266,7 @@ _021964e0:
 	bl func_ov51_02196004
 	mov r0, #1
 	add sp, sp, #0x2c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov51_021962b4
 _021964f4: .word data_027e0e58
@@ -1279,14 +1279,14 @@ _02196508: .word 0x00000262
 	.global func_ov51_0219650c
 	arm_func_start func_ov51_0219650c
 func_ov51_0219650c: ; 0x0219650c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x24
 	mov r10, r0
 	add r0, r10, #0x6c
 	add r0, r0, #0x400
 	ldr r5, _021965b8 ; =0x000004cd
 	add r8, r10, #0x18
-	add sb, r0, #0x18
+	add r9, r0, #0x18
 	mov r7, #2
 	add r6, sp, #0x18
 	mov r4, #0x1f
@@ -1310,19 +1310,19 @@ _0219653c:
 	str r11, [sp, #0x10]
 	ldr r0, _021965bc ; =data_ov00_020e9370
 	mov r1, #0
-	mov r2, sb
+	mov r2, r9
 	mov r3, r5
 	str r11, [sp, #0x14]
 	bl func_ov05_02102c2c
 	sub r0, r7, #1
 	mov r0, r0, lsl #0x10
 	sub r8, r8, #0xc
-	sub sb, sb, #0xc
+	sub r9, r9, #0xc
 	movs r7, r0, asr #0x10
 	bpl _0219653c
 	mov r0, #1
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov51_0219650c
 _021965b8: .word 0x000004cd
@@ -1599,7 +1599,7 @@ _02196920: .word data_ov51_02198918
 	.global func_ov51_02196924
 	arm_func_start func_ov51_02196924
 func_ov51_02196924: ; 0x02196924
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x68
 	ldr r2, _02196b38 ; =func_ov51_02196b4c
 	ldr r3, _02196b3c ; =func_ov51_02196b50
@@ -1683,33 +1683,33 @@ func_ov51_02196924: ; 0x02196924
 	str r3, [sp, #0x14]
 	str ip, [sp, #0x18]
 	str r11, [sp, #0x10]
-	ldr sb, [sp, #0xc]
+	ldr r9, [sp, #0xc]
 	add r1, r7, #1
-	smull r2, r7, sb, r0
+	smull r2, r7, r9, r0
 	adds r8, r2, #0x800
 	mov r1, r1, lsl #0x1
 	ldrsh r6, [r5, r1]
 	ldr r10, [sp, #8]
 	ldr r1, [sp, #4]
 	add r3, r3, r10
-	smull r5, r2, sb, r6
+	smull r5, r2, r9, r6
 	adc r7, r7, #0
 	adds r5, r5, #0x800
 	mov r8, r8, lsr #0xc
 	orr r8, r8, r7, lsl #20
 	smull r10, r6, r1, r6
-	adc sb, r2, #0
+	adc r9, r2, #0
 	mov r5, r5, lsr #0xc
 	sub r7, lr, #0x8000
 	rsb r0, r0, #0
 	adds r2, r10, #0x800
-	orr r5, r5, sb, lsl #20
-	smull r10, sb, r1, r0
+	orr r5, r5, r9, lsl #20
+	smull r10, r9, r1, r0
 	adc r0, r6, #0
 	adds r6, r10, #0x800
 	mov r10, r2, lsr #0xc
 	mov r2, r6, lsr #0xc
-	adc r1, sb, #0
+	adc r1, r9, #0
 	orr r10, r10, r0, lsl #20
 	add r6, r11, r8
 	add r6, r6, r10
@@ -1731,7 +1731,7 @@ func_ov51_02196924: ; 0x02196924
 	bl func_0204f754
 	mov r0, #1
 	add sp, sp, #0x68
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov51_02196924
 _02196b38: .word func_ov51_02196b4c
@@ -1985,21 +1985,21 @@ func_ov51_02196dec: ; 0x02196dec
 	.global func_ov51_02196e18
 	arm_func_start func_ov51_02196e18
 func_ov51_02196e18: ; 0x02196e18
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x30
 	ldr r1, _02196f00 ; =data_027e0f94
 	add r8, sp, #0x24
 	mov r10, r0
 	ldmia r1, {r0, r1, r2}
-	mov sb, #0
+	mov r9, #0
 	stmia r8, {r0, r1, r2}
 	ldr r4, _02196f04 ; =data_027e0e60
-	mov r5, sb
+	mov r5, r9
 	mov r7, #0xa000
 	mov r6, #0x800
 	mov r11, #0x2000
 _02196e4c:
-	mov r1, sb
+	mov r1, r9
 	mov r2, r6
 	add r0, r10, #0x48
 	mov r3, r11
@@ -2033,18 +2033,18 @@ _02196e4c:
 	movne r0, #0
 	cmp r0, #0
 	addne sp, sp, #0x30
-	strne sb, [r10, #0x74]
+	strne r9, [r10, #0x74]
 	movne r0, #1
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02196ee0:
-	add r0, sb, #1
+	add r0, r9, #1
 	mov r0, r0, lsl #0x10
-	mov sb, r0, asr #0x10
-	cmp sb, #4
+	mov r9, r0, asr #0x10
+	cmp r9, #4
 	blt _02196e4c
 	mov r0, #0
 	add sp, sp, #0x30
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov51_02196e18
 _02196f00: .word data_027e0f94
@@ -3187,7 +3187,7 @@ _02197df4:
 	.global func_ov51_02197e08
 	arm_func_start func_ov51_02197e08
 func_ov51_02197e08: ; 0x02197e08
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x90
 	mov r4, r0
 	cmp r1, #0
@@ -3195,7 +3195,7 @@ func_ov51_02197e08: ; 0x02197e08
 	ldreqb r0, [r4, #0xa4]
 	cmp r0, #0
 	addeq sp, sp, #0x90
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	mov r0, #0x1000
 	str r0, [sp, #0x84]
 	str r0, [sp, #0x88]
@@ -3262,13 +3262,13 @@ _02197f0c:
 	str r1, [sp, #0x54]
 	str r0, [sp, #0x5c]
 _02197f1c:
-	mov sb, #0
-	str sb, [sp, #0x58]
+	mov r9, #0
+	str r9, [sp, #0x58]
 	add r5, r4, #0x100
 	ldrh r0, [r5, #0xe6]
 	cmp r0, #0
 	ble _02197f94
-	mov r10, sb
+	mov r10, r9
 	add r8, r4, #0x48
 	add r7, sp, #0x48
 	add r6, sp, #0x54
@@ -3289,9 +3289,9 @@ _02197f48:
 	mov r3, r7
 	blx ip
 	ldrh r0, [r5, #0xe6]
-	add sb, sb, #1
+	add r9, r9, #1
 	add r10, r10, #0x1000
-	cmp sb, r0
+	cmp r9, r0
 	blt _02197f48
 _02197f94:
 	add r0, r4, #0x48
@@ -3326,7 +3326,7 @@ _02197f94:
 	mov r3, r3, lsl #0xb
 	bl func_ov05_02102c2c
 	add sp, sp, #0x90
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov51_02197e08
 _02198018: .word data_02050f54
@@ -3336,15 +3336,15 @@ _02198020: .word data_ov00_020e9370
 	.global func_ov51_02198024
 	arm_func_start func_ov51_02198024
 func_ov51_02198024: ; 0x02198024
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
-	mov sb, r0
-	ldr r4, [sb, #0x48]
-	ldr r5, [sb, #0x50]
-	ldr r0, [sb, #0x74]
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
+	mov r9, r0
+	ldr r4, [r9, #0x48]
+	ldr r5, [r9, #0x50]
+	ldr r0, [r9, #0x74]
 	mov r8, r1
 	mov r6, r4
 	mov r7, r5
-	ldr r10, [sb, #0x4c]
+	ldr r10, [r9, #0x4c]
 	bl func_0202bb98
 	cmp r0, #3
 	addls pc, pc, r0, lsl #2
@@ -3355,7 +3355,7 @@ _02198058: ; jump table
 	b _02198128 ; case 2
 	b _021980e8 ; case 3
 _02198068:
-	add r0, sb, #0x100
+	add r0, r9, #0x100
 	ldrh r0, [r0, #0xe6]
 	ldr r1, _02198180 ; =0x000004cd
 	sub r5, r5, #0xcd
@@ -3372,7 +3372,7 @@ _02198068:
 	sub r6, r6, #0x400
 	b _02198164
 _021980a8:
-	add r0, sb, #0x100
+	add r0, r9, #0x100
 	ldrh r1, [r0, #0xe6]
 	ldr r0, _02198180 ; =0x000004cd
 	sub r5, r5, #0xcd
@@ -3389,7 +3389,7 @@ _021980a8:
 	sub r6, r6, r0
 	b _02198164
 _021980e8:
-	add r0, sb, #0x100
+	add r0, r9, #0x100
 	ldrh r1, [r0, #0xe6]
 	ldr r0, _02198180 ; =0x000004cd
 	sub r4, r4, #0xcd
@@ -3406,7 +3406,7 @@ _021980e8:
 	sub r7, r7, r0
 	b _02198164
 _02198128:
-	add r0, sb, #0x100
+	add r0, r9, #0x100
 	ldrh r0, [r0, #0xe6]
 	ldr r1, _02198180 ; =0x000004cd
 	sub r4, r4, #0xcd
@@ -3428,7 +3428,7 @@ _02198164:
 	add r0, r10, #0x800
 	str r0, [r8, #0x10]
 	str r7, [r8, #0x14]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov51_02198024
 _02198180: .word 0x000004cd

--- a/asm/ov52.s
+++ b/asm/ov52.s
@@ -724,7 +724,7 @@ func_ov52_02195d9c: ; 0x02195d9c
 	.global func_ov52_02195da0
 	arm_func_start func_ov52_02195da0
 func_ov52_02195da0: ; 0x02195da0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #0x3c
 	ldr r2, _02196104 ; =data_027e0618
 	mov sb, r0
@@ -732,7 +732,7 @@ func_ov52_02195da0: ; 0x02195da0
 	mov r4, r1
 	cmp r0, #0
 	addne sp, sp, #0x3c
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	ldr r0, _02196108 ; =data_027e0f74
 	ldr r0, [r0]
 	bl func_ov00_02097738
@@ -742,12 +742,12 @@ func_ov52_02195da0: ; 0x02195da0
 	ldr r0, [r0, #0x130]
 	cmp r0, #0
 	addeq sp, sp, #0x3c
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 _02195dec:
 	ldrh r0, [r4]
 	tst r0, #2
 	addeq sp, sp, #0x3c
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	add r0, sp, #0x1c
 	bl func_01ffbe34
 	mov r1, #0
@@ -781,9 +781,9 @@ _02195dec:
 	mov r8, #0
 	beq _02195ef4
 	bl func_ov52_0219564c
-	mov sl, r0
+	mov r10, r0
 	bl func_ov52_02195500
-	cmp sl, r0
+	cmp r10, r0
 	bls _02195ea0
 	mov r5, #0x1f
 	mov r6, #0xe
@@ -946,7 +946,7 @@ _02195ff8:
 	mov r3, #0xd
 	bl func_02034bc8
 	add sp, sp, #0x3c
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov52_02195da0
 _02196104: .word data_027e0618

--- a/asm/ov52.s
+++ b/asm/ov52.s
@@ -724,15 +724,15 @@ func_ov52_02195d9c: ; 0x02195d9c
 	.global func_ov52_02195da0
 	arm_func_start func_ov52_02195da0
 func_ov52_02195da0: ; 0x02195da0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #0x3c
 	ldr r2, _02196104 ; =data_027e0618
-	mov sb, r0
+	mov r9, r0
 	ldrb r0, [r2, #0x101]
 	mov r4, r1
 	cmp r0, #0
 	addne sp, sp, #0x3c
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	ldr r0, _02196108 ; =data_027e0f74
 	ldr r0, [r0]
 	bl func_ov00_02097738
@@ -742,12 +742,12 @@ func_ov52_02195da0: ; 0x02195da0
 	ldr r0, [r0, #0x130]
 	cmp r0, #0
 	addeq sp, sp, #0x3c
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 _02195dec:
 	ldrh r0, [r4]
 	tst r0, #2
 	addeq sp, sp, #0x3c
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	add r0, sp, #0x1c
 	bl func_01ffbe34
 	mov r1, #0
@@ -772,7 +772,7 @@ _02195dec:
 	mov r0, #0x6b
 	mov r1, #0x10
 	bl func_0203493c
-	ldrb r0, [sb, #0xd]
+	ldrb r0, [r9, #0xd]
 	mov r4, #1
 	mov r6, #6
 	cmp r0, #0
@@ -790,10 +790,10 @@ _02195dec:
 	mov r7, #0xf
 	mov r8, r4
 _02195ea0:
-	ldrsh r0, [sb, #0xe]
+	ldrsh r0, [r9, #0xe]
 	add r0, r0, #1
-	strh r0, [sb, #0xe]
-	ldrsh r0, [sb, #0xe]
+	strh r0, [r9, #0xe]
+	ldrsh r0, [r9, #0xe]
 	cmp r0, #0xa
 	ble _02195eec
 	cmp r0, #0xb
@@ -804,11 +804,11 @@ _02195ea0:
 	mov r1, #0xc0
 	bl func_ov00_020d77e4
 _02195ed4:
-	ldrsh r0, [sb, #0xe]
+	ldrsh r0, [r9, #0xe]
 	mov r4, #1
 	cmp r0, #0x22
 	movgt r0, #0
-	strgth r0, [sb, #0xe]
+	strgth r0, [r9, #0xe]
 	b _02195ef4
 _02195eec:
 	cmp r0, #0
@@ -946,7 +946,7 @@ _02195ff8:
 	mov r3, #0xd
 	bl func_02034bc8
 	add sp, sp, #0x3c
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov52_02195da0
 _02196104: .word data_027e0618

--- a/asm/ov53.s
+++ b/asm/ov53.s
@@ -435,7 +435,7 @@ _021991e8: .word 0x00007a29
 	.global func_ov53_021991ec
 	arm_func_start func_ov53_021991ec
 func_ov53_021991ec: ; 0x021991ec
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x2c
 	ldr r5, _02199304 ; =data_ov53_0219a580
 	mov sl, r0
@@ -446,7 +446,7 @@ func_ov53_021991ec: ; 0x021991ec
 	ldr r8, _02199308 ; =data_ov53_0219a5bc
 	ldr r4, _0219930c ; =data_027e0e60
 	add r6, sp, #0x20
-	mov fp, #2
+	mov r11, #2
 	add r7, sp, #4
 _02199220:
 	add r0, r8, sb, lsl #1
@@ -462,7 +462,7 @@ _02199220:
 	ldr r3, [r0]
 	mov r1, r6
 	ldr r3, [r3, #0x64]
-	mov r2, fp
+	mov r2, r11
 	blx r3
 	ldrsh r1, [sl, #0x2c]
 	mov r0, sl
@@ -480,7 +480,7 @@ _02199280:
 	ldrh r0, [sb, #0x6c]
 	cmp r7, r0
 	addge sp, sp, #0x2c
-	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r6, _02199310 ; =data_ov53_0219a5e4
 	ldr r8, _02199314 ; =data_027e0fe4
 	add r4, sp, #0x10
@@ -509,7 +509,7 @@ _021992ec:
 	cmp r7, r0
 	blt _021992a8
 	add sp, sp, #0x2c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov53_021991ec
 _02199304: .word data_ov53_0219a580

--- a/asm/ov53.s
+++ b/asm/ov53.s
@@ -435,13 +435,13 @@ _021991e8: .word 0x00007a29
 	.global func_ov53_021991ec
 	arm_func_start func_ov53_021991ec
 func_ov53_021991ec: ; 0x021991ec
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x2c
 	ldr r5, _02199304 ; =data_ov53_0219a580
 	mov r10, r0
-	ldrh sb, [r5, #0x42]
+	ldrh r9, [r5, #0x42]
 	ldrh r0, [r5, #0x40]
-	cmp sb, r0
+	cmp r9, r0
 	bge _02199280
 	ldr r8, _02199308 ; =data_ov53_0219a5bc
 	ldr r4, _0219930c ; =data_027e0e60
@@ -449,7 +449,7 @@ func_ov53_021991ec: ; 0x021991ec
 	mov r11, #2
 	add r7, sp, #4
 _02199220:
-	add r0, r8, sb, lsl #1
+	add r0, r8, r9, lsl #1
 	ldrb r3, [r0, #8]
 	ldrb r2, [r0, #9]
 	ldr r0, [r4]
@@ -471,16 +471,16 @@ _02199220:
 	bl func_ov00_020be9e4
 _02199270:
 	ldrh r0, [r5, #0x40]
-	add sb, sb, #1
-	cmp sb, r0
+	add r9, r9, #1
+	cmp r9, r0
 	blt _02199220
 _02199280:
-	ldr sb, _02199304 ; =data_ov53_0219a580
-	ldrh r7, [sb, #0x6e]
-	ldrh r0, [sb, #0x6c]
+	ldr r9, _02199304 ; =data_ov53_0219a580
+	ldrh r7, [r9, #0x6e]
+	ldrh r0, [r9, #0x6c]
 	cmp r7, r0
 	addge sp, sp, #0x2c
-	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmgeia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r6, _02199310 ; =data_ov53_0219a5e4
 	ldr r8, _02199314 ; =data_027e0fe4
 	add r4, sp, #0x10
@@ -504,12 +504,12 @@ _021992a8:
 	ldmia r4, {r1, r2, r3}
 	bl func_ov00_020be9e4
 _021992ec:
-	ldrh r0, [sb, #0x6c]
+	ldrh r0, [r9, #0x6c]
 	add r7, r7, #1
 	cmp r7, r0
 	blt _021992a8
 	add sp, sp, #0x2c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov53_021991ec
 _02199304: .word data_ov53_0219a580

--- a/asm/ov53.s
+++ b/asm/ov53.s
@@ -435,10 +435,10 @@ _021991e8: .word 0x00007a29
 	.global func_ov53_021991ec
 	arm_func_start func_ov53_021991ec
 func_ov53_021991ec: ; 0x021991ec
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x2c
 	ldr r5, _02199304 ; =data_ov53_0219a580
-	mov sl, r0
+	mov r10, r0
 	ldrh sb, [r5, #0x42]
 	ldrh r0, [r5, #0x40]
 	cmp sb, r0
@@ -464,8 +464,8 @@ _02199220:
 	ldr r3, [r3, #0x64]
 	mov r2, r11
 	blx r3
-	ldrsh r1, [sl, #0x2c]
-	mov r0, sl
+	ldrsh r1, [r10, #0x2c]
+	mov r0, r10
 	str r1, [sp]
 	ldmia r6, {r1, r2, r3}
 	bl func_ov00_020be9e4
@@ -480,7 +480,7 @@ _02199280:
 	ldrh r0, [sb, #0x6c]
 	cmp r7, r0
 	addge sp, sp, #0x2c
-	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r6, _02199310 ; =data_ov53_0219a5e4
 	ldr r8, _02199314 ; =data_027e0fe4
 	add r4, sp, #0x10
@@ -498,8 +498,8 @@ _021992a8:
 	beq _021992ec
 	mov r1, r4
 	bl _ZN5Actor9GetHitboxEP8Cylinder
-	ldrsh r1, [sl, #0x2c]
-	mov r0, sl
+	ldrsh r1, [r10, #0x2c]
+	mov r0, r10
 	str r1, [sp]
 	ldmia r4, {r1, r2, r3}
 	bl func_ov00_020be9e4
@@ -509,7 +509,7 @@ _021992ec:
 	cmp r7, r0
 	blt _021992a8
 	add sp, sp, #0x2c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov53_021991ec
 _02199304: .word data_ov53_0219a580

--- a/asm/ov55.s
+++ b/asm/ov55.s
@@ -544,7 +544,7 @@ _021993b4: .word data_027e0fcc
 	.global func_ov55_021993b8
 	arm_func_start func_ov55_021993b8
 func_ov55_021993b8: ; 0x021993b8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x13c
 	mov r4, r0
 	mvn r1, #0
@@ -671,7 +671,7 @@ _021994d4:
 	str r1, [sp, #0x10c]
 	mov r1, #1
 	strb r1, [sp, #0xa0]
-	mov fp, #0x5c
+	mov r11, #0x5c
 	ldr r0, [r0]
 	add r1, sp, #0x8c
 	str r6, [sp, #0x114]
@@ -690,7 +690,7 @@ _021994d4:
 	strb ip, [sp, #0x11a]
 	strb r3, [sp, #0x11b]
 	strb r2, [sp, #0x11c]
-	str fp, [sp, #0x120]
+	str r11, [sp, #0x120]
 	bl func_ov00_02097810
 	ldr r2, _02199650 ; =data_027e103c
 	str r0, [r4, #0x5c]
@@ -705,7 +705,7 @@ _021994d4:
 	strb r2, [r1, #0x2a]
 	bl func_ov00_0209a508
 	add sp, sp, #0x13c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov55_021993b8
 _02199638: .word data_027e0f64

--- a/asm/ov55.s
+++ b/asm/ov55.s
@@ -544,7 +544,7 @@ _021993b4: .word data_027e0fcc
 	.global func_ov55_021993b8
 	arm_func_start func_ov55_021993b8
 func_ov55_021993b8: ; 0x021993b8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x13c
 	mov r4, r0
 	mvn r1, #0
@@ -588,26 +588,26 @@ func_ov55_021993b8: ; 0x021993b8
 	ldr r0, _02199640 ; =data_027e0e60
 	ldr sb, [sp, #0x1c]
 	ldr r7, [sp, #0x20]
-	ldr sl, [sp, #0x18]
+	ldr r10, [sp, #0x18]
 	mov r6, #1
 	add r3, r7, #0x2000
 	ldr r0, [r0]
 	add r1, sp, #0xc
 	mov r2, r6
 	add r8, sb, #0x1800
-	str sl, [sp, #0xc]
+	str r10, [sp, #0xc]
 	str sb, [sp, #0x10]
 	str r3, [sp, #0x14]
 	bl func_ov00_02083f44
 	cmp r0, r8
 	bge _021994cc
 	ldr r0, _02199640 ; =data_027e0e60
-	ldr sl, [sp, #0x18]
+	ldr r10, [sp, #0x18]
 	ldr r0, [r0]
 	add r3, r7, #0x3000
 	add r1, sp, #0
 	mov r2, r6
-	str sl, [sp]
+	str r10, [sp]
 	str sb, [sp, #4]
 	str r3, [sp, #8]
 	bl func_ov00_02083f44
@@ -634,7 +634,7 @@ _021994d4:
 	ldr r1, [sp, #0x38]
 	str r0, [sp, #0xe0]
 	ldr r0, [sp, #0x58]
-	ldr sl, _02199648 ; =0x0000038e
+	ldr r10, _02199648 ; =0x0000038e
 	mov sb, #0xf000
 	mov r7, #0x1000
 	str r6, [sp, #0xc8]
@@ -675,12 +675,12 @@ _021994d4:
 	ldr r0, [r0]
 	add r1, sp, #0x8c
 	str r6, [sp, #0x114]
-	str sl, [sp, #0x30]
+	str r10, [sp, #0x30]
 	str sb, [sp, #0x3c]
 	str r8, [sp, #0x48]
 	str r7, [sp, #0x44]
 	str r8, [sp, #0x40]
-	str sl, [sp, #0xc4]
+	str r10, [sp, #0xc4]
 	str sb, [sp, #0xd0]
 	str r8, [sp, #0xd4]
 	str r7, [sp, #0xd8]
@@ -705,7 +705,7 @@ _021994d4:
 	strb r2, [r1, #0x2a]
 	bl func_ov00_0209a508
 	add sp, sp, #0x13c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov55_021993b8
 _02199638: .word data_027e0f64

--- a/asm/ov55.s
+++ b/asm/ov55.s
@@ -544,7 +544,7 @@ _021993b4: .word data_027e0fcc
 	.global func_ov55_021993b8
 	arm_func_start func_ov55_021993b8
 func_ov55_021993b8: ; 0x021993b8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x13c
 	mov r4, r0
 	mvn r1, #0
@@ -586,7 +586,7 @@ func_ov55_021993b8: ; 0x021993b8
 	cmp r0, #0
 	bne _021994d4
 	ldr r0, _02199640 ; =data_027e0e60
-	ldr sb, [sp, #0x1c]
+	ldr r9, [sp, #0x1c]
 	ldr r7, [sp, #0x20]
 	ldr r10, [sp, #0x18]
 	mov r6, #1
@@ -594,9 +594,9 @@ func_ov55_021993b8: ; 0x021993b8
 	ldr r0, [r0]
 	add r1, sp, #0xc
 	mov r2, r6
-	add r8, sb, #0x1800
+	add r8, r9, #0x1800
 	str r10, [sp, #0xc]
-	str sb, [sp, #0x10]
+	str r9, [sp, #0x10]
 	str r3, [sp, #0x14]
 	bl func_ov00_02083f44
 	cmp r0, r8
@@ -608,7 +608,7 @@ func_ov55_021993b8: ; 0x021993b8
 	add r1, sp, #0
 	mov r2, r6
 	str r10, [sp]
-	str sb, [sp, #4]
+	str r9, [sp, #4]
 	str r3, [sp, #8]
 	bl func_ov00_02083f44
 	cmp r0, r8
@@ -635,7 +635,7 @@ _021994d4:
 	str r0, [sp, #0xe0]
 	ldr r0, [sp, #0x58]
 	ldr r10, _02199648 ; =0x0000038e
-	mov sb, #0xf000
+	mov r9, #0xf000
 	mov r7, #0x1000
 	str r6, [sp, #0xc8]
 	ldr r6, [sp, #0x50]
@@ -676,12 +676,12 @@ _021994d4:
 	add r1, sp, #0x8c
 	str r6, [sp, #0x114]
 	str r10, [sp, #0x30]
-	str sb, [sp, #0x3c]
+	str r9, [sp, #0x3c]
 	str r8, [sp, #0x48]
 	str r7, [sp, #0x44]
 	str r8, [sp, #0x40]
 	str r10, [sp, #0xc4]
-	str sb, [sp, #0xd0]
+	str r9, [sp, #0xd0]
 	str r8, [sp, #0xd4]
 	str r7, [sp, #0xd8]
 	str r8, [sp, #0xdc]
@@ -705,7 +705,7 @@ _021994d4:
 	strb r2, [r1, #0x2a]
 	bl func_ov00_0209a508
 	add sp, sp, #0x13c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov55_021993b8
 _02199638: .word data_027e0f64

--- a/asm/ov57.s
+++ b/asm/ov57.s
@@ -1186,13 +1186,13 @@ _02199c74: .word 0x00002ccd
 	.global func_ov57_02199c78
 	arm_func_start func_ov57_02199c78
 func_ov57_02199c78: ; 0x02199c78
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x20
-	mov sl, r0
+	mov r10, r0
 	ldr r11, _02199d4c ; =data_027e0e60
-	mov r7, sl
-	add r8, sl, #0x2c
-	add sb, sl, #0x24
+	mov r7, r10
+	add r8, r10, #0x2c
+	add sb, r10, #0x24
 	mov r6, #0
 	add r4, sp, #4
 	add r5, sp, #0x14
@@ -1214,8 +1214,8 @@ _02199cb8:
 	ldr r3, [r3, #0x64]
 	mov r2, #6
 	blx r3
-	ldrsh r1, [sl, #0x6c]
-	mov r0, sl
+	ldrsh r1, [r10, #0x6c]
+	mov r0, r10
 	str r1, [sp]
 	ldmia r5, {r1, r2, r3}
 	bl func_ov00_020be9e4
@@ -1229,8 +1229,8 @@ _02199cf8:
 	beq _02199d2c
 	mov r1, r4
 	bl _ZN5Actor9GetHitboxEP8Cylinder
-	ldrsh r1, [sl, #0x6c]
-	mov r0, sl
+	ldrsh r1, [r10, #0x6c]
+	mov r0, r10
 	str r1, [sp]
 	ldmia r4, {r1, r2, r3}
 	bl func_ov00_020be9e4
@@ -1242,7 +1242,7 @@ _02199d2c:
 	add sb, sb, #0x1c
 	blt _02199ca0
 	add sp, sp, #0x20
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov57_02199c78
 _02199d4c: .word data_027e0e60
@@ -1882,11 +1882,11 @@ _0219a5a8: .word data_ov57_0219ab28
 	.global func_ov57_0219a5ac
 	arm_func_start func_ov57_0219a5ac
 func_ov57_0219a5ac: ; 0x0219a5ac
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0xc
-	mov sl, r0
+	mov r10, r0
 	bl func_ov57_02199ecc
-	add r1, sl, #0x100
+	add r1, r10, #0x100
 	ldrsh r2, [r1, #0x64]
 	add r1, sp, #0
 	mov sb, r0
@@ -1894,13 +1894,13 @@ func_ov57_0219a5ac: ; 0x0219a5ac
 	cmp r0, #0
 	beq _0219a664
 	ldr r11, _0219a6b0 ; =0x00000666
-	add r5, sl, #0x164
-	add r4, sl, #0x100
+	add r5, r10, #0x164
+	add r4, r10, #0x100
 	mov r6, #0x2d
 	add r8, sp, #0
 _0219a5ec:
 	mov r1, r8
-	add r0, sl, #0x48
+	add r0, r10, #0x48
 	bl func_01ff9ec0
 	ldrh r1, [r4, #0x68]
 	mov r7, r0
@@ -1909,16 +1909,16 @@ _0219a5ec:
 	cmp r7, r11
 	ble _0219a63c
 	add r1, sp, #0
-	mov r0, sl
+	mov r0, r10
 	mov r2, #1
 	bl func_ov14_02123cd0
-	ldrsh r2, [sl, #0x78]
-	add r1, sl, #0x100
+	ldrsh r2, [r10, #0x78]
+	add r1, r10, #0x100
 	add sp, sp, #0xc
 	sub r2, r2, #0x8000
 	strh r2, [r1, #0x70]
 	mov r0, r7
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0219a63c:
 	strh r6, [r4, #0x68]
 	ldrsh r2, [r5]
@@ -1935,22 +1935,22 @@ _0219a664:
 	bl func_ov14_0213dda0
 	cmp r0, #1
 	blt _0219a698
-	add r1, sl, #0x100
+	add r1, r10, #0x100
 	ldrsh r1, [r1, #0x64]
 	cmp r1, r0
 	ble _0219a698
 	ldr r1, _0219a6b4 ; =0x00000b33
 	mov r2, #1
-	mov r0, sl
+	mov r0, r10
 	strb r2, [sb, #0x69]
 	bl func_ov14_02123e1c
 _0219a698:
-	mov r0, sl
+	mov r0, r10
 	mov r1, #1
 	bl func_ov14_02123e48
 	mov r0, #0
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov57_0219a5ac
 _0219a6b0: .word 0x00000666

--- a/asm/ov57.s
+++ b/asm/ov57.s
@@ -1186,10 +1186,10 @@ _02199c74: .word 0x00002ccd
 	.global func_ov57_02199c78
 	arm_func_start func_ov57_02199c78
 func_ov57_02199c78: ; 0x02199c78
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x20
 	mov sl, r0
-	ldr fp, _02199d4c ; =data_027e0e60
+	ldr r11, _02199d4c ; =data_027e0e60
 	mov r7, sl
 	add r8, sl, #0x2c
 	add sb, sl, #0x24
@@ -1204,7 +1204,7 @@ _02199ca0:
 	beq _02199cf8
 	b _02199d2c
 _02199cb8:
-	ldr r0, [fp]
+	ldr r0, [r11]
 	mov r1, r8
 	bl func_ov00_020840c4
 	cmp r0, #0
@@ -1242,7 +1242,7 @@ _02199d2c:
 	add sb, sb, #0x1c
 	blt _02199ca0
 	add sp, sp, #0x20
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov57_02199c78
 _02199d4c: .word data_027e0e60
@@ -1882,7 +1882,7 @@ _0219a5a8: .word data_ov57_0219ab28
 	.global func_ov57_0219a5ac
 	arm_func_start func_ov57_0219a5ac
 func_ov57_0219a5ac: ; 0x0219a5ac
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0xc
 	mov sl, r0
 	bl func_ov57_02199ecc
@@ -1893,7 +1893,7 @@ func_ov57_0219a5ac: ; 0x0219a5ac
 	bl func_ov57_0219939c
 	cmp r0, #0
 	beq _0219a664
-	ldr fp, _0219a6b0 ; =0x00000666
+	ldr r11, _0219a6b0 ; =0x00000666
 	add r5, sl, #0x164
 	add r4, sl, #0x100
 	mov r6, #0x2d
@@ -1906,7 +1906,7 @@ _0219a5ec:
 	mov r7, r0
 	cmp r1, #0
 	beq _0219a63c
-	cmp r7, fp
+	cmp r7, r11
 	ble _0219a63c
 	add r1, sp, #0
 	mov r0, sl
@@ -1918,7 +1918,7 @@ _0219a5ec:
 	sub r2, r2, #0x8000
 	strh r2, [r1, #0x70]
 	mov r0, r7
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0219a63c:
 	strh r6, [r4, #0x68]
 	ldrsh r2, [r5]
@@ -1950,7 +1950,7 @@ _0219a698:
 	bl func_ov14_02123e48
 	mov r0, #0
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov57_0219a5ac
 _0219a6b0: .word 0x00000666

--- a/asm/ov57.s
+++ b/asm/ov57.s
@@ -1186,13 +1186,13 @@ _02199c74: .word 0x00002ccd
 	.global func_ov57_02199c78
 	arm_func_start func_ov57_02199c78
 func_ov57_02199c78: ; 0x02199c78
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x20
 	mov r10, r0
 	ldr r11, _02199d4c ; =data_027e0e60
 	mov r7, r10
 	add r8, r10, #0x2c
-	add sb, r10, #0x24
+	add r9, r10, #0x24
 	mov r6, #0
 	add r4, sp, #4
 	add r5, sp, #0x14
@@ -1222,7 +1222,7 @@ _02199cb8:
 	b _02199d2c
 _02199cf8:
 	ldr r0, _02199d50 ; =data_027e0fe4
-	mov r1, sb
+	mov r1, r9
 	ldr r0, [r0]
 	bl _ZN12ActorManager8GetActorEP8ActorRef
 	cmp r0, #0
@@ -1239,10 +1239,10 @@ _02199d2c:
 	cmp r6, #2
 	add r7, r7, #0x1c
 	add r8, r8, #0x1c
-	add sb, sb, #0x1c
+	add r9, r9, #0x1c
 	blt _02199ca0
 	add sp, sp, #0x20
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov57_02199c78
 _02199d4c: .word data_027e0e60
@@ -1882,14 +1882,14 @@ _0219a5a8: .word data_ov57_0219ab28
 	.global func_ov57_0219a5ac
 	arm_func_start func_ov57_0219a5ac
 func_ov57_0219a5ac: ; 0x0219a5ac
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0xc
 	mov r10, r0
 	bl func_ov57_02199ecc
 	add r1, r10, #0x100
 	ldrsh r2, [r1, #0x64]
 	add r1, sp, #0
-	mov sb, r0
+	mov r9, r0
 	bl func_ov57_0219939c
 	cmp r0, #0
 	beq _0219a664
@@ -1918,11 +1918,11 @@ _0219a5ec:
 	sub r2, r2, #0x8000
 	strh r2, [r1, #0x70]
 	mov r0, r7
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0219a63c:
 	strh r6, [r4, #0x68]
 	ldrsh r2, [r5]
-	mov r0, sb
+	mov r0, r9
 	mov r1, r8
 	add r2, r2, #1
 	strh r2, [r5]
@@ -1931,7 +1931,7 @@ _0219a63c:
 	cmp r0, #0
 	bne _0219a5ec
 _0219a664:
-	mov r0, sb
+	mov r0, r9
 	bl func_ov14_0213dda0
 	cmp r0, #1
 	blt _0219a698
@@ -1942,7 +1942,7 @@ _0219a664:
 	ldr r1, _0219a6b4 ; =0x00000b33
 	mov r2, #1
 	mov r0, r10
-	strb r2, [sb, #0x69]
+	strb r2, [r9, #0x69]
 	bl func_ov14_02123e1c
 _0219a698:
 	mov r0, r10
@@ -1950,7 +1950,7 @@ _0219a698:
 	bl func_ov14_02123e48
 	mov r0, #0
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov57_0219a5ac
 _0219a6b0: .word 0x00000666

--- a/asm/ov58.s
+++ b/asm/ov58.s
@@ -2085,7 +2085,7 @@ _02199eec: .word 0x00001333
 	arm_func_start func_ov58_02199ef0
 func_ov58_02199ef0: ; 0x02199ef0
 	stmdb sp!, {r0, r1, r2, r3}
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x24
 	ldr r0, _02199fd4 ; =data_027e0e60
 	ldrb r1, [sp, #0x4c]
@@ -2128,20 +2128,20 @@ _02199f40:
 	mov r1, r5
 	bne _02199fa4
 	bl func_ov00_02083f44
-	mov sl, r0
+	mov r10, r0
 	b _02199fb0
 _02199fa4:
 	bl func_ov00_02083f44
-	cmp sl, r0
-	movle sl, r0
+	cmp r10, r0
+	movle r10, r0
 _02199fb0:
 	add r8, r8, #1
 	cmp r8, #4
 	add sb, sb, #0x4000
 	blt _02199f40
-	mov r0, sl
+	mov r0, r10
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	add sp, sp, #0x10
 	bx lr
 	.align 2, 0
@@ -2202,7 +2202,7 @@ _0219a080: .word data_ov58_0219afc0
 	arm_func_start func_ov58_0219a084
 func_ov58_0219a084: ; 0x0219a084
 	stmdb sp!, {r0, r1, r2, r3}
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0xcc
 	ldr r0, _0219a3a8 ; =data_027e0e60
 	ldrb r1, [sp, #0xf4]
@@ -2216,7 +2216,7 @@ func_ov58_0219a084: ; 0x0219a084
 	bl func_ov00_02083c7c
 	mov r8, #0
 	ldr r4, _0219a3a8 ; =data_027e0e60
-	add sl, sp, #0x3c
+	add r10, sp, #0x3c
 	mov sb, r8
 	mov r7, r8
 	mov r6, #0x400
@@ -2232,21 +2232,21 @@ _0219a0d8:
 	bl func_ov00_020a61ac
 	ldr r1, [sp, #0x30]
 	ldr r0, [sp, #0x34]
-	str r1, [sl]
+	str r1, [r10]
 	ldr r2, [sp, #0x38]
-	str r0, [sl, #4]
-	mov r0, sl
+	str r0, [r10, #4]
+	mov r0, r10
 	mov r1, r5
-	str r2, [sl, #8]
-	mov r2, sl
+	str r2, [r10, #8]
+	mov r2, r10
 	bl func_01ff9bc4
 	ldr r0, [r4]
-	mov r1, sl
+	mov r1, r10
 	mov r2, r11
 	bl func_ov00_02083f44
-	str r0, [sl, #4]
+	str r0, [r10, #4]
 	add sb, sb, #0x4000
-	add sl, sl, #0xc
+	add r10, r10, #0xc
 	add r8, r8, #1
 	cmp r8, #4
 	blt _0219a0d8
@@ -2293,7 +2293,7 @@ _0219a0d8:
 	cmp r0, #0
 	addne sp, sp, #0xcc
 	movne r0, #7
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	addne sp, sp, #0x10
 	bxne lr
 	mov r0, #0x200
@@ -2315,7 +2315,7 @@ _0219a0d8:
 	cmp r0, #0
 	addne sp, sp, #0xcc
 	movne r0, #7
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	addne sp, sp, #0x10
 	bxne lr
 	mov r0, #0x200
@@ -2337,7 +2337,7 @@ _0219a0d8:
 	cmp r0, #0
 	addne sp, sp, #0xcc
 	movne r0, #7
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	addne sp, sp, #0x10
 	bxne lr
 	mov r0, #0x200
@@ -2360,7 +2360,7 @@ _0219a0d8:
 	movne r0, #7
 	add sp, sp, #0xcc
 	moveq r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	add sp, sp, #0x10
 	bx lr
 _0219a308:
@@ -2373,7 +2373,7 @@ _0219a308:
 	movlt r0, #4
 	add sp, sp, #0xcc
 	movge r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	add sp, sp, #0x10
 	bx lr
 _0219a338:
@@ -2386,7 +2386,7 @@ _0219a338:
 	movlt r0, #3
 	add sp, sp, #0xcc
 	movge r0, #2
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	add sp, sp, #0x10
 	bx lr
 _0219a368:
@@ -2403,7 +2403,7 @@ _0219a368:
 	movne r0, #5
 	moveq r0, #7
 	add sp, sp, #0xcc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	add sp, sp, #0x10
 	bx lr
 	.align 2, 0
@@ -2652,16 +2652,16 @@ _0219a698: .word data_027e0c38
 	.global func_ov58_0219a69c
 	arm_func_start func_ov58_0219a69c
 func_ov58_0219a69c: ; 0x0219a69c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	ldr r1, _0219a768 ; =data_027e077c
-	mov sl, r0
+	mov r10, r0
 	ldr r0, [r1]
 	mov sb, #0
 	cmp r0, #0xd
 	bne _0219a760
 	mov r6, sb
-	mov r8, sl
-	add r7, sl, #8
+	mov r8, r10
+	add r7, r10, #8
 	mov r11, sb
 	mov r4, #1
 	mov r5, sb
@@ -2680,19 +2680,19 @@ _0219a6d0:
 	beq _0219a718
 	cmp r6, #2
 	bne _0219a724
-	ldrb r0, [sl, #0xdf]
+	ldrb r0, [r10, #0xdf]
 	cmp r0, #0
 	beq _0219a724
 	b _0219a74c
 _0219a718:
-	ldrb r0, [sl, #0xdf]
+	ldrb r0, [r10, #0xdf]
 	cmp r0, #0
 	beq _0219a74c
 _0219a724:
 	cmp sb, #0
 	bne _0219a740
 	ldrh r1, [r8, #0x12]
-	mov r0, sl
+	mov r0, r10
 	bl func_ov58_0219a76c
 	cmp r0, #0
 	beq _0219a748
@@ -2709,7 +2709,7 @@ _0219a74c:
 	blt _0219a6d0
 _0219a760:
 	mov r0, sb
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov58_0219a69c
 _0219a768: .word data_027e077c

--- a/asm/ov58.s
+++ b/asm/ov58.s
@@ -2085,7 +2085,7 @@ _02199eec: .word 0x00001333
 	arm_func_start func_ov58_02199ef0
 func_ov58_02199ef0: ; 0x02199ef0
 	stmdb sp!, {r0, r1, r2, r3}
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x24
 	ldr r0, _02199fd4 ; =data_027e0e60
 	ldrb r1, [sp, #0x4c]
@@ -2102,7 +2102,7 @@ func_ov58_02199ef0: ; 0x02199ef0
 	mov sb, r8
 	add r5, sp, #0xc
 	mov r7, r8
-	mov fp, #0x400
+	mov r11, #0x400
 	add r6, sp, #0
 _02199f40:
 	mov r1, sb, lsl #0x10
@@ -2110,7 +2110,7 @@ _02199f40:
 	mov r1, r1, asr #0x10
 	str r7, [sp]
 	str r7, [sp, #4]
-	str fp, [sp, #8]
+	str r11, [sp, #8]
 	bl func_ov00_020a61ac
 	ldr r1, [sp, #0x18]
 	ldr r0, [sp, #0x1c]
@@ -2141,7 +2141,7 @@ _02199fb0:
 	blt _02199f40
 	mov r0, sl
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	add sp, sp, #0x10
 	bx lr
 	.align 2, 0
@@ -2202,7 +2202,7 @@ _0219a080: .word data_ov58_0219afc0
 	arm_func_start func_ov58_0219a084
 func_ov58_0219a084: ; 0x0219a084
 	stmdb sp!, {r0, r1, r2, r3}
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0xcc
 	ldr r0, _0219a3a8 ; =data_027e0e60
 	ldrb r1, [sp, #0xf4]
@@ -2221,7 +2221,7 @@ func_ov58_0219a084: ; 0x0219a084
 	mov r7, r8
 	mov r6, #0x400
 	add r5, sp, #0x24
-	mov fp, r8
+	mov r11, r8
 _0219a0d8:
 	mov r1, sb, lsl #0x10
 	mov r0, r5
@@ -2242,7 +2242,7 @@ _0219a0d8:
 	bl func_01ff9bc4
 	ldr r0, [r4]
 	mov r1, sl
-	mov r2, fp
+	mov r2, r11
 	bl func_ov00_02083f44
 	str r0, [sl, #4]
 	add sb, sb, #0x4000
@@ -2293,7 +2293,7 @@ _0219a0d8:
 	cmp r0, #0
 	addne sp, sp, #0xcc
 	movne r0, #7
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	addne sp, sp, #0x10
 	bxne lr
 	mov r0, #0x200
@@ -2315,7 +2315,7 @@ _0219a0d8:
 	cmp r0, #0
 	addne sp, sp, #0xcc
 	movne r0, #7
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	addne sp, sp, #0x10
 	bxne lr
 	mov r0, #0x200
@@ -2337,7 +2337,7 @@ _0219a0d8:
 	cmp r0, #0
 	addne sp, sp, #0xcc
 	movne r0, #7
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	addne sp, sp, #0x10
 	bxne lr
 	mov r0, #0x200
@@ -2360,7 +2360,7 @@ _0219a0d8:
 	movne r0, #7
 	add sp, sp, #0xcc
 	moveq r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	add sp, sp, #0x10
 	bx lr
 _0219a308:
@@ -2373,7 +2373,7 @@ _0219a308:
 	movlt r0, #4
 	add sp, sp, #0xcc
 	movge r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	add sp, sp, #0x10
 	bx lr
 _0219a338:
@@ -2386,7 +2386,7 @@ _0219a338:
 	movlt r0, #3
 	add sp, sp, #0xcc
 	movge r0, #2
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	add sp, sp, #0x10
 	bx lr
 _0219a368:
@@ -2403,7 +2403,7 @@ _0219a368:
 	movne r0, #5
 	moveq r0, #7
 	add sp, sp, #0xcc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	add sp, sp, #0x10
 	bx lr
 	.align 2, 0
@@ -2652,7 +2652,7 @@ _0219a698: .word data_027e0c38
 	.global func_ov58_0219a69c
 	arm_func_start func_ov58_0219a69c
 func_ov58_0219a69c: ; 0x0219a69c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	ldr r1, _0219a768 ; =data_027e077c
 	mov sl, r0
 	ldr r0, [r1]
@@ -2662,7 +2662,7 @@ func_ov58_0219a69c: ; 0x0219a69c
 	mov r6, sb
 	mov r8, sl
 	add r7, sl, #8
-	mov fp, sb
+	mov r11, sb
 	mov r4, #1
 	mov r5, sb
 _0219a6d0:
@@ -2700,7 +2700,7 @@ _0219a740:
 	mov sb, r4
 	b _0219a74c
 _0219a748:
-	mov sb, fp
+	mov sb, r11
 _0219a74c:
 	add r6, r6, #1
 	cmp r6, #3
@@ -2709,7 +2709,7 @@ _0219a74c:
 	blt _0219a6d0
 _0219a760:
 	mov r0, sb
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov58_0219a69c
 _0219a768: .word data_027e077c

--- a/asm/ov58.s
+++ b/asm/ov58.s
@@ -2085,7 +2085,7 @@ _02199eec: .word 0x00001333
 	arm_func_start func_ov58_02199ef0
 func_ov58_02199ef0: ; 0x02199ef0
 	stmdb sp!, {r0, r1, r2, r3}
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x24
 	ldr r0, _02199fd4 ; =data_027e0e60
 	ldrb r1, [sp, #0x4c]
@@ -2099,13 +2099,13 @@ func_ov58_02199ef0: ; 0x02199ef0
 	bl func_ov00_02083c7c
 	mov r8, #0
 	ldr r4, _02199fd4 ; =data_027e0e60
-	mov sb, r8
+	mov r9, r8
 	add r5, sp, #0xc
 	mov r7, r8
 	mov r11, #0x400
 	add r6, sp, #0
 _02199f40:
-	mov r1, sb, lsl #0x10
+	mov r1, r9, lsl #0x10
 	mov r0, r6
 	mov r1, r1, asr #0x10
 	str r7, [sp]
@@ -2137,11 +2137,11 @@ _02199fa4:
 _02199fb0:
 	add r8, r8, #1
 	cmp r8, #4
-	add sb, sb, #0x4000
+	add r9, r9, #0x4000
 	blt _02199f40
 	mov r0, r10
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	add sp, sp, #0x10
 	bx lr
 	.align 2, 0
@@ -2202,7 +2202,7 @@ _0219a080: .word data_ov58_0219afc0
 	arm_func_start func_ov58_0219a084
 func_ov58_0219a084: ; 0x0219a084
 	stmdb sp!, {r0, r1, r2, r3}
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0xcc
 	ldr r0, _0219a3a8 ; =data_027e0e60
 	ldrb r1, [sp, #0xf4]
@@ -2217,13 +2217,13 @@ func_ov58_0219a084: ; 0x0219a084
 	mov r8, #0
 	ldr r4, _0219a3a8 ; =data_027e0e60
 	add r10, sp, #0x3c
-	mov sb, r8
+	mov r9, r8
 	mov r7, r8
 	mov r6, #0x400
 	add r5, sp, #0x24
 	mov r11, r8
 _0219a0d8:
-	mov r1, sb, lsl #0x10
+	mov r1, r9, lsl #0x10
 	mov r0, r5
 	mov r1, r1, asr #0x10
 	str r7, [sp, #0x24]
@@ -2245,7 +2245,7 @@ _0219a0d8:
 	mov r2, r11
 	bl func_ov00_02083f44
 	str r0, [r10, #4]
-	add sb, sb, #0x4000
+	add r9, r9, #0x4000
 	add r10, r10, #0xc
 	add r8, r8, #1
 	cmp r8, #4
@@ -2293,7 +2293,7 @@ _0219a0d8:
 	cmp r0, #0
 	addne sp, sp, #0xcc
 	movne r0, #7
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	addne sp, sp, #0x10
 	bxne lr
 	mov r0, #0x200
@@ -2315,7 +2315,7 @@ _0219a0d8:
 	cmp r0, #0
 	addne sp, sp, #0xcc
 	movne r0, #7
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	addne sp, sp, #0x10
 	bxne lr
 	mov r0, #0x200
@@ -2337,7 +2337,7 @@ _0219a0d8:
 	cmp r0, #0
 	addne sp, sp, #0xcc
 	movne r0, #7
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	addne sp, sp, #0x10
 	bxne lr
 	mov r0, #0x200
@@ -2360,7 +2360,7 @@ _0219a0d8:
 	movne r0, #7
 	add sp, sp, #0xcc
 	moveq r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	add sp, sp, #0x10
 	bx lr
 _0219a308:
@@ -2373,7 +2373,7 @@ _0219a308:
 	movlt r0, #4
 	add sp, sp, #0xcc
 	movge r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	add sp, sp, #0x10
 	bx lr
 _0219a338:
@@ -2386,7 +2386,7 @@ _0219a338:
 	movlt r0, #3
 	add sp, sp, #0xcc
 	movge r0, #2
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	add sp, sp, #0x10
 	bx lr
 _0219a368:
@@ -2403,7 +2403,7 @@ _0219a368:
 	movne r0, #5
 	moveq r0, #7
 	add sp, sp, #0xcc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	add sp, sp, #0x10
 	bx lr
 	.align 2, 0
@@ -2652,19 +2652,19 @@ _0219a698: .word data_027e0c38
 	.global func_ov58_0219a69c
 	arm_func_start func_ov58_0219a69c
 func_ov58_0219a69c: ; 0x0219a69c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	ldr r1, _0219a768 ; =data_027e077c
 	mov r10, r0
 	ldr r0, [r1]
-	mov sb, #0
+	mov r9, #0
 	cmp r0, #0xd
 	bne _0219a760
-	mov r6, sb
+	mov r6, r9
 	mov r8, r10
 	add r7, r10, #8
-	mov r11, sb
+	mov r11, r9
 	mov r4, #1
-	mov r5, sb
+	mov r5, r9
 _0219a6d0:
 	mov r0, r7
 	ldr ip, [r0]
@@ -2689,7 +2689,7 @@ _0219a718:
 	cmp r0, #0
 	beq _0219a74c
 _0219a724:
-	cmp sb, #0
+	cmp r9, #0
 	bne _0219a740
 	ldrh r1, [r8, #0x12]
 	mov r0, r10
@@ -2697,10 +2697,10 @@ _0219a724:
 	cmp r0, #0
 	beq _0219a748
 _0219a740:
-	mov sb, r4
+	mov r9, r4
 	b _0219a74c
 _0219a748:
-	mov sb, r11
+	mov r9, r11
 _0219a74c:
 	add r6, r6, #1
 	cmp r6, #3
@@ -2708,8 +2708,8 @@ _0219a74c:
 	add r8, r8, #0x18
 	blt _0219a6d0
 _0219a760:
-	mov r0, sb
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	mov r0, r9
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov58_0219a69c
 _0219a768: .word data_027e077c

--- a/asm/ov59.s
+++ b/asm/ov59.s
@@ -1421,7 +1421,7 @@ _0219a0a8: .word data_027e1038
 	.global func_ov59_0219a0ac
 	arm_func_start func_ov59_0219a0ac
 func_ov59_0219a0ac: ; 0x0219a0ac
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x220
 	mov sl, r0
 	bl func_ov59_02198e2c
@@ -1433,7 +1433,7 @@ func_ov59_0219a0ac: ; 0x0219a0ac
 	movne r2, #1
 	cmp r2, #0
 	addne sp, sp, #0x220
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r1, [sl, #0x2f4]
 	ldr r0, _0219a9e8 ; =gItemManager
 	ldr r4, [r1, #8]
@@ -1442,7 +1442,7 @@ func_ov59_0219a0ac: ; 0x0219a0ac
 	bl _ZNK11ItemManager18func_ov00_020ad538Ei
 	cmp r4, r0
 	addeq sp, sp, #0x220
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldrb r0, [sl, #0x3c2]
 	cmp r0, #0
 	bne _0219a4ec
@@ -1459,7 +1459,7 @@ func_ov59_0219a0ac: ; 0x0219a0ac
 	ldr lr, _0219a9f4 ; =0x00000666
 	str r0, [sp, #0x88]
 	ldr r0, [sl, #0x58]
-	mov fp, #0
+	mov r11, #0
 	str r0, [sp, #0x8c]
 	ldr r0, [sl, #0x5c]
 	add r1, sl, #0x300
@@ -1476,7 +1476,7 @@ func_ov59_0219a0ac: ; 0x0219a0ac
 	ldr r5, [sl, #0x344]
 	ldrh r1, [r1, #0x40]
 	umull r4, r3, r5, lr
-	mla r3, r5, fp, r3
+	mla r3, r5, r11, r3
 	mov r5, r5, asr #0x1f
 	mla r3, r5, lr, r3
 	adds r4, r4, #0x800
@@ -1514,17 +1514,17 @@ func_ov59_0219a0ac: ; 0x0219a0ac
 	strh r5, [r0, #0xca]
 	strh r5, [r0, #0xcc]
 	strh r5, [r0, #0xce]
-	strh fp, [r0, #0xd0]
-	strb fp, [sp, #0x20e]
-	strb fp, [sp, #0x20f]
-	strb fp, [sp, #0x210]
-	strb fp, [sp, #0x211]
-	strb fp, [sp, #0x218]
-	strb fp, [sp, #0x219]
-	strb fp, [sp, #0x21a]
-	strb fp, [sp, #0x21b]
-	strb fp, [sp, #0x21c]
-	strb fp, [sp, #0x21d]
+	strh r11, [r0, #0xd0]
+	strb r11, [sp, #0x20e]
+	strb r11, [sp, #0x20f]
+	strb r11, [sp, #0x210]
+	strb r11, [sp, #0x211]
+	strb r11, [sp, #0x218]
+	strb r11, [sp, #0x219]
+	strb r11, [sp, #0x21a]
+	strb r11, [sp, #0x21b]
+	strb r11, [sp, #0x21c]
+	strb r11, [sp, #0x21d]
 _0219a24c:
 	ldr r1, [sl, #0x98]
 	add r0, sp, #0x88
@@ -1618,7 +1618,7 @@ _0219a24c:
 	strh r7, [r0, #0x6e]
 	mov r6, #0
 	strh r6, [r0, #0x70]
-	ldr fp, _0219a9fc ; =data_027e0e60
+	ldr r11, _0219a9fc ; =data_027e0e60
 	strb r6, [sp, #0x1ae]
 	strb r6, [sp, #0x1af]
 	strb r6, [sp, #0x1b0]
@@ -1650,7 +1650,7 @@ _0219a3f8:
 	ldmia r5, {r0, r1, r2}
 	stmia ip, {r0, r1, r2}
 	ldr ip, [sl, #8]
-	ldr r0, [fp]
+	ldr r0, [r11]
 	ldr r2, [sl, #0x98]
 	add r1, sp, #0x160
 	stmia sp, {r2, ip}
@@ -1719,20 +1719,20 @@ _0219a4ec:
 	mla r2, r4, r1, r2
 	mov r4, r4, asr #0x1f
 	mov r5, r5, asr #0x4
-	mov fp, r5, lsl #0x1
+	mov r11, r5, lsl #0x1
 	str r7, [sp, #0x8c]
 	adds r3, r3, #0x800
 	mla r2, r4, r0, r2
-	add sb, fp, #1
+	add sb, r11, #1
 	ldr r5, _0219a9f8 ; =data_02050f54
-	mov r7, fp, lsl #0x1
+	mov r7, r11, lsl #0x1
 	mov r4, sb, lsl #0x1
-	ldrsh fp, [r5, r7]
+	ldrsh r11, [r5, r7]
 	ldrsh r7, [r5, r4]
 	adc r2, r2, #0
 	mov r3, r3, lsr #0xc
 	orr r3, r3, r2, lsl #20
-	smull sb, r2, fp, r3
+	smull sb, r2, r11, r3
 	smull r4, r3, r7, r3
 	adds r7, sb, #0x800
 	adc r2, r2, #0
@@ -1750,7 +1750,7 @@ _0219a4ec:
 	str r2, [sp, #0x88]
 	str r4, [sp, #0x90]
 	ldr sb, [sl, #0x48]
-	mov fp, #0x800
+	mov r11, #0x800
 	str sb, [sp, #0x7c]
 	ldr r2, [sl, #0x4c]
 	str r2, [sp, #0x80]
@@ -1775,10 +1775,10 @@ _0219a4ec:
 	ldrsh r6, [r5, r3]
 	ldrsh r2, [r5, r2]
 	smull r4, r3, r6, r7
-	adds r4, r4, fp
+	adds r4, r4, r11
 	smull r7, r6, r2, r7
 	adc r3, r3, r1
-	adds r2, r7, fp
+	adds r2, r7, r11
 	mov r4, r4, lsr #0xc
 	adc r1, r6, r1
 	mov r2, r2, lsr #0xc
@@ -1857,10 +1857,10 @@ _0219a668:
 	str r0, [sp, #0x90]
 	ldr sb, [sl, #0x344]
 	mov r6, r8
-	ldr fp, [sp, #0x14]
+	ldr r11, [sp, #0x14]
 	umull r8, r3, sb, r7
 	ldr r2, [sp, #0x18]
-	mla r3, sb, fp, r3
+	mla r3, sb, r11, r3
 	mov ip, sb, asr #0x1f
 	ldrh r2, [r2, #0x40]
 	adds sb, r8, #0x800
@@ -1875,13 +1875,13 @@ _0219a668:
 	ldrsh r2, [r5, r2]
 	add r8, r8, #1
 	mov r8, r8, lsl #0x1
-	smull fp, sb, r2, r3
+	smull r11, sb, r2, r3
 	ldrsh r8, [r5, r8]
-	adds fp, fp, #0x800
+	adds r11, r11, #0x800
 	smull r3, r2, r8, r3
 	mov r8, r6
 	adc r8, sb, r8
-	mov sb, fp, lsr #0xc
+	mov sb, r11, lsr #0xc
 	orr sb, sb, r8, lsl #20
 	add r1, r1, sb
 	str r1, [r4]
@@ -1925,7 +1925,7 @@ _0219a820:
 	str r2, [sp, #0x9c]
 	str r2, [sp, #0x90]
 	ldr r2, [sl, #0x48]
-	mov fp, sb
+	mov r11, sb
 	str r2, [sp, #0x7c]
 	ldr r2, [sl, #0x4c]
 	add r6, sp, #0x28
@@ -1991,7 +1991,7 @@ _0219a8c8:
 	str r1, [sp, #0x8c]
 	str r0, [sp, #0x90]
 	mov sb, #0
-	strb fp, [sl, #0x3c2]
+	strb r11, [sl, #0x3c2]
 _0219a968:
 	cmp sb, #0
 	beq _0219a990
@@ -2010,7 +2010,7 @@ _0219a998:
 	ldrb r0, [sl, #0x3c2]
 	cmp r0, #0
 	addeq sp, sp, #0x220
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, [sp, #0x88]
 	str r0, [sl, #0x48]
 	str r0, [sl, #0x158]
@@ -2026,7 +2026,7 @@ _0219a998:
 	str r0, [sl, #0x64]
 	str r0, [sl, #0x68]
 	add sp, sp, #0x220
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov59_0219a0ac
 _0219a9e8: .word gItemManager

--- a/asm/ov59.s
+++ b/asm/ov59.s
@@ -1421,7 +1421,7 @@ _0219a0a8: .word data_027e1038
 	.global func_ov59_0219a0ac
 	arm_func_start func_ov59_0219a0ac
 func_ov59_0219a0ac: ; 0x0219a0ac
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x220
 	mov r10, r0
 	bl func_ov59_02198e2c
@@ -1433,7 +1433,7 @@ func_ov59_0219a0ac: ; 0x0219a0ac
 	movne r2, #1
 	cmp r2, #0
 	addne sp, sp, #0x220
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r1, [r10, #0x2f4]
 	ldr r0, _0219a9e8 ; =gItemManager
 	ldr r4, [r1, #8]
@@ -1442,7 +1442,7 @@ func_ov59_0219a0ac: ; 0x0219a0ac
 	bl _ZNK11ItemManager18func_ov00_020ad538Ei
 	cmp r4, r0
 	addeq sp, sp, #0x220
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldrb r0, [r10, #0x3c2]
 	cmp r0, #0
 	bne _0219a4ec
@@ -1468,7 +1468,7 @@ func_ov59_0219a0ac: ; 0x0219a0ac
 	ldr r2, _0219a9f8 ; =data_02050f54
 	str r7, [sp, #0x7c]
 	ldr r0, [r10, #0x4c]
-	mov sb, #1
+	mov r9, #1
 	str r0, [sp, #0x80]
 	ldr r6, [r10, #0x50]
 	add r0, sp, #0x7c
@@ -1505,7 +1505,7 @@ func_ov59_0219a0ac: ; 0x0219a0ac
 	orr r2, r2, r1, lsl #20
 	add r1, r6, r2
 	str r1, [r0, #8]
-	rsb r5, sb, #0x10000
+	rsb r5, r9, #0x10000
 	str ip, [sp, #0x98]
 	str ip, [sp, #0x8c]
 	str ip, [sp, #0x80]
@@ -1554,7 +1554,7 @@ _0219a24c:
 	mov r4, #0
 	str r5, [sp, #8]
 	ldr r5, [r10, #0xa0]
-	movne sb, #0
+	movne r9, #0
 	str r5, [sp, #0xc]
 	str r4, [sp, #0x10]
 	bl func_01ffbf5c
@@ -1656,7 +1656,7 @@ _0219a3f8:
 	stmia sp, {r2, ip}
 	ldrh ip, [r10, #0x9c]
 	mov r2, r6
-	movne sb, #0
+	movne r9, #0
 	str ip, [sp, #8]
 	ldr ip, [r10, #0xa0]
 	str ip, [sp, #0xc]
@@ -1668,11 +1668,11 @@ _0219a3f8:
 	ldr r1, [sp, #0x164]
 	ldr r0, [sp, #0x168]
 	str r2, [sp, #0x88]
-	mov sb, #0
+	mov r9, #0
 	str r1, [sp, #0x8c]
 	str r0, [sp, #0x90]
 _0219a48c:
-	cmp sb, #0
+	cmp r9, #0
 	beq _0219a4b4
 	ldr r1, [r10, #0x98]
 	mov r0, r5
@@ -1683,10 +1683,10 @@ _0219a48c:
 	mov r2, r2, asr #0x2
 	bl func_0202b2f8
 _0219a4b4:
-	cmp sb, #0
+	cmp r9, #0
 	bne _0219a3f8
 _0219a4bc:
-	cmp sb, #0
+	cmp r9, #0
 	beq _0219a4e4
 	ldr r1, [r10, #0x98]
 	add r0, sp, #0x94
@@ -1697,7 +1697,7 @@ _0219a4bc:
 	mov r2, r2, asr #0x2
 	bl func_0202b2f8
 _0219a4e4:
-	cmp sb, #0
+	cmp r9, #0
 	bne _0219a24c
 _0219a4ec:
 	ldrb r0, [r10, #0x3c2]
@@ -1723,18 +1723,18 @@ _0219a4ec:
 	str r7, [sp, #0x8c]
 	adds r3, r3, #0x800
 	mla r2, r4, r0, r2
-	add sb, r11, #1
+	add r9, r11, #1
 	ldr r5, _0219a9f8 ; =data_02050f54
 	mov r7, r11, lsl #0x1
-	mov r4, sb, lsl #0x1
+	mov r4, r9, lsl #0x1
 	ldrsh r11, [r5, r7]
 	ldrsh r7, [r5, r4]
 	adc r2, r2, #0
 	mov r3, r3, lsr #0xc
 	orr r3, r3, r2, lsl #20
-	smull sb, r2, r11, r3
+	smull r9, r2, r11, r3
 	smull r4, r3, r7, r3
-	adds r7, sb, #0x800
+	adds r7, r9, #0x800
 	adc r2, r2, #0
 	adds r4, r4, #0x800
 	mov r7, r7, lsr #0xc
@@ -1749,9 +1749,9 @@ _0219a4ec:
 	str r4, [r3, #8]
 	str r2, [sp, #0x88]
 	str r4, [sp, #0x90]
-	ldr sb, [r10, #0x48]
+	ldr r9, [r10, #0x48]
 	mov r11, #0x800
-	str sb, [sp, #0x7c]
+	str r9, [sp, #0x7c]
 	ldr r2, [r10, #0x4c]
 	str r2, [sp, #0x80]
 	ldr r8, [r10, #0x50]
@@ -1786,7 +1786,7 @@ _0219a4ec:
 	rsb r7, r0, #0
 	ldr r0, _0219aa04 ; =0x0000ffff
 	orr r4, r4, r3, lsl #20
-	add r3, sb, r4
+	add r3, r9, r4
 	add r1, sp, #0x7c
 	add r2, r8, r2
 	sub r0, r0, #0x10000
@@ -1855,19 +1855,19 @@ _0219a668:
 	ldr r0, [sp, #0x108]
 	str r1, [sp, #0x88]
 	str r0, [sp, #0x90]
-	ldr sb, [r10, #0x344]
+	ldr r9, [r10, #0x344]
 	mov r6, r8
 	ldr r11, [sp, #0x14]
-	umull r8, r3, sb, r7
+	umull r8, r3, r9, r7
 	ldr r2, [sp, #0x18]
-	mla r3, sb, r11, r3
-	mov ip, sb, asr #0x1f
+	mla r3, r9, r11, r3
+	mov ip, r9, asr #0x1f
 	ldrh r2, [r2, #0x40]
-	adds sb, r8, #0x800
+	adds r9, r8, #0x800
 	mla r3, ip, r7, r3
 	mov r8, r6
 	adc r8, r3, r8
-	mov r3, sb, lsr #0xc
+	mov r3, r9, lsr #0xc
 	mov r2, r2, asr #0x4
 	orr r3, r3, r8, lsl #20
 	mov r8, r2, lsl #0x1
@@ -1875,15 +1875,15 @@ _0219a668:
 	ldrsh r2, [r5, r2]
 	add r8, r8, #1
 	mov r8, r8, lsl #0x1
-	smull r11, sb, r2, r3
+	smull r11, r9, r2, r3
 	ldrsh r8, [r5, r8]
 	adds r11, r11, #0x800
 	smull r3, r2, r8, r3
 	mov r8, r6
-	adc r8, sb, r8
-	mov sb, r11, lsr #0xc
-	orr sb, sb, r8, lsl #20
-	add r1, r1, sb
+	adc r8, r9, r8
+	mov r9, r11, lsr #0xc
+	orr r9, r9, r8, lsl #20
+	add r1, r1, r9
 	str r1, [r4]
 	adds r3, r3, #0x800
 	mov r1, r6
@@ -1913,7 +1913,7 @@ _0219a820:
 	cmp r0, #0
 	bne _0219a998
 	ldr r4, [r10, #0x54]
-	mov sb, #1
+	mov r9, #1
 	str r4, [sp, #0x94]
 	ldr r3, [r10, #0x58]
 	ldr r1, _0219aa04 ; =0x0000ffff
@@ -1925,7 +1925,7 @@ _0219a820:
 	str r2, [sp, #0x9c]
 	str r2, [sp, #0x90]
 	ldr r2, [r10, #0x48]
-	mov r11, sb
+	mov r11, r9
 	str r2, [sp, #0x7c]
 	ldr r2, [r10, #0x4c]
 	add r6, sp, #0x28
@@ -1976,7 +1976,7 @@ _0219a8c8:
 	str r2, [sp, #4]
 	ldrh ip, [r10, #0x9c]
 	mov r2, r6
-	movne sb, #0
+	movne r9, #0
 	str ip, [sp, #8]
 	ldr ip, [r10, #0xa0]
 	str ip, [sp, #0xc]
@@ -1990,10 +1990,10 @@ _0219a8c8:
 	ldr r0, [sp, #0xa8]
 	str r1, [sp, #0x8c]
 	str r0, [sp, #0x90]
-	mov sb, #0
+	mov r9, #0
 	strb r11, [r10, #0x3c2]
 _0219a968:
-	cmp sb, #0
+	cmp r9, #0
 	beq _0219a990
 	ldr r1, [r10, #0x98]
 	mov r0, r5
@@ -2004,13 +2004,13 @@ _0219a968:
 	mov r2, r2, asr #0x2
 	bl func_0202b2f8
 _0219a990:
-	cmp sb, #0
+	cmp r9, #0
 	bne _0219a8c8
 _0219a998:
 	ldrb r0, [r10, #0x3c2]
 	cmp r0, #0
 	addeq sp, sp, #0x220
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, [sp, #0x88]
 	str r0, [r10, #0x48]
 	str r0, [r10, #0x158]
@@ -2026,7 +2026,7 @@ _0219a998:
 	str r0, [r10, #0x64]
 	str r0, [r10, #0x68]
 	add sp, sp, #0x220
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov59_0219a0ac
 _0219a9e8: .word gItemManager
@@ -2151,7 +2151,7 @@ _0219aba4: .word data_ov00_020e9370
 	.global func_ov59_0219aba8
 	arm_func_start func_ov59_0219aba8
 func_ov59_0219aba8: ; 0x0219aba8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x128
 	mov r4, r1
 	mov r5, r0
@@ -2180,14 +2180,14 @@ _0219abcc:
 	ldr r6, [r5, #0x48]
 	ldr r8, [r5, #0x50]
 	mov ip, #0
-	ldr sb, _0219aefc ; =0x0000ffff
+	ldr r9, _0219aefc ; =0x0000ffff
 	add r3, sp, #0x2c
 	ldmia lr, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
-	strh sb, [sp, #0xec]
-	strh sb, [sp, #0xee]
-	strh sb, [sp, #0xf0]
-	strh sb, [sp, #0xf2]
+	strh r9, [sp, #0xec]
+	strh r9, [sp, #0xee]
+	strh r9, [sp, #0xf0]
+	strh r9, [sp, #0xf2]
 	strh ip, [sp, #0xf4]
 	strb ip, [sp, #0x116]
 	strb ip, [sp, #0x117]
@@ -2341,7 +2341,7 @@ _0219ae74:
 	cmp r4, #4
 	beq _0219aebc
 	add sp, sp, #0x128
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _0219ae8c:
 	ldr r0, _0219af08 ; =gItemManager
 	ldr r1, _0219af0c ; =data_ov00_020dc7d0
@@ -2354,7 +2354,7 @@ _0219ae8c:
 	mov r1, #0
 	bl func_ov00_020c0e5c
 	add sp, sp, #0x128
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _0219aebc:
 	mov r1, #0
 	ldr r0, _0219af08 ; =gItemManager
@@ -2369,7 +2369,7 @@ _0219aebc:
 	mov r1, #1
 	bl func_ov00_020c0e5c
 	add sp, sp, #0x128
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov59_0219aba8
 _0219aef4: .word data_027e0fd4

--- a/asm/ov59.s
+++ b/asm/ov59.s
@@ -1421,9 +1421,9 @@ _0219a0a8: .word data_027e1038
 	.global func_ov59_0219a0ac
 	arm_func_start func_ov59_0219a0ac
 func_ov59_0219a0ac: ; 0x0219a0ac
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x220
-	mov sl, r0
+	mov r10, r0
 	bl func_ov59_02198e2c
 	ldrb r1, [r0, #0x27]
 	mov r2, #0
@@ -1433,8 +1433,8 @@ func_ov59_0219a0ac: ; 0x0219a0ac
 	movne r2, #1
 	cmp r2, #0
 	addne sp, sp, #0x220
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
-	ldr r1, [sl, #0x2f4]
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldr r1, [r10, #0x2f4]
 	ldr r0, _0219a9e8 ; =gItemManager
 	ldr r4, [r1, #8]
 	ldr r0, [r0]
@@ -1442,38 +1442,38 @@ func_ov59_0219a0ac: ; 0x0219a0ac
 	bl _ZNK11ItemManager18func_ov00_020ad538Ei
 	cmp r4, r0
 	addeq sp, sp, #0x220
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
-	ldrb r0, [sl, #0x3c2]
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldrb r0, [r10, #0x3c2]
 	cmp r0, #0
 	bne _0219a4ec
-	ldr r1, [sl, #0x54]
+	ldr r1, [r10, #0x54]
 	ldr r0, _0219a9f0 ; =data_027e0f94
 	str r1, [sp, #0x94]
-	ldr r1, [sl, #0x58]
+	ldr r1, [r10, #0x58]
 	ldr r0, [r0, #4]
 	str r1, [sp, #0x98]
-	ldr r1, [sl, #0x5c]
+	ldr r1, [r10, #0x5c]
 	add r8, r0, #0x99
 	str r1, [sp, #0x9c]
-	ldr r0, [sl, #0x54]
+	ldr r0, [r10, #0x54]
 	ldr lr, _0219a9f4 ; =0x00000666
 	str r0, [sp, #0x88]
-	ldr r0, [sl, #0x58]
+	ldr r0, [r10, #0x58]
 	mov r11, #0
 	str r0, [sp, #0x8c]
-	ldr r0, [sl, #0x5c]
-	add r1, sl, #0x300
+	ldr r0, [r10, #0x5c]
+	add r1, r10, #0x300
 	str r0, [sp, #0x90]
-	ldr r7, [sl, #0x48]
+	ldr r7, [r10, #0x48]
 	ldr r2, _0219a9f8 ; =data_02050f54
 	str r7, [sp, #0x7c]
-	ldr r0, [sl, #0x4c]
+	ldr r0, [r10, #0x4c]
 	mov sb, #1
 	str r0, [sp, #0x80]
-	ldr r6, [sl, #0x50]
+	ldr r6, [r10, #0x50]
 	add r0, sp, #0x7c
 	str r6, [sp, #0x84]
-	ldr r5, [sl, #0x344]
+	ldr r5, [r10, #0x344]
 	ldrh r1, [r1, #0x40]
 	umull r4, r3, r5, lr
 	mla r3, r5, r11, r3
@@ -1526,7 +1526,7 @@ func_ov59_0219a0ac: ; 0x0219a0ac
 	strb r11, [sp, #0x21c]
 	strb r11, [sp, #0x21d]
 _0219a24c:
-	ldr r1, [sl, #0x98]
+	ldr r1, [r10, #0x98]
 	add r0, sp, #0x88
 	add r2, r1, r1, lsl #1
 	mov r1, r2, asr #0x1
@@ -1544,16 +1544,16 @@ _0219a24c:
 	ldmia r4, {r0, r1, r2}
 	stmia r3, {r0, r1, r2}
 	ldr r0, _0219a9fc ; =data_027e0e60
-	ldr r4, [sl, #8]
+	ldr r4, [r10, #8]
 	ldr r0, [r0]
-	ldr r2, [sl, #0x98]
+	ldr r2, [r10, #0x98]
 	add r1, sp, #0x1c0
 	stmia sp, {r2, r4}
-	ldrh r5, [sl, #0x9c]
+	ldrh r5, [r10, #0x9c]
 	mov r2, r6
 	mov r4, #0
 	str r5, [sp, #8]
-	ldr r5, [sl, #0xa0]
+	ldr r5, [r10, #0xa0]
 	movne sb, #0
 	str r5, [sp, #0xc]
 	str r4, [sp, #0x10]
@@ -1561,7 +1561,7 @@ _0219a24c:
 	cmp r0, #0
 	beq _0219a4bc
 	mov r6, #1
-	strb r6, [sl, #0x3c2]
+	strb r6, [r10, #0x3c2]
 	ldr r4, [sp, #0x1c0]
 	ldr r0, [sp, #0x1c4]
 	ldr r3, [sp, #0x1c8]
@@ -1574,9 +1574,9 @@ _0219a24c:
 	str r4, [sp, #0x7c]
 	str r0, [sp, #0x80]
 	str r3, [sp, #0x84]
-	add r1, sl, #0x300
+	add r1, r10, #0x300
 	ldr r5, _0219aa00 ; =0xfffff99a
-	ldr r2, [sl, #0x344]
+	ldr r2, [r10, #0x344]
 	sub r6, r6, #2
 	umull r7, r0, r2, r5
 	mla r0, r2, r6, r0
@@ -1634,7 +1634,7 @@ _0219a24c:
 	add r5, sp, #0x94
 	mov r4, #0
 _0219a3f8:
-	ldr r1, [sl, #0x98]
+	ldr r1, [r10, #0x98]
 	mov r0, r7
 	add r3, r1, r1, lsl #1
 	mov r2, r3, asr #0x1
@@ -1649,16 +1649,16 @@ _0219a3f8:
 	mov ip, r3
 	ldmia r5, {r0, r1, r2}
 	stmia ip, {r0, r1, r2}
-	ldr ip, [sl, #8]
+	ldr ip, [r10, #8]
 	ldr r0, [r11]
-	ldr r2, [sl, #0x98]
+	ldr r2, [r10, #0x98]
 	add r1, sp, #0x160
 	stmia sp, {r2, ip}
-	ldrh ip, [sl, #0x9c]
+	ldrh ip, [r10, #0x9c]
 	mov r2, r6
 	movne sb, #0
 	str ip, [sp, #8]
-	ldr ip, [sl, #0xa0]
+	ldr ip, [r10, #0xa0]
 	str ip, [sp, #0xc]
 	str r4, [sp, #0x10]
 	bl func_01ffbf5c
@@ -1674,7 +1674,7 @@ _0219a3f8:
 _0219a48c:
 	cmp sb, #0
 	beq _0219a4b4
-	ldr r1, [sl, #0x98]
+	ldr r1, [r10, #0x98]
 	mov r0, r5
 	add r3, r1, r1, lsl #1
 	mov r1, r8
@@ -1688,7 +1688,7 @@ _0219a4b4:
 _0219a4bc:
 	cmp sb, #0
 	beq _0219a4e4
-	ldr r1, [sl, #0x98]
+	ldr r1, [r10, #0x98]
 	add r0, sp, #0x94
 	add r2, r1, r1, lsl #1
 	mov r1, r2, asr #0x1
@@ -1700,19 +1700,19 @@ _0219a4e4:
 	cmp sb, #0
 	bne _0219a24c
 _0219a4ec:
-	ldrb r0, [sl, #0x3c2]
+	ldrb r0, [r10, #0x3c2]
 	cmp r0, #0
 	bne _0219a820
-	ldr r8, [sl, #0x54]
-	add r2, sl, #0x300
+	ldr r8, [r10, #0x54]
+	add r2, r10, #0x300
 	str r8, [sp, #0x94]
-	ldr r7, [sl, #0x58]
+	ldr r7, [r10, #0x58]
 	ldr r0, _0219a9f4 ; =0x00000666
 	str r7, [sp, #0x98]
-	ldr r6, [sl, #0x5c]
+	ldr r6, [r10, #0x5c]
 	mov r1, #0
 	str r6, [sp, #0x9c]
-	ldr r4, [sl, #0x344]
+	ldr r4, [r10, #0x344]
 	ldrh r5, [r2, #0x40]
 	str r2, [sp, #0x18]
 	umull r3, r2, r4, r0
@@ -1749,15 +1749,15 @@ _0219a4ec:
 	str r4, [r3, #8]
 	str r2, [sp, #0x88]
 	str r4, [sp, #0x90]
-	ldr sb, [sl, #0x48]
+	ldr sb, [r10, #0x48]
 	mov r11, #0x800
 	str sb, [sp, #0x7c]
-	ldr r2, [sl, #0x4c]
+	ldr r2, [r10, #0x4c]
 	str r2, [sp, #0x80]
-	ldr r8, [sl, #0x50]
+	ldr r8, [r10, #0x50]
 	ldr r2, [sp, #0x18]
 	str r8, [sp, #0x84]
-	ldr r7, [sl, #0x344]
+	ldr r7, [r10, #0x344]
 	ldrh r2, [r2, #0x40]
 	umull r6, r4, r7, r0
 	mov r2, r2, asr #0x4
@@ -1796,7 +1796,7 @@ _0219a4ec:
 	str r0, [sp, #0x14]
 	add r4, sp, #0x88
 _0219a668:
-	ldr r2, [sl, #0x98]
+	ldr r2, [r10, #0x98]
 	mov r0, r4
 	add r3, r2, r2, lsl #1
 	mov r2, r3, asr #0x1
@@ -1833,16 +1833,16 @@ _0219a668:
 	ldmia r0, {r0, r1, r2}
 	stmia r8, {r0, r1, r2}
 	ldr r0, _0219a9fc ; =data_027e0e60
-	ldr r8, [sl, #8]
+	ldr r8, [r10, #8]
 	ldr r0, [r0]
-	ldr r2, [sl, #0x98]
+	ldr r2, [r10, #0x98]
 	add r1, sp, #0x100
 	stmia sp, {r2, r8}
-	ldrh r8, [sl, #0x9c]
+	ldrh r8, [r10, #0x9c]
 	add r2, sp, #0x40
 	movne r6, #0
 	str r8, [sp, #8]
-	ldr r8, [sl, #0xa0]
+	ldr r8, [r10, #0xa0]
 	str r8, [sp, #0xc]
 	mov r8, #0
 	str r8, [sp, #0x10]
@@ -1855,7 +1855,7 @@ _0219a668:
 	ldr r0, [sp, #0x108]
 	str r1, [sp, #0x88]
 	str r0, [sp, #0x90]
-	ldr sb, [sl, #0x344]
+	ldr sb, [r10, #0x344]
 	mov r6, r8
 	ldr r11, [sp, #0x14]
 	umull r8, r3, sb, r7
@@ -1893,11 +1893,11 @@ _0219a668:
 	add r0, r0, r2
 	str r0, [r4, #8]
 	mov r0, #1
-	strb r0, [sl, #0x3c2]
+	strb r0, [r10, #0x3c2]
 _0219a7f0:
 	cmp r6, #0
 	beq _0219a818
-	ldr r2, [sl, #0x98]
+	ldr r2, [r10, #0x98]
 	add r0, sp, #0x94
 	add r3, r2, r2, lsl #1
 	mov r2, r3, asr #0x1
@@ -1909,28 +1909,28 @@ _0219a818:
 	cmp r6, #0
 	bne _0219a668
 _0219a820:
-	ldrb r0, [sl, #0x3c2]
+	ldrb r0, [r10, #0x3c2]
 	cmp r0, #0
 	bne _0219a998
-	ldr r4, [sl, #0x54]
+	ldr r4, [r10, #0x54]
 	mov sb, #1
 	str r4, [sp, #0x94]
-	ldr r3, [sl, #0x58]
+	ldr r3, [r10, #0x58]
 	ldr r1, _0219aa04 ; =0x0000ffff
 	str r3, [sp, #0x98]
-	ldr r2, [sl, #0x5c]
+	ldr r2, [r10, #0x5c]
 	mov r0, #0
 	str r4, [sp, #0x88]
 	str r3, [sp, #0x8c]
 	str r2, [sp, #0x9c]
 	str r2, [sp, #0x90]
-	ldr r2, [sl, #0x48]
+	ldr r2, [r10, #0x48]
 	mov r11, sb
 	str r2, [sp, #0x7c]
-	ldr r2, [sl, #0x4c]
+	ldr r2, [r10, #0x4c]
 	add r6, sp, #0x28
 	str r2, [sp, #0x80]
-	ldr r2, [sl, #0x50]
+	ldr r2, [r10, #0x50]
 	add r8, sp, #0x88
 	str r2, [sp, #0x84]
 	strh r1, [sp, #0xc4]
@@ -1952,7 +1952,7 @@ _0219a820:
 	mov r4, r0
 	add r7, sp, #0x7c
 _0219a8c8:
-	ldr r1, [sl, #0x98]
+	ldr r1, [r10, #0x98]
 	mov r0, r8
 	add r3, r1, r1, lsl #1
 	mov r2, r3, asr #0x1
@@ -1968,17 +1968,17 @@ _0219a8c8:
 	ldmia r5, {r0, r1, r2}
 	stmia ip, {r0, r1, r2}
 	ldr r0, _0219a9fc ; =data_027e0e60
-	ldr r2, [sl, #8]
+	ldr r2, [r10, #8]
 	ldr r0, [r0]
-	ldr ip, [sl, #0x98]
+	ldr ip, [r10, #0x98]
 	add r1, sp, #0xa0
 	str ip, [sp]
 	str r2, [sp, #4]
-	ldrh ip, [sl, #0x9c]
+	ldrh ip, [r10, #0x9c]
 	mov r2, r6
 	movne sb, #0
 	str ip, [sp, #8]
-	ldr ip, [sl, #0xa0]
+	ldr ip, [r10, #0xa0]
 	str ip, [sp, #0xc]
 	str r4, [sp, #0x10]
 	bl func_01ffbf5c
@@ -1991,11 +1991,11 @@ _0219a8c8:
 	str r1, [sp, #0x8c]
 	str r0, [sp, #0x90]
 	mov sb, #0
-	strb r11, [sl, #0x3c2]
+	strb r11, [r10, #0x3c2]
 _0219a968:
 	cmp sb, #0
 	beq _0219a990
-	ldr r1, [sl, #0x98]
+	ldr r1, [r10, #0x98]
 	mov r0, r5
 	add r3, r1, r1, lsl #1
 	mov r1, r7
@@ -2007,26 +2007,26 @@ _0219a990:
 	cmp sb, #0
 	bne _0219a8c8
 _0219a998:
-	ldrb r0, [sl, #0x3c2]
+	ldrb r0, [r10, #0x3c2]
 	cmp r0, #0
 	addeq sp, sp, #0x220
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, [sp, #0x88]
-	str r0, [sl, #0x48]
-	str r0, [sl, #0x158]
+	str r0, [r10, #0x48]
+	str r0, [r10, #0x158]
 	ldr r0, [sp, #0x90]
-	str r0, [sl, #0x50]
-	str r0, [sl, #0x160]
-	ldrb r0, [sl, #0x3c0]
+	str r0, [r10, #0x50]
+	str r0, [r10, #0x160]
+	ldrb r0, [r10, #0x3c0]
 	cmp r0, #0
 	moveq r0, #1
-	streqb r0, [sl, #0x3c0]
+	streqb r0, [r10, #0x3c0]
 	mov r0, #0
-	str r0, [sl, #0x60]
-	str r0, [sl, #0x64]
-	str r0, [sl, #0x68]
+	str r0, [r10, #0x60]
+	str r0, [r10, #0x64]
+	str r0, [r10, #0x68]
 	add sp, sp, #0x220
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov59_0219a0ac
 _0219a9e8: .word gItemManager

--- a/asm/ov60.s
+++ b/asm/ov60.s
@@ -6,22 +6,22 @@
 	.global func_ov60_0213dec0
 	arm_func_start func_ov60_0213dec0
 func_ov60_0213dec0: ; 0x0213dec0
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	mov sb, r0
 	mov r8, r1
 	bl func_ov60_021400d0
 	mov r7, r0
 	cmp sb, #0x3e8
 	movlo r0, r8
-	ldmloia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmloia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	cmp r7, #0
 	beq _0213df88
 _0213dee8:
 	ldr r0, [r7]
 	cmp r0, sb
 	bne _0213df7c
-	ldr sl, _0213df90 ; =data_ov60_02147700
-	ldr r0, [sl, #4]
+	ldr r10, _0213df90 ; =data_ov60_02147700
+	ldr r0, [r10, #4]
 	cmp sb, r0
 	bne _0213df60
 	mov r6, #0
@@ -44,9 +44,9 @@ _0213df10:
 	cmp r6, #2
 	bgt _0213df60
 _0213df4c:
-	ldr r0, [sl]
+	ldr r0, [r10]
 	cmp r8, r0
-	ldrne r0, [sl, #8]
+	ldrne r0, [r10, #8]
 	cmpne r8, r0
 	beq _0213df10
 _0213df60:
@@ -56,14 +56,14 @@ _0213df60:
 	ldr r2, [r1]
 	str r2, [r1, #8]
 	str r8, [r1]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _0213df7c:
 	ldr r7, [r7, #0x28]
 	cmp r7, #0
 	bne _0213dee8
 _0213df88:
 	mvn r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov60_0213dec0
 _0213df90: .word data_ov60_02147700
@@ -421,7 +421,7 @@ _0213e3e8:
 	.global func_ov60_0213e3fc
 	arm_func_start func_ov60_0213e3fc
 func_ov60_0213e3fc: ; 0x0213e3fc
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #8
 	mov r5, r1
 	mov r1, #0x6c
@@ -434,14 +434,14 @@ func_ov60_0213e3fc: ; 0x0213e3fc
 	strb r8, [r1, r0]
 	add sb, r1, r0
 	add r0, r6, #0x1f8
-	movs sl, r3
+	movs r10, r3
 	str r0, [sp, #4]
 	mov r7, #0
 	mov r4, r2
 	addeq sp, sp, #8
 	moveq r0, r7
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
-	cmp sl, #0
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	cmp r10, #0
 	ble _0213e914
 	mvn r11, #0
 _0213e458:
@@ -490,7 +490,7 @@ _0213e4f0:
 	cmp r0, #0
 	addeq sp, sp, #8
 	moveq r0, r7
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	mov r8, #3
 	b _0213e90c
 _0213e508:
@@ -520,7 +520,7 @@ _0213e530: ; jump table
 _0213e560:
 	add sp, sp, #8
 	mov r0, r7
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0213e56c:
 	mov r8, #5
 	b _0213e90c
@@ -537,7 +537,7 @@ _0213e57c:
 _0213e594:
 	add sp, sp, #8
 	mov r0, r7
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0213e5a0:
 	mov r8, #0xa
 	b _0213e90c
@@ -564,7 +564,7 @@ _0213e5d0:
 	strb r0, [sb]
 	add sp, sp, #8
 	add r0, r7, #9
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0213e5fc:
 	mov r0, r4
 	add r1, sb, #0xa
@@ -608,7 +608,7 @@ _0213e678:
 	strb r0, [sb]
 	add sp, sp, #8
 	add r0, r7, #4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0213e69c:
 	ldr r0, [r6]
 	cmp r0, #2
@@ -619,7 +619,7 @@ _0213e69c:
 _0213e6b4:
 	add sp, sp, #8
 	add r0, r7, #4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0213e6c0:
 	mov r0, r6
 	mov r2, r5
@@ -628,7 +628,7 @@ _0213e6c0:
 	bl func_ov60_0213e204
 	add sp, sp, #8
 	add r0, r7, #4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0213e6e0:
 	mov r0, r4
 	add r1, sb, #0x10
@@ -660,7 +660,7 @@ _0213e730:
 	add sp, sp, #8
 	mov r0, r7
 	strb r1, [sb]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0213e754:
 	ldr r0, [r6]
 	cmp r0, #4
@@ -687,7 +687,7 @@ _0213e784:
 _0213e7a8:
 	add sp, sp, #8
 	mov r0, r7
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0213e7b4:
 	mov r8, #8
 	b _0213e90c
@@ -723,7 +723,7 @@ _0213e81c:
 	add sp, sp, #8
 	mov r0, r7
 	strb r1, [sb]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0213e830:
 	str r4, [sb, #0x20]
 	ldr r0, [r6]
@@ -770,7 +770,7 @@ _0213e8c0:
 _0213e8d4:
 	add sp, sp, #8
 	mov r0, r7
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0213e8e0:
 	mov r0, r6
 	mov r1, #0xf
@@ -785,7 +785,7 @@ _0213e8f8:
 	mov r3, #4
 	bl func_ov60_0213e204
 _0213e90c:
-	cmp r7, sl
+	cmp r7, r10
 	blt _0213e458
 _0213e914:
 	mov r0, r6
@@ -795,13 +795,13 @@ _0213e914:
 	bl func_ov60_0213e204
 	mov r0, r7
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	arm_func_end func_ov60_0213e3fc
 
 	.global func_ov60_0213e934
 	arm_func_start func_ov60_0213e934
 func_ov60_0213e934: ; 0x0213e934
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #8
 	mov r3, #0x6c
 	mul r6, r1, r3
@@ -819,15 +819,15 @@ func_ov60_0213e934: ; 0x0213e934
 	mov r0, #0
 	cmpeq r1, #2
 	addne sp, sp, #8
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	bl func_ov60_0213fc64
-	mov sl, r0
+	mov r10, r0
 	bl func_ov60_0214000c
 	mov sb, r0
 	bl func_ov60_0213fffc
 	str sb, [sp]
 	mov r1, r5
-	mov r2, sl, lsl #0x10
+	mov r2, r10, lsl #0x10
 	mov r3, r2, asr #0x10
 	str r0, [sp, #4]
 	mov r0, r7
@@ -839,7 +839,7 @@ func_ov60_0213e934: ; 0x0213e934
 	mov r2, #0
 	str r2, [r1, #0x23c]
 	add sp, sp, #8
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	arm_func_end func_ov60_0213e934
 
 	.global func_ov60_0213e9d0
@@ -906,16 +906,16 @@ func_ov60_0213ea38: ; 0x0213ea38
 	.global func_ov60_0213ea9c
 	arm_func_start func_ov60_0213ea9c
 func_ov60_0213ea9c: ; 0x0213ea9c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x14
 	mov r3, #0x6c
 	mul r7, r1, r3
-	mov sl, r0
+	mov r10, r0
 	str r1, [sp, #0xc]
-	add r1, sl, #0x1d4
+	add r1, r10, #0x1d4
 	ldrb r0, [r1, r7]
 	mov sb, r2
-	add r5, sl, #0x138
+	add r5, r10, #0x138
 	cmp r0, #2
 	add r6, r1, r7
 	mov r11, #0
@@ -967,7 +967,7 @@ _0213eb68:
 	strh r0, [r5, #0x20]
 	mov r3, #0
 	ldr r2, [sp, #0xc]
-	mov r0, sl
+	mov r0, r10
 	str r3, [r5, #0x1c]
 	mov r1, #0xd
 	bl func_ov60_0213e204
@@ -987,13 +987,13 @@ _0213eb68:
 _0213ebd0:
 	mov r0, #1
 	strb r0, [r6]
-	add r0, sl, r7
+	add r0, r10, r7
 	mov r1, #0
 	str r1, [r0, #0x23c]
 _0213ebe4:
 	mov r0, r11
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov60_0213ea9c
 _0213ebf0: .word 0x0000fffe
@@ -1109,7 +1109,7 @@ _0213ed60: .word 0x0000ffff
 	.global func_ov60_0213ed64
 	arm_func_start func_ov60_0213ed64
 func_ov60_0213ed64: ; 0x0213ed64
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #4
 	mov r5, r0
 	ldr r2, [r5]
@@ -1141,16 +1141,16 @@ _0213edb4:
 	mov r3, r6
 	bl func_ov60_0213f144
 	add sp, sp, #4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 _0213ede0:
 	mov r8, r0
 	add sb, r5, #0x1f8
 	mov r7, #1
 	mvn r6, #0
 _0213edf0:
-	mov sl, r7, lsl r8
+	mov r10, r7, lsl r8
 	ldrh r2, [r5, #8]
-	mov r1, sl, lsl #0x10
+	mov r1, r10, lsl #0x10
 	tst r2, r1, lsr #16
 	beq _0213ee70
 	mov r0, sb
@@ -1158,7 +1158,7 @@ _0213edf0:
 	cmp r0, r6
 	bne _0213ee30
 	ldrb r2, [r5, #0xc]
-	mov r1, sl, lsl #0x10
+	mov r1, r10, lsl #0x10
 	ldr r3, [r5, #0x14]
 	mov r0, r4
 	mov r1, r1, lsr #0x10
@@ -1182,14 +1182,14 @@ _0213ee58:
 _0213ee64:
 	cmp r0, #0
 	addne sp, sp, #4
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 _0213ee70:
 	add r8, r8, #1
 	cmp r8, #0x10
 	add sb, sb, #0x6c
 	blt _0213edf0
 	add sp, sp, #4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 _0213ee88:
 	ldrb r1, [r5, #0x1d]
 	mov r0, r4
@@ -1200,7 +1200,7 @@ _0213ee88:
 	bl func_ov60_0213f5c4
 _0213eea4:
 	add sp, sp, #4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	arm_func_end func_ov60_0213ed64
 
 	.global func_ov60_0213eeac
@@ -2457,7 +2457,7 @@ _0213fed0:
 	.global func_ov60_0213ff00
 	arm_func_start func_ov60_0213ff00
 func_ov60_0213ff00: ; 0x0213ff00
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	mov sb, r0
 	mov r7, #0
 	bl func_0200ee4c
@@ -2472,7 +2472,7 @@ func_ov60_0213ff00: ; 0x0213ff00
 	cmp r0, #0
 	beq _0213ffa0
 	mov r6, r7
-	mov sl, #0x10
+	mov r10, #0x10
 	mov r4, #1
 _0213ff44:
 	mov r0, r4, lsl r6
@@ -2485,7 +2485,7 @@ _0213ff44:
 	mvn r1, r0
 	and r1, r2, r1
 	strh r1, [r8, #8]
-	str sl, [r8, #4]
+	str r10, [r8, #4]
 	strh r0, [r8, #0xa]
 	ldr r1, [r8, #0x10]
 	mov r7, r4
@@ -2503,7 +2503,7 @@ _0213ffa0:
 	mov r0, r5
 	bl func_0200ee60
 	mov r0, r7
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov60_0213ff00
 _0213ffb0: .word data_ov60_021477e0
@@ -2767,10 +2767,10 @@ func_ov60_021401dc: ; 0x021401dc
 	.global func_ov60_02140210
 	arm_func_start func_ov60_02140210
 func_ov60_02140210: ; 0x02140210
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	ldrh r4, [sp, #0x28]
-	mov sl, r0
-	ldrb r0, [sl, #1]
+	mov r10, r0
+	ldrb r0, [r10, #1]
 	cmp r4, #0xff
 	movhi r4, #0xff
 	mov sb, r1
@@ -2779,13 +2779,13 @@ func_ov60_02140210: ; 0x02140210
 	and r4, r4, #0xff
 	cmp r0, #0
 	beq _021403dc
-	ldrb r0, [sl, #2]
+	ldrb r0, [r10, #2]
 	mov r6, #0
 	cmp r0, #0
 	ble _021403dc
 	mov r5, r6
 _02140254:
-	ldr r1, [sl, #4]
+	ldr r1, [r10, #4]
 	ldrh r0, [r1, r5]
 	add r2, r1, r5
 	cmp r0, #1
@@ -2795,18 +2795,18 @@ _02140254:
 	bl func_ov60_0214289c
 	cmp r0, #0
 	bne _021403c8
-	ldr r1, [sl, #8]
+	ldr r1, [r10, #8]
 	mov r0, #0x2c
 	mla r0, r6, r0, r1
 	bl func_0200ec14
 	bl func_0200ee4c
 	mov r1, #0xe0
 	mul r2, r6, r1
-	ldr r1, [sl, #4]
+	ldr r1, [r10, #4]
 	ldr r8, _02140540 ; =0x2aaaaaab
 	add r1, r1, r2
 	strh r7, [r1, #8]
-	ldr r1, [sl, #4]
+	ldr r1, [r10, #4]
 	mov r5, r0
 	add r1, r1, #0xb
 	ldrb r7, [r1, r2]
@@ -2820,12 +2820,12 @@ _02140254:
 	sub ip, r0, r7
 	and r7, ip, #0xff
 	strb r7, [r1, r2]
-	ldr r0, [sl, #4]
+	ldr r0, [r10, #4]
 	mov r1, r3
 	add r0, r0, r2
 	add r0, r0, r7
 	strb r4, [r0, #0xc]
-	ldr r7, [sl, #4]
+	ldr r7, [r10, #4]
 	add r2, r7, r2
 _021402fc:
 	ldrb r0, [r2, #0xc]
@@ -2841,13 +2841,13 @@ _021402fc:
 	smull r0, r7, r1, r3
 	add r7, r7, r3, lsr #31
 	strb r7, [r2, #0xa]
-	ldr r1, [sl, #4]
+	ldr r1, [r10, #4]
 	ldr r0, [sp, #0x2c]
 	add r1, r1, r4
 	add r1, r1, #0x20
 	mov r2, #0xc0
 	bl func_02007984
-	ldr r0, [sl, #4]
+	ldr r0, [r10, #4]
 	mov r1, #0xc0
 	add r0, r0, r4
 	add r0, r0, #0x20
@@ -2856,12 +2856,12 @@ _021402fc:
 	bl func_0200ee60
 	mov r0, #0x2c
 	mul r5, r6, r0
-	ldr r0, [sl, #4]
+	ldr r0, [r10, #4]
 	mov r6, #0
 	add r0, r0, r4
 	ldr r1, _02140544 ; =0x000082ea
 	str r0, [sp]
-	ldr r0, [sl, #8]
+	ldr r0, [r10, #8]
 	mov r2, r6
 	umull r7, r4, sb, r1
 	mla r4, sb, r2, r4
@@ -2872,35 +2872,35 @@ _021402fc:
 	mov r2, r4, lsr #0x6
 	orr r1, r1, r4, lsl #26
 	bl func_0200eba8
-	ldrb r1, [sl]
-	ldr r0, [sl, #8]
+	ldrb r1, [r10]
+	ldr r0, [r10, #8]
 	add r0, r0, r5
 	add r1, r1, #0x80
 	bl func_0200ed9c
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _021403c8:
-	ldrb r0, [sl, #2]
+	ldrb r0, [r10, #2]
 	add r6, r6, #1
 	add r5, r5, #0xe0
 	cmp r6, r0
 	blt _02140254
 _021403dc:
-	ldrb r0, [sl, #2]
+	ldrb r0, [r10, #2]
 	mov r6, #0
 	cmp r0, #0
 	ble _02140538
-	ldr r5, [sl, #4]
+	ldr r5, [r10, #4]
 _021403f0:
 	ldrh r0, [r5]
 	cmp r0, #0
 	bne _02140524
 	bl func_0200ee4c
-	ldrb r3, [sl, #1]
+	ldrb r3, [r10, #1]
 	mov r2, #1
 	mov r1, #0
 	add r3, r3, #1
-	strb r3, [sl, #1]
+	strb r3, [r10, #1]
 	strh r2, [r5]
 	ldrb r2, [r8]
 	mov r11, r0
@@ -2916,7 +2916,7 @@ _021403f0:
 	ldrb r0, [r8, #5]
 	strb r0, [r5, #7]
 	strh r7, [r5, #8]
-	str sl, [r5, #0x14]
+	str r10, [r5, #0x14]
 	strb r1, [r5, #0xb]
 _02140458:
 	add r0, r5, r1
@@ -2936,50 +2936,50 @@ _02140458:
 	bl func_0200ee60
 	mov r0, #0x2c
 	mul r4, r6, r0
-	ldr r0, [sl, #8]
+	ldr r0, [r10, #8]
 	add r0, r0, r4
 	bl func_0200ec14
 	mov r0, #0xe0
 	mul r5, r6, r0
 	mov r6, #0
 	ldr r1, _02140544 ; =0x000082ea
-	ldr r0, [sl, #4]
+	ldr r0, [r10, #4]
 	mov r2, r6
 	umull r8, r7, sb, r1
 	mla r7, sb, r2, r7
 	mla r7, r6, r1, r7
 	add r0, r0, r5
 	str r0, [sp]
-	ldr r0, [sl, #8]
+	ldr r0, [r10, #8]
 	mov r1, r8, lsr #0x6
 	ldr r3, _02140548 ; =func_ov60_0214054c
 	add r0, r0, r4
 	mov r2, r7, lsr #0x6
 	orr r1, r1, r7, lsl #26
 	bl func_0200eba8
-	ldrb r1, [sl]
-	ldr r0, [sl, #8]
+	ldrb r1, [r10]
+	ldr r0, [r10, #8]
 	add r0, r0, r4
 	add r1, r1, #0x80
 	bl func_0200ed9c
-	ldr r1, [sl, #0xc]
+	ldr r1, [r10, #0xc]
 	cmp r1, #0
 	beq _0214051c
-	ldr r0, [sl, #4]
+	ldr r0, [r10, #4]
 	add r0, r0, r5
 	blx r1
 _0214051c:
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02140524:
-	ldrb r0, [sl, #2]
+	ldrb r0, [r10, #2]
 	add r6, r6, #1
 	add r5, r5, #0xe0
 	cmp r6, r0
 	blt _021403f0
 _02140538:
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov60_02140210
 _02140540: .word 0x2aaaaaab
@@ -3061,14 +3061,14 @@ func_ov60_021405c4: ; 0x021405c4
 	.global func_ov60_02140604
 	arm_func_start func_ov60_02140604
 func_ov60_02140604: ; 0x02140604
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #4
-	mov sl, r0
-	ldrb r0, [sl, #2]
+	mov r10, r0
+	ldrb r0, [r10, #2]
 	mov r5, #0
 	cmp r0, #0
 	addle sp, sp, #4
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	ldr r0, _021406c4 ; =0x000082ea
 	mov r2, r5
 	umull r4, r3, r1, r0
@@ -3081,36 +3081,36 @@ func_ov60_02140604: ; 0x02140604
 	mov r8, r3, lsr #0x6
 	orr sb, sb, r3, lsl #26
 _02140650:
-	ldr r0, [sl, #4]
+	ldr r0, [r10, #4]
 	ldrh r0, [r0, r6]
 	cmp r0, #1
 	bne _021406a4
-	ldr r0, [sl, #8]
+	ldr r0, [r10, #8]
 	add r0, r0, r7
 	bl func_0200ec14
-	ldr r0, [sl, #4]
+	ldr r0, [r10, #4]
 	mov r1, sb
 	add r0, r0, r6
 	str r0, [sp]
-	ldr r0, [sl, #8]
+	ldr r0, [r10, #8]
 	mov r2, r8
 	add r0, r0, r7
 	mov r3, r4
 	bl func_0200eba8
-	ldrb r1, [sl]
-	ldr r0, [sl, #8]
+	ldrb r1, [r10]
+	ldr r0, [r10, #8]
 	add r0, r0, r7
 	add r1, r1, #0x80
 	bl func_0200ed9c
 _021406a4:
-	ldrb r0, [sl, #2]
+	ldrb r0, [r10, #2]
 	add r5, r5, #1
 	add r6, r6, #0xe0
 	cmp r5, r0
 	add r7, r7, #0x2c
 	blt _02140650
 	add sp, sp, #4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov60_02140604
 _021406c4: .word 0x000082ea
@@ -4669,14 +4669,14 @@ _02141ad0: .word data_ov60_02148088
 	.global func_ov60_02141ad4
 	arm_func_start func_ov60_02141ad4
 func_ov60_02141ad4: ; 0x02141ad4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
-	mov sl, r0
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	mov r10, r0
 	mov r11, r1
 	mov r4, #0
 _02141ae4:
 	mov r0, #6
 	mul r7, r4, r0
-	add sb, sl, r7
+	add sb, r10, r7
 	mov r0, sb
 	bl func_ov60_02142cb4
 	add r8, r11, r7
@@ -4687,7 +4687,7 @@ _02141ae4:
 	ldrb r1, [r8, #1]
 	mov r6, r0
 	cmp r5, #0
-	strb r2, [sl, r7]
+	strb r2, [r10, r7]
 	strb r1, [sb, #1]
 	ldrb r1, [r8, #2]
 	ldrb r0, [r8, #3]
@@ -4717,7 +4717,7 @@ _02141b74:
 	mov r4, r0, lsr #0x10
 	cmp r4, #0x10
 	blo _02141ae4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	arm_func_end func_ov60_02141ad4
 
 	.global func_ov60_02141b8c
@@ -6000,10 +6000,10 @@ _02142ad0: .word 0x1b0cb173
 	.global func_ov60_02142ad4
 	arm_func_start func_ov60_02142ad4
 func_ov60_02142ad4: ; 0x02142ad4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
-	ldr sl, _02142b98 ; =data_ov60_021480a0
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	ldr r10, _02142b98 ; =data_ov60_021480a0
 	mov r6, #0
-	ldr r0, [sl]
+	ldr r0, [r10]
 	mov r5, r6
 	ldrb r0, [r0, #0xc]
 	cmp r0, #0
@@ -6038,7 +6038,7 @@ _02142b00:
 _02142b5c:
 	mov r6, r4
 _02142b60:
-	ldr r0, [sl]
+	ldr r0, [r10]
 	add r1, r5, #1
 	ldrb r0, [r0, #0xc]
 	and r5, r1, #0xff
@@ -6047,12 +6047,12 @@ _02142b60:
 _02142b78:
 	cmp r6, #0
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	add r0, r6, #0x20
 	mov r1, #1
 	bl func_ov60_021417f8
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov60_02142ad4
 _02142b98: .word data_ov60_021480a0
@@ -7054,15 +7054,15 @@ _021438a4: .word data_ov60_02148090
 	.global func_ov60_021438a8
 	arm_func_start func_ov60_021438a8
 func_ov60_021438a8: ; 0x021438a8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
-	mov sl, r1
-	ldrh r5, [sl, #0x22]
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	mov r10, r1
+	ldrh r5, [r10, #0x22]
 	mov r11, r0
 	mov r4, #0
 	cmp r5, #0
 	beq _021439a8
 	ldr r0, _021439b0 ; =data_ov60_02148090
-	add r7, sl, #0x24
+	add r7, r10, #0x24
 	ldr r0, [r0]
 	add r8, r11, #0x24
 	ldrb sb, [r0]
@@ -7098,8 +7098,8 @@ _02143940:
 	ldr r0, [r0]
 	ldr r1, [r0, #0x18]
 	ldr r0, [r1, r4, lsl #2]
-	cmp r0, sl
-	ldreq r0, [sl, #4]
+	cmp r0, r10
+	ldreq r0, [r10, #4]
 	streq r0, [r1, r4, lsl #2]
 	add r0, r4, #1
 	mov r0, r0, lsl #0x10
@@ -7112,7 +7112,7 @@ _02143968:
 	blt _02143914
 	mov r2, #0
 	ldr r0, _021439b8 ; =data_ov60_02148088
-	strh r2, [sl, #0x22]
+	strh r2, [r10, #0x22]
 	ldr r1, [r0]
 	add r0, r11, #0x20
 	ldrh r1, [r1, #0x98]
@@ -7123,7 +7123,7 @@ _02143968:
 	mov r4, #1
 _021439a8:
 	mov r0, r4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov60_021438a8
 _021439b0: .word data_ov60_02148090
@@ -9052,9 +9052,9 @@ _02145060: .word data_ov60_02148088
 	.global func_ov60_02145064
 	arm_func_start func_ov60_02145064
 func_ov60_02145064: ; 0x02145064
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	ldr r1, _021450dc ; =data_ov00_020ee698
-	mov sl, r0
+	mov r10, r0
 	ldrh r8, [r1, #2]
 	cmp r8, #0
 	beq _021450c8
@@ -9067,7 +9067,7 @@ _0214508c:
 	beq _021450b4
 	sub r0, r7, #1
 	mla sb, r0, r4, r5
-	add r0, sl, #0xa
+	add r0, r10, #0xa
 	add r1, sb, #0x16
 	bl func_ov60_0214289c
 	cmp r0, #0
@@ -9085,7 +9085,7 @@ _021450cc:
 	cmp r0, #0
 	movne r0, #1
 	moveq r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov60_02145064
 _021450dc: .word data_ov00_020ee698
@@ -11316,7 +11316,7 @@ _02146d5c: .word func_ov60_02146458
 	.global func_ov60_02146d60
 	arm_func_start func_ov60_02146d60
 func_ov60_02146d60: ; 0x02146d60
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #8
 	mov r8, r0
 	mov r7, r1
@@ -11328,18 +11328,18 @@ func_ov60_02146d60: ; 0x02146d60
 	ldr r1, [sb, #8]
 	cmp r1, #0
 	bne _02146f58
-	mov sl, #1
+	mov r10, #1
 	mov r0, r8
 	mov r1, r7
 	mov r2, r6
 	mov r3, r5
-	str sl, [sb, #8]
+	str r10, [sb, #8]
 	bl func_ov60_02146cb4
 	mov r0, r4
 	bl func_0200ee60
 	mov r0, sb
 	ldr r8, [r0, #4]
-	mov r3, sl
+	mov r3, r10
 	add sb, r8, #0x440
 	ldr r2, _02146f68 ; =0x00010770
 	mov r0, sb
@@ -11350,34 +11350,34 @@ func_ov60_02146d60: ; 0x02146d60
 	mov r0, sb
 	bl func_0200e2c0
 	bl func_0200e2e4
-	add sl, sb, #0xc0
+	add r10, sb, #0xc0
 	add r0, sb, #0x10000
-	str sl, [r0, #0x740]
+	str r10, [r0, #0x740]
 	add r0, sb, #0x740
 	ldr r4, _02146f6c ; =0xea0ea0eb
-	mov r6, sl
+	mov r6, r10
 	add r5, r0, #0x10000
 	mov r7, #0
 _02146e08:
-	add r1, sl, #0x8c0
-	add r0, sl, #0x38
-	str r1, [sl]
+	add r1, r10, #0x8c0
+	add r0, r10, #0x38
+	str r1, [r10]
 	blx func_02041ca8
-	add r0, sl, #0x8c0
+	add r0, r10, #0x8c0
 	add r0, r0, #0x8c00000
 	sub r1, r0, r6
 	smull r0, r2, r4, r1
-	str r7, [sl, #0x84]
+	str r7, [r10, #0x84]
 	add r2, r1, r2
 	mov r0, r1, lsr #0x1f
-	str r7, [sl, #0x80]
+	str r7, [r10, #0x80]
 	add r2, r0, r2, asr #11
-	str r2, [sl, #0x8c]
-	ldr r0, [sl]
+	str r2, [r10, #0x8c]
+	ldr r0, [r10]
 	cmp r0, r5
-	strhs r7, [sl]
+	strhs r7, [r10]
 	bhs _02146e58
-	mov sl, r0
+	mov r10, r0
 	b _02146e08
 _02146e58:
 	add r2, sb, #0x10000
@@ -11444,11 +11444,11 @@ _02146f44:
 	bl func_0200ee60
 	bl func_ov60_02145c58
 	add sp, sp, #8
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _02146f58:
 	bl func_0200ee60
 	add sp, sp, #8
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov60_02146d60
 _02146f64: .word data_ov60_0214857c
@@ -11715,7 +11715,7 @@ _02147278: .word data_ov60_02148580
 	.global func_ov60_0214727c
 	arm_func_start func_ov60_0214727c
 func_ov60_0214727c: ; 0x0214727c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0xf4
 	movs r5, r0
 	mov r0, #0
@@ -11854,18 +11854,18 @@ _02147450:
 	mov r0, r5
 	bl func_0200ee60
 	ldr r0, [sp, #8]
-	mov sl, #0
+	mov r10, #0
 	str r7, [r0]
 	add sb, r0, #4
 	add r6, sp, #0x2c
 	add r5, sp, #0x4c
 _02147498:
-	add r0, r6, sl, lsl #3
+	add r0, r6, r10, lsl #3
 	ldr r1, [r0, #4]
 	add r0, sp, #0xc
 	str r1, [sb]
-	ldr r1, [r6, sl, lsl #3]
-	str sb, [r0, sl, lsl #2]
+	ldr r1, [r6, r10, lsl #3]
+	str sb, [r0, r10, lsl #2]
 	mov r0, r5
 	mov r2, #0
 	add r1, r7, r1
@@ -11875,11 +11875,11 @@ _02147498:
 	add r1, sb, #4
 	blx func_02041fa4
 	add r0, sp, #0x1c
-	ldr r0, [r0, sl, lsl #2]
-	add sl, sl, #1
+	ldr r0, [r0, r10, lsl #2]
+	add r10, r10, #1
 	add r0, r0, #4
 	add sb, sb, r0
-	cmp sl, #4
+	cmp r10, #4
 	blt _02147498
 	cmp r11, #0
 	beq _021475bc
@@ -11890,7 +11890,7 @@ _02147498:
 	mov r0, #2
 	add r5, r2, #4
 	mov r6, r1, lsr #0x3
-	add sl, r5, r6, lsl #3
+	add r10, r5, r6, lsl #3
 	str r0, [sp]
 _02147518:
 	ldr r0, [sp]
@@ -11910,7 +11910,7 @@ _0214753c:
 	add r1, r11, r1, lsl #3
 	blx func_02041fb0
 	add r0, sp, #0x4c
-	mov r1, sl
+	mov r1, r10
 	mov r2, #8
 	blx func_02041fa4
 	ldr r2, [r5, r6, lsl #3]
@@ -11920,7 +11920,7 @@ _0214753c:
 	add r0, r5, r6, lsl #3
 	str r2, [r5, r6, lsl #3]
 	ldr r2, [r0, #4]
-	add sl, sl, #8
+	add r10, r10, #8
 	add r2, r2, r4
 	str r2, [r0, #4]
 	str r6, [r1, #0x18]
@@ -11951,7 +11951,7 @@ _021475bc:
 	ldr r0, [sp, #4]
 	str r0, [r1, #0x24]
 	add sp, sp, #0xf4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov60_0214727c
 _021475f8: .word data_ov60_02148580

--- a/asm/ov60.s
+++ b/asm/ov60.s
@@ -421,7 +421,7 @@ _0213e3e8:
 	.global func_ov60_0213e3fc
 	arm_func_start func_ov60_0213e3fc
 func_ov60_0213e3fc: ; 0x0213e3fc
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #8
 	mov r5, r1
 	mov r1, #0x6c
@@ -440,10 +440,10 @@ func_ov60_0213e3fc: ; 0x0213e3fc
 	mov r4, r2
 	addeq sp, sp, #8
 	moveq r0, r7
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	cmp sl, #0
 	ble _0213e914
-	mvn fp, #0
+	mvn r11, #0
 _0213e458:
 	cmp r8, #0xa
 	addls pc, pc, r8, lsl #2
@@ -478,7 +478,7 @@ _0213e4b0:
 	add r7, r7, #2
 	ldrh r8, [sb, #8]
 	bl func_ov60_02140134
-	cmp r0, fp
+	cmp r0, r11
 	moveq r0, #0
 	beq _0213e4f0
 	bl func_ov60_02140134
@@ -490,7 +490,7 @@ _0213e4f0:
 	cmp r0, #0
 	addeq sp, sp, #8
 	moveq r0, r7
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	mov r8, #3
 	b _0213e90c
 _0213e508:
@@ -520,7 +520,7 @@ _0213e530: ; jump table
 _0213e560:
 	add sp, sp, #8
 	mov r0, r7
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0213e56c:
 	mov r8, #5
 	b _0213e90c
@@ -537,7 +537,7 @@ _0213e57c:
 _0213e594:
 	add sp, sp, #8
 	mov r0, r7
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0213e5a0:
 	mov r8, #0xa
 	b _0213e90c
@@ -564,7 +564,7 @@ _0213e5d0:
 	strb r0, [sb]
 	add sp, sp, #8
 	add r0, r7, #9
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0213e5fc:
 	mov r0, r4
 	add r1, sb, #0xa
@@ -608,7 +608,7 @@ _0213e678:
 	strb r0, [sb]
 	add sp, sp, #8
 	add r0, r7, #4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0213e69c:
 	ldr r0, [r6]
 	cmp r0, #2
@@ -619,7 +619,7 @@ _0213e69c:
 _0213e6b4:
 	add sp, sp, #8
 	add r0, r7, #4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0213e6c0:
 	mov r0, r6
 	mov r2, r5
@@ -628,7 +628,7 @@ _0213e6c0:
 	bl func_ov60_0213e204
 	add sp, sp, #8
 	add r0, r7, #4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0213e6e0:
 	mov r0, r4
 	add r1, sb, #0x10
@@ -660,7 +660,7 @@ _0213e730:
 	add sp, sp, #8
 	mov r0, r7
 	strb r1, [sb]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0213e754:
 	ldr r0, [r6]
 	cmp r0, #4
@@ -687,7 +687,7 @@ _0213e784:
 _0213e7a8:
 	add sp, sp, #8
 	mov r0, r7
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0213e7b4:
 	mov r8, #8
 	b _0213e90c
@@ -723,7 +723,7 @@ _0213e81c:
 	add sp, sp, #8
 	mov r0, r7
 	strb r1, [sb]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0213e830:
 	str r4, [sb, #0x20]
 	ldr r0, [r6]
@@ -770,7 +770,7 @@ _0213e8c0:
 _0213e8d4:
 	add sp, sp, #8
 	mov r0, r7
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0213e8e0:
 	mov r0, r6
 	mov r1, #0xf
@@ -795,7 +795,7 @@ _0213e914:
 	bl func_ov60_0213e204
 	mov r0, r7
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	arm_func_end func_ov60_0213e3fc
 
 	.global func_ov60_0213e934
@@ -906,7 +906,7 @@ func_ov60_0213ea38: ; 0x0213ea38
 	.global func_ov60_0213ea9c
 	arm_func_start func_ov60_0213ea9c
 func_ov60_0213ea9c: ; 0x0213ea9c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x14
 	mov r3, #0x6c
 	mul r7, r1, r3
@@ -918,7 +918,7 @@ func_ov60_0213ea9c: ; 0x0213ea9c
 	add r5, sl, #0x138
 	cmp r0, #2
 	add r6, r1, r7
-	mov fp, #0
+	mov r11, #0
 	bne _0213ebe4
 	bl func_ov60_02140134
 	cmp r0, #0
@@ -955,7 +955,7 @@ func_ov60_0213ea9c: ; 0x0213ea9c
 	mov r0, sb
 	mov r1, r8
 	bl func_ov60_0213f2e0
-	mov fp, r0
+	mov r11, r0
 	b _0213ebd0
 _0213eb68:
 	cmp r0, #1
@@ -983,7 +983,7 @@ _0213eb68:
 	ldrb r2, [r6, #2]
 	ldr r3, [r5, #0x14]
 	bl func_ov60_0213f2e0
-	mov fp, r0
+	mov r11, r0
 _0213ebd0:
 	mov r0, #1
 	strb r0, [r6]
@@ -991,9 +991,9 @@ _0213ebd0:
 	mov r1, #0
 	str r1, [r0, #0x23c]
 _0213ebe4:
-	mov r0, fp
+	mov r0, r11
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov60_0213ea9c
 _0213ebf0: .word 0x0000fffe
@@ -2767,7 +2767,7 @@ func_ov60_021401dc: ; 0x021401dc
 	.global func_ov60_02140210
 	arm_func_start func_ov60_02140210
 func_ov60_02140210: ; 0x02140210
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	ldrh r4, [sp, #0x28]
 	mov sl, r0
 	ldrb r0, [sl, #1]
@@ -2810,13 +2810,13 @@ _02140254:
 	mov r5, r0
 	add r1, r1, #0xb
 	ldrb r7, [r1, r2]
-	mov fp, #6
+	mov r11, #6
 	mov r3, #0
 	add r0, r7, #1
 	and r0, r0, #0xff
 	smull r7, ip, r8, r0
 	add ip, ip, r0, lsr #31
-	smull r7, r8, fp, ip
+	smull r7, r8, r11, ip
 	sub ip, r0, r7
 	and r7, ip, #0xff
 	strb r7, [r1, r2]
@@ -2878,7 +2878,7 @@ _021402fc:
 	add r1, r1, #0x80
 	bl func_0200ed9c
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _021403c8:
 	ldrb r0, [sl, #2]
 	add r6, r6, #1
@@ -2903,7 +2903,7 @@ _021403f0:
 	strb r3, [sl, #1]
 	strh r2, [r5]
 	ldrb r2, [r8]
-	mov fp, r0
+	mov r11, r0
 	strb r2, [r5, #2]
 	ldrb r0, [r8, #1]
 	strb r0, [r5, #3]
@@ -2932,7 +2932,7 @@ _02140458:
 	add r0, r5, #0x20
 	mov r1, #0xc0
 	bl func_0200e2a4
-	mov r0, fp
+	mov r0, r11
 	bl func_0200ee60
 	mov r0, #0x2c
 	mul r4, r6, r0
@@ -2970,7 +2970,7 @@ _02140458:
 	blx r1
 _0214051c:
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02140524:
 	ldrb r0, [sl, #2]
 	add r6, r6, #1
@@ -2979,7 +2979,7 @@ _02140524:
 	blt _021403f0
 _02140538:
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov60_02140210
 _02140540: .word 0x2aaaaaab
@@ -4669,9 +4669,9 @@ _02141ad0: .word data_ov60_02148088
 	.global func_ov60_02141ad4
 	arm_func_start func_ov60_02141ad4
 func_ov60_02141ad4: ; 0x02141ad4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	mov sl, r0
-	mov fp, r1
+	mov r11, r1
 	mov r4, #0
 _02141ae4:
 	mov r0, #6
@@ -4679,11 +4679,11 @@ _02141ae4:
 	add sb, sl, r7
 	mov r0, sb
 	bl func_ov60_02142cb4
-	add r8, fp, r7
+	add r8, r11, r7
 	mov r5, r0
 	mov r0, r8
 	bl func_ov60_02142cb4
-	ldrb r2, [fp, r7]
+	ldrb r2, [r11, r7]
 	ldrb r1, [r8, #1]
 	mov r6, r0
 	cmp r5, #0
@@ -4717,7 +4717,7 @@ _02141b74:
 	mov r4, r0, lsr #0x10
 	cmp r4, #0x10
 	blo _02141ae4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	arm_func_end func_ov60_02141ad4
 
 	.global func_ov60_02141b8c
@@ -7054,21 +7054,21 @@ _021438a4: .word data_ov60_02148090
 	.global func_ov60_021438a8
 	arm_func_start func_ov60_021438a8
 func_ov60_021438a8: ; 0x021438a8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	mov sl, r1
 	ldrh r5, [sl, #0x22]
-	mov fp, r0
+	mov r11, r0
 	mov r4, #0
 	cmp r5, #0
 	beq _021439a8
 	ldr r0, _021439b0 ; =data_ov60_02148090
 	add r7, sl, #0x24
 	ldr r0, [r0]
-	add r8, fp, #0x24
+	add r8, r11, #0x24
 	ldrb sb, [r0]
 	ldr r0, _021439b0 ; =data_ov60_02148090
 	mov r6, #4
-	strh r5, [fp, #0x22]
+	strh r5, [r11, #0x22]
 	ldr r1, [r0]
 	ldrb r3, [r1, #1]
 	mov r0, r3, lsl #0x1c
@@ -7079,7 +7079,7 @@ func_ov60_021438a8: ; 0x021438a8
 	and r2, r2, #0xf
 	orr r2, r3, r2
 	strb r2, [r1, #1]
-	strb r0, [fp, #0x20]
+	strb r0, [r11, #0x20]
 	b _02143968
 _02143914:
 	mov r0, #1
@@ -7114,16 +7114,16 @@ _02143968:
 	ldr r0, _021439b8 ; =data_ov60_02148088
 	strh r2, [sl, #0x22]
 	ldr r1, [r0]
-	add r0, fp, #0x20
+	add r0, r11, #0x20
 	ldrh r1, [r1, #0x98]
-	strh r1, [fp, #0xa]
-	strh r2, [fp, #0xc]
-	strh r6, [fp, #8]
+	strh r1, [r11, #0xa]
+	strh r2, [r11, #0xc]
+	strh r6, [r11, #8]
 	bl func_ov60_02143810
 	mov r4, #1
 _021439a8:
 	mov r0, r4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov60_021438a8
 _021439b0: .word data_ov60_02148090
@@ -11715,7 +11715,7 @@ _02147278: .word data_ov60_02148580
 	.global func_ov60_0214727c
 	arm_func_start func_ov60_0214727c
 func_ov60_0214727c: ; 0x0214727c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0xf4
 	movs r5, r0
 	mov r0, #0
@@ -11725,10 +11725,10 @@ func_ov60_0214727c: ; 0x0214727c
 	cmp r4, #0
 	bne _021472ac
 	cmp r1, #0
-	movne fp, #1
+	movne r11, #1
 	bne _021472b0
 _021472ac:
-	mov fp, #0
+	mov r11, #0
 _021472b0:
 	add r0, sp, #0x4c
 	blx func_02041ca8
@@ -11759,7 +11759,7 @@ _021472e4:
 	mov r2, #0
 	blx func_02041fb0
 _0214731c:
-	cmp fp, #0
+	cmp r11, #0
 	bne _02147368
 	ldr r0, [r8, #0x48]
 	str r0, [sp, #0x2c]
@@ -11820,7 +11820,7 @@ _021473d4:
 	cmp r0, #4
 	str r1, [sp, #4]
 	blt _021473d4
-	cmp fp, #0
+	cmp r11, #0
 	beq _02147450
 	mov r0, #2
 	add r2, sp, #0x2c
@@ -11881,12 +11881,12 @@ _02147498:
 	add sb, sb, r0
 	cmp sl, #4
 	blt _02147498
-	cmp fp, #0
+	cmp r11, #0
 	beq _021475bc
 	ldr r2, [sp, #0xc]
 	ldr r0, [r8, #0x48]
 	ldr r1, [r2]
-	add fp, r4, r0
+	add r11, r4, r0
 	mov r0, #2
 	add r5, r2, #4
 	mov r6, r1, lsr #0x3
@@ -11907,7 +11907,7 @@ _0214753c:
 	ldr r1, [r1, #0x18]
 	add r0, sp, #0x4c
 	mov r2, #0
-	add r1, fp, r1, lsl #3
+	add r1, r11, r1, lsl #3
 	blx func_02041fb0
 	add r0, sp, #0x4c
 	mov r1, sl
@@ -11951,7 +11951,7 @@ _021475bc:
 	ldr r0, [sp, #4]
 	str r0, [r1, #0x24]
 	add sp, sp, #0xf4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov60_0214727c
 _021475f8: .word data_ov60_02148580

--- a/asm/ov60.s
+++ b/asm/ov60.s
@@ -6,23 +6,23 @@
 	.global func_ov60_0213dec0
 	arm_func_start func_ov60_0213dec0
 func_ov60_0213dec0: ; 0x0213dec0
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
-	mov sb, r0
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
+	mov r9, r0
 	mov r8, r1
 	bl func_ov60_021400d0
 	mov r7, r0
-	cmp sb, #0x3e8
+	cmp r9, #0x3e8
 	movlo r0, r8
-	ldmloia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmloia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	cmp r7, #0
 	beq _0213df88
 _0213dee8:
 	ldr r0, [r7]
-	cmp r0, sb
+	cmp r0, r9
 	bne _0213df7c
 	ldr r10, _0213df90 ; =data_ov60_02147700
 	ldr r0, [r10, #4]
-	cmp sb, r0
+	cmp r9, r0
 	bne _0213df60
 	mov r6, #0
 	mov r4, r6
@@ -52,18 +52,18 @@ _0213df4c:
 _0213df60:
 	ldr r1, _0213df90 ; =data_ov60_02147700
 	mov r0, r8
-	str sb, [r1, #4]
+	str r9, [r1, #4]
 	ldr r2, [r1]
 	str r2, [r1, #8]
 	str r8, [r1]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _0213df7c:
 	ldr r7, [r7, #0x28]
 	cmp r7, #0
 	bne _0213dee8
 _0213df88:
 	mvn r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov60_0213dec0
 _0213df90: .word data_ov60_02147700
@@ -117,7 +117,7 @@ _0213e014:
 	.global func_ov60_0213e01c
 	arm_func_start func_ov60_0213e01c
 func_ov60_0213e01c: ; 0x0213e01c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	mov r7, r0
 	mov r6, r1
 	mov r5, r2
@@ -133,12 +133,12 @@ func_ov60_0213e01c: ; 0x0213e01c
 	str r2, [r7, #0x10]
 	bl func_02002c14
 	cmp r1, #0
-	movne sb, #1
-	moveq sb, #0
+	movne r9, #1
+	moveq r9, #0
 	mov r0, r6
 	mov r1, r8
 	bl func_02002c14
-	add r0, r0, sb
+	add r0, r0, r9
 	str r0, [r7, #4]
 	str r5, [r7, #0x14]
 	mov r0, r6
@@ -148,7 +148,7 @@ func_ov60_0213e01c: ; 0x0213e01c
 	mov r0, r5
 	mov r1, #0
 	bl func_02007a44
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	arm_func_end func_ov60_0213e01c
 
 	.global func_ov60_0213e09c
@@ -421,7 +421,7 @@ _0213e3e8:
 	.global func_ov60_0213e3fc
 	arm_func_start func_ov60_0213e3fc
 func_ov60_0213e3fc: ; 0x0213e3fc
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #8
 	mov r5, r1
 	mov r1, #0x6c
@@ -432,7 +432,7 @@ func_ov60_0213e3fc: ; 0x0213e3fc
 	add r1, r6, #0x1d4
 	mov r8, #1
 	strb r8, [r1, r0]
-	add sb, r1, r0
+	add r9, r1, r0
 	add r0, r6, #0x1f8
 	movs r10, r3
 	str r0, [sp, #4]
@@ -440,7 +440,7 @@ func_ov60_0213e3fc: ; 0x0213e3fc
 	mov r4, r2
 	addeq sp, sp, #8
 	moveq r0, r7
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	cmp r10, #0
 	ble _0213e914
 	mvn r11, #0
@@ -462,7 +462,7 @@ _0213e464: ; jump table
 	b _0213e5b0 ; case 10
 _0213e490:
 	mov r0, r4
-	add r1, sb, #1
+	add r1, r9, #1
 	mov r2, #1
 	bl func_02007ad8
 	add r4, r4, #1
@@ -471,12 +471,12 @@ _0213e490:
 	b _0213e90c
 _0213e4b0:
 	mov r0, r4
-	add r1, sb, #8
+	add r1, r9, #8
 	mov r2, #2
 	bl func_02007ad8
 	add r4, r4, #2
 	add r7, r7, #2
-	ldrh r8, [sb, #8]
+	ldrh r8, [r9, #8]
 	bl func_ov60_02140134
 	cmp r0, r11
 	moveq r0, #0
@@ -490,15 +490,15 @@ _0213e4f0:
 	cmp r0, #0
 	addeq sp, sp, #8
 	moveq r0, r7
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	mov r8, #3
 	b _0213e90c
 _0213e508:
 	mov r0, r4
-	add r1, sb, #2
+	add r1, r9, #2
 	mov r2, #1
 	bl func_02007ad8
-	ldrb r1, [sb, #1]
+	ldrb r1, [r9, #1]
 	add r4, r4, #1
 	add r7, r7, #1
 	cmp r1, #0xb
@@ -520,7 +520,7 @@ _0213e530: ; jump table
 _0213e560:
 	add sp, sp, #8
 	mov r0, r7
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0213e56c:
 	mov r8, #5
 	b _0213e90c
@@ -537,7 +537,7 @@ _0213e57c:
 _0213e594:
 	add sp, sp, #8
 	mov r0, r7
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0213e5a0:
 	mov r8, #0xa
 	b _0213e90c
@@ -546,7 +546,7 @@ _0213e5a8:
 	b _0213e90c
 _0213e5b0:
 	mov r0, r4
-	add r1, sb, #0xd
+	add r1, r9, #0xd
 	mov r2, #1
 	bl func_02007ad8
 	add r4, r4, #1
@@ -554,23 +554,23 @@ _0213e5b0:
 	mov r8, #9
 	b _0213e90c
 _0213e5d0:
-	str r4, [sb, #0x20]
-	ldrb r1, [sb, #1]
+	str r4, [r9, #0x20]
+	ldrb r1, [r9, #1]
 	mov r0, r6
 	mov r2, r5
 	mov r3, #0
 	bl func_ov60_0213e204
 	mov r0, #2
-	strb r0, [sb]
+	strb r0, [r9]
 	add sp, sp, #8
 	add r0, r7, #9
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0213e5fc:
 	mov r0, r4
-	add r1, sb, #0xa
+	add r1, r9, #0xa
 	mov r2, #2
 	bl func_02007ad8
-	ldrb r0, [sb, #1]
+	ldrb r0, [r9, #1]
 	add r4, r4, #2
 	add r7, r7, #2
 	cmp r0, #3
@@ -578,22 +578,22 @@ _0213e5fc:
 	b _0213e90c
 _0213e624:
 	mov r0, r4
-	add r1, sb, #6
+	add r1, r9, #6
 	mov r2, #2
 	bl func_02007ad8
 	add r0, r4, #2
-	add r1, sb, #4
+	add r1, r9, #4
 	mov r2, #2
 	bl func_02007ad8
 	bl func_ov60_02140134
 	cmp r0, #0
 	beq _0213e660
-	ldrsh r0, [sb, #4]
+	ldrsh r0, [r9, #4]
 	bl func_ov60_0214002c
-	ldrsh r0, [sb, #6]
+	ldrsh r0, [r9, #6]
 	bl func_ov60_0214001c
 _0213e660:
-	ldrb r1, [sb, #1]
+	ldrb r1, [r9, #1]
 	cmp r1, #2
 	beq _0213e678
 	cmp r1, #3
@@ -605,10 +605,10 @@ _0213e678:
 	mov r3, #0
 	bl func_ov60_0213e204
 	mov r0, #2
-	strb r0, [sb]
+	strb r0, [r9]
 	add sp, sp, #8
 	add r0, r7, #4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0213e69c:
 	ldr r0, [r6]
 	cmp r0, #2
@@ -619,7 +619,7 @@ _0213e69c:
 _0213e6b4:
 	add sp, sp, #8
 	add r0, r7, #4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0213e6c0:
 	mov r0, r6
 	mov r2, r5
@@ -628,13 +628,13 @@ _0213e6c0:
 	bl func_ov60_0213e204
 	add sp, sp, #8
 	add r0, r7, #4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0213e6e0:
 	mov r0, r4
-	add r1, sb, #0x10
+	add r1, r9, #0x10
 	mov r2, #4
 	bl func_02007ad8
-	ldrb r1, [sb, #1]
+	ldrb r1, [r9, #1]
 	add r4, r4, #4
 	add r7, r7, #4
 	cmp r1, #9
@@ -659,14 +659,14 @@ _0213e730:
 	mov r1, #2
 	add sp, sp, #8
 	mov r0, r7
-	strb r1, [sb]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	strb r1, [r9]
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0213e754:
 	ldr r0, [r6]
 	cmp r0, #4
 	bne _0213e784
 	ldr r1, [r6, #0x14]
-	ldr r0, [sb, #0x10]
+	ldr r0, [r9, #0x10]
 	cmp r1, r0
 	bne _0213e7a8
 	mov r0, r6
@@ -677,7 +677,7 @@ _0213e754:
 _0213e784:
 	cmp r0, #6
 	ldreq r1, [r6, #0x14]
-	ldreq r0, [sb, #0x10]
+	ldreq r0, [r9, #0x10]
 	cmpeq r1, r0
 	bne _0213e7a8
 	mov r0, r6
@@ -687,7 +687,7 @@ _0213e784:
 _0213e7a8:
 	add sp, sp, #8
 	mov r0, r7
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0213e7b4:
 	mov r8, #8
 	b _0213e90c
@@ -700,10 +700,10 @@ _0213e7bc:
 	b _0213e90c
 _0213e7d4:
 	mov r0, r4
-	add r1, sb, #0x14
+	add r1, r9, #0x14
 	mov r2, #4
 	bl func_02007ad8
-	ldrb r0, [sb, #1]
+	ldrb r0, [r9, #1]
 	add r4, r4, #4
 	add r7, r7, #4
 	cmp r0, #7
@@ -722,15 +722,15 @@ _0213e81c:
 	mov r1, #2
 	add sp, sp, #8
 	mov r0, r7
-	strb r1, [sb]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	strb r1, [r9]
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0213e830:
-	str r4, [sb, #0x20]
+	str r4, [r9, #0x20]
 	ldr r0, [r6]
 	cmp r0, #4
 	cmpne r0, #6
 	bne _0213e8d4
-	ldr r1, [sb, #0x10]
+	ldr r1, [r9, #0x10]
 	ldr r0, [r6, #0x14]
 	cmp r1, r0
 	bne _0213e8d4
@@ -742,22 +742,22 @@ _0213e830:
 	beq _0213e8d4
 	ldr r2, [sp, #4]
 	ldr r0, [sp]
-	ldr r1, [sb, #0x14]
+	ldr r1, [r9, #0x14]
 	add r0, r2, r0
 	bl func_ov60_0213e09c
 	cmp r0, #0
 	bne _0213e8d4
 	ldr r3, [sp, #4]
 	ldr r0, [sp]
-	ldr r1, [sb, #0x14]
-	ldr r2, [sb, #0x20]
+	ldr r1, [r9, #0x14]
+	ldr r2, [r9, #0x20]
 	add r0, r3, r0
 	bl func_ov60_0213e17c
 	cmp r0, #1
 	bne _0213e8c0
 	ldr r2, [sp, #4]
 	ldr r0, [sp]
-	ldr r1, [sb, #0x14]
+	ldr r1, [r9, #0x14]
 	add r0, r2, r0
 	bl func_ov60_0213e0bc
 	b _0213e8d4
@@ -770,7 +770,7 @@ _0213e8c0:
 _0213e8d4:
 	add sp, sp, #8
 	mov r0, r7
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0213e8e0:
 	mov r0, r6
 	mov r1, #0xf
@@ -795,13 +795,13 @@ _0213e914:
 	bl func_ov60_0213e204
 	mov r0, r7
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	arm_func_end func_ov60_0213e3fc
 
 	.global func_ov60_0213e934
 	arm_func_start func_ov60_0213e934
 func_ov60_0213e934: ; 0x0213e934
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #8
 	mov r3, #0x6c
 	mul r6, r1, r3
@@ -819,13 +819,13 @@ func_ov60_0213e934: ; 0x0213e934
 	mov r0, #0
 	cmpeq r1, #2
 	addne sp, sp, #8
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	bl func_ov60_0213fc64
 	mov r10, r0
 	bl func_ov60_0214000c
-	mov sb, r0
+	mov r9, r0
 	bl func_ov60_0213fffc
-	str sb, [sp]
+	str r9, [sp]
 	mov r1, r5
 	mov r2, r10, lsl #0x10
 	mov r3, r2, asr #0x10
@@ -839,7 +839,7 @@ func_ov60_0213e934: ; 0x0213e934
 	mov r2, #0
 	str r2, [r1, #0x23c]
 	add sp, sp, #8
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	arm_func_end func_ov60_0213e934
 
 	.global func_ov60_0213e9d0
@@ -906,7 +906,7 @@ func_ov60_0213ea38: ; 0x0213ea38
 	.global func_ov60_0213ea9c
 	arm_func_start func_ov60_0213ea9c
 func_ov60_0213ea9c: ; 0x0213ea9c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x14
 	mov r3, #0x6c
 	mul r7, r1, r3
@@ -914,7 +914,7 @@ func_ov60_0213ea9c: ; 0x0213ea9c
 	str r1, [sp, #0xc]
 	add r1, r10, #0x1d4
 	ldrb r0, [r1, r7]
-	mov sb, r2
+	mov r9, r2
 	add r5, r10, #0x138
 	cmp r0, #2
 	add r6, r1, r7
@@ -952,7 +952,7 @@ func_ov60_0213ea9c: ; 0x0213ea9c
 	str r0, [sp, #8]
 	ldrb r2, [r6, #2]
 	ldr r3, [r6, #0x10]
-	mov r0, sb
+	mov r0, r9
 	mov r1, r8
 	bl func_ov60_0213f2e0
 	mov r11, r0
@@ -975,7 +975,7 @@ _0213eb68:
 	cmp r2, #0
 	beq _0213ebd0
 	ldr r1, [r5, #0x18]
-	mov r0, sb
+	mov r0, r9
 	stmia sp, {r1, r2}
 	ldrsh r2, [r5, #0x20]
 	mov r1, r8
@@ -993,7 +993,7 @@ _0213ebd0:
 _0213ebe4:
 	mov r0, r11
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov60_0213ea9c
 _0213ebf0: .word 0x0000fffe
@@ -1001,12 +1001,12 @@ _0213ebf0: .word 0x0000fffe
 	.global func_ov60_0213ebf4
 	arm_func_start func_ov60_0213ebf4
 func_ov60_0213ebf4: ; 0x0213ebf4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0xc
 	mov r3, #0x6c
 	mul r6, r1, r3
-	mov sb, r0
-	add r1, sb, #0x1d4
+	mov r9, r0
+	add r1, r9, #0x1d4
 	ldrb r0, [r1, r6]
 	mov r8, r2
 	add r5, r1, r6
@@ -1020,7 +1020,7 @@ func_ov60_0213ebf4: ; 0x0213ebf4
 	movne r7, #1
 	cmp r0, #6
 	bne _0213ec9c
-	add r0, sb, r6
+	add r0, r9, r6
 	ldr r0, [r0, #0x23c]
 	cmp r0, #1
 	moveq r6, #0
@@ -1047,7 +1047,7 @@ _0213ec64:
 _0213ec9c:
 	mov r0, r4
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov60_0213ebf4
 _0213eca8: .word 0x0000ffff
@@ -1055,14 +1055,14 @@ _0213eca8: .word 0x0000ffff
 	.global func_ov60_0213ecac
 	arm_func_start func_ov60_0213ecac
 func_ov60_0213ecac: ; 0x0213ecac
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0xc
 	mov r3, #0x6c
 	mul r7, r1, r3
 	mov r5, r0
 	add r1, r5, #0x1d4
 	ldrb r0, [r1, r7]
-	mov sb, r2
+	mov r9, r2
 	add r6, r1, r7
 	cmp r0, #2
 	mov r4, #0
@@ -1093,7 +1093,7 @@ _0213ed24:
 	str r0, [sp, #8]
 	ldrb r2, [r6, #2]
 	ldr r3, [r6, #0x10]
-	mov r0, sb
+	mov r0, r9
 	bl func_ov60_0213f420
 	mov r1, #1
 	mov r4, r0
@@ -1101,7 +1101,7 @@ _0213ed24:
 _0213ed54:
 	mov r0, r4
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov60_0213ecac
 _0213ed60: .word 0x0000ffff
@@ -1109,7 +1109,7 @@ _0213ed60: .word 0x0000ffff
 	.global func_ov60_0213ed64
 	arm_func_start func_ov60_0213ed64
 func_ov60_0213ed64: ; 0x0213ed64
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #4
 	mov r5, r0
 	ldr r2, [r5]
@@ -1141,10 +1141,10 @@ _0213edb4:
 	mov r3, r6
 	bl func_ov60_0213f144
 	add sp, sp, #4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 _0213ede0:
 	mov r8, r0
-	add sb, r5, #0x1f8
+	add r9, r5, #0x1f8
 	mov r7, #1
 	mvn r6, #0
 _0213edf0:
@@ -1153,7 +1153,7 @@ _0213edf0:
 	mov r1, r10, lsl #0x10
 	tst r2, r1, lsr #16
 	beq _0213ee70
-	mov r0, sb
+	mov r0, r9
 	bl func_ov60_0213e0ec
 	cmp r0, r6
 	bne _0213ee30
@@ -1182,14 +1182,14 @@ _0213ee58:
 _0213ee64:
 	cmp r0, #0
 	addne sp, sp, #4
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 _0213ee70:
 	add r8, r8, #1
 	cmp r8, #0x10
-	add sb, sb, #0x6c
+	add r9, r9, #0x6c
 	blt _0213edf0
 	add sp, sp, #4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 _0213ee88:
 	ldrb r1, [r5, #0x1d]
 	mov r0, r4
@@ -1200,7 +1200,7 @@ _0213ee88:
 	bl func_ov60_0213f5c4
 _0213eea4:
 	add sp, sp, #4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	arm_func_end func_ov60_0213ed64
 
 	.global func_ov60_0213eeac
@@ -1793,18 +1793,18 @@ func_ov60_0213f644: ; 0x0213f644
 	.global func_ov60_0213f6a8
 	arm_func_start func_ov60_0213f6a8
 func_ov60_0213f6a8: ; 0x0213f6a8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	mov r7, r0
 	mov r6, r1
 	bl func_ov60_0214003c
 	ldr r8, _0213f828 ; =data_ov60_0214770c
 	mov r5, r0
 	ldr r4, [r8]
-	mov sb, #1
+	mov r9, #1
 _0213f6c8:
 	add r4, r4, #1
 	cmp r4, #0xf
-	movgt r4, sb
+	movgt r4, r9
 	mov r0, r5
 	mov r1, r4
 	mov r2, r7
@@ -1813,7 +1813,7 @@ _0213f6c8:
 	cmp r0, #0
 	ldrne r1, _0213f828 ; =data_ov60_0214770c
 	strne r4, [r1]
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	mov r0, r5
 	mov r1, r4
 	mov r2, r7
@@ -1822,7 +1822,7 @@ _0213f6c8:
 	cmp r0, #0
 	ldrne r1, _0213f828 ; =data_ov60_0214770c
 	strne r4, [r1]
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	mov r0, r5
 	mov r1, r4
 	mov r2, r7
@@ -1831,7 +1831,7 @@ _0213f6c8:
 	cmp r0, #0
 	ldrne r1, _0213f828 ; =data_ov60_0214770c
 	strne r4, [r1]
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	mov r0, r5
 	mov r1, r4
 	mov r2, r7
@@ -1840,7 +1840,7 @@ _0213f6c8:
 	cmp r0, #0
 	ldrne r1, _0213f828 ; =data_ov60_0214770c
 	strne r4, [r1]
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	ldr r0, [r8]
 	cmp r4, r0
 	bne _0213f6c8
@@ -1849,20 +1849,20 @@ _0213f6c8:
 	mov r2, r6
 	bl func_ov60_0213ed64
 	cmp r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	mov r0, r5
 	mov r1, r7
 	mov r2, r6
 	bl func_ov60_0213eeac
 	cmp r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	ldr r8, _0213f828 ; =data_ov60_0214770c
-	mov sb, #1
+	mov r9, #1
 	ldr r4, [r8]
 _0213f7ac:
 	add r4, r4, #1
 	cmp r4, #0xf
-	movgt r4, sb
+	movgt r4, r9
 	mov r0, r5
 	mov r1, r4
 	mov r2, r7
@@ -1871,7 +1871,7 @@ _0213f7ac:
 	cmp r0, #0
 	ldrne r1, _0213f828 ; =data_ov60_0214770c
 	strne r4, [r1]
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	ldr r0, [r8]
 	cmp r4, r0
 	bne _0213f7ac
@@ -1883,7 +1883,7 @@ _0213f7ec:
 	mov r3, r6
 	bl func_ov60_0213ecac
 	cmp r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	add r4, r4, #1
 	cmp r4, #0x10
 	blt _0213f7ec
@@ -1891,7 +1891,7 @@ _0213f7ec:
 	mov r0, r7
 	mov r2, #0
 	bl func_ov60_0213f0e4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov60_0213f6a8
 _0213f828: .word data_ov60_0214770c
@@ -2457,8 +2457,8 @@ _0213fed0:
 	.global func_ov60_0213ff00
 	arm_func_start func_ov60_0213ff00
 func_ov60_0213ff00: ; 0x0213ff00
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
-	mov sb, r0
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
+	mov r9, r0
 	mov r7, #0
 	bl func_0200ee4c
 	ldr r1, _0213ffb0 ; =data_ov60_021477e0
@@ -2480,7 +2480,7 @@ _0213ff44:
 	ldrh r2, [r8, #8]
 	mov r0, r1, lsr #0x10
 	and r1, r2, r1, lsr #16
-	tst sb, r1
+	tst r9, r1
 	beq _0213ff8c
 	mvn r1, r0
 	and r1, r2, r1
@@ -2503,7 +2503,7 @@ _0213ffa0:
 	mov r0, r5
 	bl func_0200ee60
 	mov r0, r7
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov60_0213ff00
 _0213ffb0: .word data_ov60_021477e0
@@ -2767,13 +2767,13 @@ func_ov60_021401dc: ; 0x021401dc
 	.global func_ov60_02140210
 	arm_func_start func_ov60_02140210
 func_ov60_02140210: ; 0x02140210
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	ldrh r4, [sp, #0x28]
 	mov r10, r0
 	ldrb r0, [r10, #1]
 	cmp r4, #0xff
 	movhi r4, #0xff
-	mov sb, r1
+	mov r9, r1
 	mov r8, r2
 	mov r7, r3
 	and r4, r4, #0xff
@@ -2863,8 +2863,8 @@ _021402fc:
 	str r0, [sp]
 	ldr r0, [r10, #8]
 	mov r2, r6
-	umull r7, r4, sb, r1
-	mla r4, sb, r2, r4
+	umull r7, r4, r9, r1
+	mla r4, r9, r2, r4
 	mla r4, r6, r1, r4
 	mov r1, r7, lsr #0x6
 	ldr r3, _02140548 ; =func_ov60_0214054c
@@ -2878,7 +2878,7 @@ _021402fc:
 	add r1, r1, #0x80
 	bl func_0200ed9c
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _021403c8:
 	ldrb r0, [r10, #2]
 	add r6, r6, #1
@@ -2945,8 +2945,8 @@ _02140458:
 	ldr r1, _02140544 ; =0x000082ea
 	ldr r0, [r10, #4]
 	mov r2, r6
-	umull r8, r7, sb, r1
-	mla r7, sb, r2, r7
+	umull r8, r7, r9, r1
+	mla r7, r9, r2, r7
 	mla r7, r6, r1, r7
 	add r0, r0, r5
 	str r0, [sp]
@@ -2970,7 +2970,7 @@ _02140458:
 	blx r1
 _0214051c:
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02140524:
 	ldrb r0, [r10, #2]
 	add r6, r6, #1
@@ -2979,7 +2979,7 @@ _02140524:
 	blt _021403f0
 _02140538:
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov60_02140210
 _02140540: .word 0x2aaaaaab
@@ -3061,25 +3061,25 @@ func_ov60_021405c4: ; 0x021405c4
 	.global func_ov60_02140604
 	arm_func_start func_ov60_02140604
 func_ov60_02140604: ; 0x02140604
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #4
 	mov r10, r0
 	ldrb r0, [r10, #2]
 	mov r5, #0
 	cmp r0, #0
 	addle sp, sp, #4
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	ldr r0, _021406c4 ; =0x000082ea
 	mov r2, r5
 	umull r4, r3, r1, r0
 	mla r3, r1, r5, r3
 	mla r3, r2, r0, r3
-	mov sb, r4, lsr #0x6
+	mov r9, r4, lsr #0x6
 	ldr r4, _021406c8 ; =func_ov60_0214054c
 	mov r6, r5
 	mov r7, r5
 	mov r8, r3, lsr #0x6
-	orr sb, sb, r3, lsl #26
+	orr r9, r9, r3, lsl #26
 _02140650:
 	ldr r0, [r10, #4]
 	ldrh r0, [r0, r6]
@@ -3089,7 +3089,7 @@ _02140650:
 	add r0, r0, r7
 	bl func_0200ec14
 	ldr r0, [r10, #4]
-	mov r1, sb
+	mov r1, r9
 	add r0, r0, r6
 	str r0, [sp]
 	ldr r0, [r10, #8]
@@ -3110,7 +3110,7 @@ _021406a4:
 	add r7, r7, #0x2c
 	blt _02140650
 	add sp, sp, #4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov60_02140604
 _021406c4: .word 0x000082ea
@@ -4669,15 +4669,15 @@ _02141ad0: .word data_ov60_02148088
 	.global func_ov60_02141ad4
 	arm_func_start func_ov60_02141ad4
 func_ov60_02141ad4: ; 0x02141ad4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	mov r10, r0
 	mov r11, r1
 	mov r4, #0
 _02141ae4:
 	mov r0, #6
 	mul r7, r4, r0
-	add sb, r10, r7
-	mov r0, sb
+	add r9, r10, r7
+	mov r0, r9
 	bl func_ov60_02142cb4
 	add r8, r11, r7
 	mov r5, r0
@@ -4688,15 +4688,15 @@ _02141ae4:
 	mov r6, r0
 	cmp r5, #0
 	strb r2, [r10, r7]
-	strb r1, [sb, #1]
+	strb r1, [r9, #1]
 	ldrb r1, [r8, #2]
 	ldrb r0, [r8, #3]
-	strb r1, [sb, #2]
-	strb r0, [sb, #3]
+	strb r1, [r9, #2]
+	strb r0, [r9, #3]
 	ldrb r1, [r8, #4]
 	ldrb r0, [r8, #5]
-	strb r1, [sb, #4]
-	strb r0, [sb, #5]
+	strb r1, [r9, #4]
+	strb r0, [r9, #5]
 	bne _02141b58
 	cmp r6, #0
 	beq _02141b58
@@ -4717,7 +4717,7 @@ _02141b74:
 	mov r4, r0, lsr #0x10
 	cmp r4, #0x10
 	blo _02141ae4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	arm_func_end func_ov60_02141ad4
 
 	.global func_ov60_02141b8c
@@ -6000,7 +6000,7 @@ _02142ad0: .word 0x1b0cb173
 	.global func_ov60_02142ad4
 	arm_func_start func_ov60_02142ad4
 func_ov60_02142ad4: ; 0x02142ad4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	ldr r10, _02142b98 ; =data_ov60_021480a0
 	mov r6, #0
 	ldr r0, [r10]
@@ -6010,9 +6010,9 @@ func_ov60_02142ad4: ; 0x02142ad4
 	bls _02142b78
 	ldr r8, _02142b9c ; =0x0000bd8a
 	ldr r7, _02142ba0 ; =0x00002348
-	ldr sb, _02142ba4 ; =data_ov60_02148088
+	ldr r9, _02142ba4 ; =data_ov60_02148088
 _02142b00:
-	ldr r0, [sb]
+	ldr r0, [r9]
 	mov r1, r5
 	ldrb r0, [r0, #0x95]
 	bl func_ov60_02140edc
@@ -6047,12 +6047,12 @@ _02142b60:
 _02142b78:
 	cmp r6, #0
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	add r0, r6, #0x20
 	mov r1, #1
 	bl func_ov60_021417f8
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov60_02142ad4
 _02142b98: .word data_ov60_021480a0
@@ -6577,8 +6577,8 @@ _02143254: .word data_ov60_021480a0
 	.global func_ov60_02143258
 	arm_func_start func_ov60_02143258
 func_ov60_02143258: ; 0x02143258
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
-	mov sb, r0
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
+	mov r9, r0
 	mov r8, r1
 	mov r7, r2
 	mov r6, r3
@@ -6600,7 +6600,7 @@ func_ov60_02143258: ; 0x02143258
 	bic r1, r1, #0x10
 	strb r1, [r3, #4]
 	ldr r1, [r0]
-	str sb, [r1, #0x20]
+	str r9, [r1, #0x20]
 	ldr r1, [r0]
 	str r8, [r1, #0x24]
 	ldr r1, [r0]
@@ -6613,7 +6613,7 @@ _021432d8:
 	mov r0, r5
 	bl func_0200ee60
 	mov r0, r4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov60_02143258
 _021432e8: .word data_ov60_02148090
@@ -7007,15 +7007,15 @@ _0214380c: .word data_ov60_02148088
 	.global func_ov60_02143810
 	arm_func_start func_ov60_02143810
 func_ov60_02143810: ; 0x02143810
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
-	ldr sb, _021438a0 ; =data_ov60_021480a0
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
+	ldr r9, _021438a0 ; =data_ov60_021480a0
 	mov r7, r0
-	ldr r0, [sb]
+	ldr r0, [r9]
 	add r6, r7, #4
 	ldrb r0, [r0, #0xb]
 	mov r5, #0
 	cmp r0, #0
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	ldr r8, _021438a4 ; =data_ov60_02148090
 	mov r4, #1
 _0214383c:
@@ -7038,14 +7038,14 @@ _02143864:
 	bic r0, r0, #1
 	add r6, r6, r0
 _02143880:
-	ldr r0, [sb]
+	ldr r0, [r9]
 	add r2, r5, #1
 	ldrb r1, [r0, #0xb]
 	mov r0, r2, lsl #0x10
 	mov r5, r0, lsr #0x10
 	cmp r1, r0, lsr #16
 	bgt _0214383c
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov60_02143810
 _021438a0: .word data_ov60_021480a0
@@ -7054,7 +7054,7 @@ _021438a4: .word data_ov60_02148090
 	.global func_ov60_021438a8
 	arm_func_start func_ov60_021438a8
 func_ov60_021438a8: ; 0x021438a8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	mov r10, r1
 	ldrh r5, [r10, #0x22]
 	mov r11, r0
@@ -7065,7 +7065,7 @@ func_ov60_021438a8: ; 0x021438a8
 	add r7, r10, #0x24
 	ldr r0, [r0]
 	add r8, r11, #0x24
-	ldrb sb, [r0]
+	ldrb r9, [r0]
 	ldr r0, _021439b0 ; =data_ov60_02148090
 	mov r6, #4
 	strh r5, [r11, #0x22]
@@ -7085,13 +7085,13 @@ _02143914:
 	mov r0, #1
 	tst r5, r0, lsl r4
 	beq _02143940
-	mla r0, sb, r4, r7
+	mla r0, r9, r4, r7
 	mov r1, r8
-	mov r2, sb
+	mov r2, r9
 	bl func_02007ad8
-	add r0, r6, sb
+	add r0, r6, r9
 	mov r0, r0, lsl #0x10
-	add r8, r8, sb
+	add r8, r8, r9
 	mov r6, r0, lsr #0x10
 _02143940:
 	ldr r0, _021439b0 ; =data_ov60_02148090
@@ -7123,7 +7123,7 @@ _02143968:
 	mov r4, #1
 _021439a8:
 	mov r0, r4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov60_021438a8
 _021439b0: .word data_ov60_02148090
@@ -9052,7 +9052,7 @@ _02145060: .word data_ov60_02148088
 	.global func_ov60_02145064
 	arm_func_start func_ov60_02145064
 func_ov60_02145064: ; 0x02145064
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	ldr r1, _021450dc ; =data_ov00_020ee698
 	mov r10, r0
 	ldrh r8, [r1, #2]
@@ -9066,12 +9066,12 @@ _0214508c:
 	tst r8, r6, lsl r7
 	beq _021450b4
 	sub r0, r7, #1
-	mla sb, r0, r4, r5
+	mla r9, r0, r4, r5
 	add r0, r10, #0xa
-	add r1, sb, #0x16
+	add r1, r9, #0x16
 	bl func_ov60_0214289c
 	cmp r0, #0
-	ldreqh r0, [sb, #0x1c]
+	ldreqh r0, [r9, #0x1c]
 	beq _021450cc
 _021450b4:
 	add r0, r7, #1
@@ -9085,7 +9085,7 @@ _021450cc:
 	cmp r0, #0
 	movne r0, #1
 	moveq r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov60_02145064
 _021450dc: .word data_ov00_020ee698
@@ -9955,7 +9955,7 @@ _02145b28: .word data_ov60_021484b4
 	.global func_ov60_02145b2c
 	arm_func_start func_ov60_02145b2c
 func_ov60_02145b2c: ; 0x02145b2c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	ldr r0, _02145c54 ; =data_ov60_02148580
 	ldr r0, [r0]
 	add r4, r0, #0x440
@@ -9967,7 +9967,7 @@ _02145b3c:
 	cmp r5, #0
 	bne _02145b8c
 	ldr r8, _02145c54 ; =data_ov60_02148580
-	mov sb, #0
+	mov r9, #0
 _02145b5c:
 	ldr r0, [r8]
 	ldr r0, [r0, #0xc]
@@ -9975,9 +9975,9 @@ _02145b5c:
 	bne _02145b78
 	mov r0, r6
 	bl func_0200ee60
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _02145b78:
-	mov r0, sb
+	mov r0, r9
 	bl func_0200d880
 	ldr r5, [r7, #0x748]
 	cmp r5, #0
@@ -9994,11 +9994,11 @@ _02145b8c:
 	blx func_020421d8
 	mov r7, #0
 	mov r8, r7
-	add sb, r5, #0xc0
+	add r9, r5, #0xc0
 	mov r6, #0x400
 _02145bc0:
 	add r3, r5, r7, lsl #2
-	mov r1, sb
+	mov r1, r9
 	mov r2, r6
 	add r0, r5, #0x38
 	str r8, [r3, #0xa4]
@@ -10006,7 +10006,7 @@ _02145bc0:
 	add r7, r7, #1
 	cmp r7, #2
 	add r8, r8, #0x400
-	add sb, sb, #0x400
+	add r9, r9, #0x400
 	blt _02145bc0
 	mov r0, #0
 	str r0, [r5, #0x98]
@@ -10035,7 +10035,7 @@ _02145c28:
 	bl func_0200ee60
 	b _02145b3c
 _02145c50:
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	arm_func_end func_ov60_02145b2c
 _02145c54: .word data_ov60_02148580
 
@@ -11316,16 +11316,16 @@ _02146d5c: .word func_ov60_02146458
 	.global func_ov60_02146d60
 	arm_func_start func_ov60_02146d60
 func_ov60_02146d60: ; 0x02146d60
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #8
 	mov r8, r0
 	mov r7, r1
 	mov r6, r2
 	mov r5, r3
 	bl func_0200ee4c
-	ldr sb, _02146f64 ; =data_ov60_0214857c
+	ldr r9, _02146f64 ; =data_ov60_0214857c
 	mov r4, r0
-	ldr r1, [sb, #8]
+	ldr r1, [r9, #8]
 	cmp r1, #0
 	bne _02146f58
 	mov r10, #1
@@ -11333,27 +11333,27 @@ func_ov60_02146d60: ; 0x02146d60
 	mov r1, r7
 	mov r2, r6
 	mov r3, r5
-	str r10, [sb, #8]
+	str r10, [r9, #8]
 	bl func_ov60_02146cb4
 	mov r0, r4
 	bl func_0200ee60
-	mov r0, sb
+	mov r0, r9
 	ldr r8, [r0, #4]
 	mov r3, r10
-	add sb, r8, #0x440
+	add r9, r8, #0x440
 	ldr r2, _02146f68 ; =0x00010770
-	mov r0, sb
+	mov r0, r9
 	mov r1, #0
 	str r3, [r8]
 	bl func_02007a44
 	ldr r1, _02146f68 ; =0x00010770
-	mov r0, sb
+	mov r0, r9
 	bl func_0200e2c0
 	bl func_0200e2e4
-	add r10, sb, #0xc0
-	add r0, sb, #0x10000
+	add r10, r9, #0xc0
+	add r0, r9, #0x10000
 	str r10, [r0, #0x740]
-	add r0, sb, #0x740
+	add r0, r9, #0x740
 	ldr r4, _02146f6c ; =0xea0ea0eb
 	mov r6, r10
 	add r5, r0, #0x10000
@@ -11380,7 +11380,7 @@ _02146e08:
 	mov r10, r0
 	b _02146e08
 _02146e58:
-	add r2, sb, #0x10000
+	add r2, r9, #0x10000
 	str r7, [r2, #0x750]
 	str r7, [r2, #0x74c]
 	str r7, [r2, #0x754]
@@ -11396,7 +11396,7 @@ _02146e58:
 	str r7, [r2, #0x764]
 	ldr r3, [r8, #0x28]
 	ldr r1, _02146f68 ; =0x00010770
-	mov r0, sb
+	mov r0, r9
 	str r3, [r2, #0x76c]
 	bl func_0200e2c0
 	bl func_0200e2e4
@@ -11407,7 +11407,7 @@ _02146e58:
 	ldr r0, [sp, #0x2c]
 	ldr r1, [sp, #0x30]
 	bl func_ov60_0214727c
-	add r2, sb, #0x10000
+	add r2, r9, #0x10000
 	ldr r5, [r2, #0x740]
 	mov r3, #1
 	ldr r1, [r5]
@@ -11444,11 +11444,11 @@ _02146f44:
 	bl func_0200ee60
 	bl func_ov60_02145c58
 	add sp, sp, #8
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _02146f58:
 	bl func_0200ee60
 	add sp, sp, #8
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov60_02146d60
 _02146f64: .word data_ov60_0214857c
@@ -11715,7 +11715,7 @@ _02147278: .word data_ov60_02148580
 	.global func_ov60_0214727c
 	arm_func_start func_ov60_0214727c
 func_ov60_0214727c: ; 0x0214727c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0xf4
 	movs r5, r0
 	mov r0, #0
@@ -11856,29 +11856,29 @@ _02147450:
 	ldr r0, [sp, #8]
 	mov r10, #0
 	str r7, [r0]
-	add sb, r0, #4
+	add r9, r0, #4
 	add r6, sp, #0x2c
 	add r5, sp, #0x4c
 _02147498:
 	add r0, r6, r10, lsl #3
 	ldr r1, [r0, #4]
 	add r0, sp, #0xc
-	str r1, [sb]
+	str r1, [r9]
 	ldr r1, [r6, r10, lsl #3]
-	str sb, [r0, r10, lsl #2]
+	str r9, [r0, r10, lsl #2]
 	mov r0, r5
 	mov r2, #0
 	add r1, r7, r1
 	blx func_02041fb0
-	ldr r2, [sb]
+	ldr r2, [r9]
 	mov r0, r5
-	add r1, sb, #4
+	add r1, r9, #4
 	blx func_02041fa4
 	add r0, sp, #0x1c
 	ldr r0, [r0, r10, lsl #2]
 	add r10, r10, #1
 	add r0, r0, #4
-	add sb, sb, r0
+	add r9, r9, r0
 	cmp r10, #4
 	blt _02147498
 	cmp r11, #0
@@ -11896,14 +11896,14 @@ _02147518:
 	ldr r0, [sp]
 	add r1, sp, #0xc
 	ldr r0, [r1, r0, lsl #2]
-	mov sb, #0
+	mov r9, #0
 	add r7, r0, #4
 	ldr r0, [r0]
 	mov r8, r0, lsr #0x5
 	cmp r8, #0
 	ble _0214759c
 _0214753c:
-	add r1, r7, sb, lsl #5
+	add r1, r7, r9, lsl #5
 	ldr r1, [r1, #0x18]
 	add r0, sp, #0x4c
 	mov r2, #0
@@ -11914,9 +11914,9 @@ _0214753c:
 	mov r2, #8
 	blx func_02041fa4
 	ldr r2, [r5, r6, lsl #3]
-	add r1, r7, sb, lsl #5
+	add r1, r7, r9, lsl #5
 	add r2, r2, r4
-	add sb, sb, #1
+	add r9, r9, #1
 	add r0, r5, r6, lsl #3
 	str r2, [r5, r6, lsl #3]
 	ldr r2, [r0, #4]
@@ -11925,7 +11925,7 @@ _0214753c:
 	str r2, [r0, #4]
 	str r6, [r1, #0x18]
 	add r6, r6, #1
-	cmp sb, r8
+	cmp r9, r8
 	blt _0214753c
 _0214759c:
 	ldr r0, [sp]
@@ -11951,7 +11951,7 @@ _021475bc:
 	ldr r0, [sp, #4]
 	str r0, [r1, #0x24]
 	add sp, sp, #0xf4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov60_0214727c
 _021475f8: .word data_ov60_02148580

--- a/asm/ov61.s
+++ b/asm/ov61.s
@@ -1444,12 +1444,12 @@ _0213f0dc: .word func_ov61_0213fa98
 	.global func_ov61_0213f0e0
 	arm_func_start func_ov61_0213f0e0
 func_ov61_0213f0e0: ; 0x0213f0e0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x90
 	mov r4, r0
 	mov sl, r1
 	mov sb, r2
-	mov fp, r3
+	mov r11, r3
 	bl func_ov61_0213dfec
 	cmp r0, #0
 	bne _0213f118
@@ -1461,7 +1461,7 @@ func_ov61_0213f0e0: ; 0x0213f0e0
 _0213f118:
 	add sp, sp, #0x90
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0213f124:
 	bl func_ov61_0213f678
 	ldr r0, _0213f284 ; =data_ov61_0217ea4c
@@ -1485,7 +1485,7 @@ _0213f124:
 	str r0, [sp, #8]
 	mov r0, r4
 	mov r1, sl
-	mov r3, fp
+	mov r3, r11
 	and r2, r2, #0xff
 	str r5, [sp, #0xc]
 	bl func_ov61_02142880
@@ -1551,14 +1551,14 @@ _0213f240:
 	str r0, [sp, #8]
 	add r0, sp, #0x50
 	mov r1, sl
-	mov r3, fp
+	mov r3, r11
 	and r2, r2, #0xff
 	str r4, [sp, #0xc]
 	bl func_ov61_02142880
 _0213f278:
 	mov r0, #1
 	add sp, sp, #0x90
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0213f0e0
 _0213f284: .word data_ov61_0217ea4c
@@ -2514,16 +2514,16 @@ _0213fdb8: .word func_ov61_0214a758
 	.global func_ov61_0213fdbc
 	arm_func_start func_ov61_0213fdbc
 func_ov61_0213fdbc: ; 0x0213fdbc
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #8
 	mov r5, #0
-	mov fp, r0
+	mov r11, r0
 	mov sb, r1
 	mov sl, r5
 	bl func_ov61_02144534
 	cmp r0, #0
 	addne sp, sp, #8
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	cmp sb, #4
 	addls pc, pc, sb, lsl #2
 	b _0213fe20
@@ -2546,11 +2546,11 @@ _0213fe18:
 _0213fe20:
 	cmp r8, #0
 	bne _0213fecc
-	mov r0, fp
+	mov r0, r11
 	bl func_ov61_02174560
 	movs r5, r0
 	addeq sp, sp, #8
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, _02140100 ; =data_ov61_0217ea4c
 	ldrb r4, [r5, #1]
 	ldr r0, [r0]
@@ -2578,9 +2578,9 @@ _0213fe8c:
 	ldr r1, _02140100 ; =data_ov61_0217ea4c
 	ldrb r5, [r5]
 	ldr r2, _02140104 ; =data_ov61_0217ea54
-	mov fp, #0
+	mov r11, #0
 	ldr r3, [r1]
-	str fp, [r2, r5, lsl #2]
+	str r11, [r2, r5, lsl #2]
 	ldrb r2, [r3, #0x361]
 	mov r5, r0
 	sub r0, r2, #1
@@ -2602,12 +2602,12 @@ _0213fecc:
 	cmp r0, #2
 	cmpeq r8, #0
 	addne sp, sp, #8
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	bl func_ov61_021443ec
 	mov r0, r5
 	bl func_ov61_02144040
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0213ff14:
 	mov r0, r8
 	mov r1, r6
@@ -2615,14 +2615,14 @@ _0213ff14:
 	bl func_ov61_02143ec4
 	cmp r0, #0
 	addne sp, sp, #8
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	cmp r8, #0
 	beq _0213ff4c
 	mov r0, r8
 	mov r1, r6
 	bl func_ov61_0213e008
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0213ff4c:
 	ldr r0, _02140100 ; =data_ov61_0217ea4c
 	ldr r1, [r0]
@@ -2726,17 +2726,17 @@ _021400b0:
 	ldreqb r0, [r1, #0x369]
 	cmpeq r0, #2
 	addeq sp, sp, #8
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldrb r0, [r1, #0x361]
 	cmp r0, #0
 	addne sp, sp, #8
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	bl func_ov61_02176dc0
 	bl func_ov61_02143cd0
 	mov r0, #3
 	bl func_ov61_0213f77c
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0213fdbc
 _021400f8: .word 0xffffe250
@@ -4517,18 +4517,18 @@ _021417f8: .word data_ov61_0217ebe0
 	.global func_ov61_021417fc
 	arm_func_start func_ov61_021417fc
 func_ov61_021417fc: ; 0x021417fc
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #8
 	mov sl, r1
-	mov fp, r0
+	mov r11, r0
 	mvn r0, #0
 	str r2, [sp]
 	cmp sl, #0
 	str r0, [sp, #4]
 	mov r5, #0
 	ble _021418f4
-	mov r7, fp
-	mov r8, fp
+	mov r7, r11
+	mov r8, r11
 _0214182c:
 	mov r0, r5
 	bl func_ov61_02141168
@@ -4541,7 +4541,7 @@ _0214182c:
 	cmp r6, sl
 	bge _021418e0
 	mov r0, #0xc
-	mla sb, r6, r0, fp
+	mla sb, r6, r0, r11
 _0214185c:
 	mov r0, r6
 	bl func_ov61_02141168
@@ -4566,7 +4566,7 @@ _02141898:
 	mov r0, r8
 	blx func_ov00_020774f8
 _021418b0:
-	mov r0, fp
+	mov r0, r11
 	mov r1, r6
 	mov r2, r5
 	bl func_ov61_021416f8
@@ -4588,7 +4588,7 @@ _021418e0:
 _021418f4:
 	ldr r0, [sp, #4]
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_021417fc
 _02141900: .word data_ov61_0217ebe0
@@ -4714,7 +4714,7 @@ _02141a64: .word 0xfffeeaa8
 	.global func_ov61_02141a68
 	arm_func_start func_ov61_02141a68
 func_ov61_02141a68: ; 0x02141a68
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	mov sb, r1
 	ldr r1, [sb]
 	mov sl, r0
@@ -4737,7 +4737,7 @@ func_ov61_02141a68: ; 0x02141a68
 	ldr r0, [r7]
 	ldr r0, [r0]
 	cmp r0, #1
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, [sb, #4]
 	mov r4, #0
 	cmp r0, #0
@@ -4762,7 +4762,7 @@ _02141adc:
 	ldr r0, [r0]
 	strb r2, [r0, #0x1e]
 	str r1, [sb, #8]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02141b28:
 	ldr r0, [sb, #4]
 	add r4, r4, #1
@@ -4774,13 +4774,13 @@ _02141b3c:
 	mov r7, #0
 	ble _02141c08
 	mov r5, r7
-	add fp, sp, #0
+	add r11, sp, #0
 	mvn r4, #0
 _02141b54:
 	ldr r1, [sb, #0xc]
 	mov r0, sl
 	ldr r1, [r1, r5]
-	mov r2, fp
+	mov r2, r11
 	bl func_ov61_021677c0
 	bl func_ov61_021419f4
 	ldr r0, [sp]
@@ -4817,7 +4817,7 @@ _02141b88:
 	str r1, [sb, #8]
 	ldr r0, [r0]
 	strb r3, [r0, #0x1d]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02141bf4:
 	ldr r0, [sb, #4]
 	add r7, r7, #1
@@ -4827,7 +4827,7 @@ _02141bf4:
 _02141c08:
 	ldr r0, [sb, #8]
 	cmp r0, #0x600
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, _02141ca0 ; =data_ov61_0217ebe0
 	mov r1, #1
 	ldr r3, [r0]
@@ -4836,14 +4836,14 @@ _02141c08:
 	strb r2, [r3, #0x1c]
 	ldr r0, [r0]
 	strb r1, [r0, #0x1e]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02141c38:
 	ldr r0, [sb]
 	cmp r0, #0
 	beq _02141c50
 	bl func_ov61_021419f4
 	cmp r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02141c50:
 	ldr r0, _02141ca0 ; =data_ov61_0217ebe0
 	ldr r1, [r0]
@@ -4855,7 +4855,7 @@ _02141c50:
 	mla r0, r8, r0, r1
 	blx func_ov00_020774c4
 	cmp r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02141c7c:
 	ldr r0, _02141ca0 ; =data_ov61_0217ebe0
 	mov r1, #1
@@ -4865,7 +4865,7 @@ _02141c7c:
 	strb r2, [r3, #0x1c]
 	ldr r0, [r0]
 	strb r1, [r0, #0x1e]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02141a68
 _02141ca0: .word data_ov61_0217ebe0
@@ -4873,7 +4873,7 @@ _02141ca0: .word data_ov61_0217ebe0
 	.global func_ov61_02141ca4
 	arm_func_start func_ov61_02141ca4
 func_ov61_02141ca4: ; 0x02141ca4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x28
 	mov sb, r1
 	ldr r1, [sb]
@@ -4881,7 +4881,7 @@ func_ov61_02141ca4: ; 0x02141ca4
 	cmp r1, #0
 	mov r6, #0
 	addne sp, sp, #0x28
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r4, _02141e4c ; =data_ov61_0217ebe0
 	mov r5, r6
 	ldr r1, [r4]
@@ -4889,7 +4889,7 @@ func_ov61_02141ca4: ; 0x02141ca4
 	cmp r0, #0
 	ble _02141e20
 	mov r7, r6
-	add fp, sp, #0x11
+	add r11, sp, #0x11
 _02141ce8:
 	ldr r0, [r1, #0x18]
 	add r0, r0, r7
@@ -4898,11 +4898,11 @@ _02141ce8:
 	bne _02141d50
 	bl func_ov61_02140308
 	ldr r1, [r4]
-	mov r2, fp
+	mov r2, r11
 	ldr r1, [r1, #0x18]
 	add r1, r1, r7
 	blx func_ov00_02077a30
-	mov r0, fp
+	mov r0, r11
 	add r1, sb, #0x8e
 	bl strcmp
 	cmp r0, #0
@@ -4978,13 +4978,13 @@ _02141e20:
 	ldr r0, [sb, #4]
 	bl func_ov61_02141904
 	add sp, sp, #0x28
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02141e38:
 	ldr r1, [sb, #4]
 	mov r0, sl
 	bl func_ov61_02167590
 	add sp, sp, #0x28
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02141ca4
 _02141e4c: .word data_ov61_0217ebe0
@@ -4993,15 +4993,15 @@ _02141e50: .word data_ov61_0217a6f0
 	.global func_ov61_02141e54
 	arm_func_start func_ov61_02141e54
 func_ov61_02141e54: ; 0x02141e54
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x18
 	mov sl, r1
 	ldr r0, [sl]
 	mov r7, #0
 	cmp r0, #0
-	mov fp, #1
+	mov r11, #1
 	addne sp, sp, #0x18
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r4, _02141fec ; =data_ov61_0217ebe0
 	mov r6, r7
 	ldr r0, [r4]
@@ -5057,7 +5057,7 @@ _02141f34:
 	add r0, r0, r8
 	blx func_ov00_0207749c
 	cmp r0, #1
-	moveq fp, #0
+	moveq r11, #0
 	beq _02141f98
 	ldr sb, [sl, #4]
 	bl func_ov61_02140308
@@ -5087,11 +5087,11 @@ _02141f98:
 _02141fb0:
 	cmp r7, #0
 	addeq sp, sp, #0x18
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, [r0, #0x18]
 	ldr r2, [sl, #4]
 	bl func_ov61_021417fc
-	cmp fp, #0
+	cmp r11, #0
 	beq _02141fd4
 	bl func_ov61_021412fc
 _02141fd4:
@@ -5100,7 +5100,7 @@ _02141fd4:
 	ldr r0, [r0]
 	strb r1, [r0, #0x1d]
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02141e54
 _02141fec: .word data_ov61_0217ebe0
@@ -5489,7 +5489,7 @@ _021424f4: .word data_ov61_0217ebe8
 	.global func_ov61_021424f8
 	arm_func_start func_ov61_021424f8
 func_ov61_021424f8: ; 0x021424f8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x28
 	mov r4, r0
 	bl func_ov61_0214a214
@@ -5497,11 +5497,11 @@ func_ov61_021424f8: ; 0x021424f8
 	cmp r0, #0
 	addne sp, sp, #0x28
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	bl func_ov61_0214a214
 	str r4, [r0, #0x200]
 	ldr r4, _02142670 ; =func_ov61_021499d0
-	ldr fp, _02142674 ; =func_ov61_02149b18
+	ldr r11, _02142674 ; =func_ov61_02149b18
 	mov sl, #0
 	mov r5, #1
 _02142534:
@@ -5526,7 +5526,7 @@ _02142534:
 	str r5, [sp, #8]
 	str r4, [sp, #0xc]
 	ldr r3, _02142678 ; =func_ov61_02149b1c
-	str fp, [sp, #0x10]
+	str r11, [sp, #0x10]
 	str r3, [sp, #0x14]
 	ldr r3, _0214267c ; =func_ov61_02149b20
 	mov r2, r7
@@ -5557,7 +5557,7 @@ _021425f0:
 	bl func_ov61_02149060
 	add sp, sp, #0x28
 	mov r0, r6
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02142604:
 	add sl, sl, #1
 	cmp sl, #5
@@ -5586,7 +5586,7 @@ _02142610:
 	bl func_ov61_02177f3c
 	mov r0, r6
 	add sp, sp, #0x28
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_021424f8
 _02142670: .word func_ov61_021499d0
@@ -7039,10 +7039,10 @@ _02143b6c: .word 0xfffeabc4
 	.global func_ov61_02143b70
 	arm_func_start func_ov61_02143b70
 func_ov61_02143b70: ; 0x02143b70
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x218
 	mov sb, #0
-	mov fp, r1
+	mov r11, r1
 	mov sl, r2
 	add r8, sp, #8
 	mov r7, sb
@@ -7069,11 +7069,11 @@ _02143bd0:
 	stmia sp, {r0, sb}
 	mov r2, #0
 	ldrb r0, [sl]
-	mov r1, fp
+	mov r1, r11
 	mov r3, r2
 	bl func_ov61_02145420
 	add sp, sp, #0x218
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	arm_func_end func_ov61_02143b70
 
 	.global func_ov61_02143bf4
@@ -7448,16 +7448,16 @@ _021440c0:
 	.global func_ov61_021440c8
 	arm_func_start func_ov61_021440c8
 func_ov61_021440c8: ; 0x021440c8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	mov sb, r0
 	mov r8, r1
 	bl func_ov61_0214a214
 	cmp r0, #0
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	bl func_ov61_0214a214
 	add r0, r0, sb, lsl #2
-	ldr fp, [r0, #0xf4]
+	ldr r11, [r0, #0xf4]
 	bl func_ov61_0214a214
 	mov r4, r0
 	bl func_ov61_0214a214
@@ -7559,8 +7559,8 @@ _02144208:
 	mov r1, #0
 	strb r1, [r0, #0x2d0]
 _02144278:
-	mov r0, fp
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	mov r0, r11
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	arm_func_end func_ov61_021440c8
 
 	.global func_ov61_02144280
@@ -8122,7 +8122,7 @@ _02144a0c: .word data_ov61_0217ebe8
 	.global func_ov61_02144a10
 	arm_func_start func_ov61_02144a10
 func_ov61_02144a10: ; 0x02144a10
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x1b0
 	mov r7, #8
 	mov r6, #0xa
@@ -8221,7 +8221,7 @@ _02144b5c:
 	mov r6, #6
 	mov r5, #1
 	mov r4, sl
-	add fp, sp, #0xc
+	add r11, sp, #0xc
 _02144b80:
 	bl func_ov61_0214a214
 	str r8, [sp]
@@ -8230,7 +8230,7 @@ _02144b80:
 	ldr r0, [r0, #0xe4]
 	mov r1, r5
 	mov r2, r4
-	mov r3, fp
+	mov r3, r11
 	bl func_ov61_02162cf4
 	movs sb, r0
 	beq _02144bc0
@@ -8253,7 +8253,7 @@ _02144bc0:
 _02144be8:
 	mov r0, sb
 	add sp, sp, #0x1b0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02144a10
 _02144bf4: .word data_ov61_0217ebf8
@@ -8557,7 +8557,7 @@ _02145018: .word func_ov61_02149db8
 	.global func_ov61_0214501c
 	arm_func_start func_ov61_0214501c
 func_ov61_0214501c: ; 0x0214501c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x220
 	str r3, [sp, #0xc]
 	mov sl, r0
@@ -8604,7 +8604,7 @@ _02145098:
 	mov r7, #1
 	ble _02145108
 	add r5, sp, #0x10
-	add fp, sp, #0x20
+	add r11, sp, #0x20
 _021450d0:
 	ldr r3, [sb, r7, lsl #2]
 	ldr r2, _021451cc ; =data_ov61_0217a7fc
@@ -8613,7 +8613,7 @@ _021450d0:
 	bl func_0200c910
 	mov r4, r0
 	mov r0, r5
-	add r1, fp, r6
+	add r1, r11, r6
 	mov r2, r4
 	bl func_02007ad8
 	add r7, r7, #1
@@ -8671,7 +8671,7 @@ _0214514c:
 _021451bc:
 	mov r0, r4
 	add sp, sp, #0x220
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0214501c
 _021451c8: .word data_ov61_0217a708
@@ -10375,11 +10375,11 @@ _021469e8: .word 0x00001770
 	.global func_ov61_021469ec
 	arm_func_start func_ov61_021469ec
 func_ov61_021469ec: ; 0x021469ec
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x228
 	movs r4, r1
 	mov r8, r0
-	mov fp, r2
+	mov r11, r2
 	beq _02146a10
 	bl func_ov61_0214a214
 	ldrb r6, [r0, #0x1a5]
@@ -10440,7 +10440,7 @@ _02146a94:
 	str r1, [r0, #0x1bc]
 	add sp, sp, #0x228
 	mov r0, r1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02146ae4:
 	mov r5, #1
 	bl func_ov61_02140308
@@ -10549,13 +10549,13 @@ _02146bac:
 	ldrb r0, [r0, #0x16]
 	cmp sb, r0
 	bne _02146a50
-	cmp r4, fp
+	cmp r4, r11
 	moveq r8, #1
 	mov r0, r4
 	mov r1, r8
 	bl func_ov61_0214683c
 	add sp, sp, #0x228
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_021469ec
 _02146ca4: .word 0x00000bb8
@@ -13807,7 +13807,7 @@ _0214985c: .word data_ov61_0217a784
 	.global func_ov61_02149860
 	arm_func_start func_ov61_02149860
 func_ov61_02149860: ; 0x02149860
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x18
 	mov r7, #0
 	mov r8, r7
@@ -13816,7 +13816,7 @@ func_ov61_02149860: ; 0x02149860
 	bl func_ov61_02162e84
 	cmp r0, #1
 	addle sp, sp, #0x18
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	mov sb, r7
 	bl func_ov61_0214a214
 	ldr r0, [r0, #0xe4]
@@ -13856,7 +13856,7 @@ _021498f0:
 	ble _02149980
 	ldr r4, _021499c8 ; =data_ov61_0217a210
 	add r5, sp, #0
-	mov fp, #0x64
+	mov r11, #0x64
 _02149920:
 	bl func_ov61_0214a214
 	ldr r0, [r0, #0xe4]
@@ -13868,7 +13868,7 @@ _02149920:
 	cmp sb, #0
 	addgt r0, r5, sb, lsl #2
 	ldrgt sl, [r0, #-4]
-	mul r0, r2, fp
+	mul r0, r2, r11
 	movle sl, #0
 	mov r1, r8
 	bl func_02002c14
@@ -13900,7 +13900,7 @@ _02149980:
 	mov r3, r1
 	bl func_ov61_02162e94
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02149860
 _021499c8: .word data_ov61_0217a210
@@ -14153,7 +14153,7 @@ _02149c74:
 	.global func_ov61_02149cac
 	arm_func_start func_ov61_02149cac
 func_ov61_02149cac: ; 0x02149cac
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x9c
 	mov sl, r0
 	mov sb, r1
@@ -14164,7 +14164,7 @@ func_ov61_02149cac: ; 0x02149cac
 	bl func_ov61_0213f4e4
 	cmp r0, #6
 	addne sp, sp, #0x9c
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	bl func_ov61_0214a214
 	ldrb r0, [r0, #0x15]
 	cmp r0, #2
@@ -14173,16 +14173,16 @@ func_ov61_02149cac: ; 0x02149cac
 	ldrb r0, [r0, #0x15]
 	cmp r0, #3
 	addne sp, sp, #0x9c
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02149d00:
 	cmp sb, #0x14
 	addlo sp, sp, #0x9c
-	ldmloia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmloia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r5, _02149db4 ; =data_ov61_0217a800
 	add r4, sp, #0x1c
 	add r7, sp, #8
 	mov r6, #0x14
-	mov fp, #4
+	mov r11, #4
 _02149d20:
 	mov r0, sl
 	mov r1, r7
@@ -14190,13 +14190,13 @@ _02149d20:
 	bl func_02007ad8
 	mov r0, r7
 	mov r1, r5
-	mov r2, fp
+	mov r2, r11
 	bl strncmp
 	cmp r0, #0
 	ldreq r0, [sp, #0xc]
 	cmpeq r0, #3
 	addne sp, sp, #0x9c
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldrb r2, [sp, #0x11]
 	mov r1, r4
 	add r0, sl, #0x14
@@ -14212,7 +14212,7 @@ _02149d20:
 	bl func_ov61_02145420
 	cmp r0, #0
 	addeq sp, sp, #0x9c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldrb r0, [sp, #0x11]
 	add r0, r0, #0x14
 	add r8, r8, r0
@@ -14220,7 +14220,7 @@ _02149d20:
 	cmp r0, sb
 	bls _02149d20
 	add sp, sp, #0x9c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02149cac
 _02149db4: .word data_ov61_0217a800
@@ -15046,19 +15046,19 @@ _0214a7d0: .word data_ov61_0217f350
 	.global func_ov61_0214a7d4
 	arm_func_start func_ov61_0214a7d4
 func_ov61_0214a7d4: ; 0x0214a7d4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	ldr r0, _0214a960 ; =data_ov61_0217f350
 	ldr r0, [r0]
 	cmp r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r0, sp, #0
 	bl func_ov61_0213f428
 	mov r7, r0
 	mov r8, #0
 	cmp r7, #0
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r4, _0214a960 ; =data_ov61_0217f350
-	mov fp, r8
+	mov r11, r8
 _0214a808:
 	ldr r0, [sp]
 	ldrb sb, [r0, r8]
@@ -15133,10 +15133,10 @@ _0214a89c:
 	ldr r0, [r5, #0x14]
 	cmp r1, r0
 	bne _0214a950
-	strb fp, [r5, #0x1c]
-	str fp, [r5]
-	str fp, [r5, #0xc]
-	str fp, [r5, #0x14]
+	strb r11, [r5, #0x1c]
+	str r11, [r5]
+	str r11, [r5, #0xc]
+	str r11, [r5, #0x14]
 	ldr r1, [r4]
 	ldr r2, [r1, #0x600]
 	cmp r2, #0
@@ -15147,7 +15147,7 @@ _0214a950:
 	add r8, r8, #1
 	cmp r8, r7
 	blt _0214a808
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0214a7d4
 _0214a960: .word data_ov61_0217f350
@@ -16466,7 +16466,7 @@ _0214b9c0:
 	.global func_ov61_0214b9d4
 	arm_func_start func_ov61_0214b9d4
 func_ov61_0214b9d4: ; 0x0214b9d4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0xc4
 	mov r4, r0
 	add r0, r1, #0x44
@@ -16477,7 +16477,7 @@ func_ov61_0214b9d4: ; 0x0214b9d4
 	mov r0, #0xc0
 	mla sl, r6, r0, r8
 	add sb, r7, r6, lsl #2
-	add fp, sp, #0
+	add r11, sp, #0
 _0214ba04:
 	add r0, r7, r4, lsl #2
 	ldrb r1, [r0, #2]
@@ -16486,7 +16486,7 @@ _0214ba04:
 	cmp r1, r0
 	blo _0214ba9c
 	mov r0, sb
-	mov r1, fp
+	mov r1, r11
 	mov r2, #4
 	bl func_02007908
 	add r5, r7, r4, lsl #2
@@ -16495,7 +16495,7 @@ _0214ba04:
 	mov r2, #4
 	bl func_02007908
 	mov r1, r5
-	mov r0, fp
+	mov r0, r11
 	mov r2, #4
 	bl func_02007908
 	mov r0, sl
@@ -16527,7 +16527,7 @@ _0214ba9c:
 	mov r2, #0xc0
 	bl func_020078f4
 	add sp, sp, #0xc4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	arm_func_end func_ov61_0214b9d4
 
 	.global func_ov61_0214bac4
@@ -16764,7 +16764,7 @@ _0214bdc0:
 	.global func_ov61_0214bdc8
 	arm_func_start func_ov61_0214bdc8
 func_ov61_0214bdc8: ; 0x0214bdc8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	mov sl, r0
 	ldrb r2, [sl, #0xd13]
 	ldrb r1, [sl, #0xd0c]
@@ -16806,7 +16806,7 @@ _0214be4c:
 	mov r7, sl
 	add r8, sl, #0x304
 	add sb, sl, #0x300
-	add fp, sl, #0x10c
+	add r11, sl, #0x10c
 _0214be6c:
 	ldrh r2, [r4, #0xa]
 	ldrb r0, [r7, #0x303]
@@ -16825,10 +16825,10 @@ _0214be6c:
 	bic r0, r0, #0xf0
 	orr r0, r0, #0x10
 	strb r0, [sb]
-	ldrb r0, [fp, #0xc00]
+	ldrb r0, [r11, #0xc00]
 	bic r0, r0, #0xc0
 	orr r0, r0, #0x40
-	strb r0, [fp, #0xc00]
+	strb r0, [r11, #0xc00]
 _0214bec0:
 	add r6, r6, #1
 _0214bec4:
@@ -16877,7 +16877,7 @@ _0214bf48:
 _0214bf58:
 	ldr r0, [sp]
 	and r0, r0, #0xff
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	arm_func_end func_ov61_0214bdc8
 
 	.global func_ov61_0214bf64
@@ -19039,7 +19039,7 @@ _0214da20:
 	.global func_ov61_0214da4c
 	arm_func_start func_ov61_0214da4c
 func_ov61_0214da4c: ; 0x0214da4c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x18
 	add r4, r2, r2, lsl #1
 	str r0, [sp]
@@ -19048,14 +19048,14 @@ func_ov61_0214da4c: ; 0x0214da4c
 	cmp r3, r4, lsr #2
 	str r0, [sp, #8]
 	blo _0214da80
-	and fp, r2, #3
-	sub r0, r2, fp
+	and r11, r2, #3
+	sub r0, r2, r11
 	str r0, [sp, #0xc]
 	b _0214da8c
 _0214da80:
 	add sp, sp, #0x18
 	mvn r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0214da8c:
 	cmp r0, #0
 	mov r7, #0
@@ -19095,7 +19095,7 @@ _0214dae8:
 	add sb, sb, #1
 	blt _0214daa4
 _0214db14:
-	cmp fp, #0
+	cmp r11, #0
 	beq _0214dba8
 	mov r5, #0
 	mov r6, r5
@@ -19113,12 +19113,12 @@ _0214db40:
 	mul r2, r1, r7
 	orr r5, r5, r0, lsl r2
 	add r6, r6, #1
-	cmp r6, fp
+	cmp r6, r11
 	orr r8, r8, r5
 	blt _0214db40
 	str r8, [sp, #0x10]
 _0214db68:
-	cmp fp, #0
+	cmp r11, #0
 	mov r3, #0
 	ble _0214dba8
 	ldr r0, [sp, #0xc]
@@ -19132,13 +19132,13 @@ _0214db90:
 	rsb r0, r3, #2
 	ldrb r0, [r1, r0]
 	add r3, r3, #1
-	cmp r3, fp
+	cmp r3, r11
 	strb r0, [r2], #1
 	blt _0214db90
 _0214dba8:
 	ldr r0, [sp, #8]
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	arm_func_end func_ov61_0214da4c
 
 	.global func_ov61_0214dbb4
@@ -19520,7 +19520,7 @@ _0214e098: .word data_027e02a0
 	.global func_ov61_0214e09c
 	arm_func_start func_ov61_0214e09c
 func_ov61_0214e09c: ; 0x0214e09c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	mov r8, #0
 _0214e0a4:
 	ldr r0, _0214e340 ; =data_ov61_0217f368
@@ -19554,7 +19554,7 @@ _0214e0d0:
 	bne _0214e120
 	mov r0, #0x14
 	bl func_ov61_0214e994
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0214e120:
 	cmp r8, #2
 	ble _0214e15c
@@ -19562,17 +19562,17 @@ _0214e120:
 	bne _0214e13c
 	mov r0, #9
 	bl func_ov61_0214e994
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0214e13c:
 	cmp r0, #3
 	bne _0214e150
 	mov r0, #0xb
 	bl func_ov61_0214e994
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0214e150:
 	mov r0, #0xd
 	bl func_ov61_0214e994
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0214e15c:
 	mov r0, #1
 	add r8, r8, #1
@@ -19588,13 +19588,13 @@ _0214e16c:
 	bne _0214e1c0
 	mov r0, #0x15
 	bl func_ov61_0214e994
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0214e194:
 	cmp r8, #2
 	ble _0214e1a8
 	mov r0, #0x10
 	bl func_ov61_0214e994
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0214e1a8:
 	mov r0, #0
 	add r8, r8, #1
@@ -19602,12 +19602,12 @@ _0214e1a8:
 	b _0214e1dc
 _0214e1b8:
 	bl func_ov61_0214e994
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0214e1c0:
 	cmp r8, #2
 	blt _0214e1d0
 	bl func_ov61_0214e994
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0214e1d0:
 	mov r0, #1
 	add r8, r8, #1
@@ -19629,10 +19629,10 @@ _0214e1dc:
 	ldr r7, _0214e34c ; =0x00001388
 	cmpeq r0, r7
 	bhs _0214e2bc
-	mov fp, #0
+	mov r11, #0
 	ldr r6, _0214e348 ; =0x000082ea
 	ldr r5, _0214e340 ; =data_ov61_0217f368
-	mov r4, fp
+	mov r4, r11
 _0214e22c:
 	ldr r0, [r5, #8]
 	add r0, r0, #0x3d8
@@ -19652,7 +19652,7 @@ _0214e22c:
 	bl func_0200e0c8
 	mov r0, #0x14
 	bl func_ov61_0214e994
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0214e278:
 	add r0, r2, #0x3d8
 	add r0, r0, #0x1000
@@ -19666,7 +19666,7 @@ _0214e278:
 	orr r1, r1, r2, lsr #26
 	mov r0, r2, lsl #0x6
 	mov r2, r6
-	mov r3, fp
+	mov r3, r11
 	bl func_02002bac
 	cmp r1, r4
 	cmpeq r0, r7
@@ -19699,14 +19699,14 @@ _0214e2bc:
 	add r0, r0, #0x3d8
 	add r0, r0, #0x1000
 	bl func_0200e0c8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0214e32c:
 	add r0, r3, #0x3d8
 	add r0, r0, #0x1000
 	bl func_0200e0c8
 	b _0214e0a4
 _0214e33c:
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	arm_func_end func_ov61_0214e09c
 _0214e340: .word data_ov61_0217f368
 _0214e344: .word 0x00004e84
@@ -20944,7 +20944,7 @@ _0214f490: .word data_ov61_0217aba0
 	.global func_ov61_0214f494
 	arm_func_start func_ov61_0214f494
 func_ov61_0214f494: ; 0x0214f494
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x14
 	mov sl, r0
 	add r0, sl, #0x1000
@@ -20957,7 +20957,7 @@ func_ov61_0214f494: ; 0x0214f494
 	mov r0, sl
 	add r5, r1, #0x1000
 	add r7, r2, #0x1800
-	mov fp, #0
+	mov r11, #0
 	ldrle r8, _0214f79c ; =0x0000ea60
 	bl func_ov61_0214f340
 	mov r0, sl
@@ -20967,7 +20967,7 @@ func_ov61_0214f494: ; 0x0214f494
 	moveq r1, #2
 	streq r1, [r0, #0x20]
 	addeq sp, sp, #0x14
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	str r6, [r0, #0x12c]
 	bl func_ov61_02154bc0
 	add r0, sl, #0x1000
@@ -21004,7 +21004,7 @@ _0214f548:
 	bl func_ov61_02154bf4
 	bl func_ov61_02154b1c
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0214f584:
 	ldr r4, [r0, #0x9f8]
 	mov r0, r4
@@ -21074,7 +21074,7 @@ _0214f630:
 	mov r2, sb
 	bl func_02007ad8
 	ldr r0, [r7, #4]
-	cmp fp, #1
+	cmp r11, #1
 	add r1, r0, sb
 	str r1, [r7, #4]
 	mov r0, #0
@@ -21091,7 +21091,7 @@ _0214f630:
 _0214f6bc:
 	mov r0, sl
 	bl func_ov61_0214f3ac
-	mov fp, r0
+	mov r11, r0
 _0214f6c8:
 	ldr r0, [sp, #0x10]
 	cmp r0, sb
@@ -21143,14 +21143,14 @@ _0214f760:
 	mov r1, #8
 	str r1, [r0, #0x20]
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0214f784:
 	bl func_ov61_02154e44
 	bl func_ov61_02154e80
 	bl func_ov61_02154bf4
 	bl func_ov61_02154b1c
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0214f494
 _0214f79c: .word 0x0000ea60
@@ -21331,7 +21331,7 @@ _0214f9fc: .word data_ov61_0217ab70
 	.global func_ov61_0214fa00
 	arm_func_start func_ov61_0214fa00
 func_ov61_0214fa00: ; 0x0214fa00
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	mov sl, r0
 	add r0, sl, #0x1000
 	ldr r4, [r0, #0x9f4]
@@ -21343,22 +21343,22 @@ func_ov61_0214fa00: ; 0x0214fa00
 	add r5, r0, #0x1800
 	ldr r0, [r4, #0x9f4]
 	mov r7, r3
-	add fp, r0, #1
+	add r11, r0, #1
 	mov r2, #0
 	mov sb, r1
 	ldrne r6, _0214fb08 ; =data_ov61_0217ac58
 	mov r0, r8
 	mov r1, r7
 	mov r3, r2
-	str fp, [r4, #0x9f4]
+	str r11, [r4, #0x9f4]
 	bl func_ov61_02151810
 	mov r4, r0
 	mov r0, r6
 	bl strlen
-	mov fp, r0
+	mov r11, r0
 	mov r0, sb
 	bl strlen
-	sub r1, fp, #2
+	sub r1, r11, #2
 	add r2, r1, r0
 	ldmib r5, {r0, r1}
 	add r2, r4, r2
@@ -21372,7 +21372,7 @@ func_ov61_0214fa00: ; 0x0214fa00
 	bl func_ov61_0214fc38
 	cmp r0, #0
 	moveq r0, #1
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldmib r5, {r0, r1}
 	sub r1, r1, r0
 _0214fab0:
@@ -21390,13 +21390,13 @@ _0214fab0:
 	bl func_ov61_02151810
 	cmp r0, #0
 	movlt r0, #1
-	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r1, [r5, #4]
 	mov r0, #0
 	add r1, r1, r4
 	str r1, [r5, #4]
 	strb r0, [r1]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0214fa00
 _0214fb04: .word data_ov61_0217ac54
@@ -21741,7 +21741,7 @@ _0214ff84: .word data_ov61_0217ad14
 	.global func_ov61_0214ff88
 	arm_func_start func_ov61_0214ff88
 func_ov61_0214ff88: ; 0x0214ff88
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x10
 	mov r4, r0
 	add r0, r4, #0x238
@@ -21763,19 +21763,19 @@ func_ov61_0214ff88: ; 0x0214ff88
 	cmp r0, #0
 	addeq sp, sp, #0x10
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r0, r0, #4
 	bl strlen
 	ldr r1, [sp]
 	add r1, r1, #4
-	add fp, r1, r0
+	add r11, r1, r0
 	ldr r1, _0215020c ; =data_ov61_0217ad30
 	mov r0, r5
 	bl strstr
 	movs r7, r0
 	addeq sp, sp, #0x10
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldrsb sb, [r7, #4]
 	ldr r2, _02150210 ; =data_ov61_0217ad34
 	mov r5, #0
@@ -21788,7 +21788,7 @@ func_ov61_0214ff88: ; 0x0214ff88
 	addne sp, sp, #0x10
 	strb sb, [r7, #4]
 	movne r0, r5
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	cmp r6, #1
 	beq _02150068
 	ldr r1, _02150214 ; =data_ov61_0217ad40
@@ -21800,7 +21800,7 @@ func_ov61_0214ff88: ; 0x0214ff88
 _02150068:
 	add sp, sp, #0x10
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02150074:
 	ldr r1, _02150218 ; =data_ov61_0217aba0
 	add r0, r7, #5
@@ -21808,7 +21808,7 @@ _02150074:
 	cmp r0, #0
 	addeq sp, sp, #0x10
 	moveq r0, r5
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add sb, r0, #2
 	b _02150128
 _02150098:
@@ -21841,7 +21841,7 @@ _02150098:
 	add sp, sp, #0x10
 	strb r8, [r5]
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02150110:
 	mov r0, sl
 	bl strlen
@@ -21858,7 +21858,7 @@ _02150128:
 _0215013c:
 	ldr r0, [sp]
 	add r7, r0, #4
-	cmp r7, fp
+	cmp r7, r11
 	bhs _021501fc
 _0215014c:
 	ldr r1, _02150220 ; =data_ov61_0217ad48
@@ -21896,7 +21896,7 @@ _02150194:
 	add sp, sp, #0x10
 	strneb r8, [sl]
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _021501d8:
 	mov r0, r6
 	bl strlen
@@ -21905,12 +21905,12 @@ _021501d8:
 	cmp sl, #0
 	add r7, r0, #1
 	strneb r8, [sl]
-	cmp r7, fp
+	cmp r7, r11
 	blo _0215014c
 _021501fc:
 	mov r0, #1
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0214ff88
 _02150208: .word data_ov61_0217ab70
@@ -22002,15 +22002,15 @@ func_ov61_021502d4: ; 0x021502d4
 	.global func_ov61_02150314
 	arm_func_start func_ov61_02150314
 func_ov61_02150314: ; 0x02150314
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	add r0, r0, #0x1000
 	ldr r6, [r0, #0x14]
 	mov sb, r2
 	mov sl, r1
 	mov r8, #0
 	cmp sb, #0
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
-	ldr fp, _02150394 ; =data_ov61_0217ad50
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldr r11, _02150394 ; =data_ov61_0217ad50
 	ldr r7, _02150398 ; =data_ov61_0217ad6c
 	mov r5, r8
 	mov r4, r8
@@ -22018,7 +22018,7 @@ _02150344:
 	ldr r1, [sl, r8, lsl #3]
 	cmp r1, #0
 	beq _02150360
-	mov r0, fp
+	mov r0, r11
 	mov r2, #0
 	blx r6
 	str r5, [sl, r8, lsl #3]
@@ -22036,7 +22036,7 @@ _02150384:
 	add r8, r8, #1
 	cmp r8, sb
 	blt _02150344
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02150314
 _02150394: .word data_ov61_0217ad50
@@ -22287,7 +22287,7 @@ _021506b8: .word func_ov61_021506bc
 	.global func_ov61_021506bc
 	arm_func_start func_ov61_021506bc
 func_ov61_021506bc: ; 0x021506bc
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x290
 	ldr r4, _02151520 ; =data_ov61_0217f38c
 	mov r8, #0
@@ -22584,15 +22584,15 @@ _02150af0:
 _02150b00:
 	ldr r0, [r4, #0x14]
 	add r1, r0, #0x1000
-	ldr fp, [r1, #0xa08]
-	cmp fp, #0
+	ldr r11, [r1, #0xa08]
+	cmp r11, #0
 	bne _02150b24
 	bl func_ov61_0214f7b0
 	mov r0, #2
 	bl func_ov61_021515a8
 	b _021514cc
 _02150b24:
-	mov r0, fp
+	mov r0, r11
 	bl strlen
 	add r1, r0, #1
 	ldr r0, _0215155c ; =data_ov61_0217ae34
@@ -22613,11 +22613,11 @@ _02150b24:
 	bl func_ov61_021515a8
 	b _021514cc
 _02150b74:
-	mov r0, fp
+	mov r0, r11
 	bl strlen
 	mov r2, r0
 	ldr r0, [sp, #4]
-	mov r1, fp
+	mov r1, r11
 	bl strncpy
 	b _02150ba8
 _02150b90:
@@ -22995,8 +22995,8 @@ _021510dc:
 	ldr r1, _0215157c ; =data_ov61_0217af08
 	mov r3, r2
 	bl func_ov61_02150280
-	mov fp, r0
-	cmp fp, #0
+	mov r11, r0
+	cmp r11, #0
 	bgt _02151114
 	ldr r0, _02151520 ; =data_ov61_0217f38c
 	ldr r0, [r0, #0x14]
@@ -23025,7 +23025,7 @@ _02151114:
 	b _021514cc
 _0215115c:
 	ldr r0, _02151588 ; =data_ov61_0217ae5c
-	add r1, fp, #1
+	add r1, r11, #1
 	blx r6
 	movs sb, r0
 	bne _02151188
@@ -23069,7 +23069,7 @@ _021511f4:
 	strb r1, [r8, r0]
 	ldr r0, [r4, #0x14]
 	ldr r1, _0215157c ; =data_ov61_0217af08
-	add r3, fp, #1
+	add r3, r11, #1
 	mov r2, sb
 	bl func_ov61_02150280
 	cmp r0, #0
@@ -23084,7 +23084,7 @@ _02151230:
 	mov r1, #0
 	strb r1, [sb, r0]
 	cmp r5, #0
-	mov fp, r1
+	mov r11, r1
 	ble _021512c4
 	ldr r0, [r4, #0x14]
 	ldr r1, _02151580 ; =data_ov61_0217af10
@@ -23100,7 +23100,7 @@ _02151230:
 	bl func_ov61_021515a8
 	b _021514cc
 _02151278:
-	mov r1, fp
+	mov r1, r11
 	strb r1, [sl, r0]
 	mov r0, sl
 	bl func_0204902c
@@ -23116,10 +23116,10 @@ _02151278:
 	b _021514cc
 _021512b0:
 	mov r1, #0x3e8
-	mul fp, r0, r1
+	mul r11, r0, r1
 	ldr r0, _02151590 ; =0x0002bf20
-	cmp fp, r0
-	movgt fp, r0
+	cmp r11, r0
+	movgt r11, r0
 _021512c4:
 	ldr r0, [r4, #0x14]
 	bl func_ov61_0214f7b0
@@ -23258,7 +23258,7 @@ _021514a0:
 	bl strncpy
 	ldr r0, [r4, #0x14]
 	bl func_ov61_0214f7b0
-	mov r0, fp
+	mov r0, r11
 	bl func_0200db28
 	b _02150718
 _021514cc:
@@ -23278,13 +23278,13 @@ _021514e4:
 _021514fc:
 	cmp sl, #0
 	addeq sp, sp, #0x290
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, _021515a4 ; =data_ov61_0217af30
 	mov r1, sl
 	mov r2, #0
 	blx r7
 	add sp, sp, #0x290
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_021506bc
 _02151520: .word data_ov61_0217f38c
@@ -23494,7 +23494,7 @@ _0215180c: .word data_ov61_0217f408
 	.global func_ov61_02151810
 	arm_func_start func_ov61_02151810
 func_ov61_02151810: ; 0x02151810
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #8
 	ldr r4, _02151990 ; =0xaaaaaaab
 	str r2, [sp]
@@ -23513,18 +23513,18 @@ func_ov61_02151810: ; 0x02151810
 	mov r4, r4, lsr #0x1
 	addeq sp, sp, #8
 	add r0, r5, r4, lsl #2
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	cmp r3, r0
 	addlo sp, sp, #8
 	mvnlo r0, #0
-	ldmloia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmloia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r7, sl, r1
 	ldr r8, [sp]
 	cmp sl, r7
 	beq _02151980
-	sub fp, r2, #0x80000000
+	sub r11, r2, #0x80000000
 	ldr r5, _02151994 ; =data_ov61_0217afbc
-	mov r4, fp
+	mov r4, r11
 _0215188c:
 	sub sb, r7, sl
 	mov r0, sb, lsl #0x3
@@ -23533,7 +23533,7 @@ _0215188c:
 	mov r1, #6
 	smull r2, r3, r1, r2
 	subs r2, r0, r2
-	smull r1, r2, fp, r0
+	smull r1, r2, r11, r0
 	movne r3, #1
 	moveq r3, #0
 	add r2, r2, r0, lsr #31
@@ -23594,7 +23594,7 @@ _02151980:
 	ldr r0, [sp]
 	sub r0, r8, r0
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02151810
 _02151990: .word 0xaaaaaaab
@@ -24961,7 +24961,7 @@ _02152b1c: .word data_ov61_0217f8fc
 	.global func_ov61_02152b20
 	arm_func_start func_ov61_02152b20
 func_ov61_02152b20: ; 0x02152b20
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #8
 	mov sl, r0
 	mov r0, #0x45
@@ -24974,11 +24974,11 @@ func_ov61_02152b20: ; 0x02152b20
 	ldrb r5, [sp, #0x34]
 	add r0, r0, #1
 	strh r0, [r7, #6]
-	ldrh fp, [r7, #6]
+	ldrh r11, [r7, #6]
 	mov r0, r6, lsr #0x10
 	mov r8, #0x80
-	mov sb, fp, lsl #0x8
-	orr sb, sb, fp, asr #8
+	mov sb, r11, lsl #0x8
+	orr sb, sb, r11, asr #8
 	strh sb, [sl, #-0x10]
 	strb r8, [sl, #-0xc]
 	strb r5, [sl, #-0xb]
@@ -25002,14 +25002,14 @@ func_ov61_02152b20: ; 0x02152b20
 	mov r0, r5, lsl #0x8
 	strh sb, [sl, #-6]
 	orr r7, r7, r8, asr #8
-	ldr fp, _02152d14 ; =0x000005c8
+	ldr r11, _02152d14 ; =0x000005c8
 	mov sb, r1
 	strh r7, [sl, #-4]
 	orr r0, r0, r5, asr #8
 	mov r8, r2
 	mov r7, r3
 	strh r0, [sl, #-2]
-	cmp sb, fp
+	cmp sb, r11
 	bls _02152c8c
 	mov r5, sl
 	bls _02152c30
@@ -25017,16 +25017,16 @@ _02152bf0:
 	mov r0, sl
 	mov r1, #0
 	mov r2, r5
-	mov r3, fp
+	mov r3, r11
 	str r6, [sp]
 	orr ip, r4, #0x2000
 	str ip, [sp, #4]
 	bl func_ov61_021529f8
 	add r1, r4, #0xb9
 	add r0, r5, #0x1c8
-	sub sb, sb, fp
+	sub sb, sb, r11
 	mov r1, r1, lsl #0x10
-	cmp sb, fp
+	cmp sb, r11
 	add r5, r0, #0x400
 	mov r4, r1, lsr #0x10
 	bhi _02152bf0
@@ -25057,12 +25057,12 @@ _02152c7c:
 	mov r4, r0, lsr #0x10
 	mov sb, #0
 _02152c8c:
-	ldr fp, _02152d14 ; =0x000005c8
+	ldr r11, _02152d14 ; =0x000005c8
 	add r0, sb, r7
-	cmp r0, fp
+	cmp r0, r11
 	bls _02152ce0
 _02152c9c:
-	sub r5, fp, sb
+	sub r5, r11, sb
 	mov r1, sb
 	mov r0, sl
 	mov r2, r8
@@ -25075,14 +25075,14 @@ _02152c9c:
 	sub r7, r7, r5
 	mov r0, r0, lsl #0x10
 	mov sb, #0
-	cmp r7, fp
+	cmp r7, r11
 	add r8, r8, r5
 	mov r4, r0, lsr #0x10
 	bhi _02152c9c
 _02152ce0:
 	adds r0, sb, r7
 	addeq sp, sp, #8
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	str r6, [sp]
 	mov r0, sl
 	mov r1, sb
@@ -25091,7 +25091,7 @@ _02152ce0:
 	str r4, [sp, #4]
 	bl func_ov61_021529f8
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02152b20
 _02152d10: .word data_ov61_0217f414
@@ -26853,7 +26853,7 @@ _02154518: .word data_027e02a0
 	.global func_ov61_0215451c
 	arm_func_start func_ov61_0215451c
 func_ov61_0215451c: ; 0x0215451c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0xc
 	mov r6, #0
 	mov sl, r0
@@ -26868,7 +26868,7 @@ func_ov61_0215451c: ; 0x0215451c
 	str r1, [sp, #8]
 	tst r1, r2
 	addeq sp, sp, #0xc
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldrh r3, [sl, #0xe]
 	ldrh r2, [sl, #0xc]
 	ldrb r4, [sl]
@@ -26913,9 +26913,9 @@ _021545dc:
 	rsb r0, r5, r0, lsr #16
 	str r0, [sp, #4]
 	ldr r0, [sp, #8]
-	and fp, r0, r1
+	and r11, r0, r1
 	ldr r0, [sp, #4]
-	add r8, r0, fp, lsl #3
+	add r8, r0, r11, lsl #3
 	bne _02154698
 	cmp r6, #0
 	beq _02154620
@@ -26924,7 +26924,7 @@ _021545dc:
 _02154620:
 	add sp, sp, #0xc
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0215462c:
 	ldr r1, _021547e4 ; =data_ov61_0217f414
 	add r0, r5, #0xe
@@ -26936,7 +26936,7 @@ _0215462c:
 	str r0, [r6, #0x34]
 	addeq sp, sp, #0xc
 	mov r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	str sb, [r6]
 	strh r4, [r6, #6]
 	strh r0, [r6, #8]
@@ -26968,20 +26968,20 @@ _021546ac:
 	blx r1
 	add sp, sp, #0xc
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _021546d0:
 	ldr r0, [sp, #4]
 	ldr r2, [sp, #4]
 	add r1, r0, #7
 	ldr r0, [sp, #8]
-	add r3, fp, r1, lsr #3
+	add r3, r11, r1, lsr #3
 	tst r0, #0x2000
 	streqh r8, [r7, #0xa]
 	streqh r3, [r7, #8]
 	ldrh r1, [r7, #4]
 	add r0, sl, r5
 	add r1, r7, r1, lsl #1
-	strh fp, [r1, #0xc]
+	strh r11, [r1, #0xc]
 	ldrh r1, [r7, #4]
 	add r1, r7, r1, lsl #1
 	strh r3, [r1, #0x1c]
@@ -26989,13 +26989,13 @@ _021546d0:
 	add r1, r1, #1
 	strh r1, [r7, #4]
 	ldr r1, [r7, #0x30]
-	add r1, r1, fp, lsl #3
+	add r1, r1, r11, lsl #3
 	bl func_02007ad8
 	ldrh r4, [r7, #8]
 	cmp r4, #0
 	addeq sp, sp, #0xc
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldrh r3, [r7, #4]
 	mov r6, #0
 	mov r5, r6
@@ -27021,7 +27021,7 @@ _02154780:
 	cmp r6, r4
 	addlo sp, sp, #0xc
 	movlo r0, #0
-	ldmloia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmloia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r4, [r7, #0x34]
 	ldrh r3, [r7, #0xa]
 	ldrb r0, [r4, #0xe]
@@ -27039,7 +27039,7 @@ _02154780:
 	str r1, [r0]
 	add r0, r4, #0xe
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0215451c
 _021547d8: .word 0x00003fff
@@ -27457,7 +27457,7 @@ _02154cb8: .word data_027e02a0
 	.global func_ov61_02154cbc
 	arm_func_start func_ov61_02154cbc
 func_ov61_02154cbc: ; 0x02154cbc
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	mov sl, r0
 	bl func_ov61_02154ac4
 	mov r6, #2
@@ -27465,7 +27465,7 @@ func_ov61_02154cbc: ; 0x02154cbc
 	mov r8, r0
 	mov r7, #0
 	mov r5, #1
-	mov fp, r6
+	mov r11, r6
 _02154ce0:
 	str r8, [sl, #0x28]
 	strb r6, [sl, #8]
@@ -27474,7 +27474,7 @@ _02154ce0:
 	orr r0, r0, r1, lsl #16
 	str r0, [sl, #0x10]
 	mov r0, sl
-	mov r1, fp
+	mov r1, r11
 	mov r2, #0x18
 	bl func_ov61_021538c4
 	bl func_0200ee4c
@@ -27491,7 +27491,7 @@ _02154d28:
 	ldrb r0, [sl, #8]
 	cmp r0, #4
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, [r4, #0x50]
 	cmp r0, #0
 	beq _02154d58
@@ -27500,7 +27500,7 @@ _02154d28:
 	blo _02154ce0
 _02154d58:
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02154cbc
 _02154d60: .word data_ov61_0217f414
@@ -27818,10 +27818,10 @@ _02155100: .word data_027e02a0
 	.global func_ov61_02155104
 	arm_func_start func_ov61_02155104
 func_ov61_02155104: ; 0x02155104
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	mov r8, r2
 	ldr r6, [r8, #0x34]
-	movs fp, r3
+	movs r11, r3
 	mov sl, r0
 	movne r5, #1
 	mov r0, r6, lsl #0x1
@@ -27838,7 +27838,7 @@ _02155130:
 	movhs r4, r5
 	cmp r0, r4
 	movlo r4, r0
-	cmp fp, #0
+	cmp r11, #0
 	biceq r4, r4, #1
 	cmp sb, r4
 	sub r0, r1, r6
@@ -27868,7 +27868,7 @@ _021551a8:
 	beq _02155130
 _021551bc:
 	mov r0, r4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02155104
 _021551c4: .word data_ov61_0217f414
@@ -27896,10 +27896,10 @@ func_ov61_021551c8: ; 0x021551c8
 	.global func_ov61_02155204
 	arm_func_start func_ov61_02155204
 func_ov61_02155204: ; 0x02155204
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x14
 	mov r4, #0
-	mov fp, r0
+	mov r11, r0
 	ldr r8, [sp, #0x38]
 	mov r0, r4
 	str r4, [sp, #0x10]
@@ -27917,7 +27917,7 @@ _02155248:
 	ldr r7, [r8, #0x28]
 	ldr r3, [sp, #8]
 	str r8, [sp]
-	mov r0, fp
+	mov r0, r11
 	mov r1, sl
 	mov r2, sb
 	str r6, [sp, #4]
@@ -28001,12 +28001,12 @@ _0215537c:
 	mov r6, #0
 _02155380:
 	cmp r5, sl
-	addlo fp, fp, r5
+	addlo r11, r11, r5
 	sublo sl, sl, r5
 	blo _021553a8
 	sub r1, r5, sl
 	ldr r0, [sp, #8]
-	add fp, sb, r1
+	add r11, sb, r1
 	mov sb, #0
 	sub sl, r0, r1
 	str sb, [sp, #8]
@@ -28030,7 +28030,7 @@ _021553a8:
 _021553e8:
 	ldr r0, [sp, #0x10]
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02155204
 _021553f4: .word data_ov61_0217f414
@@ -28262,7 +28262,7 @@ _021556b0: .word data_ov61_0217f414
 	.global func_ov61_021556b4
 	arm_func_start func_ov61_021556b4
 func_ov61_021556b4: ; 0x021556b4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	ldr r3, _02155a04 ; =data_ov61_0217f414
 	mov r1, #0
 	ldr r0, _02155a08 ; =data_ov61_0217f4f4
@@ -28281,7 +28281,7 @@ func_ov61_021556b4: ; 0x021556b4
 	bl func_ov61_02154b08
 	mov sl, #1
 	ldr r0, _02155a04 ; =data_ov61_0217f414
-	mov fp, sl
+	mov r11, sl
 	str sl, [sp]
 	str sl, [r0, #0xc]
 	mov r4, #0
@@ -28323,10 +28323,10 @@ _02155788: ; jump table
 	b _02155800 ; case 2
 	b _02155850 ; case 3
 _02155798:
-	cmp fp, #0
+	cmp r11, #0
 	movne r1, #2
 	strne r1, [r0, #0xc]
-	movne fp, #0
+	movne r11, #0
 	bl func_ov61_02156100
 	cmp r0, #0
 	beq _021557c8
@@ -28495,7 +28495,7 @@ _021559e4:
 	bl func_ov61_02156254
 _021559fc:
 	bl func_ov61_02154b1c
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_021556b4
 _02155a04: .word data_ov61_0217f414
@@ -28763,11 +28763,11 @@ _02155dac: .word data_ov61_0217f414
 	.global func_ov61_02155db0
 	arm_func_start func_ov61_02155db0
 func_ov61_02155db0: ; 0x02155db0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #8
 	add r1, r1, #1
 	str r0, [sp]
-	rsb fp, r1, r1, lsl #4
+	rsb r11, r1, r1, lsl #4
 	bl func_0200e8f8
 	mov r4, r0, lsr #0x10
 	orr r4, r4, r1, lsl #16
@@ -28985,12 +28985,12 @@ _021560b8:
 	mov r0, r0, lsr #0x10
 	orr r0, r0, r1, lsl #16
 	sub r0, r0, r4
-	cmp r0, fp
+	cmp r0, r11
 	blt _02155dd8
 _021560ec:
 	mov r0, r5
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02155db0
 _021560f8: .word data_ov61_0217f8fc
@@ -29156,7 +29156,7 @@ _021562cc:
 	.global func_ov61_021562f0
 	arm_func_start func_ov61_021562f0
 func_ov61_021562f0: ; 0x021562f0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x40
 	mov sb, r2
 	mov r2, sb, lsl #0x8
@@ -29177,7 +29177,7 @@ func_ov61_021562f0: ; 0x021562f0
 	strh r6, [sp, #0xe]
 	str r6, [sp]
 	ldrb r7, [r0], #1
-	mov fp, r3
+	mov r11, r3
 	ldr r8, [sp, #0x68]
 	add r2, r1, #1
 	cmp r7, #0
@@ -29192,7 +29192,7 @@ _02156364:
 	cmp r6, #0x3c
 	addge sp, sp, #0x40
 	mvnge r0, #0
-	ldmgeia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmgeia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r6, r4, #1
 	mov r4, r6
 	str r6, [sp]
@@ -29307,7 +29307,7 @@ _02156518:
 	cmp r2, r8
 	movhi r4, #2
 	bhi _02156548
-	mov r1, fp
+	mov r1, r11
 	add r0, r0, #0xa
 	bl func_02007ad8
 	mov r4, #1
@@ -29337,7 +29337,7 @@ _02156550:
 _02156584:
 	mov r0, r4
 	add sp, sp, #0x40
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_021562f0
 _02156590: .word 0x00001001
@@ -29442,7 +29442,7 @@ func_ov61_02156668: ; 0x02156668
 	.global func_ov61_021566cc
 	arm_func_start func_ov61_021566cc
 func_ov61_021566cc: ; 0x021566cc
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0xc
 	ldr r2, _021567fc ; =data_ov61_0217f414
 	mov r6, #0
@@ -29453,16 +29453,16 @@ func_ov61_021566cc: ; 0x021566cc
 	ldr sb, [r2, #0x78]
 	mla r7, r5, r1, r7
 	ldr r4, [r2, #0x74]
-	adds fp, sb, r8
+	adds r11, sb, r8
 	mla r7, r4, r3, r7
 	ldr r8, [r2, #0x7c]
-	umull r3, r1, r5, fp
+	umull r3, r1, r5, r11
 	adc sl, r8, r7
 	mla r1, r5, sl, r1
-	str fp, [r2, #0x68]
+	str r11, [r2, #0x68]
 	mov r7, r6, lsl #0x10
 	adds r5, sb, r3
-	mla r1, r4, fp, r1
+	mla r1, r4, r11, r1
 	str sl, [r2, #0x6c]
 	orr r7, r7, sl, lsr #16
 	adc r4, r8, r1
@@ -29478,14 +29478,14 @@ func_ov61_021566cc: ; 0x021566cc
 	cmp r0, #0
 	ldrne r0, [sp, #8]
 	addne sp, sp, #0xc
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	mov r0, #1
-	mov fp, r6
+	mov r11, r6
 	ldr r7, _02156800 ; =data_ov61_0217f474
 	strb r0, [sp]
 	strb r0, [sp, #1]
 	add r6, sp, #2
-	mov r5, fp
+	mov r5, r11
 	mvn r4, #0
 _02156780:
 	mov r8, #0
@@ -29510,8 +29510,8 @@ _021567c0:
 	cmp r8, #2
 	add sb, sb, #1
 	blt _02156788
-	add fp, fp, #1
-	cmp fp, #3
+	add r11, r11, #1
+	cmp r11, #3
 	blt _02156780
 _021567dc:
 	ldr r1, [sp, #8]
@@ -29521,7 +29521,7 @@ _021567dc:
 	streq r0, [sp, #8]
 	ldr r0, [sp, #8]
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_021566cc
 _021567fc: .word data_ov61_0217f414
@@ -30955,7 +30955,7 @@ _021579e0: .word func_ov61_021579e4
 	.global func_ov61_021579e4
 	arm_func_start func_ov61_021579e4
 func_ov61_021579e4: ; 0x021579e4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x14
 	ldr r7, [r0, #4]
 	ldr r1, [r0, #0x10]
@@ -30969,7 +30969,7 @@ func_ov61_021579e4: ; 0x021579e4
 	str r0, [sp, #4]
 	mov r4, #0
 	mov r5, #1
-	mov fp, #0xa
+	mov r11, #0xa
 	add r6, sp, #0x10
 _02157a24:
 	mov r0, r6
@@ -30990,7 +30990,7 @@ _02157a24:
 	cmpne r0, #4
 	movne r0, #0
 	bne _02157a78
-	mov r0, fp
+	mov r0, r11
 	bl func_0200db28
 	b _02157a24
 _02157a78:
@@ -31000,7 +31000,7 @@ _02157a78:
 	cmp r0, #0
 	addeq sp, sp, #0x14
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r1, [sp, #0x10]
 	cmp sl, r1
 	movhi sl, r1
@@ -31011,7 +31011,7 @@ _02157a78:
 	bl func_ov61_021550cc
 	add sp, sp, #0x14
 	mov r0, sl
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02157ac0:
 	cmp r0, #0
 	moveq r4, #0
@@ -31028,7 +31028,7 @@ _02157aec:
 	cmp r4, #0
 	addle sp, sp, #0x14
 	movle r0, r4
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldrh r0, [r8, #0xfc]
 	ldr r1, [r8, #0xf8]
 	cmp r1, r0
@@ -31038,7 +31038,7 @@ _02157aec:
 _02157b14:
 	mov r0, r4
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	arm_func_end func_ov61_021579e4
 
 	.global func_ov61_02157b20
@@ -31100,14 +31100,14 @@ _02157ba8:
 	.global func_ov61_02157bb8
 	arm_func_start func_ov61_02157bb8
 func_ov61_02157bb8: ; 0x02157bb8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0xc
 	mov sl, r0
 	ldr r6, [sl, #0x64]
 	str r1, [sp]
 	ldr r0, [r6, #0x104]
 	str r2, [sp, #4]
-	mov fp, r3
+	mov r11, r3
 	bl func_0200ee4c
 	ldr r7, [r6, #0x104]
 	str r0, [sp, #8]
@@ -31154,10 +31154,10 @@ _02157c54:
 	ldr r2, [sp, #4]
 	add r0, r7, #0xc
 	bl func_02007ad8
-	cmp fp, #0
+	cmp r11, #0
 	ldrneh r0, [r7, #6]
 	ldr r1, [sp, #0x30]
-	strneh r0, [fp]
+	strneh r0, [r11]
 	cmp r1, #0
 	ldrne r0, [r7, #8]
 	strne r0, [r1]
@@ -31185,7 +31185,7 @@ _02157ce4:
 	bl func_0200ee60
 	mov r0, r8
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02157bb8
 _02157cf8: .word data_ov61_0217bc28
@@ -31351,7 +31351,7 @@ _02157eec:
 	.global func_ov61_02157f24
 	arm_func_start func_ov61_02157f24
 func_ov61_02157f24: ; 0x02157f24
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x18
 	mov sl, r0
 	ldr r4, [sl, #0x68]
@@ -31370,7 +31370,7 @@ func_ov61_02157f24: ; 0x02157f24
 	cmp r8, r0
 	addgt sp, sp, #0x18
 	subgt r0, r5, #0x23
-	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	str r8, [sp, #0x10]
 	b _02157f8c
 _02157f7c:
@@ -31381,7 +31381,7 @@ _02157f7c:
 _02157f8c:
 	cmp r8, #0
 	ble _0215801c
-	and fp, r6, #1
+	and r11, r6, #1
 _02157f98:
 	ldr r2, [sp, #0x10]
 	mov r0, sl
@@ -31403,31 +31403,31 @@ _02157f98:
 	cmp r0, #0
 	addle sp, sp, #0x18
 	mvnle r0, #5
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add sb, sb, r4
 	sub r8, r8, r4
 	add r5, r5, r4
 _02157ff8:
-	cmp fp, #0
+	cmp r11, #0
 	bne _02158014
 	cmp r4, #0
 	bgt _0215801c
 	add sp, sp, #0x18
 	mvn r0, #5
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02158014:
 	cmp r8, #0
 	bgt _02157f98
 _0215801c:
 	mov r0, r5
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	arm_func_end func_ov61_02157f24
 
 	.global func_ov61_02158028
 	arm_func_start func_ov61_02158028
 func_ov61_02158028: ; 0x02158028
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	mov sl, r0
 	mov sb, r1
 	mov r8, r2
@@ -31437,7 +31437,7 @@ func_ov61_02158028: ; 0x02158028
 	movgt r8, sb
 	bl func_0200ee4c
 	ldr r1, [sp, #0x28]
-	mov fp, r0
+	mov r11, r0
 	and r6, r1, #1
 _02158058:
 	mov r0, sl
@@ -31459,10 +31459,10 @@ _02158084:
 	bl func_0200d880
 	b _02158058
 _0215809c:
-	mov r0, fp
+	mov r0, r11
 	bl func_0200ee60
 	mov r0, r5
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	arm_func_end func_ov61_02158028
 
 	.global func_ov61_021580ac
@@ -33245,16 +33245,16 @@ func_ov61_02159658: ; 0x02159658
 	.global func_ov61_02159678
 	arm_func_start func_ov61_02159678
 func_ov61_02159678: ; 0x02159678
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	mov sb, r2
 	mov r8, r3
 	mvn r2, #0
 	cmp r8, r2
 	cmpeq sb, r2
-	movne fp, #1
+	movne r11, #1
 	str r0, [sp]
 	mov sl, r1
-	moveq fp, #0
+	moveq r11, #0
 _021596a0:
 	mov r6, #0
 	ldr r4, [sp]
@@ -33276,7 +33276,7 @@ _021596b4:
 _021596e0:
 	cmp r6, #0
 	bgt _02159720
-	cmp fp, #0
+	cmp r11, #0
 	beq _02159704
 	mov r0, #0
 	subs r0, r0, sb
@@ -33293,7 +33293,7 @@ _02159704:
 	b _021596a0
 _02159720:
 	mov r0, r6
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02159678
 _02159728: .word 0x0000020b
@@ -33714,10 +33714,10 @@ _02159be8:
 	.global func_ov61_02159c1c
 	arm_func_start func_ov61_02159c1c
 func_ov61_02159c1c: ; 0x02159c1c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #8
-	mov fp, r1
-	ldr r1, [fp]
+	mov r11, r1
+	ldr r1, [r11]
 	mov sb, r0
 	add r0, r1, #1
 	str r0, [sp, #4]
@@ -33734,7 +33734,7 @@ func_ov61_02159c1c: ; 0x02159c1c
 _02159c60:
 	add sp, sp, #8
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02159c6c:
 	and r1, r5, #0x1f
 	cmp r1, #0x18
@@ -33864,7 +33864,7 @@ _02159dfc:
 	cmp r0, #0
 	addne sp, sp, #8
 	movne r0, #1
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	mov r0, #0
 	strb r0, [sb, #0x5ad]
 	b _0215a0f4
@@ -34002,7 +34002,7 @@ _02159ff0:
 	add r5, r5, #1
 	addne sp, sp, #8
 	movne r0, #1
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, [sp, #4]
 	cmp r0, sl
 	blo _02159ff0
@@ -34030,7 +34030,7 @@ _0215a058:
 	cmp r0, #0
 	addne sp, sp, #8
 	movne r0, #1
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, [sp, #4]
 	cmp r0, r6
 	blo _0215a058
@@ -34054,7 +34054,7 @@ _0215a0b0:
 	cmp r0, #0
 	addne sp, sp, #8
 	movne r0, #1
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, [sp, #4]
 	cmp r0, r6
 	blo _0215a0b0
@@ -34066,9 +34066,9 @@ _0215a0e8:
 _0215a0f4:
 	ldr r1, [sp, #4]
 	mov r0, #0
-	str r1, [fp]
+	str r1, [r11]
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02159c1c
 _0215a108: .word data_ov61_0217bc8c
@@ -34310,7 +34310,7 @@ _0215a424:
 	arm_func_start func_ov61_0215a428
 func_ov61_0215a428: ; 0x0215a428
 	stmdb sp!, {r0, r1, r2, r3}
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x18
 	ldr r1, [sp, #0x44]
 	mov sl, r0
@@ -34338,7 +34338,7 @@ func_ov61_0215a428: ; 0x0215a428
 	str r6, [sl, #0x5a0]
 	mov sb, r6
 	str r6, [sl, #0x594]
-	mov fp, #2
+	mov r11, #2
 	mvn r5, #0
 	mov r4, r6
 _0215a4a8:
@@ -34380,7 +34380,7 @@ _0215a530:
 	mov r0, #9
 	add sp, sp, #0x18
 	strb r0, [sl, #0x455]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	add sp, sp, #0x10
 	bx lr
 _0215a548:
@@ -34411,13 +34411,13 @@ _0215a578:
 	mov r0, sl
 	add r1, sp, #4
 	mov r3, r2
-	str fp, [sp]
+	str r11, [sp]
 	bl func_ov61_02159c1c
 	cmp r0, #0
 	movne r0, #9
 	addne sp, sp, #0x18
 	strneb r0, [sl, #0x455]
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	addne sp, sp, #0x10
 	bxne lr
 	mov r0, sl
@@ -34450,7 +34450,7 @@ _0215a628:
 	movne r0, #9
 	strneb r0, [sl, #0x455]
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	add sp, sp, #0x10
 	bx lr
 	arm_func_end func_ov61_0215a428
@@ -34682,15 +34682,15 @@ _0215a8e4:
 	.global func_ov61_0215a920
 	arm_func_start func_ov61_0215a920
 func_ov61_0215a920: ; 0x0215a920
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x18
 	movs sl, r2
 	str r0, [sp, #8]
 	ldrne r0, [sl]
-	mov fp, r1
+	mov r11, r1
 	cmpne r0, #0
 	addeq sp, sp, #0x18
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	mov r0, r0, lsl #0x1
 	add r0, r0, r0, lsr #31
 	mov r0, r0, asr #0x1
@@ -34702,7 +34702,7 @@ func_ov61_0215a920: ; 0x0215a920
 	blx r1
 	movs r5, r0
 	addeq sp, sp, #0x18
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r6, r5, r4, lsl #1
 	add r7, r6, r4, lsl #1
 	add r1, r7, r4, lsl #1
@@ -34712,9 +34712,9 @@ func_ov61_0215a920: ; 0x0215a920
 	str r1, [sp, #0xc]
 	ldr r2, [sl]
 	add sb, r8, r4, lsl #1
-	mov r1, fp
+	mov r1, r11
 	mov r3, r4
-	add fp, sb, r4, lsl #1
+	add r11, sb, r4, lsl #1
 	bl func_ov61_0215e8d4
 	ldr r1, [sl, #0x1c]
 	ldr r2, [sl, #0x18]
@@ -34799,7 +34799,7 @@ func_ov61_0215a920: ; 0x0215a920
 	mov r2, r6
 	mov r3, sb
 	mov r0, #0
-	stmia sp, {r4, fp}
+	stmia sp, {r4, r11}
 	bl func_ov61_0215e0e0
 	mov r0, sb
 	mov r1, r6
@@ -34812,7 +34812,7 @@ _0215ab14:
 	mov r2, r6
 	mov r3, sb
 	mov r0, #0
-	stmia sp, {r4, fp}
+	stmia sp, {r4, r11}
 	bl func_ov61_0215e0e0
 _0215ab2c:
 	ldr r0, [sp, #8]
@@ -34825,7 +34825,7 @@ _0215ab2c:
 	ldr r1, [r1]
 	blx r1
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0215a920
 _0215ab58: .word data_ov61_0217f428
@@ -34908,7 +34908,7 @@ _0215ac58: .word data_ov61_0217bce0
 	.global func_ov61_0215ac5c
 	arm_func_start func_ov61_0215ac5c
 func_ov61_0215ac5c: ; 0x0215ac5c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x24
 	mov sl, r0
 	ldrh r0, [sl, #0x32]
@@ -34935,8 +34935,8 @@ _0215aca8:
 	mov r7, #0
 	add r0, r1, r0
 	add r0, r2, r0
-	mov fp, r0, lsl #0x1
-	cmp fp, #0
+	mov r11, r0, lsl #0x1
+	cmp r11, #0
 	ble _0215ad9c
 	add r0, sl, #0x74
 	mov sb, r7
@@ -34991,7 +34991,7 @@ _0215ad18:
 	add r1, r1, sb
 	bl func_ov61_0215d0e4
 	add sb, sb, #0x10
-	cmp sb, fp
+	cmp sb, r11
 	add r7, r7, #1
 	blt _0215acdc
 _0215ad9c:
@@ -35031,7 +35031,7 @@ _0215ae00:
 	mov r2, #0x10
 	bl func_ov61_0215da48
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	arm_func_end func_ov61_0215ac5c
 
 	.global func_ov61_0215ae28
@@ -35885,7 +35885,7 @@ _0215b9c8: .word 0x00004805
 	.global func_ov61_0215b9cc
 	arm_func_start func_ov61_0215b9cc
 func_ov61_0215b9cc: ; 0x0215b9cc
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x74
 	ldr r2, _0215baec ; =data_ov61_02180e40
 	mov sl, r0
@@ -35915,10 +35915,10 @@ _0215ba30:
 	mov r8, #0
 	addle sp, sp, #0x74
 	mov r1, #0x14
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r5, _0215baf4 ; =data_ov61_02180fb8
 	add r6, sp, #0x18
-	mov fp, r1
+	mov r11, r1
 	add r4, sp, #4
 _0215ba54:
 	cmp r1, #0x14
@@ -35929,7 +35929,7 @@ _0215ba54:
 	mov r7, r0
 	mov r0, r6
 	mov r1, r5
-	mov r2, fp
+	mov r2, r11
 	bl func_ov61_0215d8f8
 	mov r0, r6
 	mov r1, r4
@@ -35960,7 +35960,7 @@ _0215bac8:
 	cmp r8, sb
 	blt _0215ba54
 	add sp, sp, #0x74
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0215b9cc
 _0215baec: .word data_ov61_02180e40
@@ -36369,10 +36369,10 @@ _0215c0b4: .word data_ov61_0217f454
 	.global func_ov61_0215c0b8
 	arm_func_start func_ov61_0215c0b8
 func_ov61_0215c0b8: ; 0x0215c0b8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #8
-	mov fp, r0
-	ldr r4, [fp, #0xc]
+	mov r11, r0
+	ldr r4, [r11, #0xc]
 	mov r0, #3
 	strb r0, [r4]
 	mov r0, #0
@@ -36392,7 +36392,7 @@ func_ov61_0215c0b8: ; 0x0215c0b8
 	moveq r0, #9
 	addeq sp, sp, #8
 	streqb r0, [r4, #0x455]
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	mov r0, #0
 	strb r0, [sb]
 	mov r2, #2
@@ -36421,7 +36421,7 @@ func_ov61_0215c0b8: ; 0x0215c0b8
 	mov r0, #9
 	add sp, sp, #8
 	strb r0, [r4, #0x455]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0215c18c:
 	add r0, r5, r8, lsl #1
 	add r6, r0, r8, lsl #1
@@ -36470,7 +36470,7 @@ _0215c18c:
 	mov r0, #9
 	add sp, sp, #8
 	strb r0, [r4, #0x455]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0215c24c:
 	mov r0, #0x16
 	strb r0, [r6]
@@ -36518,7 +36518,7 @@ _0215c2e8:
 	mov r0, r6
 	mov r3, r2
 	add r1, sl, #9
-	str fp, [sp]
+	str r11, [sp]
 	bl func_ov61_02155204
 	mov r0, r4
 	add r1, r6, #5
@@ -36537,7 +36537,7 @@ _0215c2e8:
 	ldr r1, [r1]
 	blx r1
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0215c0b8
 _0215c348: .word data_ov61_0217f428
@@ -36949,7 +36949,7 @@ _0215c878:
 	.global func_ov61_0215c880
 	arm_func_start func_ov61_0215c880
 func_ov61_0215c880: ; 0x0215c880
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0xc
 	ldr r4, [sp, #0x30]
 	mov sb, r1
@@ -36979,12 +36979,12 @@ _0215c8b4:
 	mov r0, sl
 	add r1, r4, #5
 	mov r2, r7
-	sub fp, r6, r7
+	sub r11, r6, r7
 	bl func_02007ad8
 	add r1, r4, #5
 	mov r0, r8
 	add r1, r1, r7
-	mov r2, fp
+	mov r2, r11
 	add sl, sl, r7
 	sub sb, sb, r7
 	bl func_02007ad8
@@ -36998,7 +36998,7 @@ _0215c8b4:
 	strb r0, [r4, #3]
 	ldr r0, [sp, #8]
 	mov r1, r4
-	add r8, r8, fp
+	add r8, r8, r11
 	strb r6, [r4, #4]
 	bl func_ov61_0215b348
 	ldr r1, [sp, #0x30]
@@ -37024,7 +37024,7 @@ _0215c8b4:
 _0215c99c:
 	ldr r0, [sp, #4]
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0215c880
 _0215c9a8: .word 0x00000b4f
@@ -37214,7 +37214,7 @@ _0215cbc4: .word func_02007ad8
 	.global func_ov61_0215cbc8
 	arm_func_start func_ov61_0215cbc8
 func_ov61_0215cbc8: ; 0x0215cbc8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x44
 	str r0, [sp]
 	ldr r3, [sp]
@@ -37258,7 +37258,7 @@ _0215cbf8:
 	eor r0, r4, r5
 	and r0, r7, r0
 	ldr r1, [sb, #8]
-	ldrb fp, [lr, #3]
+	ldrb r11, [lr, #3]
 	ldr sl, [r2, sl, lsl #2]
 	eor r0, r5, r0
 	add r0, r0, sl
@@ -37270,7 +37270,7 @@ _0215cbf8:
 	eor r8, r7, r4
 	add r6, r7, r1
 	and r1, r6, r8
-	ldr r0, [r2, fp, lsl #2]
+	ldr r0, [r2, r11, lsl #2]
 	eor r1, r4, r1
 	ldr sb, [sb, #0xc]
 	add r0, r1, r0
@@ -37285,7 +37285,7 @@ _0215cbf8:
 	blt _0215cbf8
 	ldr r0, _0215cfdc ; =data_ov61_0217bcf4
 	ldr lr, _0215cfe0 ; =data_ov61_0217bd74
-	mov fp, #0
+	mov r11, #0
 	add sl, r0, r3
 	add sb, sp, #4
 _0215ccec:
@@ -37340,8 +37340,8 @@ _0215ccec:
 	orr r0, r0, r1, lsl #20
 	add r5, r6, r0
 	add r3, r3, #4
-	add fp, fp, #1
-	cmp fp, #4
+	add r11, r11, #1
+	cmp r11, #4
 	blt _0215ccec
 	ldr r0, _0215cfdc ; =data_ov61_0217bcf4
 	ldr r1, _0215cfe0 ; =data_ov61_0217bd74
@@ -37350,7 +37350,7 @@ _0215ccec:
 	add r0, sp, #4
 _0215cdd8:
 	ldrb sb, [r2]
-	add fp, r1, r3, lsl #2
+	add r11, r1, r3, lsl #2
 	eor ip, r5, r6
 	ldr sl, [r0, sb, lsl #2]
 	eor ip, r7, ip
@@ -37365,7 +37365,7 @@ _0215cdd8:
 	eor sb, r4, r5
 	eor sb, r6, sb
 	ldr ip, [r0, sl, lsl #2]
-	ldr sl, [fp, #4]
+	ldr sl, [r11, #4]
 	add sb, sb, ip
 	add sb, sl, sb
 	add sb, r7, sb
@@ -37373,25 +37373,25 @@ _0215cdd8:
 	orr r7, r7, sb, lsl #11
 	ldrb sb, [r2, #2]
 	add r7, r4, r7
-	ldr sl, [fp, #8]
+	ldr sl, [r11, #8]
 	ldr ip, [r0, sb, lsl #2]
-	ldr sb, [fp, #0xc]
-	eor fp, r7, r4
-	eor fp, r5, fp
-	add fp, fp, ip
-	add sl, sl, fp
+	ldr sb, [r11, #0xc]
+	eor r11, r7, r4
+	eor r11, r5, r11
+	add r11, r11, ip
+	add sl, sl, r11
 	add sl, r6, sl
 	mov r6, sl, lsr #0x10
 	orr r6, r6, sl, lsl #16
 	add r6, r7, r6
 	eor sl, r6, r7
-	eor fp, r4, sl
+	eor r11, r4, sl
 	ldrb sl, [r2, #3]
 	add r2, r2, #4
 	add r3, r3, #4
 	ldr sl, [r0, sl, lsl #2]
 	add r8, r8, #1
-	add sl, fp, sl
+	add sl, r11, sl
 	add sb, sb, sl
 	add sb, r5, sb
 	cmp r8, #4
@@ -37406,7 +37406,7 @@ _0215cdd8:
 _0215ceb0:
 	ldr r1, _0215cfe0 ; =data_ov61_0217bd74
 	ldrb r0, [r8]
-	add fp, r1, r3, lsl #2
+	add r11, r1, r3, lsl #2
 	mvn r1, r7
 	orr sl, r5, r1
 	ldr r1, _0215cfe0 ; =data_ov61_0217bd74
@@ -37425,7 +37425,7 @@ _0215ceb0:
 	ldr ip, [r2, r1, lsl #2]
 	eor r0, r5, r0
 	add r0, r0, ip
-	ldr sl, [fp, #4]
+	ldr sl, [r11, #4]
 	ldrb ip, [r8, #2]
 	add r0, sl, r0
 	add r7, r7, r0
@@ -37434,7 +37434,7 @@ _0215ceb0:
 	add r7, r4, r0
 	mvn r0, r5
 	orr r0, r7, r0
-	ldr r1, [fp, #8]
+	ldr r1, [r11, #8]
 	ldrb lr, [r8, #3]
 	ldr ip, [r2, ip, lsl #2]
 	eor r0, r4, r0
@@ -37449,9 +37449,9 @@ _0215ceb0:
 	orr r1, r6, sl
 	ldr r0, [r2, lr, lsl #2]
 	eor r1, r7, r1
-	ldr fp, [fp, #0xc]
+	ldr r11, [r11, #0xc]
 	add r0, r1, r0
-	add r0, fp, r0
+	add r0, r11, r0
 	add r1, r5, r0
 	mov r0, r1, lsr #0xb
 	orr r0, r0, r1, lsl #21
@@ -37478,7 +37478,7 @@ _0215ceb0:
 	ldr r0, [sp]
 	str r1, [r0, #0xc]
 	add sp, sp, #0x44
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0215cbc8
 _0215cfdc: .word data_ov61_0217bcf4
@@ -37666,7 +37666,7 @@ _0215d1e4:
 	.global func_ov61_0215d21c
 	arm_func_start func_ov61_0215d21c
 func_ov61_0215d21c: ; 0x0215d21c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x50
 	str r0, [sp]
 	ldr r3, [sp]
@@ -37682,14 +37682,14 @@ _0215d24c:
 	eor r6, r7, r8
 	mov sl, r4, lsr #0x1b
 	and r6, r5, r6
-	orr fp, sl, r4, lsl #5
+	orr r11, sl, r4, lsl #5
 	eor r6, r8, r6
 	mov sl, r5, lsr #0x2
 	orr sl, sl, r5, lsl #30
 	add r5, r1, r0, lsl #2
-	add r6, fp, r6
+	add r6, r11, r6
 	ldr ip, [r1, r0, lsl #2]
-	ldr fp, [r5, #4]
+	ldr r11, [r5, #4]
 	add r6, ip, r6
 	add r6, r6, r3
 	add sb, sb, r6
@@ -37699,25 +37699,25 @@ _0215d24c:
 	and ip, r4, ip
 	eor ip, r7, ip
 	add r6, r6, ip
-	add r6, fp, r6
+	add r6, r11, r6
 	add r6, r6, r3
 	add r8, r8, r6
 	mov r6, r4, lsr #0x2
 	orr r4, r6, r4, lsl #30
-	ldr fp, [r5, #8]
+	ldr r11, [r5, #8]
 	mov r6, r8, lsr #0x1b
 	orr r6, r6, r8, lsl #5
 	eor ip, r4, sl
 	and ip, sb, ip
 	eor ip, sl, ip
 	add r6, r6, ip
-	add r6, fp, r6
+	add r6, r11, r6
 	add r6, r6, r3
 	add r6, r7, r6
 	mov r7, sb, lsr #0x2
 	orr sb, r7, sb, lsl #30
 	ldr r7, [r5, #0xc]
-	ldr fp, [r5, #0x10]
+	ldr r11, [r5, #0x10]
 	mov r5, r6, lsr #0x1b
 	orr r5, r5, r6, lsl #5
 	eor ip, sb, r4
@@ -37735,7 +37735,7 @@ _0215d24c:
 	and sl, r6, sl
 	eor sl, sb, sl
 	add r7, r7, sl
-	add r7, fp, r7
+	add r7, r11, r7
 	add r7, r7, r3
 	add r4, r4, r7
 	mov r7, r6, lsr #0x2
@@ -37820,10 +37820,10 @@ _0215d24c:
 	orr r7, r1, r7, lsl #30
 	mov sl, #4
 	str r0, [sp, #4]
-	add fp, sp, #0x10
+	add r11, sp, #0x10
 _0215d484:
 	mov r0, sl
-	mov r1, fp
+	mov r1, r11
 	bl func_ov61_0215d14c
 	mov r2, r5, lsr #0x1b
 	eor r1, r6, r7
@@ -37836,7 +37836,7 @@ _0215d484:
 	add sb, sb, r1
 	orr r6, r0, r6, lsl #30
 	add r0, sl, #1
-	mov r1, fp
+	mov r1, r11
 	bl func_ov61_0215d14c
 	mov r1, sb, lsr #0x1b
 	orr r2, r1, sb, lsl #5
@@ -37851,7 +37851,7 @@ _0215d484:
 	add r0, sl, #2
 	and sl, r0, #0xf
 	mov r0, sl
-	mov r1, fp
+	mov r1, r11
 	bl func_ov61_0215d14c
 	mov r1, r8, lsr #0x1b
 	orr r2, r1, r8, lsl #5
@@ -37864,7 +37864,7 @@ _0215d484:
 	mov r0, sb, lsr #0x2
 	orr sb, r0, sb, lsl #30
 	add r0, sl, #1
-	mov r1, fp
+	mov r1, r11
 	bl func_ov61_0215d14c
 	mov r1, r7, lsr #0x1b
 	orr r2, r1, r7, lsl #5
@@ -37877,7 +37877,7 @@ _0215d484:
 	mov r0, r8, lsr #0x2
 	orr r8, r0, r8, lsl #30
 	add r0, sl, #2
-	mov r1, fp
+	mov r1, r11
 	bl func_ov61_0215d14c
 	mov r1, r6, lsr #0x1b
 	orr r2, r1, r6, lsl #5
@@ -37898,10 +37898,10 @@ _0215d484:
 	mov r0, #0
 	ldr r4, _0215d89c ; =0x8f1bbcdc
 	str r0, [sp, #8]
-	add fp, sp, #0x10
+	add r11, sp, #0x10
 _0215d5b8:
 	mov r0, sl
-	mov r1, fp
+	mov r1, r11
 	bl func_ov61_0215d14c
 	orr r2, r7, r8
 	mov r1, r5, lsr #0x1b
@@ -37916,7 +37916,7 @@ _0215d5b8:
 	add sb, sb, r1
 	orr r6, r0, r6, lsl #30
 	add r0, sl, #1
-	mov r1, fp
+	mov r1, r11
 	bl func_ov61_0215d14c
 	mov r1, sb, lsr #0x1b
 	orr r1, r1, sb, lsl #5
@@ -37931,7 +37931,7 @@ _0215d5b8:
 	mov r0, r5, lsr #0x2
 	orr r5, r0, r5, lsl #30
 	add r0, sl, #2
-	mov r1, fp
+	mov r1, r11
 	bl func_ov61_0215d14c
 	mov r1, r8, lsr #0x1b
 	orr r1, r1, r8, lsl #5
@@ -37948,7 +37948,7 @@ _0215d5b8:
 	add r0, sl, #3
 	and sl, r0, #0xf
 	mov r0, sl
-	mov r1, fp
+	mov r1, r11
 	bl func_ov61_0215d14c
 	mov r1, r7, lsr #0x1b
 	orr r1, r1, r7, lsl #5
@@ -37963,7 +37963,7 @@ _0215d5b8:
 	mov r0, r8, lsr #0x2
 	orr r8, r0, r8, lsl #30
 	add r0, sl, #1
-	mov r1, fp
+	mov r1, r11
 	bl func_ov61_0215d14c
 	mov r1, r6, lsr #0x1b
 	orr r1, r1, r6, lsl #5
@@ -37986,10 +37986,10 @@ _0215d5b8:
 	mov r0, #0
 	ldr r4, _0215d8a0 ; =0xca62c1d6
 	str r0, [sp, #0xc]
-	add fp, sp, #0x10
+	add r11, sp, #0x10
 _0215d714:
 	mov r0, sl
-	mov r1, fp
+	mov r1, r11
 	bl func_ov61_0215d14c
 	mov r2, r5, lsr #0x1b
 	eor r1, r6, r7
@@ -38002,7 +38002,7 @@ _0215d714:
 	add sb, sb, r1
 	orr r6, r0, r6, lsl #30
 	add r0, sl, #1
-	mov r1, fp
+	mov r1, r11
 	bl func_ov61_0215d14c
 	mov r1, sb, lsr #0x1b
 	orr r2, r1, sb, lsl #5
@@ -38015,7 +38015,7 @@ _0215d714:
 	mov r0, r5, lsr #0x2
 	orr r5, r0, r5, lsl #30
 	add r0, sl, #2
-	mov r1, fp
+	mov r1, r11
 	bl func_ov61_0215d14c
 	mov r1, r8, lsr #0x1b
 	orr r2, r1, r8, lsl #5
@@ -38028,7 +38028,7 @@ _0215d714:
 	mov r0, sb, lsr #0x2
 	orr sb, r0, sb, lsl #30
 	add r0, sl, #3
-	mov r1, fp
+	mov r1, r11
 	bl func_ov61_0215d14c
 	mov r1, r7, lsr #0x1b
 	orr r2, r1, r7, lsl #5
@@ -38043,7 +38043,7 @@ _0215d714:
 	add r0, sl, #4
 	and sl, r0, #0xf
 	mov r0, sl
-	mov r1, fp
+	mov r1, r11
 	bl func_ov61_0215d14c
 	mov r1, r6, lsr #0x1b
 	orr r2, r1, r6, lsl #5
@@ -38083,7 +38083,7 @@ _0215d714:
 	ldr r0, [sp]
 	str r1, [r0, #0x10]
 	add sp, sp, #0x50
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0215d21c
 _0215d894: .word 0x5a827999
@@ -38557,7 +38557,7 @@ _0215de28:
 	.global func_ov61_0215de3c
 	arm_func_start func_ov61_0215de3c
 func_ov61_0215de3c: ; 0x0215de3c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #8
 	mov r8, r3
 	mov sl, r1
@@ -38569,7 +38569,7 @@ func_ov61_0215de3c: ; 0x0215de3c
 	mov r0, sl
 	mov r1, r8
 	bl func_ov61_0215db28
-	mov fp, r0
+	mov r11, r0
 	mov r0, sb
 	mov r1, r8
 	bl func_ov61_0215db28
@@ -38577,7 +38577,7 @@ func_ov61_0215de3c: ; 0x0215de3c
 	cmp r0, #0
 	mov r5, #0
 	addle sp, sp, #8
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0215de90:
 	mov r6, #0
 	sub r7, r8, r5
@@ -38594,7 +38594,7 @@ _0215dea0:
 	bl func_ov61_0215de08
 	add r6, r6, #1
 _0215dec4:
-	cmp r6, fp
+	cmp r6, r11
 	cmplt r6, r7
 	blt _0215dea0
 	ldr r0, [sp, #4]
@@ -38602,7 +38602,7 @@ _0215dec4:
 	cmp r5, r0
 	blt _0215de90
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	arm_func_end func_ov61_0215de3c
 
 	.global func_ov61_0215dee8
@@ -38645,16 +38645,16 @@ _0215df38:
 	.global func_ov61_0215df60
 	arm_func_start func_ov61_0215df60
 func_ov61_0215df60: ; 0x0215df60
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	mov sb, r1
 	mov r8, r2
 	mov sl, r0
 	mov r0, sb
 	mov r1, r8
 	bl func_ov61_0215db28
-	mov fp, r0
-	cmp r8, fp, lsl #1
-	mov r0, fp, lsl #0x1
+	mov r11, r0
+	cmp r8, r11, lsl #1
+	mov r0, r11, lsl #0x1
 	ble _0215dfa0
 	sub r1, r8, r0
 	add r0, sl, r0, lsl #1
@@ -38662,7 +38662,7 @@ func_ov61_0215df60: ; 0x0215df60
 	mov r1, #0
 	bl func_02007a44
 _0215dfa0:
-	cmp fp, #0
+	cmp r11, #0
 	mov r4, #0
 	ble _0215dff4
 	mov r5, r4
@@ -38681,13 +38681,13 @@ _0215dfb4:
 	mov r1, r1, lsr #0x10
 	add r0, sl, r0
 	strh r1, [r0, #2]
-	cmp r4, fp
+	cmp r4, r11
 	add r5, r5, #2
 	blt _0215dfb4
 _0215dff4:
 	mov r6, #0
-	cmp fp, #0
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	cmp r11, #0
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0215e000:
 	mov r0, r6, lsl #0x1
 	add r4, r6, #1
@@ -38721,14 +38721,14 @@ _0215e048:
 _0215e06c:
 	add r4, r4, #1
 _0215e070:
-	cmp r4, fp
+	cmp r4, r11
 	addlt r5, r6, r4
 	cmplt r5, r8
 	blt _0215e010
 	add r6, r6, #1
-	cmp r6, fp
+	cmp r6, r11
 	blt _0215e000
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0215df60
 _0215e090: .word 0x7fff8000
@@ -38775,7 +38775,7 @@ func_ov61_0215e0c4: ; 0x0215e0c4
 	.global func_ov61_0215e0e0
 	arm_func_start func_ov61_0215e0e0
 func_ov61_0215e0e0: ; 0x0215e0e0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x20
 	ldr sb, [sp, #0x48]
 	ldr r8, [sp, #0x4c]
@@ -38792,15 +38792,15 @@ func_ov61_0215e0e0: ; 0x0215e0e0
 	ldr r0, [sp, #4]
 	mov r1, sb
 	bl func_ov61_0215db28
-	mov fp, r0
+	mov r11, r0
 	mov r0, sl
 	mov r1, sb
 	bl func_ov61_0215db28
 	mov r5, r0
-	cmp fp, #0
+	cmp r11, #0
 	cmpgt r5, #0
 	ble _0215e278
-	sub r0, sb, fp
+	sub r0, sb, r11
 	add r0, r5, r0
 	sub r4, r0, #1
 	cmp r4, sb
@@ -38813,13 +38813,13 @@ func_ov61_0215e0e0: ; 0x0215e0e0
 _0215e16c:
 	ldr r0, [sp, #4]
 	add r1, r6, r4, lsl #1
-	mov r2, fp, lsl #0x1
+	mov r2, r11, lsl #0x1
 	bl func_02007ad8
 	cmp r5, #2
 	ble _0215e1a0
 	add r0, sl, r5, lsl #1
 	sub r0, r0, #2
-	mov fp, r5, lsl #0x1
+	mov r11, r5, lsl #0x1
 	bl func_ov61_0215e0b0
 	str r0, [sp, #0x18]
 	str r1, [sp, #0x10]
@@ -38829,13 +38829,13 @@ _0215e1a0:
 	cmp r5, #1
 	sub r0, r0, #2
 	ble _0215e1c4
-	mov fp, r5, lsl #0x1
+	mov r11, r5, lsl #0x1
 	bl func_ov61_0215e0a0
 	str r0, [sp, #0x18]
 	str r1, [sp, #0x10]
 	b _0215e1d4
 _0215e1c4:
-	mov fp, r5, lsl #0x1
+	mov r11, r5, lsl #0x1
 	bl func_ov61_0215e094
 	str r0, [sp, #0x18]
 	str r1, [sp, #0x10]
@@ -38851,7 +38851,7 @@ _0215e1ec:
 	mov r1, r6
 	add r0, r6, #2
 	bl func_020435b4
-	add r0, r7, fp
+	add r0, r7, r11
 	bl func_ov61_0215e0c4
 	ldr r2, [sp, #0x18]
 	ldr r3, [sp, #0x10]
@@ -38895,13 +38895,13 @@ _0215e294:
 	ldr r0, [sp, #8]
 	cmp r0, #0
 	addeq sp, sp, #0x20
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r1, [sp, #8]
 	mov r0, r7
 	mov r2, sb, lsl #0x1
 	bl func_02007ad8
 	add sp, sp, #0x20
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0215e0e0
 _0215e2bc: .word 0x0000ffff
@@ -38909,7 +38909,7 @@ _0215e2bc: .word 0x0000ffff
 	.global func_ov61_0215e2c0
 	arm_func_start func_ov61_0215e2c0
 func_ov61_0215e2c0: ; 0x0215e2c0
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0xc
 	ldr r4, _0215e44c ; =data_ov61_0217f428
 	mov r8, r3
@@ -38922,7 +38922,7 @@ func_ov61_0215e2c0: ; 0x0215e2c0
 	blx r3
 	movs r4, r0
 	addeq sp, sp, #0xc
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	sub r1, r8, #1
 	add r0, sl, #2
 	mov r2, r1, lsl #0x1
@@ -38959,7 +38959,7 @@ _0215e368:
 _0215e374:
 	cmp r6, r8, lsl #4
 	bhs _0215e434
-	mov fp, r8, lsl #0x1
+	mov r11, r8, lsl #0x1
 _0215e380:
 	mov r0, r4
 	mov r1, sl
@@ -38967,7 +38967,7 @@ _0215e380:
 	bl func_ov61_0215df60
 	mov r0, r4
 	mov r1, sl
-	mov r2, fp
+	mov r2, r11
 	bl func_02007ad8
 	cmp r7, #0
 	beq _0215e3c4
@@ -38993,7 +38993,7 @@ _0215e3c4:
 	bl func_ov61_0215de3c
 	mov r0, r4
 	mov r1, sl
-	mov r2, fp
+	mov r2, r11
 	bl func_02007ad8
 	cmp r7, #0
 	beq _0215e428
@@ -39014,7 +39014,7 @@ _0215e434:
 	ldr r1, [r1]
 	blx r1
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0215e2c0
 _0215e44c: .word data_ov61_0217f428
@@ -39023,12 +39023,12 @@ _0215e450: .word data_ov61_0217f454
 	.global func_ov61_0215e454
 	arm_func_start func_ov61_0215e454
 func_ov61_0215e454: ; 0x0215e454
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x14
 	ldr sb, [sp, #0x38]
 	mov sl, r3
-	add fp, sb, sl, lsl #1
-	add r4, fp, sl, lsl #1
+	add r11, sb, sl, lsl #1
+	add r4, r11, sl, lsl #1
 	add r5, r4, sl, lsl #1
 	add r6, r5, sl, lsl #1
 	add r7, r6, sl, lsl #1
@@ -39056,7 +39056,7 @@ _0215e4c8:
 	ldr r3, [sp, #0x10]
 	str sl, [sp]
 	str r3, [sp, #4]
-	mov r0, fp
+	mov r0, r11
 	mov r1, r4
 	mov r2, sb
 	mov r3, r7
@@ -39070,7 +39070,7 @@ _0215e4c8:
 	mov r2, r8
 	bl func_02007ad8
 	mov r0, r7
-	mov r1, fp
+	mov r1, r11
 	mov r2, r5
 	mov r3, sl
 	bl func_ov61_0215de3c
@@ -39107,7 +39107,7 @@ _0215e564:
 	str r4, [sp, #4]
 	bl func_ov61_0215e0e0
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	arm_func_end func_ov61_0215e454
 
 	.global func_ov61_0215e5a0
@@ -39196,13 +39196,13 @@ _0215e6b0:
 	.global func_ov61_0215e6c8
 	arm_func_start func_ov61_0215e6c8
 func_ov61_0215e6c8: ; 0x0215e6c8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x2c
 	mov sl, r3
 	mov r3, #0x16
 	mul r4, sl, r3
 	ldr r3, _0215e8cc ; =data_ov61_0217f428
-	mov fp, r0
+	mov r11, r0
 	ldr r3, [r3]
 	mov r0, r4
 	ldr sb, [sp, #0x50]
@@ -39212,7 +39212,7 @@ func_ov61_0215e6c8: ; 0x0215e6c8
 	str r0, [sp, #0x28]
 	cmp r0, #0
 	addeq sp, sp, #0x2c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	mov r2, r4
 	mov r1, #0
 	bl func_02007a44
@@ -39273,7 +39273,7 @@ func_ov61_0215e6c8: ; 0x0215e6c8
 	ldr r1, [sp, #0x28]
 	mov r0, #0
 	mov r2, sb
-	mov r3, fp
+	mov r3, r11
 	str r5, [sp, #4]
 	bl func_ov61_0215e0e0
 	movs r0, r4, lsl #0x4
@@ -39285,7 +39285,7 @@ _0215e818:
 	str r6, [sp, #8]
 	str r7, [sp, #0xc]
 	ldr r1, [sp, #0x20]
-	mov r0, fp
+	mov r0, r11
 	mov r2, #1
 	mov r3, sl
 	str r8, [sp, #0x10]
@@ -39303,7 +39303,7 @@ _0215e818:
 	str r7, [sp, #0xc]
 	ldr r1, [sp, #0x20]
 	ldr r2, [sp, #0x24]
-	mov r0, fp
+	mov r0, r11
 	mov r3, sl
 	str r8, [sp, #0x10]
 	bl func_ov61_0215e5a0
@@ -39317,7 +39317,7 @@ _0215e890:
 	str r6, [sp, #8]
 	str r7, [sp, #0xc]
 	ldr r1, [sp, #0x20]
-	mov r0, fp
+	mov r0, r11
 	mov r3, sl
 	mov r2, #0
 	str r8, [sp, #0x10]
@@ -39327,7 +39327,7 @@ _0215e890:
 	ldr r1, [r1]
 	blx r1
 	add sp, sp, #0x2c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0215e6c8
 _0215e8cc: .word data_ov61_0217f428
@@ -42768,15 +42768,15 @@ _021614e0: .word data_ov61_02181000
 	.global func_ov61_021614e4
 	arm_func_start func_ov61_021614e4
 func_ov61_021614e4: ; 0x021614e4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	ldr r7, [sp, #0x28]
 	ldr r6, [sp, #0x2c]
 	movs sb, r1
 	mov sl, r0
-	mov fp, r2
+	mov r11, r2
 	mov r8, r3
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	cmp sb, #1
 	mov r4, #0
 	mov r5, #1
@@ -42791,7 +42791,7 @@ _02161528:
 	add r0, r2, #1
 	str r0, [r6]
 	ldrb r1, [r7]
-	ldrb r0, [fp, r2]
+	ldrb r0, [r11, r2]
 	ldrb r1, [sl, r1]
 	add r0, r1, r0
 	strb r0, [r7]
@@ -42816,7 +42816,7 @@ _02161588:
 	cmp r0, sb
 	bhi _02161528
 	and r0, r0, #0xff
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	arm_func_end func_ov61_021614e4
 
 	.global func_ov61_02161598
@@ -44071,18 +44071,18 @@ _0216247c: .word data_ov61_02181010
 	.global func_ov61_02162480
 	arm_func_start func_ov61_02162480
 func_ov61_02162480: ; 0x02162480
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	mov sl, r0
 	add r0, r1, #1
 	mov r1, #0x5c
 	bl func_ov61_0216241c
 	movs r8, r0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	mov r4, #0
-	mov fp, #0x5c
+	mov r11, #0x5c
 	ldr r5, _021624fc ; =data_ov61_0217bf20
 	mov r7, r4
-	mov r6, fp
+	mov r6, r11
 _021624b0:
 	mov r0, r7
 	mov r1, r6
@@ -44099,11 +44099,11 @@ _021624b0:
 	bl func_ov61_0216218c
 _021624e4:
 	mov r0, r4
-	mov r1, fp
+	mov r1, r11
 	bl func_ov61_0216241c
 	movs r8, r0
 	bne _021624b0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02162480
 _021624fc: .word data_ov61_0217bf20
@@ -44111,11 +44111,11 @@ _021624fc: .word data_ov61_0217bf20
 	.global func_ov61_02162500
 	arm_func_start func_ov61_02162500
 func_ov61_02162500: ; 0x02162500
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x8c
 	mov sl, r1
 	ldrsb r1, [sl]
-	mov fp, r0
+	mov r11, r0
 	mov sb, r2
 	cmp r1, #0
 	beq _02162580
@@ -44125,7 +44125,7 @@ _02162520:
 	bl func_ov61_02163490
 	cmp r0, #0
 	addlt sp, sp, #0x8c
-	ldmltia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmltia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	mov r4, sl
 	sub sb, sb, r0
 	add sl, sl, r0
@@ -44134,12 +44134,12 @@ _02162520:
 	bl func_ov61_02163490
 	cmp r0, #0
 	addlt sp, sp, #0x8c
-	ldmltia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmltia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	mov r2, sl
 	mov r1, r4
 	add sl, sl, r0
 	sub sb, sb, r0
-	mov r0, fp
+	mov r0, r11
 	bl func_ov61_0216218c
 	ldrsb r0, [sl]
 	cmp r0, #0
@@ -44152,7 +44152,7 @@ _02162580:
 _02162590:
 	cmp sb, #2
 	addlt sp, sp, #0x8c
-	ldmltia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmltia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldrb r1, [sl]
 	ldrb r0, [sl, #1]
 	add r2, sp, #8
@@ -44178,10 +44178,10 @@ _021625e8:
 	bl func_ov61_02163490
 	cmp r0, #0
 	addlt sp, sp, #0x8c
-	ldmltia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmltia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	cmp r0, #0x64
 	addgt sp, sp, #0x8c
-	ldmgtia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmgtia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldrsb r1, [sl, r0]!
 	add r5, r5, #1
 	sub sb, sb, r0
@@ -44205,13 +44205,13 @@ _02162648:
 	bl func_ov61_02163490
 	movs r4, r0
 	addmi sp, sp, #0x8c
-	ldmmiia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmmiia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r1, _021626d4 ; =data_ov61_0217bf24
 	add r0, sp, #0xa
 	mov r2, r8
 	mov r3, r6
 	bl func_020459b8
-	mov r0, fp
+	mov r0, r11
 	add r1, sp, #0xa
 	mov r2, sl
 	bl func_ov61_0216218c
@@ -44236,7 +44236,7 @@ _021626b8:
 	cmp r0, #2
 	blt _02162590
 	add sp, sp, #0x8c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02162500
 _021626d4: .word data_ov61_0217bf24
@@ -44668,7 +44668,7 @@ func_ov61_02162ba0: ; 0x02162ba0
 	.global func_ov61_02162bc4
 	arm_func_start func_ov61_02162bc4
 func_ov61_02162bc4: ; 0x02162bc4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x108
 	ldr r8, [sp, #0x130]
 	mov sl, r0
@@ -44692,7 +44692,7 @@ _02162be8:
 	cmp r8, #0
 	ble _02162c70
 	ldr r4, _02162cec ; =data_ov61_0217e4e8
-	add fp, sp, #8
+	add r11, sp, #8
 _02162c24:
 	ldrb r0, [sb, r6]
 	ldr r7, [r4, r0, lsl #2]
@@ -44704,7 +44704,7 @@ _02162c24:
 	bge _02162c70
 	ldr r1, _02162cf0 ; =data_ov61_0217bf2c
 	mov r2, r7
-	add r0, fp, r5
+	add r0, r11, r5
 	bl func_020459b8
 	add r5, r5, r0
 	ldrb r1, [sb, r6]
@@ -44723,11 +44723,11 @@ _02162c70:
 	bl func_ov61_02163aac
 	cmp r0, #0
 	addne sp, sp, #0x108
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r1, [sp, #4]
 	cmp r1, #0
 	addne sp, sp, #0x108
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	mov r4, #0xa
 	b _02162cc0
 _02162cb0:
@@ -44742,11 +44742,11 @@ _02162cc0:
 	ldr r1, [sl, #0x10]
 	cmp r1, #0
 	addle sp, sp, #0x108
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	cmp r0, #0
 	beq _02162cb0
 	add sp, sp, #0x108
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02162bc4
 _02162cec: .word data_ov61_0217e4e8
@@ -45775,7 +45775,7 @@ func_ov61_021638f4: ; 0x021638f4
 	.global func_ov61_02163928
 	arm_func_start func_ov61_02163928
 func_ov61_02163928: ; 0x02163928
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	mov sl, r0
 	bl func_02045b48
 	ldr r5, _02163a10 ; =0x2c0b02c1
@@ -45789,7 +45789,7 @@ func_ov61_02163928: ; 0x02163928
 	add r0, r4, #0x21
 	mov r7, #1
 	strb r0, [sl, #0x74]
-	mov fp, r8
+	mov r11, r8
 	mov r6, r7
 	mov r4, r3
 _0216396c:
@@ -45800,7 +45800,7 @@ _0216396c:
 	eor r3, r7, r3
 	movlt r1, r6
 	and r3, r3, #1
-	movge r1, fp
+	movge r1, r11
 	cmp r0, #0x4f
 	movlt r2, #1
 	and r0, r0, #1
@@ -45836,7 +45836,7 @@ _02163a00:
 	add r7, r7, #1
 	cmp r7, #8
 	blt _0216396c
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02163928
 _02163a10: .word 0x2c0b02c1
@@ -45844,12 +45844,12 @@ _02163a10: .word 0x2c0b02c1
 	.global func_ov61_02163a14
 	arm_func_start func_ov61_02163a14
 func_ov61_02163a14: ; 0x02163a14
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	mov sl, r0
 	mov sb, r1
 	mov r8, r2
 	mov r7, #1
-	mov fp, #2
+	mov r11, #2
 	mov r5, #0
 _02163a30:
 	ldr r0, [sl, #0x4b0]
@@ -45868,7 +45868,7 @@ _02163a30:
 	mov r1, #0
 	mov r2, r1
 	mov r0, sl
-	mov r3, fp
+	mov r3, r11
 	str r2, [sp]
 	bl func_ov61_02163aac
 	movs r4, r0
@@ -45876,7 +45876,7 @@ _02163a30:
 	mov r0, sl
 	bl func_ov61_021635ec
 	mov r0, r4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02163a94:
 	cmp r7, #0
 	bge _02163a30
@@ -45884,7 +45884,7 @@ _02163a9c:
 	cmp r6, #0
 	movle r0, #3
 	movgt r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	arm_func_end func_ov61_02163a14
 
 	.global func_ov61_02163aac
@@ -46379,7 +46379,7 @@ _02164108:
 	.global func_ov61_0216411c
 	arm_func_start func_ov61_0216411c
 func_ov61_0216411c: ; 0x0216411c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x10
 	mov r8, r2
 	ldrb r2, [r8], #5
@@ -46459,7 +46459,7 @@ _0216422c:
 	cmp r4, #0
 	mov r5, #0
 	ble _02164344
-	add fp, sp, #0xa
+	add r11, sp, #0xa
 _02164254:
 	ldr r0, [sl, #8]
 	mov r1, r5
@@ -46484,8 +46484,8 @@ _0216429c:
 	ldrb r3, [r8]
 	ldrb r2, [r8, #1]
 	mov r0, sb
-	strb r3, [fp]
-	strb r2, [fp, #1]
+	strb r3, [r11]
+	strb r2, [r11, #1]
 	ldrh r3, [sp, #0xa]
 	ldr r1, [r1]
 	mov r2, r3, asr #0x8
@@ -46572,7 +46572,7 @@ _021643d8:
 	ldr r0, [sp, #4]
 	sub r0, r0, r7
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	arm_func_end func_ov61_0216411c
 
 	.global func_ov61_021643e8
@@ -46962,7 +46962,7 @@ _02164948: .word 0x000004af
 	.global func_ov61_0216494c
 	arm_func_start func_ov61_0216494c
 func_ov61_0216494c: ; 0x0216494c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #8
 	mov sl, r0
 	ldr r3, [sl, #8]
@@ -46982,17 +46982,17 @@ _02164978:
 	str r0, [sl, #8]
 	addeq sp, sp, #8
 	moveq r0, #5
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	cmp r7, #0
 	mov r6, #0
 	ble _02164a1c
-	add fp, sp, #0
+	add r11, sp, #0
 	mvn r4, #0
 _021649b0:
 	cmp r8, #2
 	addlt sp, sp, #8
 	movlt r0, #4
-	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r0, sb, #1
 	sub r1, r8, #1
 	bl func_ov61_02163490
@@ -47000,7 +47000,7 @@ _021649b0:
 	cmp r5, r4
 	addeq sp, sp, #8
 	moveq r0, #4
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldrb r2, [sb]
 	mov r0, sl
 	add r1, sb, #1
@@ -47008,7 +47008,7 @@ _021649b0:
 	bl func_ov61_021633a4
 	str r0, [sp]
 	ldr r0, [sl, #8]
-	mov r1, fp
+	mov r1, r11
 	bl func_ov61_02165ad8
 	add r0, r5, #1
 	add r6, r6, #1
@@ -47019,13 +47019,13 @@ _021649b0:
 _02164a1c:
 	mov r0, #0
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	arm_func_end func_ov61_0216494c
 
 	.global func_ov61_02164a28
 	arm_func_start func_ov61_02164a28
 func_ov61_02164a28: ; 0x02164a28
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x24
 	mov r8, r2
 	cmp r8, #2
@@ -47033,10 +47033,10 @@ func_ov61_02164a28: ; 0x02164a28
 	mov sb, r1
 	addlt sp, sp, #0x24
 	movlt r0, #4
-	ldmltia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmltia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldrb r0, [sb, #1]
 	sub r8, r8, #2
-	mov fp, #0
+	mov r11, #0
 	str r0, [sp, #0xc]
 	ldrb r0, [sb], #2
 	str r0, [sp, #0x14]
@@ -47054,13 +47054,13 @@ _02164a7c:
 	cmp r0, r4
 	addeq sp, sp, #0x24
 	moveq r0, #4
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	sub r3, r8, r0
 	cmp r3, #0xb
 	add r2, sb, r0
 	addlt sp, sp, #0x24
 	movlt r0, #4
-	ldmltia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmltia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldrb r1, [r2]
 	ldrb r0, [r2, #1]
 	sub r8, r3, #0xa
@@ -47104,7 +47104,7 @@ _02164a7c:
 	cmp r5, r4
 	addeq sp, sp, #0x24
 	moveq r0, #4
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r1, [sp, #0x1c]
 	mov r0, sl
 	stmia sp, {r1, sb}
@@ -47116,8 +47116,8 @@ _02164a7c:
 	ldr ip, [sl, #0x490]
 	blx ip
 	ldr r0, [sp, #0xc]
-	add fp, fp, #1
-	cmp fp, r0
+	add r11, r11, #1
+	cmp r11, r0
 	add sb, sb, r5
 	sub r8, r8, r5
 	blt _02164a7c
@@ -47138,13 +47138,13 @@ _02164ba4:
 _02164bd8:
 	mov r0, #0
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	arm_func_end func_ov61_02164a28
 
 	.global func_ov61_02164be4
 	arm_func_start func_ov61_02164be4
 func_ov61_02164be4: ; 0x02164be4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x54
 	mov r8, r2
 	cmp r8, #0xb
@@ -47152,7 +47152,7 @@ func_ov61_02164be4: ; 0x02164be4
 	mov sb, r1
 	addlt sp, sp, #0x54
 	movlt r0, #4
-	ldmltia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmltia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldrb r2, [sb]
 	ldrb r1, [sb, #1]
 	add r3, sp, #0xc
@@ -47175,13 +47175,13 @@ func_ov61_02164be4: ; 0x02164be4
 	cmp r1, r0
 	addeq sp, sp, #0x54
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	mov r0, sl
 	bl func_ov61_021632b8
 	ldrb r2, [sb, #6]
 	ldrb r1, [sb, #7]
 	add r3, sp, #0x10
-	mov fp, r0
+	mov r11, r0
 	strb r2, [r3]
 	strb r1, [r3, #1]
 	ldrb r1, [sb, #8]
@@ -47217,7 +47217,7 @@ _02164ce4:
 	cmp r0, r4
 	addeq sp, sp, #0x54
 	moveq r0, #4
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	str sb, [r5, r7, lsl #2]
 	add sb, sb, r0
 	sub r8, r8, r0
@@ -47231,19 +47231,19 @@ _02164d24:
 	cmp r4, #0
 	addeq sp, sp, #0x54
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r1, sp, #0x14
 	str r1, [sp]
 	ldr r2, [sl, #0x494]
 	mov r0, sl
 	str r2, [sp, #4]
 	ldr r2, [sp, #0x10]
-	mov r1, fp
+	mov r1, r11
 	mov r3, r7
 	blx r4
 	mov r0, #0
 	add sp, sp, #0x54
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	arm_func_end func_ov61_02164be4
 
 	.global func_ov61_02164d68
@@ -47359,7 +47359,7 @@ _02164ec8:
 	.global func_ov61_02164eec
 	arm_func_start func_ov61_02164eec
 func_ov61_02164eec: ; 0x02164eec
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	mov sb, r0
 	ldr r0, [sb, #0x80]
 	mov r8, #0
@@ -47368,7 +47368,7 @@ func_ov61_02164eec: ; 0x02164eec
 	ldr r5, _021650a0 ; =data_ov61_0217c054
 	ldr r4, _021650a4 ; =data_ov61_0217bfcc
 	ldr sl, _021650a8 ; =data_ov61_0217bf78
-	ldr fp, _021650ac ; =0x000005b4
+	ldr r11, _021650ac ; =0x000005b4
 	mov r6, r8
 	add r7, sp, #0
 _02164f1c:
@@ -47391,7 +47391,7 @@ _02164f1c:
 	ldr r0, [sb, #0x80]
 	cmp r0, r2
 	movlt r0, #0
-	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r1, [sb, #0x7c]
 	ldrsb r0, [r1, #2]
 	cmp r0, #6
@@ -47426,7 +47426,7 @@ _02164fcc:
 	cmp r0, #0
 	bgt _0216502c
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02164fe8:
 	mov r0, sb
 	add r1, r1, #3
@@ -47456,7 +47456,7 @@ _0216502c:
 	mov r0, r5
 	mov r1, r4
 	mov r2, sl
-	mov r3, fp
+	mov r3, r11
 	bl func_02042f80
 _02165054:
 	ldr r2, [sb, #0x80]
@@ -47480,7 +47480,7 @@ _02165088:
 	bl func_ov61_021635ec
 _02165098:
 	mov r0, r8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02164eec
 _021650a0: .word data_ov61_0217c054
@@ -47560,7 +47560,7 @@ _02165190:
 	arm_func_start func_ov61_02165198
 func_ov61_02165198: ; 0x02165198
 	stmdb sp!, {r0, r1, r2, r3}
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x18
 	mov r5, r0
 	ldr r1, [r5]
@@ -47577,7 +47577,7 @@ _021651cc:
 	cmp r0, #1
 	addeq sp, sp, #0x18
 	moveq r0, #3
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	addeq sp, sp, #0x10
 	bxeq lr
 	ldr r0, [sp, #0x50]
@@ -47597,7 +47597,7 @@ _021651cc:
 	add r1, sp, #6
 	ldrb r2, [r2, #1]
 	strb r3, [r1]
-	mov fp, #2
+	mov r11, #2
 	strb r2, [r1, #1]
 	ldrb sb, [r6]
 	add sl, sp, #9
@@ -47609,7 +47609,7 @@ _021651cc:
 	add lr, sp, #0xd
 	mov r0, r5
 	mov r2, #9
-	strb fp, [sp, #8]
+	strb r11, [sp, #8]
 	strb sb, [sl]
 	strb r8, [sl, #1]
 	strb r7, [sl, #2]
@@ -47619,7 +47619,7 @@ _021651cc:
 	bl func_ov61_02163a14
 	cmp r0, #0
 	addne sp, sp, #0x18
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	addne sp, sp, #0x10
 	bxne lr
 	ldr r0, [r5, #0x4b0]
@@ -47631,7 +47631,7 @@ _021651cc:
 	movlt r0, #3
 	movge r0, #0
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	add sp, sp, #0x10
 	bx lr
 	arm_func_end func_ov61_02165198
@@ -47640,7 +47640,7 @@ _021651cc:
 	arm_func_start func_ov61_021652c0
 func_ov61_021652c0: ; 0x021652c0
 	stmdb sp!, {r0, r1, r2, r3}
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x10
 	ldr r5, [sp, #0x44]
 	mov r7, #0xfd
@@ -47656,7 +47656,7 @@ func_ov61_021652c0: ; 0x021652c0
 	mov r5, #0x1e
 	mov r4, #0x66
 	mov lr, #0x6a
-	mov fp, #0xb2
+	mov r11, #0xb2
 	strb r4, [sp, #7]
 	and r8, r8, #0xff000000
 	orr r3, r3, sb
@@ -47673,7 +47673,7 @@ func_ov61_021652c0: ; 0x021652c0
 	strb r6, [sp, #5]
 	strb r5, [sp, #6]
 	strb lr, [sp, #8]
-	strb fp, [sp, #9]
+	strb r11, [sp, #9]
 	strb sl, [ip]
 	strb sb, [ip, #1]
 	strb r8, [ip, #2]
@@ -47682,7 +47682,7 @@ func_ov61_021652c0: ; 0x021652c0
 	str r4, [sp]
 	bl func_ov61_02165198
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	add sp, sp, #0x10
 	bx lr
 	arm_func_end func_ov61_021652c0
@@ -47690,7 +47690,7 @@ func_ov61_021652c0: ; 0x021652c0
 	.global func_ov61_02165378
 	arm_func_start func_ov61_02165378
 func_ov61_02165378: ; 0x02165378
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x5f0
 	mov r1, #8
 	mov sl, r0
@@ -47703,7 +47703,7 @@ func_ov61_02165378: ; 0x02165378
 	add sb, sp, #0xc
 	add r8, sp, #8
 	add r7, sp, #0x14
-	mov fp, #0
+	mov r11, #0
 	mvn r4, #0
 _021653b4:
 	str sb, [sp]
@@ -47711,7 +47711,7 @@ _021653b4:
 	ldr r0, [sl, #0x4b0]
 	mov r1, r7
 	mov r2, r6
-	mov r3, fp
+	mov r3, r11
 	bl func_ov61_02166bc0
 	cmp r0, r4
 	beq _02165430
@@ -47730,7 +47730,7 @@ _021653b4:
 	cmp r0, #0
 	addne sp, sp, #0x5f0
 	movne r0, #5
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	mov r0, r5
 	mov r1, #0x11
 	bl func_ov61_0216282c
@@ -47764,7 +47764,7 @@ _02165440:
 _02165488:
 	mov r0, #0
 	add sp, sp, #0x5f0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02165378
 _02165494: .word 0x000005db
@@ -48679,10 +48679,10 @@ _02165fd0:
 	.global func_ov61_02165fd8
 	arm_func_start func_ov61_02165fd8
 func_ov61_02165fd8: ; 0x02165fd8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	ldr r7, [sp, #0x2c]
 	mov r4, #0
-	mov fp, r0
+	mov r11, r0
 	mov sl, r1
 	mov sb, r3
 	str r4, [r7]
@@ -48693,7 +48693,7 @@ _02166000:
 	add r0, r4, r5
 	mov r6, r0, asr #0x1
 	mla r0, r6, sb, sl
-	mov r1, fp
+	mov r1, r11
 	blx r8
 	cmp r0, #0
 	moveq r1, #1
@@ -48705,7 +48705,7 @@ _02166000:
 	ble _02166000
 _02166034:
 	mla r0, r4, sb, sl
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	arm_func_end func_ov61_02165fd8
 
 	.global func_ov61_0216603c
@@ -51136,7 +51136,7 @@ _02167e3c: .word func_ov61_02167cfc
 	.global func_ov61_02167e40
 	arm_func_start func_ov61_02167e40
 func_ov61_02167e40: ; 0x02167e40
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x14
 	mov r1, #0
 	mov r4, r0
@@ -51157,7 +51157,7 @@ _02167e58:
 	bl func_ov61_021698fc
 	cmp r0, #0
 	addne sp, sp, #0x14
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r1, sp, #8
 	ldr r0, _0216812c ; =data_ov61_0217c460
 	str r1, [sp]
@@ -51171,7 +51171,7 @@ _02167e58:
 	beq _02167ef8
 	cmp r0, #3
 	addne sp, sp, #0x14
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r2, _02168130 ; =data_ov61_0217c464
 	mov r0, r4
 	mov r1, #5
@@ -51182,7 +51182,7 @@ _02167e58:
 	bl func_ov61_02169c10
 	add sp, sp, #0x14
 	mov r0, #3
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02167ef8:
 	ldr r0, [sl, #0x1dc]
 	ldr r1, _02168134 ; =data_ov61_0217c490
@@ -51191,7 +51191,7 @@ _02167ef8:
 	beq _021680c8
 	ldr r6, _02168138 ; =data_ov61_0217c4b4
 	ldr r8, _0216813c ; =data_ov61_0217c498
-	add fp, sp, #0x10
+	add r11, sp, #0x10
 	mov r7, #0x800
 	mov sb, #0
 _02167f20:
@@ -51221,7 +51221,7 @@ _02167f20:
 	bl func_ov61_02171b10
 	add sp, sp, #0x14
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02167f8c:
 	str r0, [sl, #0x1ec]
 _02167f90:
@@ -51249,7 +51249,7 @@ _02167f90:
 	bl func_0204902c
 	mov r5, r0
 	mov r0, r4
-	mov r1, fp
+	mov r1, r11
 	mov r2, r5
 	bl func_ov61_0216d9a0
 	cmp r0, #0
@@ -51267,7 +51267,7 @@ _02168018:
 	cmp r0, #0
 	beq _021680b4
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02168038:
 	mov r1, r5
 	mov r0, r4
@@ -51276,7 +51276,7 @@ _02168038:
 	cmp r0, #0
 	addne sp, sp, #0x14
 	movne r0, #4
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r5, [sl, #0x1ec]
 	ldr r1, _02168148 ; =data_ov61_0217c4e4
 	mov r0, r5
@@ -51290,7 +51290,7 @@ _02168038:
 	cmp r0, #0
 	beq _021680b4
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02168090:
 	ldr r1, _0216814c ; =data_ov61_0217c4ec
 	mov r0, r5
@@ -51321,7 +51321,7 @@ _021680c8:
 	bl func_ov61_02169c10
 	add sp, sp, #0x14
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02168100:
 	mov r0, r4
 	bl func_ov61_0216d9ec
@@ -51334,7 +51334,7 @@ _02168118:
 	bne _02167e58
 	mov r0, #0
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02167e40
 _0216812c: .word data_ov61_0217c460
@@ -51352,7 +51352,7 @@ _02168154: .word data_ov61_0217c524
 	.global func_ov61_02168158
 	arm_func_start func_ov61_02168158
 func_ov61_02168158: ; 0x02168158
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	mov sl, r0
 	ldr r6, [sl]
 	mov sb, r1
@@ -51371,7 +51371,7 @@ _0216818c:
 	bne _0216822c
 	mov r4, #0
 	mov r5, #1
-	mov fp, #0xa
+	mov r11, #0xa
 _021681a4:
 	mov r0, sl
 	bl func_ov61_0216b39c
@@ -51388,7 +51388,7 @@ _021681cc:
 _021681d0:
 	cmp r8, #0
 	beq _021681e0
-	mov r0, fp
+	mov r0, r11
 	bl func_ov61_02166640
 _021681e0:
 	cmp r8, #0
@@ -51460,7 +51460,7 @@ _021682c4:
 	mov r1, sb
 	bl func_ov61_02169fa0
 	cmp r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, [r6, #0x41c]
 	cmp r0, #0
 	beq _021682f0
@@ -51469,7 +51469,7 @@ _021682c4:
 	bl func_ov61_0216b504
 _021682f0:
 	mov r0, r7
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02168158
 _021682f8: .word data_ov61_0217c54c
@@ -51529,7 +51529,7 @@ _021683b0: .word data_ov61_0217c690
 	.global func_ov61_021683b4
 	arm_func_start func_ov61_021683b4
 func_ov61_021683b4: ; 0x021683b4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x138
 	sub sp, sp, #0x1000
 	mov r7, r1
@@ -51553,7 +51553,7 @@ func_ov61_021683b4: ; 0x021683b4
 	add sp, sp, #0x138
 	add sp, sp, #0x1000
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02168418:
 	add r0, sp, #0x138
 	bl func_0204902c
@@ -51576,7 +51576,7 @@ _02168418:
 	add sp, sp, #0x138
 	add sp, sp, #0x1000
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02168470:
 	add r0, sp, #0x138
 	bl func_0204902c
@@ -51633,7 +51633,7 @@ _021684fc:
 	add sp, sp, #0x138
 	add sp, sp, #0x1000
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02168540:
 	ldr r1, _02168d3c ; =data_ov61_0217c6ec
 	add r2, sp, #0x138
@@ -51653,7 +51653,7 @@ _02168540:
 	add sp, sp, #0x138
 	add sp, sp, #0x1000
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0216858c:
 	add r0, sp, #0x138
 	bl strlen
@@ -51668,7 +51668,7 @@ _0216858c:
 	add sp, sp, #0x138
 	add sp, sp, #0x1000
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _021685c4:
 	add r1, sp, #0x138
 	bl strcpy
@@ -51686,7 +51686,7 @@ _021685c4:
 	beq _02168d18
 	add sp, sp, #0x138
 	add sp, sp, #0x1000
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02168608:
 	mov r0, sl
 	mov r1, r6
@@ -51699,7 +51699,7 @@ _02168608:
 	add sp, sp, #0x138
 	add sp, sp, #0x1000
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02168638:
 	ldr r1, _02168d3c ; =data_ov61_0217c6ec
 	add r2, sp, #0x138
@@ -51719,7 +51719,7 @@ _02168638:
 	add sp, sp, #0x138
 	add sp, sp, #0x1000
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02168684:
 	ldr r1, _02168d40 ; =data_ov61_0217c6f4
 	add r0, sp, #0x138
@@ -51737,7 +51737,7 @@ _02168684:
 	add sp, sp, #0x138
 	add sp, sp, #0x1000
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _021686c8:
 	mov r1, #0
 	add r0, r4, #8
@@ -51756,7 +51756,7 @@ _021686c8:
 	add sp, sp, #0x138
 	add sp, sp, #0x1000
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02168710:
 	ldr r0, [r5, #0x10]
 	bl func_ov61_0213e13c
@@ -51784,7 +51784,7 @@ _02168710:
 	add sp, sp, #0x138
 	add sp, sp, #0x1000
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0216877c:
 	ldr r2, _02168d48 ; =0x00000401
 	add r1, sp, #0x138
@@ -51804,7 +51804,7 @@ _0216877c:
 	beq _02168d18
 	add sp, sp, #0x138
 	add sp, sp, #0x1000
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _021687c8:
 	mov r0, sl
 	mov r1, r6
@@ -51817,7 +51817,7 @@ _021687c8:
 	add sp, sp, #0x138
 	add sp, sp, #0x1000
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _021687f8:
 	ldr r0, [r4, #8]
 	cmp r0, #0
@@ -51833,7 +51833,7 @@ _021687f8:
 	add sp, sp, #0x138
 	add sp, sp, #0x1000
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02168834:
 	mov r2, #6
 	mov r1, #0
@@ -51870,7 +51870,7 @@ _0216886c:
 	add sp, sp, #0x138
 	add sp, sp, #0x1000
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _021688bc:
 	ldr r1, _02168d4c ; =data_ov61_0217c700
 	add r0, sp, #0x138
@@ -51890,7 +51890,7 @@ _021688bc:
 	add sp, sp, #0x138
 	add sp, sp, #0x1000
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02168908:
 	add r0, sp, #0x28
 	bl func_0204902c
@@ -51918,7 +51918,7 @@ _02168908:
 	add sp, sp, #0x138
 	add sp, sp, #0x1000
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02168974:
 	ldr r0, [r7, #0xc]
 	bl func_ov61_0213e13c
@@ -51943,7 +51943,7 @@ _02168974:
 	add sp, sp, #0x138
 	add sp, sp, #0x1000
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _021689d4:
 	ldr r1, _02168d58 ; =data_ov61_0217c714
 	add r0, sp, #0x138
@@ -51961,10 +51961,10 @@ _021689d4:
 	mov r4, r0
 	add r0, sp, #0x28
 	bl func_0204902c
-	mov fp, r0
+	mov r11, r0
 	add r0, sp, #0x28
 	bl func_0204902c
-	mov r1, fp, lsr #0x18
+	mov r1, r11, lsr #0x18
 	mov r0, r0, lsr #0x8
 	mov r2, r4, lsl #0x8
 	and r1, r1, #0xff
@@ -52014,7 +52014,7 @@ _02168a9c:
 	add sp, sp, #0x138
 	add sp, sp, #0x1000
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02168ae4:
 	str r6, [r3]
 	ldr r0, [r7]
@@ -52032,7 +52032,7 @@ _02168ae4:
 	beq _02168d18
 	add sp, sp, #0x138
 	add sp, sp, #0x1000
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02168b28:
 	ldr r1, _02168d3c ; =data_ov61_0217c6ec
 	add r2, sp, #0x138
@@ -52052,7 +52052,7 @@ _02168b28:
 	add sp, sp, #0x138
 	add sp, sp, #0x1000
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02168b74:
 	ldr r1, _02168d5c ; =data_ov61_0217c71c
 	add r0, sp, #0x138
@@ -52070,7 +52070,7 @@ _02168b74:
 	add sp, sp, #0x138
 	add sp, sp, #0x1000
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02168bb8:
 	ldrsb r1, [r0, #3]
 	cmp r1, #0
@@ -52086,7 +52086,7 @@ _02168bb8:
 	add sp, sp, #0x138
 	add sp, sp, #0x1000
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02168bf4:
 	add r0, r0, #3
 	bl func_0204902c
@@ -52119,7 +52119,7 @@ _02168c2c:
 	add sp, sp, #0x138
 	add sp, sp, #0x1000
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02168c70:
 	str r6, [r5]
 	add r1, sp, #0x38
@@ -52138,7 +52138,7 @@ _02168c70:
 	beq _02168d18
 	add sp, sp, #0x138
 	add sp, sp, #0x1000
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02168cb8:
 	ldr r1, _02168d3c ; =data_ov61_0217c6ec
 	add r2, sp, #0x138
@@ -52158,7 +52158,7 @@ _02168cb8:
 	add sp, sp, #0x138
 	add sp, sp, #0x1000
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02168d04:
 	ldr r3, _02168d64 ; =data_ov61_0217c724
 	mov r0, sl
@@ -52169,7 +52169,7 @@ _02168d18:
 	mov r0, #0
 	add sp, sp, #0x138
 	add sp, sp, #0x1000
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_021683b4
 _02168d28: .word data_ov61_0217c698
@@ -52805,7 +52805,7 @@ _021695a0: .word data_ov61_0217c8f0
 	.global func_ov61_021695a4
 	arm_func_start func_ov61_021695a4
 func_ov61_021695a4: ; 0x021695a4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x14
 	mov sb, r1
 	ldr r1, [sb, #0x28]
@@ -52824,7 +52824,7 @@ _021695dc:
 	mov r6, #0
 	addeq sp, sp, #0x14
 	moveq r0, r6
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r1, [sb, #0x30]
 	ldr r0, [sb, #0x34]
 	subs r0, r1, r0
@@ -52833,12 +52833,12 @@ _021695dc:
 	bl func_ov61_02165a68
 	cmp r0, #0
 	bne _02169660
-	ldr fp, _021696a0 ; =data_ov61_0217c8f0
+	ldr r11, _021696a0 ; =data_ov61_0217c8f0
 	add r5, sp, #0x10
 	add r4, sp, #0xc
 _0216961c:
 	str r5, [sp]
-	stmib sp, {r4, fp}
+	stmib sp, {r4, r11}
 	ldr r1, [sb, #8]
 	mov r0, sl
 	mov r3, r7
@@ -52846,7 +52846,7 @@ _0216961c:
 	bl func_ov61_021693d4
 	cmp r0, #0
 	addne sp, sp, #0x14
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, [sp, #0xc]
 	cmp r0, #0
 	subne r7, r7, r0
@@ -52864,11 +52864,11 @@ _02169660:
 	bl func_ov61_02169260
 	cmp r0, #0
 	addne sp, sp, #0x14
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02169688:
 	mov r0, #0
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_021695a4
 _02169694: .word data_ov61_0217c8cc
@@ -52896,7 +52896,7 @@ func_ov61_021696a4: ; 0x021696a4
 	.global func_ov61_021696d4
 	arm_func_start func_ov61_021696d4
 func_ov61_021696d4: ; 0x021696d4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x18
 	str r0, [sp]
 	ldr r0, [sp, #0x44]
@@ -52950,7 +52950,7 @@ _02169774:
 	mov sb, #0
 	str r0, [sp, #0x10]
 	sub r0, r4, #5
-	mov fp, sb
+	mov r11, sb
 	str r0, [sp, #0xc]
 _021697a4:
 	add r0, r6, #0x800
@@ -52967,7 +52967,7 @@ _021697a4:
 	bl func_ov61_02171b10
 	add sp, sp, #0x18
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _021697e0:
 	mov r0, sl
 	add r1, r5, r6
@@ -52991,7 +52991,7 @@ _021697e0:
 	bl func_ov61_02171b10
 	add sp, sp, #0x18
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0216983c:
 	cmp r8, #0
 	addne r6, r6, r8
@@ -53000,14 +53000,14 @@ _0216983c:
 	ldr r0, [sp]
 	ldr r1, _021698f4 ; =data_ov61_0217c974
 	ldr r2, [sp, #0x44]
-	mov fp, #1
+	mov r11, #1
 	bl func_ov61_0217163c
 _02169860:
 	mov r0, #0
 	cmp r8, r4
 	strb r0, [r5, r6]
 	beq _02169880
-	cmp fp, #0
+	cmp r11, #0
 	bne _02169880
 	cmp sb, #0x20000
 	blt _021697a4
@@ -53027,10 +53027,10 @@ _0216989c:
 	str r7, [r0, #4]
 	ldr r0, [sp, #8]
 	str sb, [r0]
-	str fp, [r1]
+	str r11, [r1]
 	mov r0, #0
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_021696d4
 _021698c8: .word data_ov61_0217c8f4
@@ -53050,7 +53050,7 @@ _021698f8: .word data_ov61_0217c998
 	.global func_ov61_021698fc
 	arm_func_start func_ov61_021698fc
 func_ov61_021698fc: ; 0x021698fc
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x1c
 	mov sl, r0
 	str r2, [sp, #0xc]
@@ -53067,13 +53067,13 @@ func_ov61_021698fc: ; 0x021698fc
 _02169934:
 	ldr r0, [sp, #0xc]
 	mov r4, #0
-	ldr fp, [r0, #8]
+	ldr r11, [r0, #8]
 	ldr r7, [r0, #0xc]
 	ldr r6, [r0]
-	subs r5, fp, r7
+	subs r5, r11, r7
 	addeq sp, sp, #0x1c
 	moveq r0, r4
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02169958:
 	add r0, sp, #0x18
 	str r0, [sp]
@@ -53088,7 +53088,7 @@ _02169958:
 	bl func_ov61_021693d4
 	cmp r0, #0
 	addne sp, sp, #0x1c
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, [sp, #0x14]
 	cmp r0, #0
 	subne r5, r5, r0
@@ -53105,12 +53105,12 @@ _02169958:
 	add r1, r6, r4
 	add r2, r5, #1
 	bl func_020435b4
-	sub fp, fp, r4
+	sub r11, r11, r4
 	b _021699dc
 _021699d8:
 	add r7, r7, r4
 _021699dc:
-	cmp fp, #0
+	cmp r11, #0
 	bge _021699f8
 	ldr r0, _02169a68 ; =data_ov61_0217c9ac
 	ldr r1, _02169a5c ; =data_ov61_0217c840
@@ -53126,7 +53126,7 @@ _021699f8:
 	ldr r3, _02169a74 ; =0x000001df
 	bl func_02042f80
 _02169a14:
-	cmp r7, fp
+	cmp r7, r11
 	ble _02169a30
 	ldr r0, _02169a78 ; =data_ov61_0217c9c4
 	ldr r1, _02169a5c ; =data_ov61_0217c840
@@ -53135,7 +53135,7 @@ _02169a14:
 	bl func_02042f80
 _02169a30:
 	ldr r0, [sp, #0xc]
-	str fp, [r0, #8]
+	str r11, [r0, #8]
 	str r7, [r0, #0xc]
 	ldr r0, [sp, #0x10]
 	cmp r0, #0
@@ -53143,7 +53143,7 @@ _02169a30:
 	strne r1, [r0]
 	mov r0, #0
 	add sp, sp, #0x1c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_021698fc
 _02169a58: .word data_ov61_0217c828
@@ -54290,7 +54290,7 @@ _0216aa48: .word data_ov61_0217cdf0
 	.global func_ov61_0216aa4c
 	arm_func_start func_ov61_0216aa4c
 func_ov61_0216aa4c: ; 0x0216aa4c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0xe8
 	mov sl, r0
 	ldr r5, [sl]
@@ -54306,10 +54306,10 @@ func_ov61_0216aa4c: ; 0x0216aa4c
 	bls _0216aac0
 	add r8, sp, #0x2d
 	mov r4, r6
-	mov fp, #0xff
+	mov r11, #0xff
 _0216aa90:
 	mov r0, r4
-	mov r1, fp
+	mov r1, r11
 	bl func_ov61_02166ddc
 	add r1, r5, r6
 	add r1, r1, #0x100
@@ -54403,10 +54403,10 @@ _0216aac0:
 	mov r8, r4
 	bls _0216ac3c
 	add r7, sp, #0xa6
-	mov fp, #0xff
+	mov r11, #0xff
 _0216ac0c:
 	mov r0, r4
-	mov r1, fp
+	mov r1, r11
 	bl func_ov61_02166ddc
 	add r1, sb, r8
 	add r1, r1, #0x200
@@ -54444,7 +54444,7 @@ _0216ac78:
 	bl func_ov61_0216936c
 	mov r0, #0
 	add sp, sp, #0xe8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0216aa4c
 _0216aca4: .word 0x79707367
@@ -55456,11 +55456,11 @@ _0216ba40:
 	.global func_ov61_0216bacc
 	arm_func_start func_ov61_0216bacc
 func_ov61_0216bacc: ; 0x0216bacc
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x268
 	mov r4, r2
 	mov sl, r0
-	mov fp, r1
+	mov r11, r1
 	mov r1, r4
 	mov r2, #1
 	ldr r6, [sl]
@@ -55468,7 +55468,7 @@ func_ov61_0216bacc: ; 0x0216bacc
 	cmp r0, #0
 	addne sp, sp, #0x268
 	movne r0, #4
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r1, _0216c254 ; =data_ov61_0217cfa4
 	mov r0, r4
 	mov r2, #4
@@ -55485,7 +55485,7 @@ func_ov61_0216bacc: ; 0x0216bacc
 	bl func_ov61_02169c10
 	add sp, sp, #0x268
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0216bb44:
 	ldr r1, _0216c25c ; =data_ov61_0217cfdc
 	add r2, sp, #0xec
@@ -55504,7 +55504,7 @@ _0216bb44:
 	bl func_ov61_02169c10
 	add sp, sp, #0x268
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0216bb8c:
 	add r0, sp, #0xec
 	bl func_0204902c
@@ -55690,7 +55690,7 @@ _0216be28:
 	bl func_ov61_0216b82c
 	cmp r0, #0
 	addne sp, sp, #0x268
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0216be58:
 	ldr r1, _0216c2a4 ; =data_ov61_0217d088
 	add r2, sp, #0xec
@@ -55868,7 +55868,7 @@ _0216c0a8:
 	bl func_ov61_02169c10
 	add sp, sp, #0x268
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0216c0f0:
 	ldr r7, [r6, #0x434]
 	ldr r8, [r6, #0x100]
@@ -55929,8 +55929,8 @@ _0216c1a4:
 	mov r0, sl
 	bl func_ov61_0216d30c
 _0216c1c0:
-	ldr r1, [fp, #0xc]
-	ldr r0, [fp, #0x10]
+	ldr r1, [r11, #0xc]
+	ldr r0, [r11, #0x10]
 	str r1, [sp, #8]
 	str r0, [sp, #0xc]
 	cmp r1, #0
@@ -55944,14 +55944,14 @@ _0216c1c0:
 	bl func_ov61_02171b10
 	add sp, sp, #0x268
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0216c200:
 	add r0, sp, #0x178
 	mov r1, r4
 	bl func_ov61_0216b8d4
 	mov r2, #0
 	stmia r4, {r2, sb}
-	str fp, [sp]
+	str r11, [sp]
 	add r1, sp, #8
 	str r2, [sp, #4]
 	mov r0, sl
@@ -55960,14 +55960,14 @@ _0216c200:
 	bl func_ov61_02169d04
 	cmp r0, #0
 	addne sp, sp, #0x268
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0216c23c:
 	mov r0, sl
-	mov r1, fp
+	mov r1, r11
 	bl func_ov61_0216d950
 	mov r0, #0
 	add sp, sp, #0x268
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0216bacc
 _0216c254: .word data_ov61_0217cfa4
@@ -58143,7 +58143,7 @@ _0216e080: .word data_ov61_0217d4ac
 	.global func_ov61_0216e084
 	arm_func_start func_ov61_0216e084
 func_ov61_0216e084: ; 0x0216e084
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0xc
 	mov sb, r1
 	ldr r1, [sb, #0x30]
@@ -58151,15 +58151,15 @@ func_ov61_0216e084: ; 0x0216e084
 	cmp r1, #0
 	addne sp, sp, #0xc
 	movne r0, #0
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, [sb, #0x38]
 	bl func_ov61_02165a68
 	cmp r0, #0
 	beq _0216e148
-	mov fp, #0
+	mov r11, #0
 	ldr r5, _0216e154 ; =data_ov61_0217d47c
-	mov r8, fp
-	mov r6, fp
+	mov r8, r11
+	mov r6, r11
 	add r4, sp, #8
 _0216e0cc:
 	ldr r0, [sb, #0x38]
@@ -58181,14 +58181,14 @@ _0216e0cc:
 	str r0, [sb]
 	add sp, sp, #0xc
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0216e11c:
 	ldr r1, [r7, #0xc]
 	ldr r0, [r7, #8]
 	cmp r1, r0
 	bne _0216e148
 	ldr r0, [sb, #0x38]
-	mov r1, fp
+	mov r1, r11
 	bl func_ov61_02165cec
 	ldr r0, [sb, #0x38]
 	bl func_ov61_02165a68
@@ -58197,7 +58197,7 @@ _0216e11c:
 _0216e148:
 	mov r0, #0
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0216e084
 _0216e154: .word data_ov61_0217d47c
@@ -58205,7 +58205,7 @@ _0216e154: .word data_ov61_0217d47c
 	.global func_ov61_0216e158
 	arm_func_start func_ov61_0216e158
 func_ov61_0216e158: ; 0x0216e158
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x24
 	mov r8, r1
 	ldr r1, [r8, #0x30]
@@ -58229,7 +58229,7 @@ func_ov61_0216e158: ; 0x0216e158
 	str r0, [r8]
 	add sp, sp, #0x24
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0216e1bc:
 	ldr r0, [r8, #0x30]
 	cmp r0, #0
@@ -58239,12 +58239,12 @@ _0216e1bc:
 	bl func_ov61_0216e084
 	cmp r0, #0
 	addne sp, sp, #0x24
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, [r8]
 	cmp r0, #0x6a
 	addeq sp, sp, #0x24
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0216e1f4:
 	add r1, sp, #0x1c
 	ldr r0, _0216e3cc ; =data_ov61_0217d47c
@@ -58261,7 +58261,7 @@ _0216e1f4:
 	str r0, [r8]
 	add sp, sp, #0x24
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0216e234:
 	ldr r0, [sp, #0x20]
 	cmp r0, #0
@@ -58273,7 +58273,7 @@ _0216e234:
 _0216e250:
 	mov r4, #0
 	mov sl, #2
-	add fp, sp, #0x14
+	add r11, sp, #0x14
 	add r6, sp, #8
 _0216e260:
 	mov r0, sb
@@ -58284,7 +58284,7 @@ _0216e260:
 	bl func_ov61_02169a7c
 	cmp r0, #0
 	addne sp, sp, #0x24
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r1, [sp, #0x10]
 	cmp r1, #0
 	beq _0216e3a4
@@ -58326,7 +58326,7 @@ _0216e2e0:
 	bl func_ov61_02171b10
 	add sp, sp, #0x24
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0216e320:
 	ldr r0, [r8, #0xc]
 	str r0, [r5]
@@ -58339,12 +58339,12 @@ _0216e320:
 	mov r3, r5
 	mov r0, sb
 	stmia sp, {r4, sl}
-	ldmia fp, {r1, r2}
+	ldmia r11, {r1, r2}
 	bl func_ov61_02169d04
 	cmp r0, #0
 	beq _0216e398
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0216e364:
 	ldr r1, [r8, #0xc]
 	ldr r3, _0216e3d4 ; =data_ov61_0217d51c
@@ -58374,7 +58374,7 @@ _0216e3a4:
 	strne r0, [r8]
 	mov r0, #0
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0216e158
 _0216e3cc: .word data_ov61_0217d47c
@@ -59890,7 +59890,7 @@ _0216f798: .word data_ov61_0217d848
 	.global func_ov61_0216f79c
 	arm_func_start func_ov61_0216f79c
 func_ov61_0216f79c: ; 0x0216f79c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x490
 	mov sl, r0
 	ldr r0, [sl]
@@ -59914,7 +59914,7 @@ _0216f7cc:
 	bl func_ov61_021698fc
 	cmp r0, #0
 	addne sp, sp, #0x490
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, [sp, #0x1c]
 	ldr r0, [r0, #0x14]
 	cmp r0, #1
@@ -59925,7 +59925,7 @@ _0216f7cc:
 	bl func_ov61_02171828
 	cmp r0, #0
 	addne sp, sp, #0x490
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, [sp, #0x7c]
 	cmp r0, #4
 	bne _0216f860
@@ -59939,7 +59939,7 @@ _0216f7cc:
 	bl func_ov61_02169c10
 	add sp, sp, #0x490
 	mov r0, #4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0216f860:
 	cmp r0, #3
 	bne _021711ec
@@ -60344,7 +60344,7 @@ _0216fe30:
 	beq _0216fe9c
 	cmp r0, #3
 	addne sp, sp, #0x490
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r1, _021705d8 ; =0x00000d01
 	ldr r2, _02170658 ; =data_ov61_0217d9a8
 	mov r0, sl
@@ -60355,7 +60355,7 @@ _0216fe30:
 	bl func_ov61_02169c10
 	add sp, sp, #0x490
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0216fe9c:
 	ldr r0, [r6, #8]
 	ldr r1, _02170654 ; =data_ov61_0217d9a0
@@ -60377,7 +60377,7 @@ _0216fe9c:
 	str r0, [r6, #0x140]
 	add sp, sp, #0x490
 	mov r0, #4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0216fef0:
 	ldr r0, [r6]
 	cmp r0, #1
@@ -60391,17 +60391,17 @@ _0216fef0:
 	str r1, [sp, #0x88]
 	add r4, sp, #0x290
 	add r5, sp, #0x90
-	add fp, sp, #0x78
+	add r11, sp, #0x78
 _0216ff24:
 	str r5, [sp]
 	ldr r1, [r6, #8]
 	mov r0, sl
-	mov r2, fp
+	mov r2, r11
 	mov r3, r4
 	bl func_ov61_0217191c
 	cmp r0, #0
 	addne sp, sp, #0x490
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r1, _02170660 ; =data_ov61_0217d9d4
 	mov r0, r4
 	bl strcmp
@@ -60410,12 +60410,12 @@ _0216ff24:
 	str r5, [sp]
 	ldr r1, [r6, #8]
 	mov r0, sl
-	mov r2, fp
+	mov r2, r11
 	mov r3, r4
 	bl func_ov61_0217191c
 	cmp r0, #0
 	addne sp, sp, #0x490
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r1, _02170664 ; =data_ov61_0217d9dc
 	mov r0, r4
 	bl strcmp
@@ -60452,7 +60452,7 @@ _0216ffb8:
 	bl func_ov61_02171b10
 	add sp, sp, #0x490
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0217000c:
 	ldr r0, [sp, #0x84]
 	mov r1, #0
@@ -60472,12 +60472,12 @@ _02170040:
 	mov r0, sl
 	str r5, [sp]
 	ldr r1, [r6, #8]
-	mov r2, fp
+	mov r2, r11
 	mov r3, r4
 	bl func_ov61_0217191c
 	cmp r0, #0
 	addne sp, sp, #0x490
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r1, _02170670 ; =data_ov61_0217d9e8
 	mov r0, r4
 	bl strcmp
@@ -60561,7 +60561,7 @@ _0217016c:
 	bl func_ov61_02169c10
 	add sp, sp, #0x490
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02170198:
 	ldr r0, [sp, #0x2c]
 	cmp r0, #0
@@ -60608,7 +60608,7 @@ _021701d0:
 	bl func_ov61_0216f5b0
 	cmp r0, #0
 	addne sp, sp, #0x490
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0217024c:
 	ldr r0, [sp, #0x8c]
 	bl func_ov61_0213e13c
@@ -60634,7 +60634,7 @@ _02170260:
 	bl func_ov61_0217191c
 	cmp r0, #0
 	addne sp, sp, #0x490
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r1, _02170688 ; =data_ov61_0217da44
 	add r0, sp, #0x290
 	bl strcmp
@@ -60650,7 +60650,7 @@ _02170260:
 	bl func_ov61_02169c10
 	add sp, sp, #0x490
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _021702ec:
 	mov r0, #0x3c
 	bl func_ov61_0213e10c
@@ -60661,7 +60661,7 @@ _021702ec:
 	bl func_ov61_02171b10
 	add sp, sp, #0x490
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02170314:
 	mov r0, #0
 	str r0, [r4]
@@ -60686,7 +60686,7 @@ _02170314:
 	cmp r0, #0
 	beq _021711e0
 	add sp, sp, #0x490
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02170374:
 	cmp r0, #3
 	bne _0217071c
@@ -60706,7 +60706,7 @@ _02170374:
 	bl func_ov61_02171b10
 	add sp, sp, #0x490
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _021703c0:
 	mov r2, #0
 	add r0, r8, #4
@@ -60726,7 +60726,7 @@ _021703c0:
 	bl func_ov61_0217191c
 	cmp r0, #0
 	addne sp, sp, #0x490
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r1, _0217068c ; =data_ov61_0217da48
 	add r0, sp, #0x290
 	bl strcmp
@@ -60742,9 +60742,9 @@ _021703c0:
 	bl func_ov61_02169c10
 	add sp, sp, #0x490
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0217044c:
-	ldr fp, _02170670 ; =data_ov61_0217d9e8
+	ldr r11, _02170670 ; =data_ov61_0217d9e8
 	mov sb, #0
 	add r4, sp, #0x290
 	add r7, sp, #0x90
@@ -60758,9 +60758,9 @@ _02170460:
 	bl func_ov61_0217191c
 	cmp r0, #0
 	addne sp, sp, #0x490
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	mov r0, r4
-	mov r1, fp
+	mov r1, r11
 	bl strcmp
 	cmp r0, #0
 	bne _0217052c
@@ -60776,7 +60776,7 @@ _02170460:
 	bl func_ov61_02171b10
 	add sp, sp, #0x490
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _021704cc:
 	str r0, [r8, #0x3c]
 	mov r0, #0x1f
@@ -60788,7 +60788,7 @@ _021704cc:
 	bl func_ov61_02171b10
 	add sp, sp, #0x490
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _021704f8:
 	ldr r3, [r8, #0x3c]
 	ldr r2, [r8, #0x38]
@@ -60822,7 +60822,7 @@ _0217052c:
 	bl func_ov61_02171b10
 	add sp, sp, #0x490
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02170578:
 	str r0, [r8, #0x40]
 	mov r0, #0x15
@@ -60834,7 +60834,7 @@ _02170578:
 	bl func_ov61_02171b10
 	add sp, sp, #0x490
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _021705a4:
 	ldr r3, [r8, #0x40]
 	ldr r2, [r8, #0x38]
@@ -60917,7 +60917,7 @@ _0217069c:
 	bl func_ov61_02169c10
 	add sp, sp, #0x490
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _021706e0:
 	cmp sb, #0
 	beq _02170460
@@ -60933,7 +60933,7 @@ _021706e0:
 	cmp r0, #0
 	beq _021711e0
 	add sp, sp, #0x490
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0217071c:
 	cmp r0, #4
 	bne _02170998
@@ -60946,21 +60946,21 @@ _0217071c:
 	beq _021711e0
 	mov r0, #0x10
 	bl func_ov61_0213e10c
-	movs fp, r0
+	movs r11, r0
 	bne _02170768
 	ldr r1, _0217066c ; =data_ov61_0217d758
 	mov r0, sl
 	bl func_ov61_02171b10
 	add sp, sp, #0x490
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02170768:
 	ldr r1, [r6, #0x138]
 	mov r0, #0
-	stmia fp, {r0, r1}
-	str r0, [fp, #8]
+	stmia r11, {r0, r1}
+	str r0, [r11, #8]
 	str r0, [sp, #0x20]
-	str r0, [fp, #0xc]
+	str r0, [r11, #0xc]
 	add r4, sp, #0x290
 	add r5, sp, #0x90
 _02170788:
@@ -60972,7 +60972,7 @@ _02170788:
 	bl func_ov61_0217191c
 	cmp r0, #0
 	addne sp, sp, #0x490
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r1, _02170694 ; =data_ov61_0217da54
 	mov r0, r4
 	bl strcmp
@@ -60985,14 +60985,14 @@ _02170788:
 	bl strcmp
 	cmp r0, #0
 	bne _0217092c
-	ldr r0, [fp, #8]
+	ldr r0, [r11, #8]
 	add r2, r0, #1
 	mov r0, #0x128
 	mul r1, r2, r0
-	str r2, [fp, #8]
-	ldr r0, [fp, #0xc]
+	str r2, [r11, #8]
+	ldr r0, [r11, #0xc]
 	bl func_ov61_0213e120
-	str r0, [fp, #0xc]
+	str r0, [r11, #0xc]
 	movs r8, r0
 	bne _0217081c
 	ldr r1, _0217066c ; =data_ov61_0217d758
@@ -61000,9 +61000,9 @@ _02170788:
 	bl func_ov61_02171b10
 	add sp, sp, #0x490
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0217081c:
-	ldr r0, [fp, #8]
+	ldr r0, [r11, #8]
 	mov r1, #0
 	sub r2, r0, #1
 	mov r0, #0x128
@@ -61027,7 +61027,7 @@ _02170858:
 	bl func_ov61_0217191c
 	cmp r0, #0
 	addne sp, sp, #0x490
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r1, _02171210 ; =data_ov61_0217da60
 	mov r0, r4
 	bl strcmp
@@ -61087,7 +61087,7 @@ _0217092c:
 	bl func_ov61_02169c10
 	add sp, sp, #0x490
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02170958:
 	ldr r0, [sp, #0x20]
 	cmp r0, #0
@@ -61098,13 +61098,13 @@ _02170958:
 	mov r1, #4
 	str r1, [sp, #4]
 	mov r0, sl
-	mov r3, fp
+	mov r3, r11
 	ldmia r2, {r1, r2}
 	bl func_ov61_02169d04
 	cmp r0, #0
 	beq _021711e0
 	add sp, sp, #0x490
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02170998:
 	cmp r0, #5
 	bne _02170af4
@@ -61124,7 +61124,7 @@ _02170998:
 	bl func_ov61_0217191c
 	cmp r0, #0
 	addne sp, sp, #0x490
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r1, _02171218 ; =data_ov61_0217da74
 	add r0, sp, #0x290
 	bl strcmp
@@ -61140,7 +61140,7 @@ _02170998:
 	bl func_ov61_02169c10
 	add sp, sp, #0x490
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02170a24:
 	add r0, sp, #0x90
 	bl func_0204902c
@@ -61168,7 +61168,7 @@ _02170a44:
 	bl func_ov61_02169c10
 	add sp, sp, #0x490
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02170a8c:
 	add r0, sp, #0x90
 	bl func_0204902c
@@ -61183,7 +61183,7 @@ _02170a98:
 	bl func_ov61_02171b10
 	add sp, sp, #0x490
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02170ac0:
 	stmia r3, {r4, r5}
 	ldr r1, [sp, #0x1c]
@@ -61197,7 +61197,7 @@ _02170ac0:
 	cmp r0, #0
 	beq _021711e0
 	add sp, sp, #0x490
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02170af4:
 	cmp r0, #6
 	bne _02170c54
@@ -61217,7 +61217,7 @@ _02170af4:
 	bl func_ov61_0217191c
 	cmp r0, #0
 	addne sp, sp, #0x490
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r1, _02171220 ; =data_ov61_0217da80
 	add r0, sp, #0x290
 	bl strcmp
@@ -61233,7 +61233,7 @@ _02170af4:
 	bl func_ov61_02169c10
 	add sp, sp, #0x490
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02170b80:
 	add r0, sp, #0x90
 	bl func_0204902c
@@ -61259,7 +61259,7 @@ _02170b80:
 	bl func_ov61_02169c10
 	add sp, sp, #0x490
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02170be4:
 	mov r5, #0
 	b _02170bf8
@@ -61277,7 +61277,7 @@ _02170bf8:
 	bl func_ov61_02171b10
 	add sp, sp, #0x490
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02170c20:
 	stmia r3, {r4, r5}
 	ldr r1, [sp, #0x1c]
@@ -61291,7 +61291,7 @@ _02170c20:
 	cmp r0, #0
 	beq _021711e0
 	add sp, sp, #0x490
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02170c54:
 	cmp r0, #7
 	bne _02170f90
@@ -61304,20 +61304,20 @@ _02170c54:
 	beq _021711e0
 	mov r0, #0xc
 	bl func_ov61_0213e10c
-	movs fp, r0
+	movs r11, r0
 	bne _02170ca0
 	ldr r1, _0217066c ; =data_ov61_0217d758
 	mov r0, sl
 	bl func_ov61_02171b10
 	add sp, sp, #0x490
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02170ca0:
 	mov r1, #0
-	str r1, [fp]
-	str r1, [fp, #4]
+	str r1, [r11]
+	str r1, [r11, #4]
 	add r0, sp, #0x90
-	str r1, [fp, #8]
+	str r1, [r11, #8]
 	str r0, [sp]
 	ldr r1, [r6, #8]
 	add r2, sp, #0x78
@@ -61326,7 +61326,7 @@ _02170ca0:
 	bl func_ov61_0217191c
 	cmp r0, #0
 	addne sp, sp, #0x490
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r1, _02171224 ; =data_ov61_0217da84
 	add r0, sp, #0x290
 	bl strcmp
@@ -61342,7 +61342,7 @@ _02170ca0:
 	bl func_ov61_02169c10
 	add sp, sp, #0x490
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02170d18:
 	mov r0, #0
 	str r0, [sp, #0x24]
@@ -61357,7 +61357,7 @@ _02170d28:
 	bl func_ov61_0217191c
 	cmp r0, #0
 	addne sp, sp, #0x490
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r1, _02171228 ; =data_ov61_0217da8c
 	mov r0, r4
 	bl strcmp
@@ -61370,8 +61370,8 @@ _02170d28:
 	bl strcmp
 	cmp r0, #0
 	bne _02170f24
-	ldr r1, [fp, #4]
-	ldr r0, [fp, #8]
+	ldr r1, [r11, #4]
+	ldr r0, [r11, #8]
 	add r2, r1, #1
 	mov r1, #0xac
 	mul r1, r2, r1
@@ -61383,10 +61383,10 @@ _02170d28:
 	bl func_ov61_02171b10
 	add sp, sp, #0x490
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02170db4:
-	str r0, [fp, #8]
-	ldr r2, [fp, #4]
+	str r0, [r11, #8]
+	ldr r2, [r11, #4]
 	mov r8, r0
 	mov r0, #0xac
 	mul sb, r2, r0
@@ -61395,10 +61395,10 @@ _02170db4:
 	mov r0, r7
 	mov r2, #0xac
 	bl func_02043600
-	ldr r1, [fp, #4]
+	ldr r1, [r11, #4]
 	mov r0, r5
 	add r1, r1, #1
-	str r1, [fp, #4]
+	str r1, [r11, #4]
 	bl func_0204902c
 	str r0, [r8, sb]
 	mov r8, #0
@@ -61412,7 +61412,7 @@ _02170df8:
 	bl func_ov61_0217191c
 	cmp r0, #0
 	addne sp, sp, #0x490
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r1, _02170670 ; =data_ov61_0217d9e8
 	mov r0, r4
 	bl strcmp
@@ -61496,7 +61496,7 @@ _02170f24:
 	bl func_ov61_02169c10
 	add sp, sp, #0x490
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02170f50:
 	ldr r0, [sp, #0x24]
 	cmp r0, #0
@@ -61507,13 +61507,13 @@ _02170f50:
 	mov r1, #8
 	str r1, [sp, #4]
 	mov r0, sl
-	mov r3, fp
+	mov r3, r11
 	ldmia r2, {r1, r2}
 	bl func_ov61_02169d04
 	cmp r0, #0
 	beq _021711e0
 	add sp, sp, #0x490
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02170f90:
 	cmp r0, #8
 	bne _021711cc
@@ -61534,7 +61534,7 @@ _02170f90:
 	bl func_ov61_02171b10
 	add sp, sp, #0x490
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02170fe0:
 	mov r1, r7
 	str r1, [r8]
@@ -61549,7 +61549,7 @@ _02170fe0:
 	bl func_ov61_0217191c
 	cmp r0, #0
 	addne sp, sp, #0x490
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r1, _02171238 ; =data_ov61_0217daa8
 	add r0, sp, #0x290
 	bl strcmp
@@ -61565,7 +61565,7 @@ _02170fe0:
 	bl func_ov61_02169c10
 	add sp, sp, #0x490
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02171058:
 	add r0, sp, #0x90
 	bl func_0204902c
@@ -61580,22 +61580,22 @@ _02171058:
 	bl func_ov61_02171b10
 	add sp, sp, #0x490
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02171090:
 	mov sb, r7
 	add r4, sp, #0x290
 	add r5, sp, #0x90
-	add fp, sp, #0x78
+	add r11, sp, #0x78
 _021710a0:
 	str r5, [sp]
 	ldr r1, [r6, #8]
 	mov r0, sl
-	mov r2, fp
+	mov r2, r11
 	mov r3, r4
 	bl func_ov61_0217191c
 	cmp r0, #0
 	addne sp, sp, #0x490
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r1, _02170670 ; =data_ov61_0217d9e8
 	mov r0, r4
 	bl strcmp
@@ -61614,7 +61614,7 @@ _021710a0:
 	bl func_ov61_02171b10
 	add sp, sp, #0x490
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02171110:
 	mov r1, r5
 	mov r2, #0x15
@@ -61650,7 +61650,7 @@ _02171164:
 	bl func_ov61_02169c10
 	add sp, sp, #0x490
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02171190:
 	cmp sb, #0
 	beq _021710a0
@@ -61666,7 +61666,7 @@ _02171190:
 	cmp r0, #0
 	beq _021711e0
 	add sp, sp, #0x490
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _021711cc:
 	ldr r0, _0217063c ; =data_ov61_0217d990
 	ldr r1, _02170640 ; =data_ov61_0217d814
@@ -61687,7 +61687,7 @@ _021711fc:
 	bne _0216f7cc
 	mov r0, #0
 	add sp, sp, #0x490
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 _02171210: .word data_ov61_0217da60
 _02171214: .word data_ov61_0217da68
@@ -61708,7 +61708,7 @@ _02171248: .word 0x0000052a
 	.global func_ov61_0217124c
 	arm_func_start func_ov61_0217124c
 func_ov61_0217124c: ; 0x0217124c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	mov sl, r0
 	ldr r6, [sl]
 	mov sb, #0
@@ -61723,13 +61723,13 @@ func_ov61_0217124c: ; 0x0217124c
 	mov r0, sl
 	bl func_ov61_02171b10
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _0217128c:
 	ldr r8, [r6, #0x424]
 	cmp r8, #0
 	beq _02171308
 	ldr r5, _0217138c ; =data_ov61_0217dad4
-	ldr fp, _02171390 ; =data_ov61_0217d814
+	ldr r11, _02171390 ; =data_ov61_0217d814
 	mov r4, #1
 _021712a4:
 	ldr r0, [r8]
@@ -61748,7 +61748,7 @@ _021712a4:
 	ldr r2, _02171394 ; =data_ov61_0217d6ec
 	ldr r3, _02171398 ; =0x00000563
 	mov r0, r5
-	mov r1, fp
+	mov r1, r11
 	bl func_02042f80
 _021712ec:
 	str r8, [r7, sb, lsl #2]
@@ -61797,7 +61797,7 @@ _02171378:
 	bl func_ov61_0213e13c
 _02171380:
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0217124c
 _02171388: .word data_ov61_0217d758
@@ -63985,7 +63985,7 @@ _02172f58:
 	.global func_ov61_02172f6c
 	arm_func_start func_ov61_02172f6c
 func_ov61_02172f6c: ; 0x02172f6c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	movs sl, r0
 	bne _02172f8c
 	ldr r0, _02173078 ; =data_ov61_0217de38
@@ -64008,7 +64008,7 @@ _02172f8c:
 	sub r4, r0, r1
 	add r0, r4, #0x21
 	strb r0, [sl]
-	mov fp, r8
+	mov r11, r8
 	mov r6, r7
 	mov r4, r3
 _02172fd0:
@@ -64019,7 +64019,7 @@ _02172fd0:
 	eor r3, r7, r3
 	movlo r1, r6
 	and r3, r3, #1
-	movhs r1, fp
+	movhs r1, r11
 	cmp r0, #0x4f
 	movlo r2, #1
 	and r0, r0, #1
@@ -64056,7 +64056,7 @@ _02173064:
 	cmp r7, #0x20
 	blt _02172fd0
 	mov r0, sl
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02172f6c
 _02173078: .word data_ov61_0217de38
@@ -64067,7 +64067,7 @@ _02173084: .word 0x2c0b02c1
 	.global func_ov61_02173088
 	arm_func_start func_ov61_02173088
 func_ov61_02173088: ; 0x02173088
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	mov r5, r0
 	ldr r0, _02173188 ; =data_ov61_0217de14
 	mov r4, r1
@@ -64076,10 +64076,10 @@ func_ov61_02173088: ; 0x02173088
 	mov r0, r4
 	bl func_ov61_02172ed0
 	mov sl, #0
-	mov fp, r0
+	mov r11, r0
 	mov r8, sl
 _021730b4:
-	cmp fp, #0
+	cmp r11, #0
 	cmpne sl, #0
 	cmpne sl, #0xd
 	bne _021730ec
@@ -64133,7 +64133,7 @@ _02173168:
 	add r8, r0, #0x4600
 	blt _021730b4
 	mov r0, r5
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02173088
 _02173188: .word data_ov61_0217de14
@@ -67158,7 +67158,7 @@ _02175804:
 	.global func_ov61_02175810
 	arm_func_start func_ov61_02175810
 func_ov61_02175810: ; 0x02175810
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x5f0
 	mov sl, r0
 	ldr r0, [sl]
@@ -67171,10 +67171,10 @@ func_ov61_02175810: ; 0x02175810
 	add r7, sp, #0x14
 	mov sb, #8
 	add r8, sp, #0xc
-	add fp, sp, #8
+	add r11, sp, #8
 _02175848:
 	str sb, [sp, #8]
-	stmia sp, {r8, fp}
+	stmia sp, {r8, r11}
 	ldr r0, [sl]
 	ldr r2, _0217593c ; =0x000005dc
 	mov r1, r7
@@ -67202,7 +67202,7 @@ _02175848:
 	bne _02175920
 	add sp, sp, #0x5f0
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _021758c0:
 	cmp r0, r4
 	beq _02175920
@@ -67210,7 +67210,7 @@ _021758c0:
 	bl func_ov61_02176968
 	add sp, sp, #0x5f0
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _021758dc:
 	ldrh ip, [sp, #0xe]
 	mov r0, sl
@@ -67228,7 +67228,7 @@ _021758dc:
 	cmp r0, #0
 	addeq sp, sp, #0x5f0
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02175920:
 	ldr r0, [sl]
 	bl func_ov61_02166914
@@ -67237,7 +67237,7 @@ _02175920:
 _02175930:
 	mov r0, #1
 	add sp, sp, #0x5f0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02175810
 _0217593c: .word 0x000005dc
@@ -70012,7 +70012,7 @@ _02177d78: .word data_ov61_0217e1a0
 	.global func_ov61_02177d7c
 	arm_func_start func_ov61_02177d7c
 func_ov61_02177d7c: ; 0x02177d7c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x14
 	mov r1, #8
 	mov sl, r0
@@ -70020,18 +70020,18 @@ func_ov61_02177d7c: ; 0x02177d7c
 	ldr r0, [sl, #0xc4]
 	cmp r0, #0
 	addeq sp, sp, #0x14
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r0, [sl]
 	bl func_ov61_02166914
 	cmp r0, #0
 	addeq sp, sp, #0x14
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	mov r5, #0
 	ldr r7, _02177e24 ; =data_ov61_02181824
 	add sb, sp, #0xc
 	add r8, sp, #8
 	mov r6, #0xff
-	mov fp, r5
+	mov r11, r5
 	mvn r4, #0
 _02177dd0:
 	str sb, [sp]
@@ -70039,7 +70039,7 @@ _02177dd0:
 	ldr r0, [sl]
 	mov r1, r7
 	mov r2, r6
-	mov r3, fp
+	mov r3, r11
 	bl func_ov61_02166bc0
 	mov r2, r0
 	cmp r2, r4
@@ -70055,7 +70055,7 @@ _02177e0c:
 	cmp r0, #0
 	bne _02177dd0
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02177d7c
 _02177e24: .word data_ov61_02181824
@@ -70454,7 +70454,7 @@ _02178304:
 	.global func_ov61_02178314
 	arm_func_start func_ov61_02178314
 func_ov61_02178314: ; 0x02178314
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x104
 	str r1, [sp]
 	add r4, sp, #4
@@ -70473,7 +70473,7 @@ _02178334:
 	add r6, sp, #4
 	mov r5, r4
 	mov r7, r4
-	mov fp, r6
+	mov r11, r6
 _02178360:
 	ldrb r3, [r6]
 	ldrb r2, [sl, r4]
@@ -70488,7 +70488,7 @@ _02178360:
 	bl func_02002c14
 	and r4, r1, #0xff
 	mov r0, r6
-	add r1, fp, r5
+	add r1, r11, r5
 	bl func_ov61_021781f4
 	add r0, r7, #1
 	mov r0, r0, lsl #0x10
@@ -70501,7 +70501,7 @@ _02178360:
 	mov r7, r6
 	mov r5, r6
 	addle sp, sp, #0x104
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r4, sp, #4
 _021783d0:
 	ldrb r0, [sb, r5]
@@ -70537,7 +70537,7 @@ _021783d0:
 	mov r5, r2, asr #0x10
 	bgt _021783d0
 	add sp, sp, #0x104
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	arm_func_end func_ov61_02178314
 
 	.global func_ov61_02178458
@@ -70655,9 +70655,9 @@ _021785d4: .word data_ov61_0217e320
 	.global func_ov61_021785d8
 	arm_func_start func_ov61_021785d8
 func_ov61_021785d8: ; 0x021785d8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x10c
-	movs fp, r3
+	movs r11, r3
 	mov r3, #0
 	ldr r7, [sp, #0x130]
 	str r3, [sp, #0x108]
@@ -70665,7 +70665,7 @@ func_ov61_021785d8: ; 0x021785d8
 	mov sb, r1
 	mov r8, r2
 	addeq sp, sp, #0x10c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	sub r0, r8, #1
 	cmp r0, #1
 	bhi _02178684
@@ -70673,7 +70673,7 @@ func_ov61_021785d8: ; 0x021785d8
 	rsb r0, r0, #0x800
 	cmp r0, #2
 	addlo sp, sp, #0x10c
-	ldmloia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmloia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	ldr r1, [sl, #0x10c]
 	ldr r2, [sl, #0x98]
 	mov r0, r8
@@ -70702,7 +70702,7 @@ _02178684:
 	mov r0, #1
 	str r0, [sp]
 _0217868c:
-	cmp fp, #0xff
+	cmp r11, #0xff
 	bne _02178760
 	ldr r2, [sl, #0x10c]
 	ldr r3, [sl, #0x94]
@@ -70713,7 +70713,7 @@ _0217868c:
 	mov r5, #0
 	cmp r0, #0
 	ble _02178728
-	ldr fp, _02178824 ; =data_ov61_0217e32c
+	ldr r11, _02178824 ; =data_ov61_0217e32c
 	ldr r4, _02178828 ; =data_ov61_0217e4e8
 	add r7, sp, #8
 _021786c4:
@@ -70721,7 +70721,7 @@ _021786c4:
 	ldr r1, [r4, r0, lsl #2]
 	mov r0, sb
 	cmp r1, #0
-	moveq r1, fp
+	moveq r1, r11
 	bl func_ov61_0217807c
 	cmp r8, #0
 	bne _02178714
@@ -70748,25 +70748,25 @@ _02178728:
 	rsb r0, r1, #0x800
 	cmp r0, #1
 	addlt sp, sp, #0x10c
-	ldmltia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmltia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r0, r1, #1
 	str r0, [sb, #0x800]
 	mov r0, #0
 	strb r0, [sb, r1]
-	ldr fp, [sp, #0x108]
+	ldr r11, [sp, #0x108]
 	cmp r8, #0
 	add r7, sp, #8
 	addeq sp, sp, #0x10c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02178760:
 	ldr r0, [sp]
 	mov r4, #0
 	cmp r0, #0
 	addle sp, sp, #0x10c
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 _02178774:
 	mov r5, #0
-	cmp fp, #0
+	cmp r11, #0
 	ble _0217880c
 _02178780:
 	cmp r8, #0
@@ -70806,7 +70806,7 @@ _021787e8:
 	bl func_ov61_0217807c
 _02178800:
 	add r5, r5, #1
-	cmp r5, fp
+	cmp r5, r11
 	blt _02178780
 _0217880c:
 	ldr r0, [sp]
@@ -70814,7 +70814,7 @@ _0217880c:
 	cmp r4, r0
 	blt _02178774
 	add sp, sp, #0x10c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_021785d8
 _02178824: .word data_ov61_0217e32c
@@ -70902,7 +70902,7 @@ func_ov61_02178888: ; 0x02178888
 	.global func_ov61_02178940
 	arm_func_start func_ov61_02178940
 func_ov61_02178940: ; 0x02178940
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x188
 	mov r8, r2
 	sub r2, r8, #1
@@ -70911,13 +70911,13 @@ func_ov61_02178940: ; 0x02178940
 	mov sl, r0
 	mov sb, r1
 	str r3, [sp, #0x104]
-	movhi fp, #1
+	movhi r11, #1
 	bhi _02178980
 	ldr r1, [sl, #0x10c]
 	ldr r2, [sl, #0x98]
 	mov r0, r8
 	blx r2
-	mov fp, r0
+	mov r11, r0
 _02178980:
 	ldr r2, [sl, #0x10c]
 	ldr r3, [sl, #0x94]
@@ -70929,7 +70929,7 @@ _02178980:
 	str r0, [sp]
 	cmp r1, #0
 	addle sp, sp, #0x188
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	add r6, sp, #4
 _021789b0:
 	ldrb r1, [r6]
@@ -70965,7 +70965,7 @@ _02178a18:
 	strb r1, [r0, #-1]
 	b _02178ae4
 _02178a2c:
-	cmp fp, #0
+	cmp r11, #0
 	mov r4, #0
 	ble _02178ae4
 _02178a38:
@@ -71013,7 +71013,7 @@ _02178ac8:
 	add r1, sb, r0
 	mov r0, #0x5c
 	strb r0, [r1, #-1]
-	cmp r4, fp
+	cmp r4, r11
 	blt _02178a38
 _02178ae4:
 	ldr r0, [sp]
@@ -71024,7 +71024,7 @@ _02178ae4:
 	add r6, r6, #1
 	blt _021789b0
 	add sp, sp, #0x188
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02178940
 _02178b08: .word data_ov61_0217e4e8
@@ -71427,7 +71427,7 @@ func_ov61_0217901c: ; 0x0217901c
 	.global func_ov61_0217907c
 	arm_func_start func_ov61_0217907c
 func_ov61_0217907c: ; 0x0217907c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
 	sub sp, sp, #0x28
 	sub sp, sp, #0x800
 	mov sl, r0
@@ -71443,13 +71443,13 @@ func_ov61_0217907c: ; 0x0217907c
 	ldr r0, [r4]
 	cmp r0, #0
 	ble _0217910c
-	ldr fp, _02179260 ; =data_ov61_0217e354
+	ldr r11, _02179260 ; =data_ov61_0217e354
 	ldr r5, _02179264 ; =data_ov61_021817d0
 	add r7, sp, #0x10
 	add r6, sp, #0x24
 _021790cc:
 	mov r0, r7
-	mov r1, fp
+	mov r1, r11
 	mov r2, r8
 	bl func_020459b8
 	mov r0, r6
@@ -71552,7 +71552,7 @@ _02179214:
 	strne r0, [sl, #0xb4]
 	add sp, sp, #0x28
 	add sp, sp, #0x800
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0217907c
 _0217925c: .word data_ov61_021817cc

--- a/asm/ov61.s
+++ b/asm/ov61.s
@@ -1444,11 +1444,11 @@ _0213f0dc: .word func_ov61_0213fa98
 	.global func_ov61_0213f0e0
 	arm_func_start func_ov61_0213f0e0
 func_ov61_0213f0e0: ; 0x0213f0e0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x90
 	mov r4, r0
 	mov r10, r1
-	mov sb, r2
+	mov r9, r2
 	mov r11, r3
 	bl func_ov61_0213dfec
 	cmp r0, #0
@@ -1461,7 +1461,7 @@ func_ov61_0213f0e0: ; 0x0213f0e0
 _0213f118:
 	add sp, sp, #0x90
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0213f124:
 	bl func_ov61_0213f678
 	ldr r0, _0213f284 ; =data_ov61_0217ea4c
@@ -1476,7 +1476,7 @@ _0213f124:
 	cmp r4, #0
 	beq _0213f190
 	ldr r0, _0213f288 ; =func_ov61_0213fa98
-	sub r2, sb, #1
+	sub r2, r9, #1
 	str r0, [sp]
 	mov r1, #0
 	ldr r0, [sp, #0xc0]
@@ -1542,7 +1542,7 @@ _0213f22c:
 	blt _0213f1d8
 _0213f240:
 	ldr r0, _0213f288 ; =func_ov61_0213fa98
-	sub r2, sb, #1
+	sub r2, r9, #1
 	str r0, [sp]
 	mov r1, #0
 	str r1, [sp, #4]
@@ -1558,7 +1558,7 @@ _0213f240:
 _0213f278:
 	mov r0, #1
 	add sp, sp, #0x90
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0213f0e0
 _0213f284: .word data_ov61_0217ea4c
@@ -2514,18 +2514,18 @@ _0213fdb8: .word func_ov61_0214a758
 	.global func_ov61_0213fdbc
 	arm_func_start func_ov61_0213fdbc
 func_ov61_0213fdbc: ; 0x0213fdbc
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #8
 	mov r5, #0
 	mov r11, r0
-	mov sb, r1
+	mov r9, r1
 	mov r10, r5
 	bl func_ov61_02144534
 	cmp r0, #0
 	addne sp, sp, #8
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
-	cmp sb, #4
-	addls pc, pc, sb, lsl #2
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
+	cmp r9, #4
+	addls pc, pc, r9, lsl #2
 	b _0213fe20
 _0213fdf0: ; jump table
 	b _0213fe04 ; case 0
@@ -2550,7 +2550,7 @@ _0213fe20:
 	bl func_ov61_02174560
 	movs r5, r0
 	addeq sp, sp, #8
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, _02140100 ; =data_ov61_0217ea4c
 	ldrb r4, [r5, #1]
 	ldr r0, [r0]
@@ -2564,7 +2564,7 @@ _0213fe20:
 	ldr r1, [r0]
 	ldrb r0, [r1, #0x369]
 	cmp r0, #2
-	cmpeq sb, #0
+	cmpeq r9, #0
 	beq _0213fe88
 	ldrb r0, [r1, #0x369]
 	cmp r0, #3
@@ -2602,12 +2602,12 @@ _0213fecc:
 	cmp r0, #2
 	cmpeq r8, #0
 	addne sp, sp, #8
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	bl func_ov61_021443ec
 	mov r0, r5
 	bl func_ov61_02144040
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0213ff14:
 	mov r0, r8
 	mov r1, r6
@@ -2615,14 +2615,14 @@ _0213ff14:
 	bl func_ov61_02143ec4
 	cmp r0, #0
 	addne sp, sp, #8
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	cmp r8, #0
 	beq _0213ff4c
 	mov r0, r8
 	mov r1, r6
 	bl func_ov61_0213e008
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0213ff4c:
 	ldr r0, _02140100 ; =data_ov61_0217ea4c
 	ldr r1, [r0]
@@ -2702,7 +2702,7 @@ _02140058:
 	cmp r0, #0
 	cmpne r7, #0
 	beq _021400b0
-	cmp sb, #0
+	cmp r9, #0
 	moveq r7, #1
 	mov r0, r5
 	movne r7, #0
@@ -2726,17 +2726,17 @@ _021400b0:
 	ldreqb r0, [r1, #0x369]
 	cmpeq r0, #2
 	addeq sp, sp, #8
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldrb r0, [r1, #0x361]
 	cmp r0, #0
 	addne sp, sp, #8
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	bl func_ov61_02176dc0
 	bl func_ov61_02143cd0
 	mov r0, #3
 	bl func_ov61_0213f77c
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0213fdbc
 _021400f8: .word 0xffffe250
@@ -4244,7 +4244,7 @@ _02141450: .word data_ov61_0217ebe0
 	.global func_ov61_02141454
 	arm_func_start func_ov61_02141454
 func_ov61_02141454: ; 0x02141454
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #0x248
 	ldr r2, _021416b8 ; =data_ov61_0217ebe0
 	mov r7, r0
@@ -4332,10 +4332,10 @@ _02141584:
 	ldrb r0, [r0, #0x1c]
 	cmp r0, r6
 	addge sp, sp, #0x248
-	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmgeia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	add r4, sp, #0x18
 	mov r8, #0xc
-	mvn sb, #0
+	mvn r9, #0
 _021415a8:
 	bl func_ov61_02141168
 	movs r5, r0
@@ -4354,7 +4354,7 @@ _021415a8:
 	bl func_ov61_021677c0
 	bl func_ov61_021419f4
 	ldr r0, [sp, #0x18]
-	cmp r0, sb
+	cmp r0, r9
 	bne _02141690
 	mov r0, r5
 	bl func_ov61_02141904
@@ -4365,7 +4365,7 @@ _02141600:
 	ldrb r2, [r1, #0x1c]
 	mla r1, r2, r8, r7
 	blx func_ov00_02077948
-	cmp r0, sb
+	cmp r0, r9
 	bne _02141690
 	bl func_ov61_02140308
 	ldr r2, _021416b8 ; =data_ov61_0217ebe0
@@ -4395,7 +4395,7 @@ _02141600:
 	ldr r0, [r0]
 	add sp, sp, #0x248
 	strb r1, [r0, #0x1e]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _02141690:
 	ldr r1, [r10]
 	ldrb r0, [r1, #0x1c]
@@ -4406,7 +4406,7 @@ _02141690:
 	cmp r0, r6
 	blt _021415a8
 	add sp, sp, #0x248
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02141454
 _021416b8: .word data_ov61_0217ebe0
@@ -4517,7 +4517,7 @@ _021417f8: .word data_ov61_0217ebe0
 	.global func_ov61_021417fc
 	arm_func_start func_ov61_021417fc
 func_ov61_021417fc: ; 0x021417fc
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #8
 	mov r10, r1
 	mov r11, r0
@@ -4541,7 +4541,7 @@ _0214182c:
 	cmp r6, r10
 	bge _021418e0
 	mov r0, #0xc
-	mla sb, r6, r0, r11
+	mla r9, r6, r0, r11
 _0214185c:
 	mov r0, r6
 	bl func_ov61_02141168
@@ -4551,7 +4551,7 @@ _0214185c:
 	blx func_ov00_020774c4
 	cmp r0, #2
 	bne _02141898
-	mov r0, sb
+	mov r0, r9
 	blx func_ov00_020774c4
 	cmp r0, #3
 	bne _02141898
@@ -4559,7 +4559,7 @@ _0214185c:
 	mov r1, r4
 	blx func_ov00_02077a10
 _02141898:
-	mov r0, sb
+	mov r0, r9
 	blx func_ov00_0207749c
 	cmp r0, #0
 	beq _021418b0
@@ -4577,7 +4577,7 @@ _021418b0:
 _021418d0:
 	add r6, r6, #1
 	cmp r6, r10
-	add sb, sb, #0xc
+	add r9, r9, #0xc
 	blt _0214185c
 _021418e0:
 	add r5, r5, #1
@@ -4588,7 +4588,7 @@ _021418e0:
 _021418f4:
 	ldr r0, [sp, #4]
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_021417fc
 _02141900: .word data_ov61_0217ebe0
@@ -4714,14 +4714,14 @@ _02141a64: .word 0xfffeeaa8
 	.global func_ov61_02141a68
 	arm_func_start func_ov61_02141a68
 func_ov61_02141a68: ; 0x02141a68
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
-	mov sb, r1
-	ldr r1, [sb]
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
+	mov r9, r1
+	ldr r1, [r9]
 	mov r10, r0
 	mov r8, r2
 	cmp r1, #0
 	bne _02141c38
-	ldr r0, [sb, #4]
+	ldr r0, [r9, #4]
 	cmp r0, #0
 	beq _02141c38
 	mov r0, #0xc
@@ -4737,15 +4737,15 @@ func_ov61_02141a68: ; 0x02141a68
 	ldr r0, [r7]
 	ldr r0, [r0]
 	cmp r0, #1
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
-	ldr r0, [sb, #4]
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
+	ldr r0, [r9, #4]
 	mov r4, #0
 	cmp r0, #0
 	ble _02141b3c
 	mov r5, r4
 _02141adc:
 	ldr r0, [r7]
-	ldr r1, [sb, #0xc]
+	ldr r1, [r9, #0xc]
 	ldr r0, [r0, #0x18]
 	ldr r2, [r1, r5]
 	mov r1, r8
@@ -4761,10 +4761,10 @@ _02141adc:
 	strb r3, [r4, #0x1c]
 	ldr r0, [r0]
 	strb r2, [r0, #0x1e]
-	str r1, [sb, #8]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	str r1, [r9, #8]
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02141b28:
-	ldr r0, [sb, #4]
+	ldr r0, [r9, #4]
 	add r4, r4, #1
 	cmp r4, r0
 	add r5, r5, #0xac
@@ -4777,7 +4777,7 @@ _02141b3c:
 	add r11, sp, #0
 	mvn r4, #0
 _02141b54:
-	ldr r1, [sb, #0xc]
+	ldr r1, [r9, #0xc]
 	mov r0, r10
 	ldr r1, [r1, r5]
 	mov r2, r11
@@ -4786,13 +4786,13 @@ _02141b54:
 	ldr r0, [sp]
 	cmp r0, r4
 	bne _02141b88
-	ldr r0, [sb, #0xc]
+	ldr r0, [r9, #0xc]
 	ldr r0, [r0, r5]
 	bl func_ov61_02141904
 	b _02141bf4
 _02141b88:
 	ldr r0, _02141ca0 ; =data_ov61_0217ebe0
-	ldr r1, [sb, #0xc]
+	ldr r1, [r9, #0xc]
 	ldr r0, [r0]
 	ldr r1, [r1]
 	ldr r0, [r0, #0x18]
@@ -4814,20 +4814,20 @@ _02141b88:
 	strb r2, [r4, #0x1c]
 	ldr r2, [r0]
 	strb r3, [r2, #0x1e]
-	str r1, [sb, #8]
+	str r1, [r9, #8]
 	ldr r0, [r0]
 	strb r3, [r0, #0x1d]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02141bf4:
-	ldr r0, [sb, #4]
+	ldr r0, [r9, #4]
 	add r7, r7, #1
 	cmp r7, r0
 	add r5, r5, #0xac
 	blt _02141b54
 _02141c08:
-	ldr r0, [sb, #8]
+	ldr r0, [r9, #8]
 	cmp r0, #0x600
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, _02141ca0 ; =data_ov61_0217ebe0
 	mov r1, #1
 	ldr r3, [r0]
@@ -4836,14 +4836,14 @@ _02141c08:
 	strb r2, [r3, #0x1c]
 	ldr r0, [r0]
 	strb r1, [r0, #0x1e]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02141c38:
-	ldr r0, [sb]
+	ldr r0, [r9]
 	cmp r0, #0
 	beq _02141c50
 	bl func_ov61_021419f4
 	cmp r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02141c50:
 	ldr r0, _02141ca0 ; =data_ov61_0217ebe0
 	ldr r1, [r0]
@@ -4855,7 +4855,7 @@ _02141c50:
 	mla r0, r8, r0, r1
 	blx func_ov00_020774c4
 	cmp r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02141c7c:
 	ldr r0, _02141ca0 ; =data_ov61_0217ebe0
 	mov r1, #1
@@ -4865,7 +4865,7 @@ _02141c7c:
 	strb r2, [r3, #0x1c]
 	ldr r0, [r0]
 	strb r1, [r0, #0x1e]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02141a68
 _02141ca0: .word data_ov61_0217ebe0
@@ -4873,15 +4873,15 @@ _02141ca0: .word data_ov61_0217ebe0
 	.global func_ov61_02141ca4
 	arm_func_start func_ov61_02141ca4
 func_ov61_02141ca4: ; 0x02141ca4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x28
-	mov sb, r1
-	ldr r1, [sb]
+	mov r9, r1
+	ldr r1, [r9]
 	mov r10, r0
 	cmp r1, #0
 	mov r6, #0
 	addne sp, sp, #0x28
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r4, _02141e4c ; =data_ov61_0217ebe0
 	mov r5, r6
 	ldr r1, [r4]
@@ -4903,15 +4903,15 @@ _02141ce8:
 	add r1, r1, r7
 	blx func_ov00_02077a30
 	mov r0, r11
-	add r1, sb, #0x8e
+	add r1, r9, #0x8e
 	bl strcmp
 	cmp r0, #0
 	bne _02141e08
-	ldr r1, [sb, #4]
+	ldr r1, [r9, #4]
 	mov r0, r10
 	bl func_ov61_02167540
 	ldr r0, [r4]
-	ldr r1, [sb, #4]
+	ldr r1, [r9, #4]
 	ldr r0, [r0, #0x18]
 	add r0, r0, r7
 	blx func_ov00_02077a10
@@ -4947,7 +4947,7 @@ _02141d80:
 	ldr r2, _02141e50 ; =data_ov61_0217a6f0
 	mov r1, #5
 	bl func_0200c910
-	ldr r8, [sb, #4]
+	ldr r8, [r9, #4]
 	bl func_ov61_02140308
 	ldr r1, [r4]
 	ldr r1, [r1, #0x18]
@@ -4956,7 +4956,7 @@ _02141d80:
 	cmp r8, r0
 	bne _02141e08
 	add r0, sp, #0xc
-	add r1, sb, #0x97
+	add r1, r9, #0x97
 	mov r2, #4
 	bl func_0204366c
 	cmp r0, #0
@@ -4975,16 +4975,16 @@ _02141e08:
 _02141e20:
 	cmp r6, #0
 	beq _02141e38
-	ldr r0, [sb, #4]
+	ldr r0, [r9, #4]
 	bl func_ov61_02141904
 	add sp, sp, #0x28
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02141e38:
-	ldr r1, [sb, #4]
+	ldr r1, [r9, #4]
 	mov r0, r10
 	bl func_ov61_02167590
 	add sp, sp, #0x28
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02141ca4
 _02141e4c: .word data_ov61_0217ebe0
@@ -4993,7 +4993,7 @@ _02141e50: .word data_ov61_0217a6f0
 	.global func_ov61_02141e54
 	arm_func_start func_ov61_02141e54
 func_ov61_02141e54: ; 0x02141e54
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x18
 	mov r10, r1
 	ldr r0, [r10]
@@ -5001,7 +5001,7 @@ func_ov61_02141e54: ; 0x02141e54
 	cmp r0, #0
 	mov r11, #1
 	addne sp, sp, #0x18
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r4, _02141fec ; =data_ov61_0217ebe0
 	mov r6, r7
 	ldr r0, [r4]
@@ -5059,16 +5059,16 @@ _02141f34:
 	cmp r0, #1
 	moveq r11, #0
 	beq _02141f98
-	ldr sb, [r10, #4]
+	ldr r9, [r10, #4]
 	bl func_ov61_02140308
 	ldr r1, [r4]
 	ldr r1, [r1, #0x18]
 	add r1, r1, r8
 	blx func_ov00_02077948
-	cmp sb, r0
+	cmp r9, r0
 	bne _02141f98
 	ldr r0, [r4]
-	mov r1, sb
+	mov r1, r9
 	ldr r0, [r0, #0x18]
 	add r0, r0, r8
 	blx func_ov00_02077a10
@@ -5087,7 +5087,7 @@ _02141f98:
 _02141fb0:
 	cmp r7, #0
 	addeq sp, sp, #0x18
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, [r0, #0x18]
 	ldr r2, [r10, #4]
 	bl func_ov61_021417fc
@@ -5100,7 +5100,7 @@ _02141fd4:
 	ldr r0, [r0]
 	strb r1, [r0, #0x1d]
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02141e54
 _02141fec: .word data_ov61_0217ebe0
@@ -5489,7 +5489,7 @@ _021424f4: .word data_ov61_0217ebe8
 	.global func_ov61_021424f8
 	arm_func_start func_ov61_021424f8
 func_ov61_021424f8: ; 0x021424f8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x28
 	mov r4, r0
 	bl func_ov61_0214a214
@@ -5497,7 +5497,7 @@ func_ov61_021424f8: ; 0x021424f8
 	cmp r0, #0
 	addne sp, sp, #0x28
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	bl func_ov61_0214a214
 	str r4, [r0, #0x200]
 	ldr r4, _02142670 ; =func_ov61_021499d0
@@ -5506,7 +5506,7 @@ func_ov61_021424f8: ; 0x021424f8
 	mov r5, #1
 _02142534:
 	bl func_ov61_0214a214
-	mov sb, r0
+	mov r9, r0
 	bl func_ov61_0214a214
 	ldr r0, [r0, #4]
 	ldr r0, [r0]
@@ -5532,7 +5532,7 @@ _02142534:
 	mov r2, r7
 	str r3, [sp, #0x18]
 	ldr r3, _02142680 ; =func_ov61_02149bc4
-	add r0, sb, #0x10
+	add r0, r9, #0x10
 	str r3, [sp, #0x1c]
 	ldr r3, _02142684 ; =func_ov61_02149bcc
 	str r3, [sp, #0x20]
@@ -5557,7 +5557,7 @@ _021425f0:
 	bl func_ov61_02149060
 	add sp, sp, #0x28
 	mov r0, r6
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02142604:
 	add r10, r10, #1
 	cmp r10, #5
@@ -5586,7 +5586,7 @@ _02142610:
 	bl func_ov61_02177f3c
 	mov r0, r6
 	add sp, sp, #0x28
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_021424f8
 _02142670: .word func_ov61_021499d0
@@ -6705,7 +6705,7 @@ _021436a0: .word data_ov61_0217e158
 	.global func_ov61_021436a4
 	arm_func_start func_ov61_021436a4
 func_ov61_021436a4: ; 0x021436a4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	mov r8, r1
 	mov r7, r2
 	mov r6, r3
@@ -6725,7 +6725,7 @@ _021436e0:
 	mov r0, r8
 	mvn r2, #0
 	bl func_ov61_0217428c
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _021436f4:
 	bl func_ov61_0213f64c
 	mov r5, r0
@@ -6738,7 +6738,7 @@ _021436f4:
 	ldr r1, _021438dc ; =0xfffeabc4
 	mov r0, #6
 	bl func_ov61_02143c14
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _02143724:
 	bl func_ov61_0214a214
 	mov r4, r0
@@ -6767,10 +6767,10 @@ _02143768:
 	bl func_02048ecc
 	mov r4, r0
 	bl func_ov61_0214a214
-	mov sb, r0
+	mov r9, r0
 	bl func_ov61_0214a214
 	ldrb r0, [r0, #0xd]
-	add r0, sb, r0, lsl #2
+	add r0, r9, r0, lsl #2
 	ldr r0, [r0, #0xf4]
 	cmp r4, r0
 	bne _021437e0
@@ -6793,7 +6793,7 @@ _021437e0:
 	mov r0, r8
 	mvn r2, #0
 	bl func_ov61_0217428c
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _021437f4:
 	bl func_ov61_0214a214
 	mov r1, #0
@@ -6808,7 +6808,7 @@ _021437f4:
 	ldr r1, _021438e4 ; =0xfffec5e6
 	mov r0, #6
 	bl func_ov61_02143c14
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _0214382c:
 	bl func_ov61_02143bf4
 	bl func_ov61_0214a214
@@ -6852,7 +6852,7 @@ _02143860:
 	bl func_ov61_02174524
 	mov r0, #2
 	bl func_ov61_021471a0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov61_021436a4
 _021438d4: .word data_ov61_0217a720
@@ -7039,19 +7039,19 @@ _02143b6c: .word 0xfffeabc4
 	.global func_ov61_02143b70
 	arm_func_start func_ov61_02143b70
 func_ov61_02143b70: ; 0x02143b70
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x218
-	mov sb, #0
+	mov r9, #0
 	mov r11, r1
 	mov r10, r2
 	add r8, sp, #8
-	mov r7, sb
+	mov r7, r9
 	mov r6, #0xa
 	add r5, sp, #0x18
 	mvn r4, #0
 _02143b98:
 	mov r0, r8
-	mov r2, sb
+	mov r2, r9
 	add r1, r10, #1
 	bl func_ov61_02145384
 	cmp r0, r4
@@ -7060,20 +7060,20 @@ _02143b98:
 	mov r1, r7
 	mov r2, r6
 	bl func_02048ecc
-	str r0, [r5, sb, lsl #2]
-	add sb, sb, #1
-	cmp sb, #0x80
+	str r0, [r5, r9, lsl #2]
+	add r9, r9, #1
+	cmp r9, #0x80
 	blt _02143b98
 _02143bd0:
 	add r0, sp, #0x18
-	stmia sp, {r0, sb}
+	stmia sp, {r0, r9}
 	mov r2, #0
 	ldrb r0, [r10]
 	mov r1, r11
 	mov r3, r2
 	bl func_ov61_02145420
 	add sp, sp, #0x218
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	arm_func_end func_ov61_02143b70
 
 	.global func_ov61_02143bf4
@@ -7448,20 +7448,20 @@ _021440c0:
 	.global func_ov61_021440c8
 	arm_func_start func_ov61_021440c8
 func_ov61_021440c8: ; 0x021440c8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
-	mov sb, r0
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
+	mov r9, r0
 	mov r8, r1
 	bl func_ov61_0214a214
 	cmp r0, #0
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	bl func_ov61_0214a214
-	add r0, r0, sb, lsl #2
+	add r0, r0, r9, lsl #2
 	ldr r11, [r0, #0xf4]
 	bl func_ov61_0214a214
 	mov r4, r0
 	bl func_ov61_0214a214
-	add r0, r0, sb
+	add r0, r0, r9
 	ldrb r0, [r0, #0x2d0]
 	mov r1, #1
 	ldr r2, [r4, #0x2f0]
@@ -7470,15 +7470,15 @@ func_ov61_021440c8: ; 0x021440c8
 	str r0, [r4, #0x2f0]
 	bl func_ov61_021442c0
 	sub r0, r8, #1
-	cmp sb, r0
+	cmp r9, r0
 	bge _02144208
-	sub r0, r8, sb
+	sub r0, r8, r9
 	sub r5, r0, #1
 	cmp r5, #0
 	mov r4, #0
 	ble _02144208
 _0214413c:
-	add r7, sb, r4
+	add r7, r9, r4
 	add r6, r7, #1
 	bl func_ov61_0214a214
 	mov r10, r0
@@ -7520,10 +7520,10 @@ _0214413c:
 	bl func_ov61_0214a214
 	mov r6, r0
 	bl func_ov61_0214a214
-	add r0, sb, r0
+	add r0, r9, r0
 	add r0, r4, r0
 	ldrb r1, [r0, #0x2d1]
-	add r0, sb, r6
+	add r0, r9, r6
 	add r0, r4, r0
 	strb r1, [r0, #0x2d0]
 	add r4, r4, #1
@@ -7560,7 +7560,7 @@ _02144208:
 	strb r1, [r0, #0x2d0]
 _02144278:
 	mov r0, r11
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	arm_func_end func_ov61_021440c8
 
 	.global func_ov61_02144280
@@ -8122,7 +8122,7 @@ _02144a0c: .word data_ov61_0217ebe8
 	.global func_ov61_02144a10
 	arm_func_start func_ov61_02144a10
 func_ov61_02144a10: ; 0x02144a10
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x1b0
 	mov r7, #8
 	mov r6, #0xa
@@ -8232,15 +8232,15 @@ _02144b80:
 	mov r2, r4
 	mov r3, r11
 	bl func_ov61_02162cf4
-	movs sb, r0
+	movs r9, r0
 	beq _02144bc0
-	cmp sb, #2
+	cmp r9, #2
 	bne _02144bc0
 	add r10, r10, #1
 	cmp r10, #5
 	blt _02144b80
 _02144bc0:
-	cmp sb, #0
+	cmp r9, #0
 	bne _02144be8
 	bl func_ov61_0214a214
 	mov r4, r0
@@ -8251,9 +8251,9 @@ _02144bc0:
 	adc r0, r1, #0
 	str r0, [r4, #0x178]
 _02144be8:
-	mov r0, sb
+	mov r0, r9
 	add sp, sp, #0x1b0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02144a10
 _02144bf4: .word data_ov61_0217ebf8
@@ -8298,7 +8298,7 @@ _02144c70: .word data_ov61_0217a778
 	.global func_ov61_02144c74
 	arm_func_start func_ov61_02144c74
 func_ov61_02144c74: ; 0x02144c74
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x10
 	mov r4, r0
 	mov r8, r1
@@ -8404,13 +8404,13 @@ _02144de4:
 	bl func_ov61_021744fc
 	str r0, [sp, #0xc]
 	bl func_ov61_0214a214
-	mov sb, r0
+	mov r9, r0
 	mov r0, r7
 	bl func_ov61_02162334
 	mov r8, r0
 	mov r0, r7
 	bl func_ov61_0216233c
-	add r1, sb, r4, lsl #2
+	add r1, r9, r4, lsl #2
 	add r4, sp, #8
 	mov r3, r0
 	mov r0, #2
@@ -8427,7 +8427,7 @@ _02144de4:
 	strb r1, [r0, #0x3cd]
 	addne sp, sp, #0x10
 	movne r0, #2
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	bl func_ov61_0214a214
 	mov r1, #0
 	str r1, [r0, #0x19c]
@@ -8494,7 +8494,7 @@ _02144f14:
 _02144f50:
 	mov r0, r6
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02144c74
 _02144f5c: .word 0x0000a8c0
@@ -8557,13 +8557,13 @@ _02145018: .word func_ov61_02149db8
 	.global func_ov61_0214501c
 	arm_func_start func_ov61_0214501c
 func_ov61_0214501c: ; 0x0214501c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x220
 	str r3, [sp, #0xc]
 	mov r10, r0
 	str r1, [sp, #4]
 	str r2, [sp, #8]
-	ldr sb, [sp, #0x248]
+	ldr r9, [sp, #0x248]
 	ldr r8, [sp, #0x24c]
 	mov r6, #0
 	bl func_ov61_0214a214
@@ -8585,16 +8585,16 @@ _02145078:
 	ldr r2, [sp, #0xc]
 	ldr r1, [sp, #8]
 	mov r0, r10
-	mov r3, sb
+	mov r3, r9
 	str r8, [sp]
 	bl func_ov61_021451d0
 	mov r4, r0
 	b _02145130
 _02145098:
-	cmp sb, #0
+	cmp r9, #0
 	cmpne r8, #0
 	beq _02145108
-	ldr r3, [sb]
+	ldr r3, [r9]
 	ldr r2, _021451c8 ; =data_ov61_0217a708
 	add r0, sp, #0x20
 	mov r1, #0x200
@@ -8606,7 +8606,7 @@ _02145098:
 	add r5, sp, #0x10
 	add r11, sp, #0x20
 _021450d0:
-	ldr r3, [sb, r7, lsl #2]
+	ldr r3, [r9, r7, lsl #2]
 	ldr r2, _021451cc ; =data_ov61_0217a7fc
 	mov r0, r5
 	mov r1, #0x10
@@ -8658,20 +8658,20 @@ _0214514c:
 	mov r5, r0
 	bl func_0200e8f8
 	str r0, [r5, #0x45c]
-	cmp sb, #0
+	cmp r9, #0
 	str r1, [r5, #0x460]
 	cmpne r8, #0
 	beq _021451bc
 	bl func_ov61_0214a214
 	mov r1, r0
-	mov r0, sb
+	mov r0, r9
 	add r1, r1, #0x3d4
 	mov r2, r8, lsl #0x2
 	bl func_02007908
 _021451bc:
 	mov r0, r4
 	add sp, sp, #0x220
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0214501c
 _021451c8: .word data_ov61_0217a708
@@ -8680,7 +8680,7 @@ _021451cc: .word data_ov61_0217a7fc
 	.global func_ov61_021451d0
 	arm_func_start func_ov61_021451d0
 func_ov61_021451d0: ; 0x021451d0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x98
 	ldr r5, [sp, #0xb8]
 	cmp r3, #0
@@ -8699,16 +8699,16 @@ _02145208:
 	mov r0, r5, lsl #0x2
 	ldrb r1, [r2, #4]
 	ldrb r6, [r2]
-	add sb, sp, #4
+	add r9, sp, #4
 	ldrb r5, [r2, #1]
 	ldrb r3, [r2, #2]
 	ldrb r2, [r2, #3]
-	strb r1, [sb, #4]
+	strb r1, [r9, #4]
 	mov r1, #3
-	strb r6, [sb]
-	strb r5, [sb, #1]
-	strb r3, [sb, #2]
-	strb r2, [sb, #3]
+	strb r6, [r9]
+	strb r5, [r9, #1]
+	strb r3, [r9, #2]
+	strb r2, [r9, #3]
 	str r1, [sp, #8]
 	strb r4, [sp, #0xc]
 	strb r0, [sp, #0xd]
@@ -8733,22 +8733,22 @@ _02145278:
 	mov r1, r0
 	ldrb r0, [sp, #0xd]
 	mov r2, r7
-	mov r3, sb
+	mov r3, r9
 	add r0, r0, #0x14
 	str r0, [sp]
 	ldr r0, [r5, #0xe4]
 	bl func_ov61_02162d28
 	cmp r0, #0
 	addeq sp, sp, #0x98
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	cmp r0, #2
 	addne sp, sp, #0x98
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	add r6, r6, #1
 	cmp r6, #5
 	blt _02145278
 	add sp, sp, #0x98
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov61_021451d0
 _021452dc: .word data_ov61_0217a800
@@ -8804,11 +8804,11 @@ _02145380: .word data_ov61_0217a810
 	.global func_ov61_02145384
 	arm_func_start func_ov61_02145384
 func_ov61_02145384: ; 0x02145384
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
-	mov sb, r1
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
+	mov r9, r1
 	mov r4, r0
 	mov r8, r2
-	mov r0, sb
+	mov r0, r9
 	mov r1, #0
 	bl strchr
 	mov r6, r0
@@ -8817,42 +8817,42 @@ func_ov61_02145384: ; 0x02145384
 	ble _021453dc
 	mov r5, #0x2f
 _021453b4:
-	mov r0, sb
+	mov r0, r9
 	mov r1, r5
 	bl strchr
 	cmp r0, #0
 	mvneq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	add r7, r7, #1
 	cmp r7, r8
-	add sb, r0, #1
+	add r9, r0, #1
 	blt _021453b4
 _021453dc:
-	mov r0, sb
+	mov r0, r9
 	mov r1, #0x2f
 	bl strchr
 	cmp r0, #0
 	moveq r0, r6
-	cmp sb, r0
+	cmp r9, r0
 	mvneq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
-	sub r5, r0, sb
-	mov r0, sb
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
+	sub r5, r0, r9
+	mov r0, r9
 	mov r1, r4
 	mov r2, r5
 	bl func_02007ad8
 	mov r1, #0
 	mov r0, r5
 	strb r1, [r4, r5]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	arm_func_end func_ov61_02145384
 
 	.global func_ov61_02145420
 	arm_func_start func_ov61_02145420
 func_ov61_02145420: ; 0x02145420
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #0x118
-	mov sb, r0
+	mov r9, r0
 	mov r8, r1
 	mov r7, r2
 	mov r10, r3
@@ -8869,7 +8869,7 @@ func_ov61_02145420: ; 0x02145420
 _02145460:
 	add sp, sp, #0x118
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _0214546c:
 	bl func_ov61_0213f4e4
 	cmp r0, #5
@@ -8884,11 +8884,11 @@ _0214546c:
 	bne _0214549c
 	bl func_ov61_02148a94
 _0214549c:
-	cmp sb, #0x40
+	cmp r9, #0x40
 	bgt _02145538
 	bge _0214627c
-	cmp sb, #0x20
-	addls pc, pc, sb, lsl #2
+	cmp r9, #0x20
+	addls pc, pc, r9, lsl #2
 	b _021462f0
 _021454b4: ; jump table
 	b _021462f0 ; case 0
@@ -8925,7 +8925,7 @@ _021454b4: ; jump table
 	b _021462f0 ; case 31
 	b _02146180 ; case 32
 _02145538:
-	cmp sb, #0x41
+	cmp r9, #0x41
 	b _021462f0
 _02145540:
 	bl func_ov61_0214a214
@@ -8937,7 +8937,7 @@ _02145540:
 	mov r0, r0, lsl #0x10
 	mov r10, r0, lsr #0x10
 _02145560:
-	cmp sb, #0xb
+	cmp r9, #0xb
 	moveq r0, #1
 	movne r0, #0
 	str r0, [sp]
@@ -8960,7 +8960,7 @@ _02145560:
 	cmp r0, #0
 	addne sp, sp, #0x118
 	movne r0, #0
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	bl func_ov61_0214a214
 	ldrb r0, [r0, #0x15]
 	cmp r0, #2
@@ -9049,7 +9049,7 @@ _021456d0:
 	beq _021462f0
 	add sp, sp, #0x118
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _02145710:
 	bl func_ov61_0214a214
 	ldr r0, [r0, #0x1a0]
@@ -9116,7 +9116,7 @@ _021457f8:
 	cmp r0, #0
 	addne sp, sp, #0x118
 	mov r0, #0
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	mov r1, r0
 	mov r2, r8
 	bl func_ov61_021469ec
@@ -9125,7 +9125,7 @@ _021457f8:
 	beq _021462f0
 	add sp, sp, #0x118
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _02145838:
 	bl func_ov61_0214a214
 	ldrb r0, [r0, #0x15]
@@ -9143,7 +9143,7 @@ _02145838:
 	cmp r0, #0
 	addne sp, sp, #0x118
 	movne r0, #0
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _0214587c:
 	mov r0, #6
 	bl func_ov61_0214a224
@@ -9160,7 +9160,7 @@ _0214587c:
 	beq _021462f0
 	add sp, sp, #0x118
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _021458bc:
 	mov r0, #5
 	bl func_ov61_0214a224
@@ -9171,7 +9171,7 @@ _021458bc:
 	beq _021462f0
 	add sp, sp, #0x118
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _021458e4:
 	bl func_ov61_0214a214
 	ldr r0, [r0, #0x1a0]
@@ -9191,13 +9191,13 @@ _021458e4:
 	bl func_ov61_02143c14
 	add sp, sp, #0x118
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _02145930:
 	bl func_ov61_0214a214
 	ldr r0, [r0, #0x204]
 	bl func_ov61_02146cb4
 	add sp, sp, #0x118
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _02145944:
 	bl func_ov61_0214a214
 	ldr r0, [r0, #0x1a0]
@@ -9307,7 +9307,7 @@ _02145ac4:
 	bne _021462f0
 	add sp, sp, #0x118
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _02145ae0:
 	ldr r0, [r6, #4]
 	ldr r5, [r6]
@@ -9418,7 +9418,7 @@ _02145bf0:
 	cmp r0, #0
 	addne sp, sp, #0x118
 	movne r0, #0
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _02145c84:
 	bl func_ov61_0214a214
 	mov r5, r0
@@ -9512,7 +9512,7 @@ _02145d70:
 	beq _021462f0
 	add sp, sp, #0x118
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _02145df0:
 	bl func_ov61_0214a214
 	ldr r1, [sp, #0x10]
@@ -9544,7 +9544,7 @@ _02145df0:
 	cmp r0, #0
 	addne sp, sp, #0x118
 	movne r0, #0
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	bl func_ov61_0214a214
 	mov r1, #0
 	str r1, [r0, #0x1c8]
@@ -9621,7 +9621,7 @@ _02145f6c:
 	beq _021462f0
 	add sp, sp, #0x118
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _02145f84:
 	bl func_ov61_0214a214
 	ldr r0, [r0, #0xf4]
@@ -9642,7 +9642,7 @@ _02145fb4:
 	bne _021462f0
 	add sp, sp, #0x118
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _02145fd0:
 	bl func_ov61_0214a214
 	ldrb r0, [r0, #0x15]
@@ -9657,20 +9657,20 @@ _02145fd0:
 _02145ff8:
 	ldr r2, [r6]
 	mov r0, r8
-	mov r1, sb
+	mov r1, r9
 	bl func_ov61_02148354
 	cmp r0, #0
 	bne _021462f0
 	add sp, sp, #0x118
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _0214601c:
 	bl func_ov61_0214a214
 	ldr r0, [r0, #0xf4]
 	cmp r8, r0
 	addne sp, sp, #0x118
 	movne r0, #1
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	cmp r5, #0
 	mov r7, #0
 	ble _021462f0
@@ -9729,7 +9729,7 @@ _021460d0:
 	beq _021462f0
 	add sp, sp, #0x118
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _0214610c:
 	bl func_ov61_0214a214
 	ldr r0, [r0, #0x1a0]
@@ -9760,7 +9760,7 @@ _02146168:
 	bl func_ov61_02143c14
 	add sp, sp, #0x118
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _02146180:
 	bl func_ov61_0214a214
 	ldrb r0, [r0, #0x15]
@@ -9798,7 +9798,7 @@ _021461f4:
 	cmp r0, #0
 	addne sp, sp, #0x118
 	movne r0, #0
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _0214620c:
 	bl func_ov61_0214a214
 	ldr r0, [r0, #0x19c]
@@ -9856,7 +9856,7 @@ _02146290:
 	beq _021462f0
 	add sp, sp, #0x118
 	mov r0, r4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _021462dc:
 	add r4, r4, #1
 	bl func_ov61_0214a214
@@ -9866,7 +9866,7 @@ _021462dc:
 _021462f0:
 	mov r0, #1
 	add sp, sp, #0x118
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02145420
 _021462fc: .word data_ov61_0217ebe8
@@ -10093,7 +10093,7 @@ _021465fc: .word data_ov61_0217ebe8
 	.global func_ov61_02146600
 	arm_func_start func_ov61_02146600
 func_ov61_02146600: ; 0x02146600
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x10
 	mov r6, r0
 	mov r5, r1
@@ -10107,7 +10107,7 @@ func_ov61_02146600: ; 0x02146600
 	cmp r6, r0
 	addeq sp, sp, #0x10
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _0214663c:
 	bl func_ov61_0214a214
 	mov r1, #1
@@ -10180,14 +10180,14 @@ _0214663c:
 	mov r4, #7
 _02146750:
 	bl func_ov61_0214a214
-	mov sb, r0
+	mov r9, r0
 	bl func_ov61_0214a214
 	mov r8, r0
 	bl func_ov61_0214a214
 	str r6, [sp]
 	str r5, [sp, #4]
 	add r0, r0, r7, lsl #1
-	add r1, sb, r7, lsl #2
+	add r1, r9, r7, lsl #2
 	add r2, r8, r7, lsl #2
 	ldrh r3, [r0, #0xa4]
 	ldr r1, [r1, #0xf4]
@@ -10196,7 +10196,7 @@ _02146750:
 	bl func_ov61_0214501c
 	cmp r0, #0
 	addne sp, sp, #0x10
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	add r7, r7, #1
 	bl func_ov61_0214a214
 	ldrb r0, [r0, #0x14]
@@ -10207,7 +10207,7 @@ _021467ac:
 	bl func_ov61_02148abc
 	mov r0, #0
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	arm_func_end func_ov61_02146600
 
 	.global func_ov61_021467c0
@@ -10375,7 +10375,7 @@ _021469e8: .word 0x00001770
 	.global func_ov61_021469ec
 	arm_func_start func_ov61_021469ec
 func_ov61_021469ec: ; 0x021469ec
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x228
 	movs r4, r1
 	mov r8, r0
@@ -10440,19 +10440,19 @@ _02146a94:
 	str r1, [r0, #0x1bc]
 	add sp, sp, #0x228
 	mov r0, r1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02146ae4:
 	mov r5, #1
 	bl func_ov61_02140308
 	mov r10, r0
 	bl func_ov61_0214a214
-	mov sb, r0
+	mov r9, r0
 	bl func_ov61_0214a214
 	mov r4, r0
 	bl func_ov61_0214a214
 	mov r1, r0
 	ldrb r2, [r1, #0x1a5]
-	ldr r3, [sb, #0x2fc]
+	ldr r3, [r9, #0x2fc]
 	mov r1, #0xc
 	add r2, r4, r2
 	ldrb r2, [r2, #0x304]
@@ -10466,50 +10466,50 @@ _02146ae4:
 	bl func_ov61_0214a214
 	mov r10, r0
 	bl func_ov61_0214a214
-	mov sb, r0
+	mov r9, r0
 	bl func_ov61_0214a214
 	ldrb r1, [r0, #0x1a5]
 	ldr r2, [r10, #0x2fc]
 	mov r0, #0xc
-	add r1, sb, r1
+	add r1, r9, r1
 	ldrb r1, [r1, #0x304]
 	mla r0, r1, r0, r2
 	blx func_ov00_020777e4
 	cmp r0, #0
 	beq _02146a50
-	mov sb, r5
+	mov r9, r5
 	bl func_ov61_0214a214
 	ldrb r0, [r0, #0xd]
 	cmp r0, #1
 	blt _02146bac
 _02146b84:
 	bl func_ov61_0214a214
-	add r0, r0, sb, lsl #2
+	add r0, r0, r9, lsl #2
 	ldr r0, [r0, #0xf4]
 	cmp r4, r0
 	beq _02146bac
-	add sb, sb, #1
+	add r9, r9, #1
 	bl func_ov61_0214a214
 	ldrb r0, [r0, #0xd]
-	cmp sb, r0
+	cmp r9, r0
 	ble _02146b84
 _02146bac:
 	bl func_ov61_0214a214
 	ldrb r0, [r0, #0xd]
-	cmp sb, r0
+	cmp r9, r0
 	ble _02146a50
 	bl func_ov61_0214a214
 	ldr r0, [r0]
 	add r2, sp, #4
 	mov r1, r4
 	bl func_ov61_021677c0
-	mov sb, r0
+	mov r9, r0
 	bl func_ov61_0214a214
 	ldr r0, [r0]
 	ldr r1, [sp, #4]
 	add r2, sp, #0x18
 	bl func_ov61_02167680
-	orrs r0, sb, r0
+	orrs r0, r9, r0
 	ldreq r0, [sp, #0x1c]
 	cmpeq r0, #4
 	bne _02146a50
@@ -10524,14 +10524,14 @@ _02146bac:
 	add r2, sp, #0x20
 	mov r3, #0x2f
 	bl func_ov61_0213e5f8
-	mov sb, r0
+	mov r9, r0
 	ldr r0, _02146cb0 ; =data_ov61_0217a718
 	add r1, sp, #0
 	add r2, sp, #0x20
 	mov r3, #0x2f
 	bl func_ov61_0213e5f8
 	cmp r10, #0
-	cmpgt sb, #0
+	cmpgt r9, #0
 	cmpgt r0, #0
 	ble _02146a50
 	add r0, sp, #0xc
@@ -10544,10 +10544,10 @@ _02146bac:
 	mov r1, #0
 	mov r2, #0xa
 	bl func_02048ecc
-	mov sb, r0
+	mov r9, r0
 	bl func_ov61_0214a214
 	ldrb r0, [r0, #0x16]
-	cmp sb, r0
+	cmp r9, r0
 	bne _02146a50
 	cmp r4, r11
 	moveq r8, #1
@@ -10555,7 +10555,7 @@ _02146bac:
 	mov r1, r8
 	bl func_ov61_0214683c
 	add sp, sp, #0x228
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_021469ec
 _02146ca4: .word 0x00000bb8
@@ -10865,7 +10865,7 @@ _021470b8: .word 0xfffec5d2
 	.global func_ov61_021470bc
 	arm_func_start func_ov61_021470bc
 func_ov61_021470bc: ; 0x021470bc
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #8
 	mov r4, #1
 	bl func_ov61_0214a214
@@ -10875,7 +10875,7 @@ func_ov61_021470bc: ; 0x021470bc
 	mov r5, #0xa
 _021470dc:
 	bl func_ov61_0214a214
-	mov sb, r0
+	mov r9, r0
 	bl func_ov61_0214a214
 	mov r8, r0
 	bl func_ov61_0214a214
@@ -10889,7 +10889,7 @@ _021470dc:
 	add r3, r7, r4, lsl #1
 	add ip, ip, #1
 	str ip, [sp, #4]
-	add r1, sb, r4, lsl #2
+	add r1, r9, r4, lsl #2
 	add r2, r8, r4, lsl #2
 	ldrh r3, [r3, #0xa4]
 	ldr r1, [r1, #0xf4]
@@ -10898,7 +10898,7 @@ _021470dc:
 	bl func_ov61_0214501c
 	cmp r0, #0
 	addne sp, sp, #8
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	add r4, r4, #1
 	bl func_ov61_0214a214
 	ldrb r0, [r0, #0xd]
@@ -10923,13 +10923,13 @@ _02147154:
 	strb r1, [r0, #0x1a8]
 	mov r0, r1
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	arm_func_end func_ov61_021470bc
 
 	.global func_ov61_021471a0
 	arm_func_start func_ov61_021471a0
 func_ov61_021471a0: ; 0x021471a0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #0x1c
 	cmp r0, #4
 	mov r4, #3
@@ -11157,7 +11157,7 @@ _021474dc:
 	bl func_ov61_0214a214
 	mov r10, r0
 	bl func_ov61_0214a214
-	mov sb, r0
+	mov r9, r0
 	bl func_ov61_0214a214
 	mov r8, r0
 	bl func_ov61_0214a214
@@ -11168,7 +11168,7 @@ _021474dc:
 	add r1, sp, #8
 	stmia sp, {r1, r4}
 	mov ip, r0
-	ldrb r3, [sb, #0xd]
+	ldrb r3, [r9, #0xd]
 	ldrb r2, [r7, #0xd]
 	ldrb r1, [ip, #0xd]
 	add r4, r10, r3, lsl #2
@@ -11182,7 +11182,7 @@ _021474dc:
 	bl func_ov61_02146810
 	cmp r0, #0
 	addne sp, sp, #0x1c
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	bl func_ov61_0214a214
 	mov r1, #0
 	strb r1, [r0, #0x3cd]
@@ -11257,7 +11257,7 @@ _021475fc:
 	cmp r0, #0
 	beq _021477c4
 	add sp, sp, #0x1c
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 _02147678:
 	mov r0, #1
 	bl func_ov61_0214a224
@@ -11330,7 +11330,7 @@ _0214775c:
 	bl func_ov61_02148f58
 	cmp r0, #0
 	addne sp, sp, #0x1c
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	ldr r0, _021477fc ; =data_ov61_0217ebe8
 	ldrb r1, [r0, #8]
 	cmp r1, #1
@@ -11353,17 +11353,17 @@ _021477b8:
 _021477c4:
 	cmp r5, #0
 	addeq sp, sp, #0x1c
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	bl func_ov61_0214a214
 	ldrb r0, [r0, #0x15]
 	cmp r0, #3
 	addeq sp, sp, #0x1c
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	bl func_ov61_0214a214
 	ldr r0, [r0, #0xe4]
 	bl func_ov61_02162e28
 	add sp, sp, #0x1c
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov61_021471a0
 _021477f8: .word data_ov61_0217a704
@@ -11839,54 +11839,54 @@ func_ov61_02147e08: ; 0x02147e08
 	.global func_ov61_02147e38
 	arm_func_start func_ov61_02147e38
 func_ov61_02147e38: ; 0x02147e38
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #0x108
 	mov r7, #0
 	mov r10, r0
 	mov r8, r7
-	mov sb, #1
+	mov r9, #1
 	bl func_ov61_0214a214
 	ldrb r0, [r0, #0xd]
 	cmp r0, #1
 	blt _02147ec0
 	add r4, sp, #0x88
 	add r5, sp, #8
-	mov r6, sb
+	mov r6, r9
 _02147e6c:
 	bl func_ov61_0214a214
-	add r0, r0, sb
+	add r0, r0, r9
 	ldrb r0, [r0, #0x2d0]
 	tst r10, r6, lsl r0
 	beq _02147e98
 	bl func_ov61_0214a214
-	add r0, r0, sb, lsl #2
+	add r0, r0, r9, lsl #2
 	ldr r0, [r0, #0xf4]
 	str r0, [r5, r8, lsl #2]
 	add r8, r8, #1
 	b _02147eac
 _02147e98:
 	bl func_ov61_0214a214
-	add r0, r0, sb, lsl #2
+	add r0, r0, r9, lsl #2
 	ldr r0, [r0, #0xf4]
 	str r0, [r4, r7, lsl #2]
 	add r7, r7, #1
 _02147eac:
-	add sb, sb, #1
+	add r9, r9, #1
 	bl func_ov61_0214a214
 	ldrb r0, [r0, #0xd]
-	cmp sb, r0
+	cmp r9, r0
 	ble _02147e6c
 _02147ec0:
 	cmp r8, #0
 	mov r10, #0
 	ble _02147f18
-	add sb, sp, #0x88
+	add r9, sp, #0x88
 	mov r6, #0x10
 	add r5, sp, #8
 	mov r4, r10
 _02147edc:
 	ldr r1, [r5, r10, lsl #2]
-	str sb, [sp]
+	str r9, [sp]
 	mov r0, r6
 	mov r2, r4
 	mov r3, r4
@@ -11896,7 +11896,7 @@ _02147edc:
 	cmp r0, #0
 	addne sp, sp, #0x108
 	movne r0, #0
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	add r10, r10, #1
 	cmp r10, r8
 	blt _02147edc
@@ -11926,7 +11926,7 @@ _02147f5c:
 	strb r1, [r0, #0x1a8]
 	mov r0, #1
 	add sp, sp, #0x108
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	arm_func_end func_ov61_02147e38
 
 	.global func_ov61_02147f74
@@ -12816,7 +12816,7 @@ _02148b28: .word data_ov61_0217ebe8
 	.global func_ov61_02148b2c
 	arm_func_start func_ov61_02148b2c
 func_ov61_02148b2c: ; 0x02148b2c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #8
 	ldr r0, _02148f4c ; =data_ov61_0217ebe8
 	ldr r0, [r0]
@@ -12824,17 +12824,17 @@ func_ov61_02148b2c: ; 0x02148b2c
 	ldrneb r0, [r0]
 	cmpne r0, #0
 	addeq sp, sp, #8
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	bl func_ov61_0214a214
 	ldrb r0, [r0, #0x15]
 	cmp r0, #2
 	addeq sp, sp, #8
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	bl func_ov61_0214a214
 	ldrb r0, [r0, #0x15]
 	cmp r0, #3
 	addeq sp, sp, #8
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	bl func_ov61_0214a214
 	ldr r0, [r0, #0x1a0]
 	cmp r0, #0x13
@@ -12863,7 +12863,7 @@ func_ov61_02148b2c: ; 0x02148b2c
 	strb r1, [r4, #0x1a4]
 	bl func_ov61_021471a0
 	add sp, sp, #8
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _02148bec:
 	bl func_0200e8f8
 	str r0, [r5, #0x18]
@@ -12885,7 +12885,7 @@ _02148bec:
 	str r0, [r4, #0xec]
 	add sp, sp, #8
 	str r1, [r4, #0xf0]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _02148c40:
 	mov r0, #4
 	bl func_ov61_0214a224
@@ -12894,7 +12894,7 @@ _02148c40:
 	mov r0, #1
 	bl func_ov61_021469ec
 	add sp, sp, #8
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _02148c60:
 	ldrb r4, [r5, #2]
 	bl func_0200e8f8
@@ -12913,7 +12913,7 @@ _02148c60:
 	cmp r1, r2, asr #31
 	cmpeq r0, r2
 	addlo sp, sp, #8
-	ldmloia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmloia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	cmp r4, #5
 	bls _02148ccc
 	mov r0, #1
@@ -12922,7 +12922,7 @@ _02148c60:
 	mov r0, #1
 	bl func_ov61_02147ba4
 	add sp, sp, #8
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _02148ccc:
 	mov r7, #1
 	bl func_ov61_0214a214
@@ -12944,13 +12944,13 @@ _02148cf0:
 	bl func_ov61_0214a214
 	mov r10, r0
 	bl func_ov61_0214a214
-	mov sb, r0
+	mov r9, r0
 	bl func_ov61_0214a214
 	str r5, [sp]
 	str r5, [sp, #4]
 	add r0, r0, r7, lsl #1
 	add r1, r10, r7, lsl #2
-	add r2, sb, r7, lsl #2
+	add r2, r9, r7, lsl #2
 	ldrh r3, [r0, #0xa4]
 	ldr r1, [r1, #0xf4]
 	ldr r2, [r2, #0x24]
@@ -12959,7 +12959,7 @@ _02148cf0:
 	bl func_ov61_02146810
 	cmp r0, #0
 	addne sp, sp, #8
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _02148d58:
 	add r7, r7, #1
 	bl func_ov61_0214a214
@@ -12973,7 +12973,7 @@ _02148d6c:
 	ldrb r0, [r1, #2]
 	add r0, r0, #1
 	strb r0, [r1, #2]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _02148d88:
 	bl func_ov61_0214a214
 	ldr r0, [r0, #0x1a0]
@@ -12983,7 +12983,7 @@ _02148d88:
 	ldr r0, [r0, #0x1a0]
 	cmp r0, #3
 	addne sp, sp, #8
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _02148dac:
 	ldr r0, _02148f4c ; =data_ov61_0217ebe8
 	ldr r4, [r0]
@@ -12993,7 +12993,7 @@ _02148dac:
 	sub r0, r1, #1
 	cmp r2, r0
 	addlt sp, sp, #8
-	ldmltia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmltia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	ldrb r0, [r4, #2]
 	cmp r0, #0
 	bne _02148e20
@@ -13018,7 +13018,7 @@ _02148e20:
 	ldrb r0, [r4, #2]
 	cmp r0, #0
 	addeq sp, sp, #8
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	ldr r0, _02148f4c ; =data_ov61_0217ebe8
 	ldr r4, [r0]
 	bl func_0200e8f8
@@ -13036,7 +13036,7 @@ _02148e20:
 	cmp r1, #0
 	cmpeq r0, r2, lsr #2
 	addlo sp, sp, #8
-	ldmloia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmloia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _02148e78:
 	bl func_ov61_0214a214
 	ldr r0, [r0, #0x204]
@@ -13048,7 +13048,7 @@ _02148e78:
 	bl func_ov61_02146810
 	cmp r0, #0
 	addne sp, sp, #8
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _02148ea4:
 	mov r0, #0x13
 	bl func_ov61_0214a224
@@ -13078,7 +13078,7 @@ _02148ec8:
 	bl func_ov61_02146810
 	cmp r0, #0
 	addne sp, sp, #8
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	add r4, r4, #1
 	bl func_ov61_0214a214
 	ldrb r0, [r0, #0xd]
@@ -13093,7 +13093,7 @@ _02148f28:
 	mov r0, #1
 	strb r0, [r4, #2]
 	add sp, sp, #8
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02148b2c
 _02148f4c: .word data_ov61_0217ebe8
@@ -13672,7 +13672,7 @@ func_ov61_02149684: ; 0x02149684
 	.global func_ov61_02149688
 	arm_func_start func_ov61_02149688
 func_ov61_02149688: ; 0x02149688
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	mov r4, #0
 	mov r10, r0
 	mov r7, r4
@@ -13686,13 +13686,13 @@ _021496ac:
 	ldr r0, [r0, #0xe4]
 	mov r1, r7
 	bl func_ov61_02162e74
-	mov sb, r0
+	mov r9, r0
 	bl func_ov61_0214a214
 	ldrb r0, [r0, #0x15]
 	cmp r0, #0
 	bne _02149748
 	ldr r1, _02149854 ; =data_ov61_0217a758
-	mov r0, sb
+	mov r0, r9
 	mov r2, #0
 	bl func_ov61_02162270
 	mov r6, r0
@@ -13710,7 +13710,7 @@ _021496fc:
 	bne _0214972c
 	bl func_ov61_0214a214
 	ldr r0, [r0, #0xe4]
-	mov r1, sb
+	mov r1, r9
 	bl func_ov61_02162dc8
 	sub r7, r7, #1
 	mov r5, #1
@@ -13746,14 +13746,14 @@ _02149748:
 	bl func_ov61_0213e6f4
 	mov r2, r0
 	ldr r1, _0214985c ; =data_ov61_0217a784
-	mov r0, sb
+	mov r0, r9
 	orr r2, r2, r5, lsl #8
 	bl func_ov61_021621cc
 	b _021497e0
 _021497ac:
 	bl func_ov61_0214a214
 	ldr r0, [r0, #0xe4]
-	mov r1, sb
+	mov r1, r9
 	bl func_ov61_02162dc8
 	sub r7, r7, #1
 	mov r4, #1
@@ -13763,7 +13763,7 @@ _021497c8:
 	bl func_ov61_0213e6f4
 	mov r2, r0
 	ldr r1, _0214985c ; =data_ov61_0217a784
-	mov r0, sb
+	mov r0, r9
 	bl func_ov61_021621cc
 _021497e0:
 	add r7, r7, #1
@@ -13794,10 +13794,10 @@ _0214982c:
 	bl func_ov61_02162e84
 	cmp r0, #0
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _0214984c:
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02149688
 _02149854: .word data_ov61_0217a758
@@ -13807,7 +13807,7 @@ _0214985c: .word data_ov61_0217a784
 	.global func_ov61_02149860
 	arm_func_start func_ov61_02149860
 func_ov61_02149860: ; 0x02149860
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x18
 	mov r7, #0
 	mov r8, r7
@@ -13816,8 +13816,8 @@ func_ov61_02149860: ; 0x02149860
 	bl func_ov61_02162e84
 	cmp r0, #1
 	addle sp, sp, #0x18
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
-	mov sb, r7
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
+	mov r9, r7
 	bl func_ov61_0214a214
 	ldr r0, [r0, #0xe4]
 	bl func_ov61_02162e84
@@ -13829,26 +13829,26 @@ func_ov61_02149860: ; 0x02149860
 _021498ac:
 	bl func_ov61_0214a214
 	ldr r0, [r0, #0xe4]
-	mov r1, sb
+	mov r1, r9
 	bl func_ov61_02162e74
 	mov r1, r6
 	mov r2, r5
 	bl func_ov61_02162270
 	cmp r0, r7
 	movgt r7, r0
-	ldr r0, [r4, sb, lsl #2]
-	add sb, sb, #1
+	ldr r0, [r4, r9, lsl #2]
+	add r9, r9, #1
 	add r8, r8, r0
 	bl func_ov61_0214a214
 	ldr r0, [r0, #0xe4]
 	bl func_ov61_02162e84
-	cmp sb, r0
+	cmp r9, r0
 	blt _021498ac
 _021498f0:
 	mov r0, #0x64
 	bl func_ov61_0213e6f4
 	mov r6, r0
-	mov sb, #0
+	mov r9, #0
 	bl func_ov61_0214a214
 	ldr r0, [r0, #0xe4]
 	bl func_ov61_02162e84
@@ -13862,25 +13862,25 @@ _02149920:
 	ldr r0, [r0, #0xe4]
 	bl func_ov61_02162e84
 	sub r0, r0, #1
-	cmp sb, r0
+	cmp r9, r0
 	beq _02149980
-	ldr r2, [r4, sb, lsl #2]
-	cmp sb, #0
-	addgt r0, r5, sb, lsl #2
+	ldr r2, [r4, r9, lsl #2]
+	cmp r9, #0
+	addgt r0, r5, r9, lsl #2
 	ldrgt r10, [r0, #-4]
 	mul r0, r2, r11
 	movle r10, #0
 	mov r1, r8
 	bl func_02002c14
 	add r0, r0, r10
-	str r0, [r5, sb, lsl #2]
+	str r0, [r5, r9, lsl #2]
 	cmp r6, r0
 	blo _02149980
-	add sb, sb, #1
+	add r9, r9, #1
 	bl func_ov61_0214a214
 	ldr r0, [r0, #0xe4]
 	bl func_ov61_02162e84
-	cmp sb, r0
+	cmp r9, r0
 	blt _02149920
 _02149980:
 	mvn r0, #0x80000000
@@ -13888,7 +13888,7 @@ _02149980:
 	addlt r7, r7, #1
 	bl func_ov61_0214a214
 	ldr r0, [r0, #0xe4]
-	mov r1, sb
+	mov r1, r9
 	bl func_ov61_02162e74
 	ldr r1, _021499cc ; =data_ov61_0217a784
 	mov r2, r7
@@ -13900,7 +13900,7 @@ _02149980:
 	mov r3, r1
 	bl func_ov61_02162e94
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02149860
 _021499c8: .word data_ov61_0217a210
@@ -14153,10 +14153,10 @@ _02149c74:
 	.global func_ov61_02149cac
 	arm_func_start func_ov61_02149cac
 func_ov61_02149cac: ; 0x02149cac
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x9c
 	mov r10, r0
-	mov sb, r1
+	mov r9, r1
 	mov r8, #0
 	bl func_ov61_0213f4e4
 	cmp r0, #5
@@ -14164,7 +14164,7 @@ func_ov61_02149cac: ; 0x02149cac
 	bl func_ov61_0213f4e4
 	cmp r0, #6
 	addne sp, sp, #0x9c
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	bl func_ov61_0214a214
 	ldrb r0, [r0, #0x15]
 	cmp r0, #2
@@ -14173,11 +14173,11 @@ func_ov61_02149cac: ; 0x02149cac
 	ldrb r0, [r0, #0x15]
 	cmp r0, #3
 	addne sp, sp, #0x9c
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02149d00:
-	cmp sb, #0x14
+	cmp r9, #0x14
 	addlo sp, sp, #0x9c
-	ldmloia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmloia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r5, _02149db4 ; =data_ov61_0217a800
 	add r4, sp, #0x1c
 	add r7, sp, #8
@@ -14196,7 +14196,7 @@ _02149d20:
 	ldreq r0, [sp, #0xc]
 	cmpeq r0, #3
 	addne sp, sp, #0x9c
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldrb r2, [sp, #0x11]
 	mov r1, r4
 	add r0, r10, #0x14
@@ -14212,15 +14212,15 @@ _02149d20:
 	bl func_ov61_02145420
 	cmp r0, #0
 	addeq sp, sp, #0x9c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldrb r0, [sp, #0x11]
 	add r0, r0, #0x14
 	add r8, r8, r0
 	add r0, r8, #0x14
-	cmp r0, sb
+	cmp r0, r9
 	bls _02149d20
 	add sp, sp, #0x9c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02149cac
 _02149db4: .word data_ov61_0217a800
@@ -14631,7 +14631,7 @@ func_ov61_0214a2c8: ; 0x0214a2c8
 	.global func_ov61_0214a2e8
 	arm_func_start func_ov61_0214a2e8
 func_ov61_0214a2e8: ; 0x0214a2e8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #8
 	mov r7, r1
 	mov r8, r0
@@ -14646,7 +14646,7 @@ func_ov61_0214a2e8: ; 0x0214a2e8
 	cmp r0, #0
 	addeq sp, sp, #8
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	mov r0, #1
 	strb r0, [r4, #0x1c]
 	str r6, [r4]
@@ -14665,22 +14665,22 @@ func_ov61_0214a2e8: ; 0x0214a2e8
 	ldr r0, _0214a404 ; =data_ov61_0217f350
 	ldr r0, [r0]
 	add r0, r0, #0x600
-	ldrh sb, [r0, #0x10]
+	ldrh r9, [r0, #0x10]
 	mov r0, r7
-	cmp r5, sb
-	movle sb, r5
+	cmp r5, r9
+	movle r9, r5
 	bl func_ov61_0214adf4
-	cmp sb, r0
+	cmp r9, r0
 	addgt sp, sp, #8
 	movgt r0, #1
-	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	mov r0, r7
 	mov r1, r6
-	mov r2, sb
+	mov r2, r9
 	mov r3, #1
 	bl func_ov61_0214aa54
 	ldr r0, [r4, #0xc]
-	add r1, r0, sb
+	add r1, r0, r9
 	str r1, [r4, #0xc]
 	ldr r0, [r4, #0x14]
 	cmp r1, r0
@@ -14702,7 +14702,7 @@ func_ov61_0214a2e8: ; 0x0214a2e8
 _0214a3f8:
 	mov r0, #1
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0214a2e8
 _0214a404: .word data_ov61_0217f350
@@ -14710,23 +14710,23 @@ _0214a404: .word data_ov61_0217f350
 	.global func_ov61_0214a408
 	arm_func_start func_ov61_0214a408
 func_ov61_0214a408: ; 0x0214a408
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	mov r7, #1
 	mov r6, r0
 	mov r5, r1
 	mov r4, r2
-	mov sb, #0
+	mov r9, #0
 	mov r8, r7
 _0214a424:
-	cmp sb, #0
+	cmp r9, #0
 	movne r10, r8, lsl sb
 	moveq r10, r7
 	tst r6, r10
 	beq _0214a460
 	bl func_ov61_0213f40c
-	cmp sb, r0
+	cmp r9, r0
 	beq _0214a460
-	mov r0, sb
+	mov r0, r9
 	mov r1, r5
 	mov r2, r4
 	bl func_ov61_0214a2c8
@@ -14734,12 +14734,12 @@ _0214a424:
 	mvneq r0, r10
 	andeq r6, r6, r0
 _0214a460:
-	add r0, sb, #1
-	and sb, r0, #0xff
-	cmp sb, #0x20
+	add r0, r9, #1
+	and r9, r0, #0xff
+	cmp r9, #0x20
 	blo _0214a424
 	mov r0, r6
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	arm_func_end func_ov61_0214a408
 
 	.global func_ov61_0214a478
@@ -14788,23 +14788,23 @@ _0214a504: .word data_ov61_0217f350
 	.global func_ov61_0214a508
 	arm_func_start func_ov61_0214a508
 func_ov61_0214a508: ; 0x0214a508
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	mov r7, #1
 	mov r6, r0
 	mov r5, r1
 	mov r4, r2
-	mov sb, #0
+	mov r9, #0
 	mov r8, r7
 _0214a524:
-	cmp sb, #0
+	cmp r9, #0
 	movne r10, r8, lsl sb
 	moveq r10, r7
 	tst r6, r10
 	beq _0214a560
 	bl func_ov61_0213f40c
-	cmp sb, r0
+	cmp r9, r0
 	beq _0214a560
-	mov r0, sb
+	mov r0, r9
 	mov r1, r5
 	mov r2, r4
 	bl func_ov61_0214a478
@@ -14812,12 +14812,12 @@ _0214a524:
 	mvneq r0, r10
 	andeq r6, r6, r0
 _0214a560:
-	add r0, sb, #1
-	and sb, r0, #0xff
-	cmp sb, #0x20
+	add r0, r9, #1
+	and r9, r0, #0xff
+	cmp r9, #0x20
 	blo _0214a524
 	mov r0, r6
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	arm_func_end func_ov61_0214a508
 
 	.global func_ov61_0214a578
@@ -15046,27 +15046,27 @@ _0214a7d0: .word data_ov61_0217f350
 	.global func_ov61_0214a7d4
 	arm_func_start func_ov61_0214a7d4
 func_ov61_0214a7d4: ; 0x0214a7d4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	ldr r0, _0214a960 ; =data_ov61_0217f350
 	ldr r0, [r0]
 	cmp r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r0, sp, #0
 	bl func_ov61_0213f428
 	mov r7, r0
 	mov r8, #0
 	cmp r7, #0
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r4, _0214a960 ; =data_ov61_0217f350
 	mov r11, r8
 _0214a808:
 	ldr r0, [sp]
-	ldrb sb, [r0, r8]
-	mov r0, sb
+	ldrb r9, [r0, r8]
+	mov r0, r9
 	bl func_ov61_0213f4ac
 	cmp r0, #0
 	beq _0214a89c
-	mov r0, sb
+	mov r0, r9
 	bl func_ov61_0214aa04
 	ldr r1, [r4]
 	mov r6, r0
@@ -15092,20 +15092,20 @@ _0214a808:
 	cmp r0, r1
 	bls _0214a89c
 	ldr r1, [r4]
-	mov r0, sb
+	mov r0, r9
 	ldr r1, [r1, #0x608]
 	blx r1
 	str r5, [r6, #0x24]
 	str r10, [r6, #0x28]
 _0214a89c:
 	bl func_ov61_0213f40c
-	cmp sb, r0
+	cmp r9, r0
 	beq _0214a950
-	mov r0, sb
+	mov r0, r9
 	bl func_ov61_0214aa1c
 	cmp r0, #1
 	bne _0214a950
-	mov r0, sb
+	mov r0, r9
 	bl func_ov61_0214aa04
 	mov r5, r0
 	ldr r0, [r4]
@@ -15116,13 +15116,13 @@ _0214a89c:
 	sub r0, r2, r1
 	cmp r0, r6
 	movle r6, r0
-	mov r0, sb
+	mov r0, r9
 	bl func_ov61_0214adf4
 	cmp r0, r6
 	blt _0214a950
 	ldr r3, [r5]
 	ldr r1, [r5, #0xc]
-	mov r0, sb
+	mov r0, r9
 	add r1, r3, r1
 	mov r2, r6
 	mov r3, #1
@@ -15141,13 +15141,13 @@ _0214a89c:
 	ldr r2, [r1, #0x600]
 	cmp r2, #0
 	beq _0214a950
-	mov r1, sb
+	mov r1, r9
 	blx r2
 _0214a950:
 	add r8, r8, #1
 	cmp r8, r7
 	blt _0214a808
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0214a7d4
 _0214a960: .word data_ov61_0217f350
@@ -16070,7 +16070,7 @@ _0214b4a4: .word 0x00000d18
 	.global func_ov61_0214b4a8
 	arm_func_start func_ov61_0214b4a8
 func_ov61_0214b4a8: ; 0x0214b4a8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	ldr r0, _0214b544 ; =data_ov61_0217f354
 	mov r1, #0xc0
 	ldr r8, [r0]
@@ -16081,10 +16081,10 @@ func_ov61_0214b4a8: ; 0x0214b4a8
 	add r5, r0, #0x400
 	cmp r2, #6
 	movhs r0, #1
-	ldmhsia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
-	ldrb sb, [r8, #0xd12]
+	ldmhsia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
+	ldrb r9, [r8, #0xd12]
 	mov r6, #0
-	cmp sb, #0
+	cmp r9, #0
 	bls _0214b53c
 	mov r10, r1
 _0214b4ec:
@@ -16103,15 +16103,15 @@ _0214b4ec:
 	bl strncmp
 	cmp r0, #0
 	moveq r0, #2
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _0214b52c:
 	add r0, r6, #1
 	and r6, r0, #0xff
-	cmp r6, sb
+	cmp r6, r9
 	blo _0214b4ec
 _0214b53c:
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0214b4a8
 _0214b544: .word data_ov61_0217f354
@@ -16265,7 +16265,7 @@ _0214b740:
 	.global func_ov61_0214b748
 	arm_func_start func_ov61_0214b748
 func_ov61_0214b748: ; 0x0214b748
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	mov r6, r0
 	ldrh r3, [r6, #0xa]
 	mov r5, r1
@@ -16274,24 +16274,24 @@ func_ov61_0214b748: ; 0x0214b748
 	bne _0214b770
 	bl func_ov61_0214b6b4
 	cmp r0, #0
-	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _0214b770:
 	cmp r5, #0
 	mov r8, #0
 	ble _0214b7bc
-	ldrh sb, [r6, #0xa]
-	and r7, sb, #0xff
+	ldrh r9, [r6, #0xa]
+	and r7, r9, #0xff
 _0214b784:
 	ldrb r0, [r4, #3]
 	cmp r7, r0
 	bne _0214b7ac
-	mov r2, sb
+	mov r2, r9
 	add r0, r6, #0xc
 	add r1, r4, #4
 	bl strncmp
 	cmp r0, #0
 	ldreqb r0, [r4, #1]
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _0214b7ac:
 	add r8, r8, #1
 	cmp r8, r5
@@ -16299,29 +16299,29 @@ _0214b7ac:
 	blt _0214b784
 _0214b7bc:
 	mvn r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	arm_func_end func_ov61_0214b748
 
 	.global func_ov61_0214b7c4
 	arm_func_start func_ov61_0214b7c4
 func_ov61_0214b7c4: ; 0x0214b7c4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	mov r10, r0
 	ldrh r2, [r10, #0xa]
-	mov sb, r1
+	mov r9, r1
 	cmp r2, #0x20
 	bne _0214b7e8
 	bl func_ov61_0214b6b4
 	cmp r0, #0
-	ldmgtia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmgtia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _0214b7e8:
-	ldrb r8, [sb, #0xd12]
+	ldrb r8, [r9, #0xd12]
 	mov r4, #0
 	cmp r8, #0
 	ble _0214b84c
 	ldrh r7, [r10, #0xa]
-	add r0, sb, #0x7c
-	mov r5, sb
+	add r0, r9, #0x7c
+	mov r5, r9
 	add r6, r0, #0x400
 _0214b808:
 	add r0, r5, #0x400
@@ -16333,9 +16333,9 @@ _0214b808:
 	add r0, r10, #0xc
 	bl strncmp
 	cmp r0, #0
-	addeq r0, sb, r4, lsl #2
+	addeq r0, r9, r4, lsl #2
 	ldreqb r0, [r0, #0x445]
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _0214b838:
 	add r4, r4, #1
 	cmp r4, r8
@@ -16344,7 +16344,7 @@ _0214b838:
 	blt _0214b808
 _0214b84c:
 	mvn r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	arm_func_end func_ov61_0214b7c4
 
 	.global func_ov61_0214b854
@@ -16466,7 +16466,7 @@ _0214b9c0:
 	.global func_ov61_0214b9d4
 	arm_func_start func_ov61_0214b9d4
 func_ov61_0214b9d4: ; 0x0214b9d4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0xc4
 	mov r4, r0
 	add r0, r1, #0x44
@@ -16476,7 +16476,7 @@ func_ov61_0214b9d4: ; 0x0214b9d4
 	bmi _0214ba9c
 	mov r0, #0xc0
 	mla r10, r6, r0, r8
-	add sb, r7, r6, lsl #2
+	add r9, r7, r6, lsl #2
 	add r11, sp, #0
 _0214ba04:
 	add r0, r7, r4, lsl #2
@@ -16485,13 +16485,13 @@ _0214ba04:
 	ldrb r0, [r0, #2]
 	cmp r1, r0
 	blo _0214ba9c
-	mov r0, sb
+	mov r0, r9
 	mov r1, r11
 	mov r2, #4
 	bl func_02007908
 	add r5, r7, r4, lsl #2
 	mov r0, r5
-	mov r1, sb
+	mov r1, r9
 	mov r2, #4
 	bl func_02007908
 	mov r1, r5
@@ -16513,7 +16513,7 @@ _0214ba04:
 	mov r2, #0xc0
 	bl func_02007908
 	mov r4, r6
-	sub sb, sb, #4
+	sub r9, r9, #4
 	sub r10, r10, #0xc0
 	subs r6, r6, #1
 	bpl _0214ba04
@@ -16527,7 +16527,7 @@ _0214ba9c:
 	mov r2, #0xc0
 	bl func_020078f4
 	add sp, sp, #0xc4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	arm_func_end func_ov61_0214b9d4
 
 	.global func_ov61_0214bac4
@@ -16764,7 +16764,7 @@ _0214bdc0:
 	.global func_ov61_0214bdc8
 	arm_func_start func_ov61_0214bdc8
 func_ov61_0214bdc8: ; 0x0214bdc8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	mov r10, r0
 	ldrb r2, [r10, #0xd13]
 	ldrb r1, [r10, #0xd0c]
@@ -16805,7 +16805,7 @@ _0214be4c:
 	ble _0214bf58
 	mov r7, r10
 	add r8, r10, #0x304
-	add sb, r10, #0x300
+	add r9, r10, #0x300
 	add r11, r10, #0x10c
 _0214be6c:
 	ldrh r2, [r4, #0xa]
@@ -16821,10 +16821,10 @@ _0214be6c:
 	ldreqb r0, [r7, #0x301]
 	streq r0, [sp]
 	beq _0214bec0
-	ldrb r0, [sb]
+	ldrb r0, [r9]
 	bic r0, r0, #0xf0
 	orr r0, r0, #0x10
-	strb r0, [sb]
+	strb r0, [r9]
 	ldrb r0, [r11, #0xc00]
 	bic r0, r0, #0xc0
 	orr r0, r0, #0x40
@@ -16837,7 +16837,7 @@ _0214bec4:
 	add r7, r7, #0x24
 	cmp r5, r0
 	add r8, r8, #0x24
-	add sb, sb, #0x24
+	add r9, r9, #0x24
 	blt _0214be6c
 	b _0214bf58
 _0214bee4:
@@ -16877,7 +16877,7 @@ _0214bf48:
 _0214bf58:
 	ldr r0, [sp]
 	and r0, r0, #0xff
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	arm_func_end func_ov61_0214bdc8
 
 	.global func_ov61_0214bf64
@@ -19039,7 +19039,7 @@ _0214da20:
 	.global func_ov61_0214da4c
 	arm_func_start func_ov61_0214da4c
 func_ov61_0214da4c: ; 0x0214da4c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x18
 	add r4, r2, r2, lsl #1
 	str r0, [sp]
@@ -19055,12 +19055,12 @@ func_ov61_0214da4c: ; 0x0214da4c
 _0214da80:
 	add sp, sp, #0x18
 	mvn r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0214da8c:
 	cmp r0, #0
 	mov r7, #0
 	ble _0214db14
-	mov sb, r7
+	mov r9, r7
 	add r5, sp, #0x14
 	mov r4, #6
 _0214daa4:
@@ -19078,7 +19078,7 @@ _0214dab4:
 	cmp r8, #4
 	blt _0214dab4
 	ldr r0, [sp, #4]
-	add r1, sb, sb, lsl #1
+	add r1, r9, r9, lsl #1
 	mov r2, #0
 	str r6, [sp, #0x14]
 	add r1, r0, r1
@@ -19092,7 +19092,7 @@ _0214dae8:
 	ldr r0, [sp, #0xc]
 	add r7, r7, #4
 	cmp r7, r0
-	add sb, sb, #1
+	add r9, r9, #1
 	blt _0214daa4
 _0214db14:
 	cmp r11, #0
@@ -19138,7 +19138,7 @@ _0214db90:
 _0214dba8:
 	ldr r0, [sp, #8]
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	arm_func_end func_ov61_0214da4c
 
 	.global func_ov61_0214dbb4
@@ -19520,7 +19520,7 @@ _0214e098: .word data_027e02a0
 	.global func_ov61_0214e09c
 	arm_func_start func_ov61_0214e09c
 func_ov61_0214e09c: ; 0x0214e09c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	mov r8, #0
 _0214e0a4:
 	ldr r0, _0214e340 ; =data_ov61_0217f368
@@ -19554,7 +19554,7 @@ _0214e0d0:
 	bne _0214e120
 	mov r0, #0x14
 	bl func_ov61_0214e994
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0214e120:
 	cmp r8, #2
 	ble _0214e15c
@@ -19562,17 +19562,17 @@ _0214e120:
 	bne _0214e13c
 	mov r0, #9
 	bl func_ov61_0214e994
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0214e13c:
 	cmp r0, #3
 	bne _0214e150
 	mov r0, #0xb
 	bl func_ov61_0214e994
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0214e150:
 	mov r0, #0xd
 	bl func_ov61_0214e994
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0214e15c:
 	mov r0, #1
 	add r8, r8, #1
@@ -19588,13 +19588,13 @@ _0214e16c:
 	bne _0214e1c0
 	mov r0, #0x15
 	bl func_ov61_0214e994
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0214e194:
 	cmp r8, #2
 	ble _0214e1a8
 	mov r0, #0x10
 	bl func_ov61_0214e994
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0214e1a8:
 	mov r0, #0
 	add r8, r8, #1
@@ -19602,22 +19602,22 @@ _0214e1a8:
 	b _0214e1dc
 _0214e1b8:
 	bl func_ov61_0214e994
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0214e1c0:
 	cmp r8, #2
 	blt _0214e1d0
 	bl func_ov61_0214e994
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0214e1d0:
 	mov r0, #1
 	add r8, r8, #1
 	str r0, [sp]
 _0214e1dc:
 	bl func_0200e8f8
-	mov sb, r0
+	mov r9, r0
 	mov r10, r1
 	bl func_0200e8f8
-	subs r2, r0, sb
+	subs r2, r0, r9
 	sbc r0, r1, r10
 	mov r1, r0, lsl #0x6
 	orr r1, r1, r2, lsr #26
@@ -19652,7 +19652,7 @@ _0214e22c:
 	bl func_0200e0c8
 	mov r0, #0x14
 	bl func_ov61_0214e994
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0214e278:
 	add r0, r2, #0x3d8
 	add r0, r0, #0x1000
@@ -19660,7 +19660,7 @@ _0214e278:
 	mov r0, r7
 	bl func_0200db28
 	bl func_0200e8f8
-	subs r2, r0, sb
+	subs r2, r0, r9
 	sbc r0, r1, r10
 	mov r1, r0, lsl #0x6
 	orr r1, r1, r2, lsr #26
@@ -19699,14 +19699,14 @@ _0214e2bc:
 	add r0, r0, #0x3d8
 	add r0, r0, #0x1000
 	bl func_0200e0c8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0214e32c:
 	add r0, r3, #0x3d8
 	add r0, r0, #0x1000
 	bl func_0200e0c8
 	b _0214e0a4
 _0214e33c:
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	arm_func_end func_ov61_0214e09c
 _0214e340: .word data_ov61_0217f368
 _0214e344: .word 0x00004e84
@@ -20192,7 +20192,7 @@ func_ov61_0214e9d8: ; 0x0214e9d8
 	.global func_ov61_0214ea00
 	arm_func_start func_ov61_0214ea00
 func_ov61_0214ea00: ; 0x0214ea00
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x8c
 	mov r6, r1
 	mov r1, #0
@@ -20292,7 +20292,7 @@ _0214ead8:
 _0214eb70:
 	add sp, sp, #0x8c
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _0214eb7c:
 	ldr r0, [sp, #0x2c]
 	ldr r2, _0214eca8 ; =data_ov61_0217aa24
@@ -20321,18 +20321,18 @@ _0214eb7c:
 	bl func_0200ee60
 	add sp, sp, #0x8c
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _0214ebec:
 	ldr r5, _0214eca0 ; =data_ov61_0217aa10
 	add r8, r4, #0x41
-	mov sb, #0
+	mov r9, #0
 _0214ebf8:
-	ldrb r2, [r7, sb]
+	ldrb r2, [r7, r9]
 	mov r0, r8
 	mov r1, r5
 	bl func_0200c8d0
-	add sb, sb, #1
-	cmp sb, #6
+	add r9, r9, #1
+	cmp r9, #6
 	add r8, r8, #2
 	blt _0214ebf8
 	bl func_ov61_0214b0fc
@@ -20352,7 +20352,7 @@ _0214ebf8:
 	bl func_0200ee60
 	add sp, sp, #0x8c
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _0214ec60:
 	mov r0, r5
 	add r1, r4, #0x72
@@ -20365,7 +20365,7 @@ _0214ec60:
 	bl func_0200ee60
 	mov r0, #1
 	add sp, sp, #0x8c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0214ea00
 _0214ec90: .word data_ov61_0217aa00
@@ -20944,7 +20944,7 @@ _0214f490: .word data_ov61_0217aba0
 	.global func_ov61_0214f494
 	arm_func_start func_ov61_0214f494
 func_ov61_0214f494: ; 0x0214f494
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x14
 	mov r10, r0
 	add r0, r10, #0x1000
@@ -20967,7 +20967,7 @@ func_ov61_0214f494: ; 0x0214f494
 	moveq r1, #2
 	streq r1, [r0, #0x20]
 	addeq sp, sp, #0x14
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	str r6, [r0, #0x12c]
 	bl func_ov61_02154bc0
 	add r0, r10, #0x1000
@@ -21004,7 +21004,7 @@ _0214f548:
 	bl func_ov61_02154bf4
 	bl func_ov61_02154b1c
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0214f584:
 	ldr r4, [r0, #0x9f8]
 	mov r0, r4
@@ -21067,15 +21067,15 @@ _0214f630:
 	beq _0214f760
 	ldmib r7, {r1, r2}
 	sub r2, r2, #1
-	ldr sb, [sp, #0x10]
+	ldr r9, [sp, #0x10]
 	sub r2, r2, r1
-	cmp sb, r2
-	movge sb, r2
-	mov r2, sb
+	cmp r9, r2
+	movge r9, r2
+	mov r2, r9
 	bl func_02007ad8
 	ldr r0, [r7, #4]
 	cmp r11, #1
-	add r1, r0, sb
+	add r1, r0, r9
 	str r1, [r7, #4]
 	mov r0, #0
 	strb r0, [r1]
@@ -21084,7 +21084,7 @@ _0214f630:
 	bl func_0200e044
 	ldr r1, [r6]
 	add r0, r5, #0x1800
-	add r1, r1, sb
+	add r1, r1, r9
 	str r1, [r6]
 	bl func_0200e0c8
 	b _0214f6c8
@@ -21094,12 +21094,12 @@ _0214f6bc:
 	mov r11, r0
 _0214f6c8:
 	ldr r0, [sp, #0x10]
-	cmp r0, sb
+	cmp r0, r9
 	bls _0214f6dc
 	bl func_ov61_021550cc
 	b _0214f760
 _0214f6dc:
-	mov r0, sb
+	mov r0, r9
 	bl func_ov61_021550cc
 _0214f6e4:
 	ldr r1, [r4, #0xa30]
@@ -21143,14 +21143,14 @@ _0214f760:
 	mov r1, #8
 	str r1, [r0, #0x20]
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0214f784:
 	bl func_ov61_02154e44
 	bl func_ov61_02154e80
 	bl func_ov61_02154bf4
 	bl func_ov61_02154b1c
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0214f494
 _0214f79c: .word 0x0000ea60
@@ -21269,7 +21269,7 @@ _0214f920: .word data_ov61_0217ac28
 	.global func_ov61_0214f924
 	arm_func_start func_ov61_0214f924
 func_ov61_0214f924: ; 0x0214f924
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	mov r8, r0
 	mov r6, r2
 	add r2, r8, #0x1f8
@@ -21280,10 +21280,10 @@ func_ov61_0214f924: ; 0x0214f924
 	mov r4, r0
 	ldr r0, _0214f9f8 ; =data_ov61_0217ac48
 	bl strlen
-	mov sb, r0
+	mov r9, r0
 	mov r0, r7
 	bl strlen
-	sub r1, sb, #4
+	sub r1, r9, #4
 	add r0, r1, r0
 	add r4, r4, r0
 	ldmib r5, {r1, r2}
@@ -21298,31 +21298,31 @@ func_ov61_0214f924: ; 0x0214f924
 	bl func_ov61_0214fc38
 	cmp r0, #0
 	moveq r0, #1
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _0214f99c:
 	ldr r0, [r5]
 	ldr r1, _0214f9fc ; =data_ov61_0217ab70
 	bl strstr
-	add sb, r0, #2
+	add r9, r0, #2
 	ldrsb r8, [r0, #2]
-	mov r0, sb
+	mov r0, r9
 	bl strlen
 	add r2, r0, #1
-	add r0, sb, r4
-	mov r1, sb
+	add r0, r9, r4
+	mov r1, r9
 	bl func_020435b4
 	ldr r2, _0214f9f8 ; =data_ov61_0217ac48
 	str r6, [sp]
 	mov r3, r7
-	mov r0, sb
+	mov r0, r9
 	add r1, r4, #1
 	bl func_0200c910
-	strb r8, [sb, r0]
+	strb r8, [r9, r0]
 	ldr r1, [r5, #4]
 	mov r0, #0
 	add r1, r1, r4
 	str r1, [r5, #4]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0214f924
 _0214f9f8: .word data_ov61_0217ac48
@@ -21331,7 +21331,7 @@ _0214f9fc: .word data_ov61_0217ab70
 	.global func_ov61_0214fa00
 	arm_func_start func_ov61_0214fa00
 func_ov61_0214fa00: ; 0x0214fa00
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	mov r10, r0
 	add r0, r10, #0x1000
 	ldr r4, [r0, #0x9f4]
@@ -21345,7 +21345,7 @@ func_ov61_0214fa00: ; 0x0214fa00
 	mov r7, r3
 	add r11, r0, #1
 	mov r2, #0
-	mov sb, r1
+	mov r9, r1
 	ldrne r6, _0214fb08 ; =data_ov61_0217ac58
 	mov r0, r8
 	mov r1, r7
@@ -21356,7 +21356,7 @@ func_ov61_0214fa00: ; 0x0214fa00
 	mov r0, r6
 	bl strlen
 	mov r11, r0
-	mov r0, sb
+	mov r0, r9
 	bl strlen
 	sub r1, r11, #2
 	add r2, r1, r0
@@ -21372,12 +21372,12 @@ func_ov61_0214fa00: ; 0x0214fa00
 	bl func_ov61_0214fc38
 	cmp r0, #0
 	moveq r0, #1
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldmib r5, {r0, r1}
 	sub r1, r1, r0
 _0214fab0:
 	mov r2, r6
-	mov r3, sb
+	mov r3, r9
 	bl func_0200c910
 	ldr r2, [r5, #4]
 	mov r1, r7
@@ -21390,13 +21390,13 @@ _0214fab0:
 	bl func_ov61_02151810
 	cmp r0, #0
 	movlt r0, #1
-	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmltia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r1, [r5, #4]
 	mov r0, #0
 	add r1, r1, r4
 	str r1, [r5, #4]
 	strb r0, [r1]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0214fa00
 _0214fb04: .word data_ov61_0217ac54
@@ -21741,7 +21741,7 @@ _0214ff84: .word data_ov61_0217ad14
 	.global func_ov61_0214ff88
 	arm_func_start func_ov61_0214ff88
 func_ov61_0214ff88: ; 0x0214ff88
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x10
 	mov r4, r0
 	add r0, r4, #0x238
@@ -21763,7 +21763,7 @@ func_ov61_0214ff88: ; 0x0214ff88
 	cmp r0, #0
 	addeq sp, sp, #0x10
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r0, r0, #4
 	bl strlen
 	ldr r1, [sp]
@@ -21775,8 +21775,8 @@ func_ov61_0214ff88: ; 0x0214ff88
 	movs r7, r0
 	addeq sp, sp, #0x10
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
-	ldrsb sb, [r7, #4]
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
+	ldrsb r9, [r7, #4]
 	ldr r2, _02150210 ; =data_ov61_0217ad34
 	mov r5, #0
 	add r1, sp, #4
@@ -21786,9 +21786,9 @@ func_ov61_0214ff88: ; 0x0214ff88
 	bl func_ov61_0214fe34
 	cmp r0, #1
 	addne sp, sp, #0x10
-	strb sb, [r7, #4]
+	strb r9, [r7, #4]
 	movne r0, r5
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	cmp r6, #1
 	beq _02150068
 	ldr r1, _02150214 ; =data_ov61_0217ad40
@@ -21800,7 +21800,7 @@ func_ov61_0214ff88: ; 0x0214ff88
 _02150068:
 	add sp, sp, #0x10
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02150074:
 	ldr r1, _02150218 ; =data_ov61_0217aba0
 	add r0, r7, #5
@@ -21808,12 +21808,12 @@ _02150074:
 	cmp r0, #0
 	addeq sp, sp, #0x10
 	moveq r0, r5
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
-	add sb, r0, #2
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
+	add r9, r0, #2
 	b _02150128
 _02150098:
 	ldr r1, _0215021c ; =data_ov61_0217ad44
-	mov r0, sb
+	mov r0, r9
 	bl strstr
 	movs r6, r0
 	beq _0215013c
@@ -21829,7 +21829,7 @@ _02150098:
 	beq _0215013c
 	ldrsb r8, [r5]
 	mov r1, #0
-	mov r2, sb
+	mov r2, r9
 	strb r1, [r5]
 	mov r0, r4
 	add r1, sp, #4
@@ -21841,18 +21841,18 @@ _02150098:
 	add sp, sp, #0x10
 	strb r8, [r5]
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02150110:
 	mov r0, r10
 	bl strlen
 	strb r7, [r6]
 	add r0, r10, r0
 	strb r8, [r5]
-	add sb, r0, #2
+	add r9, r0, #2
 _02150128:
-	ldrsb r0, [sb]
+	ldrsb r0, [r9]
 	cmp r0, #0xd
-	ldrnesb r0, [sb, #1]
+	ldrnesb r0, [r9, #1]
 	cmpne r0, #0xa
 	bne _02150098
 _0215013c:
@@ -21866,7 +21866,7 @@ _0215014c:
 	bl strstr
 	movs r5, r0
 	beq _021501fc
-	ldrsb sb, [r5]
+	ldrsb r9, [r5]
 	mov r1, #0
 	add r6, r5, #1
 	strb r1, [r5]
@@ -21891,17 +21891,17 @@ _02150194:
 	bl func_ov61_0214fe34
 	cmp r0, #1
 	beq _021501d8
-	strb sb, [r5]
+	strb r9, [r5]
 	cmp r10, #0
 	add sp, sp, #0x10
 	strneb r8, [r10]
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _021501d8:
 	mov r0, r6
 	bl strlen
 	add r0, r6, r0
-	strb sb, [r5]
+	strb r9, [r5]
 	cmp r10, #0
 	add r7, r0, #1
 	strneb r8, [r10]
@@ -21910,7 +21910,7 @@ _021501d8:
 _021501fc:
 	mov r0, #1
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0214ff88
 _02150208: .word data_ov61_0217ab70
@@ -22002,14 +22002,14 @@ func_ov61_021502d4: ; 0x021502d4
 	.global func_ov61_02150314
 	arm_func_start func_ov61_02150314
 func_ov61_02150314: ; 0x02150314
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	add r0, r0, #0x1000
 	ldr r6, [r0, #0x14]
-	mov sb, r2
+	mov r9, r2
 	mov r10, r1
 	mov r8, #0
-	cmp sb, #0
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	cmp r9, #0
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r11, _02150394 ; =data_ov61_0217ad50
 	ldr r7, _02150398 ; =data_ov61_0217ad6c
 	mov r5, r8
@@ -22034,9 +22034,9 @@ _02150360:
 	str r4, [r0, #4]
 _02150384:
 	add r8, r8, #1
-	cmp r8, sb
+	cmp r8, r9
 	blt _02150344
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02150314
 _02150394: .word data_ov61_0217ad50
@@ -22287,12 +22287,12 @@ _021506b8: .word func_ov61_021506bc
 	.global func_ov61_021506bc
 	arm_func_start func_ov61_021506bc
 func_ov61_021506bc: ; 0x021506bc
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x290
 	ldr r4, _02151520 ; =data_ov61_0217f38c
 	mov r8, #0
 	ldr r0, [r4]
-	mov sb, r8
+	mov r9, r8
 	add r0, r0, #0x1000
 	ldr r6, [r0, #0x108]
 	ldr r7, [r0, #0x10c]
@@ -23027,7 +23027,7 @@ _0215115c:
 	ldr r0, _02151588 ; =data_ov61_0217ae5c
 	add r1, r11, #1
 	blx r6
-	movs sb, r0
+	movs r9, r0
 	bne _02151188
 	ldr r0, _02151520 ; =data_ov61_0217f38c
 	ldr r0, [r0, #0x14]
@@ -23070,7 +23070,7 @@ _021511f4:
 	ldr r0, [r4, #0x14]
 	ldr r1, _0215157c ; =data_ov61_0217af08
 	add r3, r11, #1
-	mov r2, sb
+	mov r2, r9
 	bl func_ov61_02150280
 	cmp r0, #0
 	bge _02151230
@@ -23082,7 +23082,7 @@ _021511f4:
 	b _021514cc
 _02151230:
 	mov r1, #0
-	strb r1, [sb, r0]
+	strb r1, [r9, r0]
 	cmp r5, #0
 	mov r11, r1
 	ble _021512c4
@@ -23149,7 +23149,7 @@ _021512c4:
 	b _021514cc
 _0215132c:
 	ldr r0, [r4, #0x14]
-	mov r1, sb
+	mov r1, r9
 	bl func_ov61_0214fb0c
 	cmp r0, #0
 	beq _02151358
@@ -23269,22 +23269,22 @@ _021514cc:
 	mov r2, #0
 	blx r7
 _021514e4:
-	cmp sb, #0
+	cmp r9, #0
 	beq _021514fc
 	ldr r0, _021515a0 ; =data_ov61_0217af24
-	mov r1, sb
+	mov r1, r9
 	mov r2, #0
 	blx r7
 _021514fc:
 	cmp r10, #0
 	addeq sp, sp, #0x290
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, _021515a4 ; =data_ov61_0217af30
 	mov r1, r10
 	mov r2, #0
 	blx r7
 	add sp, sp, #0x290
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_021506bc
 _02151520: .word data_ov61_0217f38c
@@ -23494,7 +23494,7 @@ _0215180c: .word data_ov61_0217f408
 	.global func_ov61_02151810
 	arm_func_start func_ov61_02151810
 func_ov61_02151810: ; 0x02151810
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #8
 	ldr r4, _02151990 ; =0xaaaaaaab
 	str r2, [sp]
@@ -23513,11 +23513,11 @@ func_ov61_02151810: ; 0x02151810
 	mov r4, r4, lsr #0x1
 	addeq sp, sp, #8
 	add r0, r5, r4, lsl #2
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	cmp r3, r0
 	addlo sp, sp, #8
 	mvnlo r0, #0
-	ldmloia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmloia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r7, r10, r1
 	ldr r8, [sp]
 	cmp r10, r7
@@ -23526,8 +23526,8 @@ func_ov61_02151810: ; 0x02151810
 	ldr r5, _02151994 ; =data_ov61_0217afbc
 	mov r4, r11
 _0215188c:
-	sub sb, r7, r10
-	mov r0, sb, lsl #0x3
+	sub r9, r7, r10
+	mov r0, r9, lsl #0x3
 	smull r1, r2, r4, r0
 	add r2, r2, r0, lsr #31
 	mov r1, #6
@@ -23537,16 +23537,16 @@ _0215188c:
 	movne r3, #1
 	moveq r3, #0
 	add r2, r2, r0, lsr #31
-	cmp sb, #3
+	cmp r9, #3
 	add r6, r2, r3
-	movge sb, #3
+	movge r9, #3
 	add r0, sp, #4
 	mov r1, #0
 	mov r2, #3
 	bl func_02007a44
 	mov r0, r10
 	add r1, sp, #4
-	mov r2, sb
+	mov r2, r9
 	bl func_02007ad8
 	ldrb r0, [sp, #4]
 	ldr r1, [r5]
@@ -23585,7 +23585,7 @@ _0215194c:
 	and r0, r0, #0x3f
 	ldrsb r0, [r1, r0]
 _0215196c:
-	add r10, r10, sb
+	add r10, r10, r9
 	strb r0, [r8, #3]
 	cmp r10, r7
 	add r8, r8, #4
@@ -23594,7 +23594,7 @@ _02151980:
 	ldr r0, [sp]
 	sub r0, r8, r0
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02151810
 _02151990: .word 0xaaaaaaab
@@ -24481,13 +24481,13 @@ _021524a8: .word data_ov61_0217f414
 	.global func_ov61_021524ac
 	arm_func_start func_ov61_021524ac
 func_ov61_021524ac: ; 0x021524ac
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	mov r7, r0
 	bl func_0200ee4c
-	ldr sb, _02152564 ; =data_ov61_0217f414
+	ldr r9, _02152564 ; =data_ov61_0217f414
 	mov r6, r0
-	ldr r1, [sb, #0x30]
-	ldr r0, [sb, #0x28]
+	ldr r1, [r9, #0x30]
+	ldr r0, [r9, #0x28]
 	cmp r1, r0
 	bne _02152500
 	mov r5, #0
@@ -24496,11 +24496,11 @@ func_ov61_021524ac: ; 0x021524ac
 _021524dc:
 	ldr r1, [r8, #4]
 	mov r0, r5
-	str r1, [sb, #0x54]
+	str r1, [r9, #0x54]
 	bl func_0200d880
-	str r4, [sb, #0x54]
-	ldr r1, [sb, #0x30]
-	ldr r0, [sb, #0x28]
+	str r4, [r9, #0x54]
+	ldr r1, [r9, #0x30]
+	ldr r0, [r9, #0x28]
 	cmp r1, r0
 	beq _021524dc
 _02152500:
@@ -24529,7 +24529,7 @@ _02152518:
 	ldr r0, [r0, #0x30]
 	add r0, r1, r0
 	add r0, r0, #2
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov61_021524ac
 _02152564: .word data_ov61_0217f414
@@ -24693,27 +24693,27 @@ _02152778: .word data_ov61_0217f414
 	.global func_ov61_0215277c
 	arm_func_start func_ov61_0215277c
 func_ov61_0215277c: ; 0x0215277c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	mov r7, #0
 	ldr r4, _021527e8 ; =data_ov61_0217f414
-	mov sb, r0
+	mov r9, r0
 	mov r5, #0x64
 	mov r6, r7
 _02152794:
-	mov r0, sb
+	mov r0, r9
 	bl func_ov61_02152680
 	mov r8, r6
 _021527a0:
 	ldr r0, [r4, #0x50]
 	cmp r0, #0
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	mov r0, r5
 	bl func_0200db28
-	mov r0, sb
+	mov r0, r9
 	bl func_ov61_021525b0
 	cmp r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	add r8, r8, #1
 	cmp r8, #0x14
 	blo _021527a0
@@ -24721,7 +24721,7 @@ _021527a0:
 	cmp r7, #8
 	blo _02152794
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0215277c
 _021527e8: .word data_ov61_0217f414
@@ -24961,7 +24961,7 @@ _02152b1c: .word data_ov61_0217f8fc
 	.global func_ov61_02152b20
 	arm_func_start func_ov61_02152b20
 func_ov61_02152b20: ; 0x02152b20
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #8
 	mov r10, r0
 	mov r0, #0x45
@@ -24977,9 +24977,9 @@ func_ov61_02152b20: ; 0x02152b20
 	ldrh r11, [r7, #6]
 	mov r0, r6, lsr #0x10
 	mov r8, #0x80
-	mov sb, r11, lsl #0x8
-	orr sb, sb, r11, asr #8
-	strh sb, [r10, #-0x10]
+	mov r9, r11, lsl #0x8
+	orr r9, r9, r11, asr #8
+	strh r9, [r10, #-0x10]
 	strb r8, [r10, #-0xc]
 	strb r5, [r10, #-0xb]
 	ldr r8, [r7, #0x50]
@@ -24996,20 +24996,20 @@ func_ov61_02152b20: ; 0x02152b20
 	mov r7, r0, lsr #0x10
 	mov r5, r7, lsl #0x8
 	mov r0, r6, lsl #0x10
-	orr sb, r5, r7, asr #8
+	orr r9, r5, r7, asr #8
 	mov r7, r8, lsl #0x8
 	mov r5, r0, lsr #0x10
 	mov r0, r5, lsl #0x8
-	strh sb, [r10, #-6]
+	strh r9, [r10, #-6]
 	orr r7, r7, r8, asr #8
 	ldr r11, _02152d14 ; =0x000005c8
-	mov sb, r1
+	mov r9, r1
 	strh r7, [r10, #-4]
 	orr r0, r0, r5, asr #8
 	mov r8, r2
 	mov r7, r3
 	strh r0, [r10, #-2]
-	cmp sb, r11
+	cmp r9, r11
 	bls _02152c8c
 	mov r5, r10
 	bls _02152c30
@@ -25024,21 +25024,21 @@ _02152bf0:
 	bl func_ov61_021529f8
 	add r1, r4, #0xb9
 	add r0, r5, #0x1c8
-	sub sb, sb, r11
+	sub r9, r9, r11
 	mov r1, r1, lsl #0x10
-	cmp sb, r11
+	cmp r9, r11
 	add r5, r0, #0x400
 	mov r4, r1, lsr #0x10
 	bhi _02152bf0
 _02152c30:
-	cmp sb, #0
+	cmp r9, #0
 	beq _02152c8c
 	cmp r7, #0
 	mov r1, #0
 	beq _02152c64
 	mov r2, r5
 	mov r0, r10
-	mov r3, sb
+	mov r3, r9
 	str r6, [sp]
 	orr r5, r4, #0x2000
 	str r5, [sp, #4]
@@ -25048,50 +25048,50 @@ _02152c64:
 	str r6, [sp]
 	mov r0, r10
 	mov r2, r5
-	mov r3, sb
+	mov r3, r9
 	str r4, [sp, #4]
 	bl func_ov61_021529f8
 _02152c7c:
-	add r0, r4, sb, lsr #3
+	add r0, r4, r9, lsr #3
 	mov r0, r0, lsl #0x10
 	mov r4, r0, lsr #0x10
-	mov sb, #0
+	mov r9, #0
 _02152c8c:
 	ldr r11, _02152d14 ; =0x000005c8
-	add r0, sb, r7
+	add r0, r9, r7
 	cmp r0, r11
 	bls _02152ce0
 _02152c9c:
-	sub r5, r11, sb
-	mov r1, sb
+	sub r5, r11, r9
+	mov r1, r9
 	mov r0, r10
 	mov r2, r8
 	mov r3, r5
 	str r6, [sp]
-	orr sb, r4, #0x2000
-	str sb, [sp, #4]
+	orr r9, r4, #0x2000
+	str r9, [sp, #4]
 	bl func_ov61_021529f8
 	add r0, r4, #0xb9
 	sub r7, r7, r5
 	mov r0, r0, lsl #0x10
-	mov sb, #0
+	mov r9, #0
 	cmp r7, r11
 	add r8, r8, r5
 	mov r4, r0, lsr #0x10
 	bhi _02152c9c
 _02152ce0:
-	adds r0, sb, r7
+	adds r0, r9, r7
 	addeq sp, sp, #8
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	str r6, [sp]
 	mov r0, r10
-	mov r1, sb
+	mov r1, r9
 	mov r2, r8
 	mov r3, r7
 	str r4, [sp, #4]
 	bl func_ov61_021529f8
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02152b20
 _02152d10: .word data_ov61_0217f414
@@ -25235,16 +25235,16 @@ _02152f00: .word data_ov61_0217f414
 	.global func_ov61_02152f04
 	arm_func_start func_ov61_02152f04
 func_ov61_02152f04: ; 0x02152f04
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #8
 	mov r7, r2
 	ldrb r2, [r7, #8]
-	mov sb, r0
+	mov r9, r0
 	mov r8, r1
 	cmp r2, #0
 	mov r6, r3
 	addeq sp, sp, #8
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	ldr r0, _02153168 ; =data_027e02a0
 	ldr r1, _0215316c ; =data_ov61_0217f67c
 	ldr r0, [r0, #4]
@@ -25362,7 +25362,7 @@ _021530e8:
 	mov r2, #0
 	bl func_ov61_02151f58
 	mov r2, r0
-	mov r0, sb
+	mov r0, r9
 	mov r1, r8
 	bl func_ov61_02151f58
 	mov r0, r0, lsl #0x10
@@ -25377,7 +25377,7 @@ _021530e8:
 	str r4, [sp]
 	str r3, [sp, #4]
 	mov r1, r5
-	mov r2, sb
+	mov r2, r9
 	mov r3, r8
 	bl func_ov61_02152b20
 	ldr r0, [r7, #0x28]
@@ -25388,7 +25388,7 @@ _021530e8:
 	addne r0, r0, #1
 	strne r0, [r7, #0x28]
 	add sp, sp, #8
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02152f04
 _02153168: .word data_027e02a0
@@ -26330,23 +26330,23 @@ _02153d28:
 	.global func_ov61_02153de0
 	arm_func_start func_ov61_02153de0
 func_ov61_02153de0: ; 0x02153de0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	mov r4, r0
-	mov sb, r1
+	mov r9, r1
 	mov r8, r2
 	bl func_ov61_021537c0
 	movs r5, r0
 	bne _02153e14
 	mov r0, r4
-	mov r1, sb
+	mov r1, r9
 	mov r2, r8
 	mov r3, #0
 	bl func_ov61_02153960
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _02153e14:
-	ldrh r7, [sb, #0xa]
-	ldrh r3, [sb, #8]
-	ldrb r6, [sb, #0xd]
+	ldrh r7, [r9, #0xa]
+	ldrh r3, [r9, #8]
+	ldrb r6, [r9, #0xd]
 	mov r1, r7, lsl #0x8
 	mov r2, r3, lsl #0x8
 	orr r3, r2, r3, asr #8
@@ -26357,8 +26357,8 @@ _02153e14:
 	mov r1, r2, lsr #0x10
 	orr r1, r1, r3, lsl #16
 	str r1, [r5, #0x30]
-	ldrh ip, [sb, #6]
-	ldrh r7, [sb, #4]
+	ldrh ip, [r9, #6]
+	ldrh r7, [r9, #4]
 	ldrb r3, [r5, #8]
 	mov r1, ip, lsl #0x8
 	mov r2, r7, lsl #0x8
@@ -26376,9 +26376,9 @@ _02153e14:
 	beq _02153e98
 	mov r1, #0
 	bl func_ov61_02153938
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _02153e98:
-	ldrh r1, [sb, #0xe]
+	ldrh r1, [r9, #0xe]
 	mov r0, r1, lsl #0x8
 	orr r0, r0, r1, asr #8
 	strh r0, [r5, #0x2c]
@@ -26399,7 +26399,7 @@ _02153eb8: ; jump table
 	b _021540a0 ; case 9
 _02153ee0:
 	mov r0, r4
-	mov r1, sb
+	mov r1, r9
 	mov r2, r8
 	mov r3, #0
 	bl func_ov61_02153960
@@ -26431,7 +26431,7 @@ _02153f24:
 	cmp r8, #0
 	beq _02153fc0
 	bl func_0200ee4c
-	ldrb r1, [sb, #0xc]
+	ldrb r1, [r9, #0xc]
 	ldr ip, [r5, #0x40]
 	ldr r3, [r5, #0x44]
 	and r2, r1, #0xf0
@@ -26439,7 +26439,7 @@ _02153f24:
 	add r1, r2, r1, lsr #30
 	mov r4, r0
 	mov r2, r8
-	add r0, sb, r1, asr #2
+	add r0, r9, r1, asr #2
 	add r1, ip, r3
 	bl func_02007ad8
 	ldr r1, [r5, #0x44]
@@ -26538,7 +26538,7 @@ _021540c4:
 	bl func_ov61_02153938
 _021540e0:
 	bl func_0200d9a4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	arm_func_end func_ov61_02153de0
 
 	.global func_ov61_021540e8
@@ -26708,7 +26708,7 @@ _02154300:
 	.global func_ov61_02154310
 	arm_func_start func_ov61_02154310
 func_ov61_02154310: ; 0x02154310
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	mov r7, r1
 	ldrh r1, [r7, #6]
 	mov r8, r0
@@ -26721,7 +26721,7 @@ func_ov61_02154310: ; 0x02154310
 	mov r3, #0x11
 	bl func_ov61_02152044
 	cmp r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _02154348:
 	bl func_0200ee4c
 	ldr r1, _02154518 ; =data_027e02a0
@@ -26760,12 +26760,12 @@ _021543c4:
 	cmp r0, #0
 	cmpne r0, ip
 	beq _02154408
-	ldrh sb, [r8, #0xe]
+	ldrh r9, [r8, #0xe]
 	ldrh lr, [r8, #0xc]
-	mov r2, sb, lsl #0x8
+	mov r2, r9, lsl #0x8
 	mov r3, lr, lsl #0x8
 	orr lr, r3, lr, asr #8
-	orr r3, r2, sb, asr #8
+	orr r3, r2, r9, asr #8
 	mov r2, lr, lsl #0x10
 	mov r3, r3, lsl #0x10
 	mov lr, r2, lsr #0x10
@@ -26845,7 +26845,7 @@ _02154500:
 _0215450c:
 	mov r0, r5
 	bl func_0200ee60
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02154310
 _02154518: .word data_027e02a0
@@ -26853,7 +26853,7 @@ _02154518: .word data_027e02a0
 	.global func_ov61_0215451c
 	arm_func_start func_ov61_0215451c
 func_ov61_0215451c: ; 0x0215451c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0xc
 	mov r6, #0
 	mov r10, r0
@@ -26868,7 +26868,7 @@ func_ov61_0215451c: ; 0x0215451c
 	str r1, [sp, #8]
 	tst r1, r2
 	addeq sp, sp, #0xc
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldrh r3, [r10, #0xe]
 	ldrh r2, [r10, #0xc]
 	ldrb r4, [r10]
@@ -26885,13 +26885,13 @@ func_ov61_0215451c: ; 0x0215451c
 	ldr r7, _021547dc ; =data_ov61_0217f73c
 	mov r0, r6
 	mov r5, r3, lsr #0x1a
-	orr sb, r1, r2, lsl #16
+	orr r9, r1, r2, lsl #16
 _021545a0:
 	ldrh r2, [r7, #4]
 	cmp r2, #0
 	beq _021545c0
 	ldr r1, [r7]
-	cmp r1, sb
+	cmp r1, r9
 	ldreqh r1, [r7, #6]
 	cmpeq r1, r4
 	beq _021545dc
@@ -26924,7 +26924,7 @@ _021545dc:
 _02154620:
 	add sp, sp, #0xc
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0215462c:
 	ldr r1, _021547e4 ; =data_ov61_0217f414
 	add r0, r5, #0xe
@@ -26936,8 +26936,8 @@ _0215462c:
 	str r0, [r6, #0x34]
 	addeq sp, sp, #0xc
 	mov r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
-	str sb, [r6]
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
+	str r9, [r6]
 	strh r4, [r6, #6]
 	strh r0, [r6, #8]
 	bl func_0200e8f8
@@ -26968,7 +26968,7 @@ _021546ac:
 	blx r1
 	add sp, sp, #0xc
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _021546d0:
 	ldr r0, [sp, #4]
 	ldr r2, [sp, #4]
@@ -26995,7 +26995,7 @@ _021546d0:
 	cmp r4, #0
 	addeq sp, sp, #0xc
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldrh r3, [r7, #4]
 	mov r6, #0
 	mov r5, r6
@@ -27021,7 +27021,7 @@ _02154780:
 	cmp r6, r4
 	addlo sp, sp, #0xc
 	movlo r0, #0
-	ldmloia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmloia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r4, [r7, #0x34]
 	ldrh r3, [r7, #0xa]
 	ldrb r0, [r4, #0xe]
@@ -27039,7 +27039,7 @@ _02154780:
 	str r1, [r0]
 	add r0, r4, #0xe
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0215451c
 _021547d8: .word 0x00003fff
@@ -27457,7 +27457,7 @@ _02154cb8: .word data_027e02a0
 	.global func_ov61_02154cbc
 	arm_func_start func_ov61_02154cbc
 func_ov61_02154cbc: ; 0x02154cbc
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	mov r10, r0
 	bl func_ov61_02154ac4
 	mov r6, #2
@@ -27478,7 +27478,7 @@ _02154ce0:
 	mov r2, #0x18
 	bl func_ov61_021538c4
 	bl func_0200ee4c
-	mov sb, r0
+	mov r9, r0
 	ldr r0, [r4, #0x50]
 	cmp r0, #0
 	beq _02154d28
@@ -27486,12 +27486,12 @@ _02154ce0:
 	str r5, [r10, #4]
 	bl func_0200d880
 _02154d28:
-	mov r0, sb
+	mov r0, r9
 	bl func_0200ee60
 	ldrb r0, [r10, #8]
 	cmp r0, #4
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, [r4, #0x50]
 	cmp r0, #0
 	beq _02154d58
@@ -27500,7 +27500,7 @@ _02154d28:
 	blo _02154ce0
 _02154d58:
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02154cbc
 _02154d60: .word data_ov61_0217f414
@@ -27651,9 +27651,9 @@ _02154f04: .word data_ov61_0217f414
 	.global func_ov61_02154f08
 	arm_func_start func_ov61_02154f08
 func_ov61_02154f08: ; 0x02154f08
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	mov r8, r1
-	mov sb, r0
+	mov r9, r0
 	bl func_0200ee4c
 	ldr r6, [r8, #0x44]
 	mov r7, r0
@@ -27671,9 +27671,9 @@ _02154f30:
 _02154f48:
 	mov r0, r7
 	bl func_0200ee60
-	str r6, [sb]
+	str r6, [r9]
 	ldr r0, [r8, #0x40]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	arm_func_end func_ov61_02154f08
 
 	.global func_ov61_02154f5c
@@ -27818,14 +27818,14 @@ _02155100: .word data_027e02a0
 	.global func_ov61_02155104
 	arm_func_start func_ov61_02155104
 func_ov61_02155104: ; 0x02155104
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	mov r8, r2
 	ldr r6, [r8, #0x34]
 	movs r11, r3
 	mov r10, r0
 	movne r5, #1
 	mov r0, r6, lsl #0x1
-	mov sb, r1
+	mov r9, r1
 	ldreqh r5, [r8, #0x2c]
 	add r7, r0, #4
 	b _021551a8
@@ -27840,9 +27840,9 @@ _02155130:
 	movlo r4, r0
 	cmp r11, #0
 	biceq r4, r4, #1
-	cmp sb, r4
+	cmp r9, r4
 	sub r0, r1, r6
-	movlo r4, sb
+	movlo r4, r9
 	adds r0, r7, r0
 	moveq r4, #0
 	mov r6, r1
@@ -27859,16 +27859,16 @@ _02155130:
 	bl func_ov61_02152f04
 	bl func_0200d9a4
 	add r10, r10, r4
-	sub sb, sb, r4
+	sub r9, r9, r4
 _021551a8:
-	cmp sb, #0
+	cmp r9, #0
 	beq _021551bc
 	ldrb r0, [r8, #8]
 	cmp r0, #4
 	beq _02155130
 _021551bc:
 	mov r0, r4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02155104
 _021551c4: .word data_ov61_0217f414
@@ -27896,7 +27896,7 @@ func_ov61_021551c8: ; 0x021551c8
 	.global func_ov61_02155204
 	arm_func_start func_ov61_02155204
 func_ov61_02155204: ; 0x02155204
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x14
 	mov r4, #0
 	mov r11, r0
@@ -27904,7 +27904,7 @@ func_ov61_02155204: ; 0x02155204
 	mov r0, r4
 	str r4, [sp, #0x10]
 	mov r10, r1
-	mov sb, r2
+	mov r9, r2
 	str r3, [sp, #8]
 	mov r6, r4
 	str r0, [r8, #0x34]
@@ -27919,7 +27919,7 @@ _02155248:
 	str r8, [sp]
 	mov r0, r11
 	mov r1, r10
-	mov r2, sb
+	mov r2, r9
 	str r6, [sp, #4]
 	bl func_ov61_021551c8
 	bl func_0200e8f8
@@ -28006,10 +28006,10 @@ _02155380:
 	blo _021553a8
 	sub r1, r5, r10
 	ldr r0, [sp, #8]
-	add r11, sb, r1
-	mov sb, #0
+	add r11, r9, r1
+	mov r9, #0
 	sub r10, r0, r1
-	str sb, [sp, #8]
+	str r9, [sp, #8]
 _021553a8:
 	ldr r0, _021553f4 ; =data_ov61_0217f414
 	ldr r0, [r0, #0x48]
@@ -28030,7 +28030,7 @@ _021553a8:
 _021553e8:
 	ldr r0, [sp, #0x10]
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02155204
 _021553f4: .word data_ov61_0217f414
@@ -28262,7 +28262,7 @@ _021556b0: .word data_ov61_0217f414
 	.global func_ov61_021556b4
 	arm_func_start func_ov61_021556b4
 func_ov61_021556b4: ; 0x021556b4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	ldr r3, _02155a04 ; =data_ov61_0217f414
 	mov r1, #0
 	ldr r0, _02155a08 ; =data_ov61_0217f4f4
@@ -28403,14 +28403,14 @@ _02155880:
 	mov r10, #0x69
 _021558b0:
 	ldr r0, _02155a1c ; =data_027e02a0
-	ldr sb, [r0, #8]
-	cmp sb, #0
+	ldr r9, [r0, #8]
+	cmp r9, #0
 	beq _02155978
 	mov r6, #0
 	mov r7, r6
 	mov r8, #1
 _021558cc:
-	ldr r0, [sb, #0xa4]
+	ldr r0, [r9, #0xa4]
 	cmp r0, #0
 	ldrne r1, [r0]
 	cmpne r1, #0
@@ -28453,14 +28453,14 @@ _0215594c:
 	ldr r0, [r0]
 	bl func_0200d938
 _0215596c:
-	ldr sb, [sb, #0x68]
-	cmp sb, #0
+	ldr r9, [r9, #0x68]
+	cmp r9, #0
 	bne _021558cc
 _02155978:
-	mov sb, #0
+	mov r9, #0
 	ldr r8, _02155a20 ; =data_ov61_0217f73c
 	ldr r6, _02155a04 ; =data_ov61_0217f414
-	mov r7, sb
+	mov r7, r9
 _02155988:
 	ldrh r0, [r8, #4]
 	cmp r0, #0
@@ -28474,8 +28474,8 @@ _02155988:
 	blx r1
 	strh r7, [r8, #4]
 _021559b4:
-	add sb, sb, #1
-	cmp sb, #8
+	add r9, r9, #1
+	cmp r9, #8
 	add r8, r8, #0x38
 	blt _02155988
 	mov r0, r5
@@ -28495,7 +28495,7 @@ _021559e4:
 	bl func_ov61_02156254
 _021559fc:
 	bl func_ov61_02154b1c
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_021556b4
 _02155a04: .word data_ov61_0217f414
@@ -28763,7 +28763,7 @@ _02155dac: .word data_ov61_0217f414
 	.global func_ov61_02155db0
 	arm_func_start func_ov61_02155db0
 func_ov61_02155db0: ; 0x02155db0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #8
 	add r1, r1, #1
 	str r0, [sp]
@@ -28833,7 +28833,7 @@ _02155dec:
 	cmpeq r0, #0x63
 	bne _021560b0
 	mov r0, #0
-	mov sb, #2
+	mov r9, #2
 	mov r10, #1
 	ldr ip, _021560fc ; =data_ov61_0217f414
 	b _0215609c
@@ -28940,7 +28940,7 @@ _02156038:
 	cmp r6, #2
 	beq _02156054
 	cmp r6, #5
-	moveq r5, sb
+	moveq r5, r9
 	streq r2, [ip, #0x50]
 	b _02156090
 _02156054:
@@ -28990,7 +28990,7 @@ _021560b8:
 _021560ec:
 	mov r0, r5
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02155db0
 _021560f8: .word data_ov61_0217f8fc
@@ -29156,12 +29156,12 @@ _021562cc:
 	.global func_ov61_021562f0
 	arm_func_start func_ov61_021562f0
 func_ov61_021562f0: ; 0x021562f0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x40
-	mov sb, r2
-	mov r2, sb, lsl #0x8
+	mov r9, r2
+	mov r2, r9, lsl #0x8
 	mov r10, r1
-	orr r1, r2, sb, asr #8
+	orr r1, r2, r9, asr #8
 	strh r1, [sp, #4]
 	cmp r10, #0x20
 	mov r6, #0
@@ -29192,7 +29192,7 @@ _02156364:
 	cmp r6, #0x3c
 	addge sp, sp, #0x40
 	mvnge r0, #0
-	ldmgeia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmgeia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r6, r4, #1
 	mov r4, r6
 	str r6, [sp]
@@ -29245,7 +29245,7 @@ _02156418:
 	mov r2, r3, lsl #0x8
 	orr r2, r2, r3, asr #8
 	mov r2, r2, lsl #0x10
-	cmp sb, r2, lsr #16
+	cmp r9, r2, lsr #16
 	bne _02156548
 	ldrb r2, [r0, #3]
 	and r2, r2, #0xf
@@ -29337,7 +29337,7 @@ _02156550:
 _02156584:
 	mov r0, r4
 	add sp, sp, #0x40
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_021562f0
 _02156590: .word 0x00001001
@@ -29442,7 +29442,7 @@ func_ov61_02156668: ; 0x02156668
 	.global func_ov61_021566cc
 	arm_func_start func_ov61_021566cc
 func_ov61_021566cc: ; 0x021566cc
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0xc
 	ldr r2, _021567fc ; =data_ov61_0217f414
 	mov r6, #0
@@ -29450,10 +29450,10 @@ func_ov61_021566cc: ; 0x021566cc
 	ldr r3, [r2, #0x68]
 	ldr r1, [r2, #0x6c]
 	umull r8, r7, r5, r3
-	ldr sb, [r2, #0x78]
+	ldr r9, [r2, #0x78]
 	mla r7, r5, r1, r7
 	ldr r4, [r2, #0x74]
-	adds r11, sb, r8
+	adds r11, r9, r8
 	mla r7, r4, r3, r7
 	ldr r8, [r2, #0x7c]
 	umull r3, r1, r5, r11
@@ -29461,7 +29461,7 @@ func_ov61_021566cc: ; 0x021566cc
 	mla r1, r5, r10, r1
 	str r11, [r2, #0x68]
 	mov r7, r6, lsl #0x10
-	adds r5, sb, r3
+	adds r5, r9, r3
 	mla r1, r4, r11, r1
 	str r10, [r2, #0x6c]
 	orr r7, r7, r10, lsr #16
@@ -29478,7 +29478,7 @@ func_ov61_021566cc: ; 0x021566cc
 	cmp r0, #0
 	ldrne r0, [sp, #8]
 	addne sp, sp, #0xc
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	mov r0, #1
 	mov r11, r6
 	ldr r7, _02156800 ; =data_ov61_0217f474
@@ -29489,9 +29489,9 @@ func_ov61_021566cc: ; 0x021566cc
 	mvn r4, #0
 _02156780:
 	mov r8, #0
-	add sb, sp, #0
+	add r9, sp, #0
 _02156788:
-	ldrb r0, [sb]
+	ldrb r0, [r9]
 	cmp r0, #0
 	beq _021567c0
 	mov r0, r8, lsl #0x1
@@ -29504,11 +29504,11 @@ _02156788:
 	cmpne r0, r4
 	bne _021567dc
 	cmp r0, r4
-	streqb r5, [sb]
+	streqb r5, [r9]
 _021567c0:
 	add r8, r8, #1
 	cmp r8, #2
-	add sb, sb, #1
+	add r9, r9, #1
 	blt _02156788
 	add r11, r11, #1
 	cmp r11, #3
@@ -29521,7 +29521,7 @@ _021567dc:
 	streq r0, [sp, #8]
 	ldr r0, [sp, #8]
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_021566cc
 _021567fc: .word data_ov61_0217f414
@@ -29961,29 +29961,29 @@ func_ov61_02156ce4: ; 0x02156ce4
 	.global func_ov61_02156cfc
 	arm_func_start func_ov61_02156cfc
 func_ov61_02156cfc: ; 0x02156cfc
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #4
 	mov r4, #0
-	mov sb, r0
+	mov r9, r0
 	mov r10, r4
 	add r6, sp, #0
 	mov r5, #1
 _02156d18:
-	mov r0, sb
+	mov r0, r9
 	mov r1, r6
 	mov r2, r5
 	bl func_0200dfb0
 	ldr r0, [sp]
 	cmp r0, #0
 	addeq sp, sp, #4
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	ldr r1, [r0]
 	blx r1
 	mov r8, r0
 	bl func_0200ee4c
 	mov r7, r0
 	bl func_0200dc28
-	mov r0, sb
+	mov r0, r9
 	mov r1, r4
 	mov r2, r4
 	bl func_0200de70
@@ -30008,7 +30008,7 @@ _02156d8c:
 	arm_func_end func_ov61_02156cfc
 _02156da4:
     add sp, sp, #4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 
 	.global func_ov61_02156dac
 	arm_func_start func_ov61_02156dac
@@ -30643,9 +30643,9 @@ _021575b0:
 	.global func_ov61_021575c4
 	arm_func_start func_ov61_021575c4
 func_ov61_021575c4: ; 0x021575c4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0xc
-	mov sb, r0
+	mov r9, r0
 	mov r8, r1
 	mov r7, r2
 	mov r6, r3
@@ -30653,19 +30653,19 @@ func_ov61_021575c4: ; 0x021575c4
 	cmp r0, #0
 	addne sp, sp, #0xc
 	mvnne r0, #0x1b
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	ldr r0, [sp, #0x2c]
 	tst r0, #4
 	bne _02157608
-	ldrsb r0, [sb, #0x72]
+	ldrsb r0, [r9, #0x72]
 	cmp r0, #0
 	bne _02157624
 _02157608:
-	ldrsb r0, [sb, #0x73]
+	ldrsb r0, [r9, #0x73]
 	cmp r0, #4
 	addeq sp, sp, #0xc
 	mvneq r0, #0x1b
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	mov r5, #0
 	b _0215763c
 _02157624:
@@ -30673,39 +30673,39 @@ _02157624:
 	cmp r0, #0x12
 	addeq sp, sp, #0xc
 	mvneq r0, #0x1b
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	mov r5, #1
 _0215763c:
-	cmp sb, #0
+	cmp r9, #0
 	mov r1, #0
 	beq _02157654
-	ldrsh r0, [sb, #0x70]
+	ldrsh r0, [r9, #0x70]
 	tst r0, #1
 	movne r1, #1
 _02157654:
 	cmp r1, #0
 	addeq sp, sp, #0xc
 	mvneq r0, #0x26
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, pc}
-	ldrsb r0, [sb, #0x73]
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, pc}
+	ldrsb r0, [r9, #0x73]
 	mov r1, #1
 	cmp r0, #0
 	cmpne r0, #4
 	movne r1, #0
 	cmp r1, #0
 	beq _021576a4
-	ldrsh r0, [sb, #0x70]
+	ldrsh r0, [r9, #0x70]
 	tst r0, #4
 	beq _02157698
-	ldrsh r0, [sb, #0x70]
+	ldrsh r0, [r9, #0x70]
 	tst r0, #8
 	beq _021576a4
 _02157698:
 	add sp, sp, #0xc
 	mvn r0, #0x37
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _021576a4:
-	ldr r4, [sb, #0x64]
+	ldr r4, [r9, #0x64]
 	tst r5, #1
 	add r0, r4, #0xe0
 	bne _021576cc
@@ -30714,14 +30714,14 @@ _021576a4:
 	bne _021576d0
 	add sp, sp, #0xc
 	mvn r0, #5
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _021576cc:
 	bl func_0200e044
 _021576d0:
 	ldr r0, [sp, #0x28]
 	ldr ip, [sp, #0x2c]
 	str r0, [sp]
-	mov r0, sb
+	mov r0, r9
 	mov r1, r8
 	mov r2, r7
 	mov r3, r6
@@ -30732,7 +30732,7 @@ _021576d0:
 	bl func_0200e0c8
 	mov r0, r5
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	arm_func_end func_ov61_021575c4
 
 	.global func_ov61_0215770c
@@ -30819,9 +30819,9 @@ _021577d8:
 	.global func_ov61_0215781c
 	arm_func_start func_ov61_0215781c
 func_ov61_0215781c: ; 0x0215781c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x10
-	mov sb, r0
+	mov r9, r0
 	mov r8, r1
 	mov r7, r2
 	mov r6, r3
@@ -30830,7 +30830,7 @@ func_ov61_0215781c: ; 0x0215781c
 	mov r4, r0
 	str r1, [sp]
 	add r1, sp, #0xc
-	mov r0, sb
+	mov r0, r9
 	add r2, sp, #6
 	add r3, sp, #4
 	bl func_ov61_02157924
@@ -30840,7 +30840,7 @@ func_ov61_0215781c: ; 0x0215781c
 	cmp r5, #0
 	mvneq r5, #5
 	beq _021578d8
-	ldrsb r1, [sb, #0x73]
+	ldrsb r1, [r9, #0x73]
 	cmp r7, r5
 	mov r2, #1
 	movgt r7, r5
@@ -30852,7 +30852,7 @@ func_ov61_0215781c: ; 0x0215781c
 	mov r2, r7
 	movne r5, r7
 	bl func_02007ad8
-	ldr r1, [sb, #0x64]
+	ldr r1, [r9, #0x64]
 	ldrsb r0, [r1, #0xfe]
 	cmp r0, #0
 	ldreq r0, [r1, #0xf8]
@@ -30862,11 +30862,11 @@ func_ov61_0215781c: ; 0x0215781c
 _021578bc:
 	ldr r0, [sp, #0xc]
 	cmp r0, #0
-	ldrsh r0, [sb, #0x70]
+	ldrsh r0, [r9, #0x70]
 	moveq r5, #0
 	mvnne r5, #0x1b
 	bic r0, r0, #6
-	strh r0, [sb, #0x70]
+	strh r0, [r9, #0x70]
 _021578d8:
 	cmp r5, #0
 	blt _02157910
@@ -30879,16 +30879,16 @@ _021578d8:
 	ldr r0, [sp, #8]
 	str r0, [r1]
 _02157900:
-	ldrh r0, [sb, #0x74]
+	ldrh r0, [r9, #0x74]
 	cmp r0, #0
 	ldreqh r0, [sp, #6]
-	streqh r0, [sb, #0x74]
+	streqh r0, [r9, #0x74]
 _02157910:
 	mov r0, r4
 	bl func_0200ee60
 	mov r0, r5
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	arm_func_end func_ov61_0215781c
 
 	.global func_ov61_02157924
@@ -30955,7 +30955,7 @@ _021579e0: .word func_ov61_021579e4
 	.global func_ov61_021579e4
 	arm_func_start func_ov61_021579e4
 func_ov61_021579e4: ; 0x021579e4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x14
 	ldr r7, [r0, #4]
 	ldr r1, [r0, #0x10]
@@ -30964,7 +30964,7 @@ func_ov61_021579e4: ; 0x021579e4
 	ldr r1, [r0, #0x18]
 	ldr r10, [r0, #0x14]
 	ldr r0, [r0, #0x1c]
-	ldr sb, [r8, #0xf8]
+	ldr r9, [r8, #0xf8]
 	str r1, [sp, #8]
 	str r0, [sp, #4]
 	mov r4, #0
@@ -30977,7 +30977,7 @@ _02157a24:
 	cmp r0, #0
 	beq _02157a78
 	ldr r1, [sp, #0x10]
-	sub r1, r1, sb
+	sub r1, r1, r9
 	cmp r1, #0
 	bgt _02157a78
 	ldrsb r0, [r7, #0x73]
@@ -31000,7 +31000,7 @@ _02157a78:
 	cmp r0, #0
 	addeq sp, sp, #0x14
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r1, [sp, #0x10]
 	cmp r10, r1
 	movhi r10, r1
@@ -31011,7 +31011,7 @@ _02157a78:
 	bl func_ov61_021550cc
 	add sp, sp, #0x14
 	mov r0, r10
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02157ac0:
 	cmp r0, #0
 	moveq r4, #0
@@ -31028,7 +31028,7 @@ _02157aec:
 	cmp r4, #0
 	addle sp, sp, #0x14
 	movle r0, r4
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldrh r0, [r8, #0xfc]
 	ldr r1, [r8, #0xf8]
 	cmp r1, r0
@@ -31038,7 +31038,7 @@ _02157aec:
 _02157b14:
 	mov r0, r4
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	arm_func_end func_ov61_021579e4
 
 	.global func_ov61_02157b20
@@ -31100,7 +31100,7 @@ _02157ba8:
 	.global func_ov61_02157bb8
 	arm_func_start func_ov61_02157bb8
 func_ov61_02157bb8: ; 0x02157bb8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0xc
 	mov r10, r0
 	ldr r6, [r10, #0x64]
@@ -31115,10 +31115,10 @@ func_ov61_02157bb8: ; 0x02157bb8
 	bne _02157c54
 	ldr r0, [sp, #0x34]
 	mov r4, #1
-	and sb, r0, #1
+	and r9, r0, #1
 	mov r5, #0
 _02157bfc:
-	cmp sb, #0
+	cmp r9, #0
 	mvneq r8, #5
 	beq _02157c54
 	add r0, r6, #0x10c
@@ -31185,7 +31185,7 @@ _02157ce4:
 	bl func_0200ee60
 	mov r0, r8
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02157bb8
 _02157cf8: .word data_ov61_0217bc28
@@ -31193,10 +31193,10 @@ _02157cf8: .word data_ov61_0217bc28
 	.global func_ov61_02157cfc
 	arm_func_start func_ov61_02157cfc
 func_ov61_02157cfc: ; 0x02157cfc
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	mov r7, r2
 	ldr r4, [r7, #0x64]
-	mov sb, r0
+	mov r9, r0
 	mov r8, r1
 	bl func_0200ee4c
 	add r1, r4, #0x100
@@ -31216,7 +31216,7 @@ func_ov61_02157cfc: ; 0x02157cfc
 	add r1, r4, #0x100
 	ldrh r3, [r1, #8]
 	mov r2, #0
-	mov r0, sb
+	mov r0, r9
 	add r3, r3, r8
 	strh r3, [r1, #8]
 	str r2, [r5]
@@ -31262,7 +31262,7 @@ _02157dd0:
 	mov r0, r6
 	bl func_0200ee60
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02157cfc
 _02157e08: .word data_ov61_0217bc28
@@ -31351,13 +31351,13 @@ _02157eec:
 	.global func_ov61_02157f24
 	arm_func_start func_ov61_02157f24
 func_ov61_02157f24: ; 0x02157f24
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x18
 	mov r10, r0
 	ldr r4, [r10, #0x68]
 	ldrsb r0, [r10, #0x73]
 	ldr r4, [r4, #0x10c]
-	mov sb, r1
+	mov r9, r1
 	str r3, [sp, #0xc]
 	cmp r0, #1
 	mov r8, r2
@@ -31370,7 +31370,7 @@ func_ov61_02157f24: ; 0x02157f24
 	cmp r8, r0
 	addgt sp, sp, #0x18
 	subgt r0, r5, #0x23
-	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	str r8, [sp, #0x10]
 	b _02157f8c
 _02157f7c:
@@ -31393,7 +31393,7 @@ _02157f98:
 	cmp r4, #0
 	ble _02157ff8
 	ldr r0, [sp, #0xc]
-	mov r1, sb
+	mov r1, r9
 	stmia sp, {r0, r7}
 	str r6, [sp, #8]
 	ldr r3, [sp, #0x14]
@@ -31403,8 +31403,8 @@ _02157f98:
 	cmp r0, #0
 	addle sp, sp, #0x18
 	mvnle r0, #5
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
-	add sb, sb, r4
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
+	add r9, r9, r4
 	sub r8, r8, r4
 	add r5, r5, r4
 _02157ff8:
@@ -31414,27 +31414,27 @@ _02157ff8:
 	bgt _0215801c
 	add sp, sp, #0x18
 	mvn r0, #5
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02158014:
 	cmp r8, #0
 	bgt _02157f98
 _0215801c:
 	mov r0, r5
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	arm_func_end func_ov61_02157f24
 
 	.global func_ov61_02158028
 	arm_func_start func_ov61_02158028
 func_ov61_02158028: ; 0x02158028
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	mov r10, r0
-	mov sb, r1
+	mov r9, r1
 	mov r8, r2
-	cmp r8, sb
+	cmp r8, r9
 	mov r7, r3
 	ldr r4, [r10, #0x68]
-	movgt r8, sb
+	movgt r8, r9
 	bl func_0200ee4c
 	ldr r1, [sp, #0x28]
 	mov r11, r0
@@ -31447,8 +31447,8 @@ _02158058:
 	blt _02158084
 	add r0, r4, #0x100
 	ldrh r0, [r0]
-	cmp r5, sb
-	movge r5, sb
+	cmp r5, r9
+	movge r5, r9
 	str r0, [r7]
 	b _0215809c
 _02158084:
@@ -31462,7 +31462,7 @@ _0215809c:
 	mov r0, r11
 	bl func_0200ee60
 	mov r0, r5
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	arm_func_end func_ov61_02158028
 
 	.global func_ov61_021580ac
@@ -31482,9 +31482,9 @@ func_ov61_021580ac: ; 0x021580ac
 	.global func_ov61_021580d0
 	arm_func_start func_ov61_021580d0
 func_ov61_021580d0: ; 0x021580d0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
-	mov sb, r0
-	ldr r4, [sb, #0x68]
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
+	mov r9, r0
+	ldr r4, [r9, #0x68]
 	mov r6, r1
 	mov r8, r2
 	ldr r1, [r4, #0x10c]
@@ -31494,11 +31494,11 @@ func_ov61_021580d0: ; 0x021580d0
 	bl func_ov61_02156b7c
 	movs r5, r0
 	mvneq r0, #0x20
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	ldr r0, [sp, #0x28]
 	add r1, r7, r8
 	tst r0, #1
-	ldrnesb r0, [sb, #0x73]
+	ldrnesb r0, [r9, #0x73]
 	cmpne r0, #1
 	movne r0, #3
 	strneb r0, [r5, #0xd]
@@ -31538,20 +31538,20 @@ _02158184:
 	strh r7, [r5, #0x20]
 	ldrh r1, [r5, #0x20]
 	strh r1, [r0]
-	ldrsb r0, [sb, #0x73]
+	ldrsb r0, [r9, #0x73]
 	cmp r0, #1
 	bne _02158214
-	ldrh r0, [sb, #0x74]
+	ldrh r0, [r9, #0x74]
 	cmp r0, #0
 	bne _021581d0
 	bl func_ov61_02154a1c
-	strh r0, [sb, #0x74]
-	ldrh r0, [sb, #0x74]
-	strh r0, [sb, #0xa]
+	strh r0, [r9, #0x74]
+	ldrh r0, [r9, #0x74]
+	strh r0, [r9, #0xa]
 _021581d0:
-	ldrh r0, [sb, #0x74]
+	ldrh r0, [r9, #0x74]
 	strh r0, [r5, #0x24]
-	ldr r1, [sb, #0x78]
+	ldr r1, [r9, #0x78]
 	cmp r1, #0
 	beq _021581f0
 	ldr r0, [sp, #0x24]
@@ -31565,7 +31565,7 @@ _021581f0:
 	b _0215821c
 _02158204:
 	str r1, [r5, #0x28]
-	ldrh r0, [sb, #0x76]
+	ldrh r0, [r9, #0x76]
 	strh r0, [r5, #0x26]
 	b _0215821c
 _02158214:
@@ -31580,7 +31580,7 @@ _0215821c:
 	movne r8, #0
 	strneh r6, [r0]
 	mov r0, r8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov61_021580d0
 _02158240: .word func_ov61_02158244
@@ -31588,9 +31588,9 @@ _02158240: .word func_ov61_02158244
 	.global func_ov61_02158244
 	arm_func_start func_ov61_02158244
 func_ov61_02158244: ; 0x02158244
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
-	mov sb, r0
-	ldr r5, [sb, #4]
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
+	mov r9, r0
+	ldr r5, [r9, #4]
 	mov r7, #0
 	ldrsb r0, [r5, #0x73]
 	mov r1, #1
@@ -31604,11 +31604,11 @@ func_ov61_02158244: ; 0x02158244
 	tst r0, #4
 	beq _02158340
 _02158280:
-	ldr r2, [sb, #0x28]
+	ldr r2, [r9, #0x28]
 	cmp r2, #0
 	beq _02158298
-	ldrh r0, [sb, #0x24]
-	ldrh r1, [sb, #0x26]
+	ldrh r0, [r9, #0x24]
+	ldrh r1, [r9, #0x26]
 	bl func_ov61_02154b60
 _02158298:
 	ldrsb r1, [r5, #0x73]
@@ -31631,7 +31631,7 @@ _02158298:
 	mov r10, r0
 _021582e0:
 	mov r1, r10
-	mov r2, sb
+	mov r2, r9
 	add r0, r4, r8
 	bl func_ov61_02158404
 	mov r1, r0
@@ -31658,13 +31658,13 @@ _02158338:
 _02158340:
 	mvn r7, #0x4b
 _02158344:
-	ldrh r2, [sb, #0x20]
+	ldrh r2, [r9, #0x20]
 	add r1, r6, #0x100
 	add r0, r6, #0x104
 	strh r2, [r1, #2]
 	bl func_0200d8d0
 	mov r0, r7
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	arm_func_end func_ov61_02158244
 
 	.global func_ov61_02158360
@@ -32036,16 +32036,16 @@ _02158810: .word data_ov61_0217bc28
 	.global func_ov61_02158814
 	arm_func_start func_ov61_02158814
 func_ov61_02158814: ; 0x02158814
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
-	movs sb, r0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
-	add r0, sb, #0x20
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
+	movs r9, r0
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
+	add r0, r9, #0x20
 	bl func_0200d83c
 	bl func_0200ee4c
 	mov r8, r0
 	bl func_0200dc28
 	add r1, sp, #0
-	mov r0, sb
+	mov r0, r9
 	mov r2, #0
 	bl func_0200de70
 	cmp r0, #0
@@ -32068,7 +32068,7 @@ _02158880:
 	ldr r0, [sp]
 	bl func_ov61_02156bbc
 _02158888:
-	mov r0, sb
+	mov r0, r9
 	mov r1, r5
 	mov r2, r4
 	bl func_0200de70
@@ -32079,7 +32079,7 @@ _021588a0:
 	bl func_0200d988
 	mov r0, r8
 	bl func_0200ee60
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	arm_func_end func_ov61_02158814
 
 	.global func_ov61_021588b4
@@ -33245,12 +33245,12 @@ func_ov61_02159658: ; 0x02159658
 	.global func_ov61_02159678
 	arm_func_start func_ov61_02159678
 func_ov61_02159678: ; 0x02159678
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
-	mov sb, r2
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
+	mov r9, r2
 	mov r8, r3
 	mvn r2, #0
 	cmp r8, r2
-	cmpeq sb, r2
+	cmpeq r9, r2
 	movne r11, #1
 	str r0, [sp]
 	mov r10, r1
@@ -33279,7 +33279,7 @@ _021596e0:
 	cmp r11, #0
 	beq _02159704
 	mov r0, #0
-	subs r0, r0, sb
+	subs r0, r0, r9
 	mov r0, #0
 	sbcs r0, r0, r8
 	bge _02159720
@@ -33287,13 +33287,13 @@ _02159704:
 	mov r0, #1
 	bl func_0200db28
 	ldr r0, _02159728 ; =0x0000020b
-	subs sb, sb, r0
+	subs r9, r9, r0
 	mov r0, #0
 	sbc r8, r8, r0
 	b _021596a0
 _02159720:
 	mov r0, r6
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02159678
 _02159728: .word 0x0000020b
@@ -33396,18 +33396,18 @@ _0215985c: .word data_ov61_02180e48
 	.global func_ov61_02159860
 	arm_func_start func_ov61_02159860
 func_ov61_02159860: ; 0x02159860
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	mov r8, r0
 	mov r7, r1
 	mov r6, r2
 	bl func_0200ee4c
 	mov r4, r0
 	bl func_0200e8f8
-	ldr sb, _02159948 ; =data_ov61_02180e48
+	ldr r9, _02159948 ; =data_ov61_02180e48
 	mov r5, r0, lsr #0x10
 	mov r2, #0
 	mov r0, r2
-	mov r3, sb
+	mov r3, r9
 	orr r5, r5, r1, lsl #16
 	mvn ip, #0
 _02159898:
@@ -33422,42 +33422,42 @@ _02159898:
 	beq _021598cc
 	ldrh r1, [r3, #0x58]
 	cmp r6, r1
-	moveq sb, r3
+	moveq r9, r3
 	beq _02159908
 _021598cc:
 	cmp r2, ip
 	beq _021598f8
 	cmp lr, #0
 	moveq r2, ip
-	moveq sb, r3
+	moveq r9, r3
 	beq _021598f8
 	ldr r1, [r3, #0x50]
 	sub r1, r5, r1
 	cmp r1, r2
 	movhi r2, r1
-	movhi sb, r3
+	movhi r9, r3
 _021598f8:
 	add r0, r0, #1
 	cmp r0, #4
 	add r3, r3, #0x5c
 	blt _02159898
 _02159908:
-	mov r1, sb
+	mov r1, r9
 	add r0, r8, #0x74
 	mov r2, #0x20
 	bl func_02007ad8
 	mov r0, r8
-	add r1, sb, #0x20
+	add r1, r9, #0x20
 	mov r2, #0x30
 	bl func_02007ad8
-	str r5, [sb, #0x50]
+	str r5, [r9, #0x50]
 	mov r0, #1
-	strb r0, [sb, #0x5a]
-	str r7, [sb, #0x54]
+	strb r0, [r9, #0x5a]
+	str r7, [r9, #0x54]
 	mov r0, r4
-	strh r6, [sb, #0x58]
+	strh r6, [r9, #0x58]
 	bl func_0200ee60
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02159860
 _02159948: .word data_ov61_02180e48
@@ -33714,11 +33714,11 @@ _02159be8:
 	.global func_ov61_02159c1c
 	arm_func_start func_ov61_02159c1c
 func_ov61_02159c1c: ; 0x02159c1c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #8
 	mov r11, r1
 	ldr r1, [r11]
-	mov sb, r0
+	mov r9, r0
 	add r0, r1, #1
 	str r0, [sp, #4]
 	add r0, sp, #4
@@ -33734,7 +33734,7 @@ func_ov61_02159c1c: ; 0x02159c1c
 _02159c60:
 	add sp, sp, #8
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02159c6c:
 	and r1, r5, #0x1f
 	cmp r1, #0x18
@@ -33767,7 +33767,7 @@ _02159c7c: ; jump table
 	b _02159f70 ; case 23
 	b _02159f70 ; case 24
 _02159ce0:
-	ldrb r0, [sb, #0x5ad]
+	ldrb r0, [r9, #0x5ad]
 	cmp r0, #0
 	beq _02159dc8
 	cmp r6, #0
@@ -33792,16 +33792,16 @@ _02159d1c:
 _02159d30:
 	cmp r4, #0x100
 	bgt _02159dc8
-	add r1, sb, #0x94
+	add r1, r9, #0x94
 	mov r2, r4
 	add r1, r1, #0x400
 	bl func_02007ad8
-	str r4, [sb, #0x594]
+	str r4, [r9, #0x594]
 	b _02159dc8
 _02159d50:
-	str r4, [sb, #0x484]
+	str r4, [r9, #0x484]
 	ldr r0, [sp, #4]
-	str r0, [sb, #0x488]
+	str r0, [r9, #0x488]
 	b _02159dc8
 _02159d60:
 	cmp r6, #1
@@ -33821,18 +33821,18 @@ _02159d90:
 	cmp r8, #0
 	beq _02159dac
 	cmp r8, #2
-	streq r4, [sb, #0x48c]
+	streq r4, [r9, #0x48c]
 	ldreq r0, [sp, #4]
-	streq r0, [sb, #0x490]
+	streq r0, [r9, #0x490]
 	b _02159dc8
 _02159dac:
 	cmp r4, #8
 	bgt _02159dc8
-	add r1, sb, #0x198
+	add r1, r9, #0x198
 	mov r2, r4
 	add r1, r1, #0x400
 	bl func_02007ad8
-	str r4, [sb, #0x5a0]
+	str r4, [r9, #0x5a0]
 _02159dc8:
 	ldr r0, [sp, #4]
 	add r0, r0, r4
@@ -33846,17 +33846,17 @@ _02159dd8:
 	ldr r1, [sp, #4]
 	sub r0, r4, #1
 	add r1, r1, #1
-	str r1, [sb, #0x5a4]
-	str r0, [sb, #0x5a8]
+	str r1, [r9, #0x5a4]
+	str r0, [r9, #0x5a8]
 _02159dfc:
-	ldrb r0, [sb, #0x5ad]
+	ldrb r0, [r9, #0x5ad]
 	cmp r0, #0
 	beq _02159e48
 	ldr r0, [sp, #4]
 	add r1, sp, #4
 	add r0, r0, #1
 	str r0, [sp, #4]
-	mov r0, sb
+	mov r0, r9
 	mov r2, r7
 	mov r3, #0
 	str r8, [sp]
@@ -33864,9 +33864,9 @@ _02159dfc:
 	cmp r0, #0
 	addne sp, sp, #8
 	movne r0, #1
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	mov r0, #0
-	strb r0, [sb, #0x5ad]
+	strb r0, [r9, #0x5ad]
 	b _0215a0f4
 _02159e48:
 	ldr r0, [sp, #4]
@@ -33899,16 +33899,16 @@ _02159e94: ; jump table
 	b _02159ec8 ; case 5
 _02159eac:
 	cmp r8, #0
-	streq r5, [sb, #0x45c]
-	strb r5, [sb, #0x5ad]
+	streq r5, [r9, #0x45c]
+	strb r5, [r9, #0x5ad]
 	b _02159ee0
 _02159ebc:
 	cmp r8, #2
-	strne r5, [sb, #0x458]
+	strne r5, [r9, #0x458]
 	b _02159ee0
 _02159ec8:
 	cmp r8, #2
-	strneb r5, [sb, #0x5ae]
+	strneb r5, [r9, #0x5ae]
 	b _02159ee0
 _02159ed4:
 	add r5, r5, #1
@@ -33922,34 +33922,34 @@ _02159ee0:
 _02159ef0:
 	cmp r8, #2
 	beq _02159f58
-	ldrb r0, [sb, #0x5ac]
+	ldrb r0, [r9, #0x5ac]
 	cmp r0, #0
 	beq _02159f48
 	ldr r1, [sp, #4]
 	mov r2, r4
-	add r0, sb, #0x6b0
+	add r0, r9, #0x6b0
 	bl func_ov61_02159b30
-	ldrb r0, [sb, #0x5ae]
+	ldrb r0, [r9, #0x5ae]
 	cmp r0, #5
 	bne _02159f58
 	cmp r4, #0x4f
 	bgt _02159f58
 	ldr r0, [sp, #4]
 	mov r2, r4
-	add r1, sb, #0x7b0
+	add r1, r9, #0x7b0
 	bl func_02007ad8
-	add r0, sb, r4
+	add r0, r9, r4
 	mov r1, #0
 	strb r1, [r0, #0x7b0]
 	b _02159f58
 _02159f48:
 	ldr r1, [sp, #4]
 	mov r2, r4
-	add r0, sb, #0x5b0
+	add r0, r9, #0x5b0
 	bl func_ov61_02159b30
 _02159f58:
 	mov r0, #0
-	strb r0, [sb, #0x5ae]
+	strb r0, [r9, #0x5ae]
 	ldr r0, [sp, #4]
 	add r0, r0, r4
 	str r0, [sp, #4]
@@ -33960,22 +33960,22 @@ _02159f70:
 	ldr r0, [sp, #4]
 	bl func_ov61_02159b9c
 	cmp r6, #0
-	ldr r1, [sb, #0x80c]
+	ldr r1, [r9, #0x80c]
 	bne _02159f9c
 	cmp r1, r0
 	movhs r0, #1
-	strhsb r0, [sb, #0x5af]
+	strhsb r0, [r9, #0x5af]
 	b _02159fa8
 _02159f9c:
 	cmp r1, r0
 	movhi r0, #0
-	strhib r0, [sb, #0x5af]
+	strhib r0, [r9, #0x5af]
 _02159fa8:
 	ldr r1, [sp, #4]
 	mov r0, #1
 	add r1, r1, r4
 	str r1, [sp, #4]
-	strb r0, [sb, #0x5ac]
+	strb r0, [r9, #0x5ac]
 	b _0215a0f4
 _02159fc0:
 	cmp r7, #0
@@ -33983,7 +33983,7 @@ _02159fc0:
 	bne _02159fd8
 	cmp r8, #2
 	ldrne r0, [sp, #4]
-	strne r0, [sb, #0x460]
+	strne r0, [r9, #0x460]
 _02159fd8:
 	ldr r0, [sp, #4]
 	mov r5, #0
@@ -33992,7 +33992,7 @@ _02159fd8:
 	bhs _0215a028
 	add r4, sp, #4
 _02159ff0:
-	mov r0, sb
+	mov r0, r9
 	mov r1, r4
 	mov r3, r5
 	add r2, r7, #1
@@ -34002,7 +34002,7 @@ _02159ff0:
 	add r5, r5, #1
 	addne sp, sp, #8
 	movne r0, #1
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, [sp, #4]
 	cmp r0, r10
 	blo _02159ff0
@@ -34011,7 +34011,7 @@ _0215a028:
 	cmpeq r6, #0
 	bne _0215a0f4
 	cmp r8, #2
-	strne r0, [sb, #0x464]
+	strne r0, [r9, #0x464]
 	b _0215a0f4
 _0215a040:
 	ldr r0, [sp, #4]
@@ -34021,7 +34021,7 @@ _0215a040:
 	add r5, sp, #4
 	mov r4, #0
 _0215a058:
-	mov r0, sb
+	mov r0, r9
 	mov r1, r5
 	mov r3, r4
 	add r2, r7, #1
@@ -34030,7 +34030,7 @@ _0215a058:
 	cmp r0, #0
 	addne sp, sp, #8
 	movne r0, #1
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, [sp, #4]
 	cmp r0, r6
 	blo _0215a058
@@ -34045,7 +34045,7 @@ _0215a090:
 	add r5, sp, #4
 	mov r4, #0
 _0215a0b0:
-	mov r0, sb
+	mov r0, r9
 	mov r1, r5
 	mov r3, r4
 	add r2, r7, #1
@@ -34054,7 +34054,7 @@ _0215a0b0:
 	cmp r0, #0
 	addne sp, sp, #8
 	movne r0, #1
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, [sp, #4]
 	cmp r0, r6
 	blo _0215a0b0
@@ -34068,7 +34068,7 @@ _0215a0f4:
 	mov r0, #0
 	str r1, [r11]
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02159c1c
 _0215a108: .word data_ov61_0217bc8c
@@ -34076,7 +34076,7 @@ _0215a108: .word data_ov61_0217bc8c
 	.global func_ov61_0215a10c
 	arm_func_start func_ov61_0215a10c
 func_ov61_0215a10c: ; 0x0215a10c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #4
 	mov r8, r0
 	ldr r0, [r8, #0x5a4]
@@ -34094,7 +34094,7 @@ func_ov61_0215a10c: ; 0x0215a10c
 	cmpne r0, #0
 	addeq sp, sp, #4
 	moveq r0, #2
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	mov r0, r0, lsl #0x1
 	ldr r1, _0215a2ac ; =data_ov61_0217f428
 	add r0, r0, r0, lsr #31
@@ -34105,18 +34105,18 @@ func_ov61_0215a10c: ; 0x0215a10c
 	movs r4, r0
 	addeq sp, sp, #4
 	moveq r0, #2
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	add r6, r4, r5, lsl #1
-	add sb, r6, r5, lsl #1
+	add r9, r6, r5, lsl #1
 	ldr r1, [r8, #0x5a4]
 	ldr r2, [r8, #0x5a8]
 	mov r0, r6
 	mov r3, r5
-	add r10, sb, r5, lsl #1
+	add r10, r9, r5, lsl #1
 	bl func_ov61_0215e8d4
 	ldr r1, [r7, #0x10]
 	ldr r2, [r7, #0xc]
-	mov r0, sb
+	mov r0, r9
 	mov r3, r5
 	bl func_ov61_0215e8d4
 	ldr r1, [r7, #8]
@@ -34125,14 +34125,14 @@ func_ov61_0215a10c: ; 0x0215a10c
 	mov r3, r5
 	bl func_ov61_0215e8d4
 	bl func_ov61_021599fc
-	mov r2, sb
-	mov sb, r0
+	mov r2, r9
+	mov r9, r0
 	mov r0, r4
 	mov r1, r6
 	mov r3, r5
 	str r10, [sp]
 	bl func_ov61_0215e2c0
-	mov r0, sb
+	mov r0, r9
 	bl func_ov61_02159a48
 	ldr r2, [r7, #4]
 	mov r0, r6
@@ -34183,7 +34183,7 @@ _0215a290:
 	blx r1
 	mov r0, r5
 	add sp, sp, #4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0215a10c
 _0215a2ac: .word data_ov61_0217f428
@@ -34310,7 +34310,7 @@ _0215a424:
 	arm_func_start func_ov61_0215a428
 func_ov61_0215a428: ; 0x0215a428
 	stmdb sp!, {r0, r1, r2, r3}
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x18
 	ldr r1, [sp, #0x44]
 	mov r10, r0
@@ -34336,7 +34336,7 @@ func_ov61_0215a428: ; 0x0215a428
 	str r0, [r10, #0x80c]
 	strb r6, [r10, #0x6b0]
 	str r6, [r10, #0x5a0]
-	mov sb, r6
+	mov r9, r6
 	str r6, [r10, #0x594]
 	mov r11, #2
 	mvn r5, #0
@@ -34380,14 +34380,14 @@ _0215a530:
 	mov r0, #9
 	add sp, sp, #0x18
 	strb r0, [r10, #0x455]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	add sp, sp, #0x10
 	bx lr
 _0215a548:
 	mov r0, r10
 	bl func_ov61_0215a2b4
 	mov r7, r0
-	cmp sb, #0
+	cmp r9, #0
 	bne _0215a578
 	ldr r0, [r10, #0x800]
 	cmp r0, #0
@@ -34417,7 +34417,7 @@ _0215a578:
 	movne r0, #9
 	addne sp, sp, #0x18
 	strneb r0, [r10, #0x455]
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	addne sp, sp, #0x10
 	bxne lr
 	mov r0, r10
@@ -34431,12 +34431,12 @@ _0215a5e8:
 	beq _0215a608
 	mov r0, r7
 	mov r1, r10
-	mov r2, sb
+	mov r2, r9
 	blx r3
 	mov r7, r0
 _0215a608:
 	cmp r6, #0
-	add sb, sb, #1
+	add r9, r9, #1
 	beq _0215a628
 	cmp r7, #0
 	bne _0215a628
@@ -34450,7 +34450,7 @@ _0215a628:
 	movne r0, #9
 	strneb r0, [r10, #0x455]
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	add sp, sp, #0x10
 	bx lr
 	arm_func_end func_ov61_0215a428
@@ -34682,7 +34682,7 @@ _0215a8e4:
 	.global func_ov61_0215a920
 	arm_func_start func_ov61_0215a920
 func_ov61_0215a920: ; 0x0215a920
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x18
 	movs r10, r2
 	str r0, [sp, #8]
@@ -34690,7 +34690,7 @@ func_ov61_0215a920: ; 0x0215a920
 	mov r11, r1
 	cmpne r0, #0
 	addeq sp, sp, #0x18
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	mov r0, r0, lsl #0x1
 	add r0, r0, r0, lsr #31
 	mov r0, r0, asr #0x1
@@ -34702,7 +34702,7 @@ func_ov61_0215a920: ; 0x0215a920
 	blx r1
 	movs r5, r0
 	addeq sp, sp, #0x18
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r6, r5, r4, lsl #1
 	add r7, r6, r4, lsl #1
 	add r1, r7, r4, lsl #1
@@ -34711,10 +34711,10 @@ func_ov61_0215a920: ; 0x0215a920
 	add r8, r1, r4, lsl #1
 	str r1, [sp, #0xc]
 	ldr r2, [r10]
-	add sb, r8, r4, lsl #1
+	add r9, r8, r4, lsl #1
 	mov r1, r11
 	mov r3, r4
-	add r11, sb, r4, lsl #1
+	add r11, r9, r4, lsl #1
 	bl func_ov61_0215e8d4
 	ldr r1, [r10, #0x1c]
 	ldr r2, [r10, #0x18]
@@ -34797,26 +34797,26 @@ func_ov61_0215a920: ; 0x0215a920
 	bl func_ov61_0215dc80
 	mov r1, r7
 	mov r2, r6
-	mov r3, sb
+	mov r3, r9
 	mov r0, #0
 	stmia sp, {r4, r11}
 	bl func_ov61_0215e0e0
-	mov r0, sb
+	mov r0, r9
 	mov r1, r6
-	mov r2, sb
+	mov r2, r9
 	mov r3, r4
 	bl func_ov61_0215dcc0
 	b _0215ab2c
 _0215ab14:
 	mov r1, r7
 	mov r2, r6
-	mov r3, sb
+	mov r3, r9
 	mov r0, #0
 	stmia sp, {r4, r11}
 	bl func_ov61_0215e0e0
 _0215ab2c:
 	ldr r0, [sp, #8]
-	mov r1, sb
+	mov r1, r9
 	mov r3, r4
 	mov r2, #0x30
 	bl func_ov61_0215e930
@@ -34825,7 +34825,7 @@ _0215ab2c:
 	ldr r1, [r1]
 	blx r1
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0215a920
 _0215ab58: .word data_ov61_0217f428
@@ -34908,7 +34908,7 @@ _0215ac58: .word data_ov61_0217bce0
 	.global func_ov61_0215ac5c
 	arm_func_start func_ov61_0215ac5c
 func_ov61_0215ac5c: ; 0x0215ac5c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x24
 	mov r10, r0
 	ldrh r0, [r10, #0x32]
@@ -34939,7 +34939,7 @@ _0215aca8:
 	cmp r11, #0
 	ble _0215ad9c
 	add r0, r10, #0x74
-	mov sb, r7
+	mov r9, r7
 	str r0, [sp, #8]
 	add r5, sp, #0xc
 	mov r4, #1
@@ -34988,10 +34988,10 @@ _0215ad18:
 	bl func_ov61_0215d02c
 	ldr r1, [sp, #8]
 	add r0, r10, #0x3fc
-	add r1, r1, sb
+	add r1, r1, r9
 	bl func_ov61_0215d0e4
-	add sb, sb, #0x10
-	cmp sb, r11
+	add r9, r9, #0x10
+	cmp r9, r11
 	add r7, r7, #1
 	blt _0215acdc
 _0215ad9c:
@@ -35031,7 +35031,7 @@ _0215ae00:
 	mov r2, #0x10
 	bl func_ov61_0215da48
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	arm_func_end func_ov61_0215ac5c
 
 	.global func_ov61_0215ae28
@@ -35596,7 +35596,7 @@ func_ov61_0215b5b8: ; 0x0215b5b8
 	.global func_ov61_0215b5e4
 	arm_func_start func_ov61_0215b5e4
 func_ov61_0215b5e4: ; 0x0215b5e4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	mov r5, r0
 	ldrb r0, [r5, #0x455]
 	mov r4, r1
@@ -35606,7 +35606,7 @@ func_ov61_0215b5e4: ; 0x0215b5e4
 	mov r0, r4
 	ldr r1, [r1]
 	blx r1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _0215b610:
 	ldrb r2, [r4, #3]
 	ldrb r1, [r4, #4]
@@ -35614,7 +35614,7 @@ _0215b610:
 	and r0, r0, #0xff
 	add r1, r1, r2, lsl #8
 	cmp r0, #1
-	add sb, r1, #5
+	add r9, r1, #5
 	ldrb r6, [r4]
 	bhi _0215b63c
 	cmp r6, #0x15
@@ -35622,18 +35622,18 @@ _0215b610:
 _0215b63c:
 	cmp r6, #0x15
 	bne _0215b65c
-	cmp sb, #7
+	cmp r9, #7
 	bls _0215b65c
 _0215b64c:
 	mov r0, r5
 	mov r1, r4
 	bl func_ov61_0215b118
-	mov sb, r0
+	mov r9, r0
 _0215b65c:
 	sub r0, r6, #0x14
 	cmp r0, #3
 	add r8, r4, #5
-	sub sb, sb, #5
+	sub r9, r9, #5
 	addls pc, pc, r0, lsl #2
 	b _0215b80c
 _0215b674: ; jump table
@@ -35738,7 +35738,7 @@ _0215b7bc:
 	bl func_ov61_0215b5b8
 	add r0, r10, #4
 	add r8, r8, r10
-	subs sb, sb, r0
+	subs r9, r9, r0
 	beq _0215b814
 	ldrb r0, [r5, #0x455]
 	cmp r0, #9
@@ -35748,11 +35748,11 @@ _0215b7ec:
 	str r4, [r5, #0x824]
 	mov r0, #5
 	str r0, [r5, #0x82c]
-	add r0, sb, #5
+	add r0, r9, #5
 	str r0, [r5, #0x828]
 	mov r0, #1
 	strb r0, [r5, #0x456]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _0215b80c:
 	mov r0, #9
 	strb r0, [r5, #0x455]
@@ -35761,7 +35761,7 @@ _0215b814:
 	mov r0, r4
 	ldr r1, [r1]
 	blx r1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0215b5e4
 _0215b828: .word data_ov61_0217f454
@@ -35885,12 +35885,12 @@ _0215b9c8: .word 0x00004805
 	.global func_ov61_0215b9cc
 	arm_func_start func_ov61_0215b9cc
 func_ov61_0215b9cc: ; 0x0215b9cc
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x74
 	ldr r2, _0215baec ; =data_ov61_02180e40
 	mov r10, r0
 	ldrb r0, [r2]
-	mov sb, r1
+	mov r9, r1
 	cmp r0, #0
 	bne _0215ba30
 	ldr r2, _0215baf0 ; =data_ov61_0217f47c
@@ -35911,11 +35911,11 @@ func_ov61_0215b9cc: ; 0x0215b9cc
 	str r3, [sp]
 	bl func_ov61_0215bafc
 _0215ba30:
-	cmp sb, #0
+	cmp r9, #0
 	mov r8, #0
 	addle sp, sp, #0x74
 	mov r1, #0x14
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r5, _0215baf4 ; =data_ov61_02180fb8
 	add r6, sp, #0x18
 	mov r11, r1
@@ -35957,10 +35957,10 @@ _0215bac8:
 	cmp r0, #0
 	strneb r0, [r10, r8]
 	addne r8, r8, #1
-	cmp r8, sb
+	cmp r8, r9
 	blt _0215ba54
 	add sp, sp, #0x74
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0215b9cc
 _0215baec: .word data_ov61_02180e40
@@ -36005,9 +36005,9 @@ _0215bb68: .word data_ov61_02180e40
 	.global func_ov61_0215bb6c
 	arm_func_start func_ov61_0215bb6c
 func_ov61_0215bb6c: ; 0x0215bb6c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
-	mov sb, r0
-	ldr r4, [sb, #0xc]
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
+	mov r9, r0
+	ldr r4, [r9, #0xc]
 	ldr r7, [r4, #0x820]
 	cmp r7, #0
 	ldrne r8, [r7]
@@ -36032,7 +36032,7 @@ func_ov61_0215bb6c: ; 0x0215bb6c
 	mov r0, #9
 	strb r0, [r4, #0x455]
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _0215bbdc:
 	mov r0, #2
 	strb r0, [r5, #5]
@@ -36151,14 +36151,14 @@ _0215bd54:
 	mov r0, r5
 	mov r3, r2
 	add r1, r6, #5
-	str sb, [sp]
+	str r9, [sp]
 	bl func_ov61_02155204
 	ldr r1, _0215bdc8 ; =data_ov61_0217f454
 	mov r0, r5
 	ldr r1, [r1]
 	blx r1
 	ldrb r0, [r4, #0x31]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0215bb6c
 _0215bdc0: .word data_ov61_0217f428
@@ -36369,7 +36369,7 @@ _0215c0b4: .word data_ov61_0217f454
 	.global func_ov61_0215c0b8
 	arm_func_start func_ov61_0215c0b8
 func_ov61_0215c0b8: ; 0x0215c0b8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #8
 	mov r11, r0
 	ldr r4, [r11, #0xc]
@@ -36388,25 +36388,25 @@ func_ov61_0215c0b8: ; 0x0215c0b8
 	mov r0, r10
 	mov r8, r1, asr #0x1
 	blx r2
-	movs sb, r0
+	movs r9, r0
 	moveq r0, #9
 	addeq sp, sp, #8
 	streqb r0, [r4, #0x455]
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	mov r0, #0
-	strb r0, [sb]
+	strb r0, [r9]
 	mov r2, #2
-	add r0, sb, #2
+	add r0, r9, #2
 	sub r1, r10, #0x33
-	strb r2, [sb, #1]
+	strb r2, [r9, #1]
 	bl func_ov61_0215b9cc
-	add r1, sb, r10
+	add r1, r9, r10
 	mov r0, r4
 	sub r3, r10, #0x31
 	mov r5, #0
 	sub r1, r1, #0x30
 	mov r2, #0x30
-	strb r5, [sb, r3]
+	strb r5, [r9, r3]
 	bl func_02007ad8
 	ldr r1, _0215c348 ; =data_ov61_0217f428
 	mov r0, r8, lsl #0x3
@@ -36415,17 +36415,17 @@ func_ov61_0215c0b8: ; 0x0215c0b8
 	movs r5, r0
 	bne _0215c18c
 	ldr r1, _0215c34c ; =data_ov61_0217f454
-	mov r0, sb
+	mov r0, r9
 	ldr r1, [r1]
 	blx r1
 	mov r0, #9
 	add sp, sp, #8
 	strb r0, [r4, #0x455]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0215c18c:
 	add r0, r5, r8, lsl #1
 	add r6, r0, r8, lsl #1
-	mov r1, sb
+	mov r1, r9
 	mov r2, r10
 	mov r3, r8
 	str r0, [sp, #4]
@@ -36460,7 +36460,7 @@ _0215c18c:
 	movs r6, r0
 	bne _0215c24c
 	ldr r1, _0215c34c ; =data_ov61_0217f454
-	mov r0, sb
+	mov r0, r9
 	ldr r1, [r1]
 	blx r1
 	ldr r1, _0215c34c ; =data_ov61_0217f454
@@ -36470,7 +36470,7 @@ _0215c18c:
 	mov r0, #9
 	add sp, sp, #8
 	strb r0, [r4, #0x455]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0215c24c:
 	mov r0, #0x16
 	strb r0, [r6]
@@ -36533,11 +36533,11 @@ _0215c2e8:
 	ldr r1, [r1]
 	blx r1
 	ldr r1, _0215c34c ; =data_ov61_0217f454
-	mov r0, sb
+	mov r0, r9
 	ldr r1, [r1]
 	blx r1
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0215c0b8
 _0215c348: .word data_ov61_0217f428
@@ -36949,10 +36949,10 @@ _0215c878:
 	.global func_ov61_0215c880
 	arm_func_start func_ov61_0215c880
 func_ov61_0215c880: ; 0x0215c880
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0xc
 	ldr r4, [sp, #0x30]
-	mov sb, r1
+	mov r9, r1
 	mov r1, r4
 	ldr r1, [r1, #0xc]
 	mov r10, r0
@@ -36960,7 +36960,7 @@ func_ov61_0215c880: ; 0x0215c880
 	str r4, [sp, #0x30]
 	str r1, [sp, #8]
 	mov r8, r2
-	add r5, sb, r3
+	add r5, r9, r3
 	str r0, [sp, #4]
 _0215c8b4:
 	ldr r0, _0215c9a8 ; =0x00000b4f
@@ -36973,9 +36973,9 @@ _0215c8b4:
 	blx r1
 	movs r4, r0
 	beq _0215c99c
-	cmp sb, r6
+	cmp r9, r6
 	movhs r7, r6
-	movlo r7, sb
+	movlo r7, r9
 	mov r0, r10
 	add r1, r4, #5
 	mov r2, r7
@@ -36986,7 +36986,7 @@ _0215c8b4:
 	add r1, r1, r7
 	mov r2, r11
 	add r10, r10, r7
-	sub sb, sb, r7
+	sub r9, r9, r7
 	bl func_02007ad8
 	mov r0, #0x17
 	strb r0, [r4]
@@ -37024,7 +37024,7 @@ _0215c8b4:
 _0215c99c:
 	ldr r0, [sp, #4]
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0215c880
 _0215c9a8: .word 0x00000b4f
@@ -37214,7 +37214,7 @@ _0215cbc4: .word func_02007ad8
 	.global func_ov61_0215cbc8
 	arm_func_start func_ov61_0215cbc8
 func_ov61_0215cbc8: ; 0x0215cbc8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x44
 	str r0, [sp]
 	ldr r3, [sp]
@@ -37229,7 +37229,7 @@ func_ov61_0215cbc8: ; 0x0215cbc8
 _0215cbf8:
 	ldr r1, _0215cfe0 ; =data_ov61_0217bd74
 	ldrb r0, [lr]
-	add sb, r1, r3, lsl #2
+	add r9, r1, r3, lsl #2
 	eor r1, r6, r7
 	and r8, r5, r1
 	ldr r1, _0215cfe0 ; =data_ov61_0217bd74
@@ -37248,7 +37248,7 @@ _0215cbf8:
 	ldr r10, [r2, r1, lsl #2]
 	eor r0, r6, r0
 	add r0, r0, r10
-	ldr r8, [sb, #4]
+	ldr r8, [r9, #4]
 	ldrb r10, [lr, #2]
 	add r0, r8, r0
 	add r7, r7, r0
@@ -37257,7 +37257,7 @@ _0215cbf8:
 	add r7, r4, r0
 	eor r0, r4, r5
 	and r0, r7, r0
-	ldr r1, [sb, #8]
+	ldr r1, [r9, #8]
 	ldrb r11, [lr, #3]
 	ldr r10, [r2, r10, lsl #2]
 	eor r0, r5, r0
@@ -37272,9 +37272,9 @@ _0215cbf8:
 	and r1, r6, r8
 	ldr r0, [r2, r11, lsl #2]
 	eor r1, r4, r1
-	ldr sb, [sb, #0xc]
+	ldr r9, [r9, #0xc]
 	add r0, r1, r0
-	add r0, sb, r0
+	add r0, r9, r0
 	add r1, r5, r0
 	mov r0, r1, lsr #0xa
 	orr r0, r0, r1, lsl #22
@@ -37287,7 +37287,7 @@ _0215cbf8:
 	ldr lr, _0215cfe0 ; =data_ov61_0217bd74
 	mov r11, #0
 	add r10, r0, r3
-	add sb, sp, #4
+	add r9, sp, #4
 _0215ccec:
 	ldrb r0, [r10]
 	add ip, lr, r3, lsl #2
@@ -37295,7 +37295,7 @@ _0215ccec:
 	and r1, r7, r1
 	ldr r8, [lr, r3, lsl #2]
 	eor r1, r6, r1
-	ldr r0, [sb, r0, lsl #2]
+	ldr r0, [r9, r0, lsl #2]
 	ldr r2, [ip, #4]
 	add r0, r1, r0
 	add r0, r8, r0
@@ -37307,7 +37307,7 @@ _0215ccec:
 	eor r1, r4, r5
 	and r1, r6, r1
 	eor r1, r5, r1
-	ldr r0, [sb, r0, lsl #2]
+	ldr r0, [r9, r0, lsl #2]
 	ldr r8, [ip, #8]
 	add r0, r1, r0
 	add r0, r2, r0
@@ -37322,8 +37322,8 @@ _0215ccec:
 	ldrb r1, [r10, #2]
 	ldrb ip, [r10, #3]
 	add r10, r10, #4
-	ldr r1, [sb, r1, lsl #2]
-	ldr ip, [sb, ip, lsl #2]
+	ldr r1, [r9, r1, lsl #2]
+	ldr ip, [r9, ip, lsl #2]
 	add r1, r2, r1
 	add r1, r8, r1
 	add r2, r6, r1
@@ -37349,33 +37349,33 @@ _0215ccec:
 	mov r8, #0
 	add r0, sp, #4
 _0215cdd8:
-	ldrb sb, [r2]
+	ldrb r9, [r2]
 	add r11, r1, r3, lsl #2
 	eor ip, r5, r6
-	ldr r10, [r0, sb, lsl #2]
+	ldr r10, [r0, r9, lsl #2]
 	eor ip, r7, ip
-	ldr sb, [r1, r3, lsl #2]
+	ldr r9, [r1, r3, lsl #2]
 	add r10, ip, r10
-	add sb, sb, r10
-	add sb, r4, sb
-	mov r4, sb, lsr #0x1c
+	add r9, r9, r10
+	add r9, r4, r9
+	mov r4, r9, lsr #0x1c
 	ldrb r10, [r2, #1]
-	orr r4, r4, sb, lsl #4
+	orr r4, r4, r9, lsl #4
 	add r4, r5, r4
-	eor sb, r4, r5
-	eor sb, r6, sb
+	eor r9, r4, r5
+	eor r9, r6, r9
 	ldr ip, [r0, r10, lsl #2]
 	ldr r10, [r11, #4]
-	add sb, sb, ip
-	add sb, r10, sb
-	add sb, r7, sb
-	mov r7, sb, lsr #0x15
-	orr r7, r7, sb, lsl #11
-	ldrb sb, [r2, #2]
+	add r9, r9, ip
+	add r9, r10, r9
+	add r9, r7, r9
+	mov r7, r9, lsr #0x15
+	orr r7, r7, r9, lsl #11
+	ldrb r9, [r2, #2]
 	add r7, r4, r7
 	ldr r10, [r11, #8]
-	ldr ip, [r0, sb, lsl #2]
-	ldr sb, [r11, #0xc]
+	ldr ip, [r0, r9, lsl #2]
+	ldr r9, [r11, #0xc]
 	eor r11, r7, r4
 	eor r11, r5, r11
 	add r11, r11, ip
@@ -37392,15 +37392,15 @@ _0215cdd8:
 	ldr r10, [r0, r10, lsl #2]
 	add r8, r8, #1
 	add r10, r11, r10
-	add sb, sb, r10
-	add sb, r5, sb
+	add r9, r9, r10
+	add r9, r5, r9
 	cmp r8, #4
-	mov r5, sb, lsr #0x9
-	orr r5, r5, sb, lsl #23
+	mov r5, r9, lsr #0x9
+	orr r5, r5, r9, lsl #23
 	add r5, r6, r5
 	blt _0215cdd8
 	ldr r0, _0215cfdc ; =data_ov61_0217bcf4
-	mov sb, #0
+	mov r9, #0
 	add r8, r0, r3
 	add r2, sp, #4
 _0215ceb0:
@@ -37443,7 +37443,7 @@ _0215ceb0:
 	add r6, r6, r0
 	mov r1, r6, lsr #0x11
 	orr r1, r1, r6, lsl #15
-	add sb, sb, #1
+	add r9, r9, #1
 	mvn r10, r4
 	add r6, r7, r1
 	orr r1, r6, r10
@@ -37458,7 +37458,7 @@ _0215ceb0:
 	add r8, r8, #4
 	add r5, r6, r0
 	add r3, r3, #4
-	cmp sb, #4
+	cmp r9, #4
 	blt _0215ceb0
 	ldr r0, [sp]
 	ldr r0, [r0]
@@ -37478,7 +37478,7 @@ _0215ceb0:
 	ldr r0, [sp]
 	str r1, [r0, #0xc]
 	add sp, sp, #0x44
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0215cbc8
 _0215cfdc: .word data_ov61_0217bcf4
@@ -37666,12 +37666,12 @@ _0215d1e4:
 	.global func_ov61_0215d21c
 	arm_func_start func_ov61_0215d21c
 func_ov61_0215d21c: ; 0x0215d21c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x50
 	str r0, [sp]
 	ldr r3, [sp]
 	add r0, sp, #0x10
-	ldmia r3, {r4, r5, r7, r8, sb}
+	ldmia r3, {r4, r5, r7, r8, r9}
 	mov r2, #0x40
 	bl func_ov61_0215d1d4
 	mov r0, #0
@@ -37692,9 +37692,9 @@ _0215d24c:
 	ldr r11, [r5, #4]
 	add r6, ip, r6
 	add r6, r6, r3
-	add sb, sb, r6
-	mov r6, sb, lsr #0x1b
-	orr r6, r6, sb, lsl #5
+	add r9, r9, r6
+	mov r6, r9, lsr #0x1b
+	orr r6, r6, r9, lsl #5
 	eor ip, r10, r7
 	and ip, r4, ip
 	eor ip, r7, ip
@@ -37708,19 +37708,19 @@ _0215d24c:
 	mov r6, r8, lsr #0x1b
 	orr r6, r6, r8, lsl #5
 	eor ip, r4, r10
-	and ip, sb, ip
+	and ip, r9, ip
 	eor ip, r10, ip
 	add r6, r6, ip
 	add r6, r11, r6
 	add r6, r6, r3
 	add r6, r7, r6
-	mov r7, sb, lsr #0x2
-	orr sb, r7, sb, lsl #30
+	mov r7, r9, lsr #0x2
+	orr r9, r7, r9, lsl #30
 	ldr r7, [r5, #0xc]
 	ldr r11, [r5, #0x10]
 	mov r5, r6, lsr #0x1b
 	orr r5, r5, r6, lsl #5
-	eor ip, sb, r4
+	eor ip, r9, r4
 	and ip, r8, ip
 	eor ip, r4, ip
 	add r5, r5, ip
@@ -37731,9 +37731,9 @@ _0215d24c:
 	orr r8, r7, r8, lsl #30
 	mov r7, r5, lsr #0x1b
 	orr r7, r7, r5, lsl #5
-	eor r10, r8, sb
+	eor r10, r8, r9
 	and r10, r6, r10
-	eor r10, sb, r10
+	eor r10, r9, r10
 	add r7, r7, r10
 	add r7, r11, r7
 	add r7, r7, r3
@@ -37757,13 +37757,13 @@ _0215d24c:
 	mov r2, r5, lsr #0x2
 	orr r6, r2, r5, lsl #30
 	mov r0, #0
-	add sb, sb, r3
+	add r9, r9, r3
 	bl func_ov61_0215d14c
 	eor r1, r6, r7
-	mov r3, sb, lsr #0x1b
+	mov r3, r9, lsr #0x1b
 	and r1, r4, r1
 	mov r2, r4, lsr #0x2
-	orr r3, r3, sb, lsl #5
+	orr r3, r3, r9, lsl #5
 	eor r1, r7, r1
 	add r1, r3, r1
 	add r3, r1, r0
@@ -37776,22 +37776,22 @@ _0215d24c:
 	bl func_ov61_0215d14c
 	eor r1, r5, r6
 	mov r2, r8, lsr #0x1b
-	and r1, sb, r1
+	and r1, r9, r1
 	orr r2, r2, r8, lsl #5
 	eor r1, r6, r1
 	add r1, r2, r1
 	add r2, r1, r0
 	ldr r0, _0215d894 ; =0x5a827999
-	mov r1, sb, lsr #0x2
+	mov r1, r9, lsr #0x2
 	add r0, r2, r0
-	orr sb, r1, sb, lsl #30
+	orr r9, r1, r9, lsl #30
 	add r7, r7, r0
 	add r1, sp, #0x10
 	mov r0, #2
 	bl func_ov61_0215d14c
 	mov r1, r7, lsr #0x1b
 	orr r2, r1, r7, lsl #5
-	eor r1, sb, r5
+	eor r1, r9, r5
 	and r1, r8, r1
 	eor r1, r5, r1
 	add r1, r2, r1
@@ -37806,9 +37806,9 @@ _0215d24c:
 	bl func_ov61_0215d14c
 	mov r1, r6, lsr #0x1b
 	orr r2, r1, r6, lsl #5
-	eor r1, r8, sb
+	eor r1, r8, r9
 	and r1, r7, r1
-	eor r1, sb, r1
+	eor r1, r9, r1
 	add r1, r2, r1
 	add r2, r1, r0
 	ldr r0, _0215d894 ; =0x5a827999
@@ -37833,13 +37833,13 @@ _0215d484:
 	add r0, r1, r0
 	add r1, r0, r4
 	mov r0, r6, lsr #0x2
-	add sb, sb, r1
+	add r9, r9, r1
 	orr r6, r0, r6, lsl #30
 	add r0, r10, #1
 	mov r1, r11
 	bl func_ov61_0215d14c
-	mov r1, sb, lsr #0x1b
-	orr r2, r1, sb, lsl #5
+	mov r1, r9, lsr #0x1b
+	orr r2, r1, r9, lsl #5
 	eor r1, r5, r6
 	eor r1, r7, r1
 	add r1, r2, r1
@@ -37855,20 +37855,20 @@ _0215d484:
 	bl func_ov61_0215d14c
 	mov r1, r8, lsr #0x1b
 	orr r2, r1, r8, lsl #5
-	eor r1, sb, r5
+	eor r1, r9, r5
 	eor r1, r6, r1
 	add r1, r2, r1
 	add r0, r1, r0
 	add r0, r0, r4
 	add r7, r7, r0
-	mov r0, sb, lsr #0x2
-	orr sb, r0, sb, lsl #30
+	mov r0, r9, lsr #0x2
+	orr r9, r0, r9, lsl #30
 	add r0, r10, #1
 	mov r1, r11
 	bl func_ov61_0215d14c
 	mov r1, r7, lsr #0x1b
 	orr r2, r1, r7, lsl #5
-	eor r1, r8, sb
+	eor r1, r8, r9
 	eor r1, r5, r1
 	add r1, r2, r1
 	add r0, r1, r0
@@ -37882,7 +37882,7 @@ _0215d484:
 	mov r1, r6, lsr #0x1b
 	orr r2, r1, r6, lsl #5
 	eor r1, r7, r8
-	eor r1, sb, r1
+	eor r1, r9, r1
 	add r1, r2, r1
 	add r0, r1, r0
 	add r0, r0, r4
@@ -37913,13 +37913,13 @@ _0215d5b8:
 	add r1, r1, r0
 	mov r0, r6, lsr #0x2
 	add r1, r1, r4
-	add sb, sb, r1
+	add r9, r9, r1
 	orr r6, r0, r6, lsl #30
 	add r0, r10, #1
 	mov r1, r11
 	bl func_ov61_0215d14c
-	mov r1, sb, lsr #0x1b
-	orr r1, r1, sb, lsl #5
+	mov r1, r9, lsr #0x1b
+	orr r1, r1, r9, lsl #5
 	orr r2, r6, r7
 	and r3, r5, r2
 	and r2, r6, r7
@@ -37936,15 +37936,15 @@ _0215d5b8:
 	mov r1, r8, lsr #0x1b
 	orr r1, r1, r8, lsl #5
 	orr r2, r5, r6
-	and r3, sb, r2
+	and r3, r9, r2
 	and r2, r5, r6
 	orr r2, r3, r2
 	add r1, r1, r2
 	add r0, r1, r0
 	add r0, r0, r4
 	add r7, r7, r0
-	mov r0, sb, lsr #0x2
-	orr sb, r0, sb, lsl #30
+	mov r0, r9, lsr #0x2
+	orr r9, r0, r9, lsl #30
 	add r0, r10, #3
 	and r10, r0, #0xf
 	mov r0, r10
@@ -37952,9 +37952,9 @@ _0215d5b8:
 	bl func_ov61_0215d14c
 	mov r1, r7, lsr #0x1b
 	orr r1, r1, r7, lsl #5
-	orr r2, sb, r5
+	orr r2, r9, r5
 	and r3, r8, r2
-	and r2, sb, r5
+	and r2, r9, r5
 	orr r2, r3, r2
 	add r1, r1, r2
 	add r0, r1, r0
@@ -37967,9 +37967,9 @@ _0215d5b8:
 	bl func_ov61_0215d14c
 	mov r1, r6, lsr #0x1b
 	orr r1, r1, r6, lsl #5
-	orr r2, r8, sb
+	orr r2, r8, r9
 	and r3, r7, r2
-	and r2, r8, sb
+	and r2, r8, r9
 	orr r2, r3, r2
 	add r1, r1, r2
 	add r0, r1, r0
@@ -37999,13 +37999,13 @@ _0215d714:
 	add r0, r1, r0
 	add r1, r0, r4
 	mov r0, r6, lsr #0x2
-	add sb, sb, r1
+	add r9, r9, r1
 	orr r6, r0, r6, lsl #30
 	add r0, r10, #1
 	mov r1, r11
 	bl func_ov61_0215d14c
-	mov r1, sb, lsr #0x1b
-	orr r2, r1, sb, lsl #5
+	mov r1, r9, lsr #0x1b
+	orr r2, r1, r9, lsl #5
 	eor r1, r5, r6
 	eor r1, r7, r1
 	add r1, r2, r1
@@ -38019,20 +38019,20 @@ _0215d714:
 	bl func_ov61_0215d14c
 	mov r1, r8, lsr #0x1b
 	orr r2, r1, r8, lsl #5
-	eor r1, sb, r5
+	eor r1, r9, r5
 	eor r1, r6, r1
 	add r1, r2, r1
 	add r0, r1, r0
 	add r0, r0, r4
 	add r7, r7, r0
-	mov r0, sb, lsr #0x2
-	orr sb, r0, sb, lsl #30
+	mov r0, r9, lsr #0x2
+	orr r9, r0, r9, lsl #30
 	add r0, r10, #3
 	mov r1, r11
 	bl func_ov61_0215d14c
 	mov r1, r7, lsr #0x1b
 	orr r2, r1, r7, lsl #5
-	eor r1, r8, sb
+	eor r1, r8, r9
 	eor r1, r5, r1
 	add r1, r2, r1
 	add r0, r1, r0
@@ -38048,7 +38048,7 @@ _0215d714:
 	mov r1, r6, lsr #0x1b
 	orr r2, r1, r6, lsl #5
 	eor r1, r7, r8
-	eor r1, sb, r1
+	eor r1, r9, r1
 	add r1, r2, r1
 	add r0, r1, r0
 	add r0, r0, r4
@@ -38079,11 +38079,11 @@ _0215d714:
 	ldr r0, [sp]
 	str r1, [r0, #0xc]
 	ldr r0, [r0, #0x10]
-	add r1, r0, sb
+	add r1, r0, r9
 	ldr r0, [sp]
 	str r1, [r0, #0x10]
 	add sp, sp, #0x50
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0215d21c
 _0215d894: .word 0x5a827999
@@ -38557,11 +38557,11 @@ _0215de28:
 	.global func_ov61_0215de3c
 	arm_func_start func_ov61_0215de3c
 func_ov61_0215de3c: ; 0x0215de3c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #8
 	mov r8, r3
 	mov r10, r1
-	mov sb, r2
+	mov r9, r2
 	mov r2, r8, lsl #0x1
 	mov r1, #0
 	str r0, [sp]
@@ -38570,14 +38570,14 @@ func_ov61_0215de3c: ; 0x0215de3c
 	mov r1, r8
 	bl func_ov61_0215db28
 	mov r11, r0
-	mov r0, sb
+	mov r0, r9
 	mov r1, r8
 	bl func_ov61_0215db28
 	str r0, [sp, #4]
 	cmp r0, #0
 	mov r5, #0
 	addle sp, sp, #8
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0215de90:
 	mov r6, #0
 	sub r7, r8, r5
@@ -38586,7 +38586,7 @@ _0215de90:
 _0215dea0:
 	mov r0, r6, lsl #0x1
 	ldrh r3, [r10, r0]
-	ldrh r1, [sb, r4]
+	ldrh r1, [r9, r4]
 	ldr r0, [sp]
 	add r2, r5, r6
 	mul r1, r3, r1
@@ -38602,7 +38602,7 @@ _0215dec4:
 	cmp r5, r0
 	blt _0215de90
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	arm_func_end func_ov61_0215de3c
 
 	.global func_ov61_0215dee8
@@ -38645,11 +38645,11 @@ _0215df38:
 	.global func_ov61_0215df60
 	arm_func_start func_ov61_0215df60
 func_ov61_0215df60: ; 0x0215df60
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
-	mov sb, r1
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
+	mov r9, r1
 	mov r8, r2
 	mov r10, r0
-	mov r0, sb
+	mov r0, r9
 	mov r1, r8
 	bl func_ov61_0215db28
 	mov r11, r0
@@ -38671,7 +38671,7 @@ _0215dfb4:
 	cmp r5, r8
 	bge _0215dff4
 	mov r0, r4, lsl #0x1
-	ldrh r3, [sb, r0]
+	ldrh r3, [r9, r0]
 	mov r0, r5, lsl #0x1
 	cmp r5, r2
 	mul r1, r3, r3
@@ -38687,7 +38687,7 @@ _0215dfb4:
 _0215dff4:
 	mov r6, #0
 	cmp r11, #0
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0215e000:
 	mov r0, r6, lsl #0x1
 	add r4, r6, #1
@@ -38695,9 +38695,9 @@ _0215e000:
 	b _0215e070
 _0215e010:
 	mov r0, r4, lsl #0x1
-	ldrh r1, [sb, r0]
+	ldrh r1, [r9, r0]
 	ldr r0, [sp]
-	ldrh r0, [sb, r0]
+	ldrh r0, [r9, r0]
 	mul r7, r1, r0
 	ldr r0, _0215e090 ; =0x7fff8000
 	cmp r7, r0
@@ -38728,7 +38728,7 @@ _0215e070:
 	add r6, r6, #1
 	cmp r6, r11
 	blt _0215e000
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0215df60
 _0215e090: .word 0x7fff8000
@@ -38775,39 +38775,39 @@ func_ov61_0215e0c4: ; 0x0215e0c4
 	.global func_ov61_0215e0e0
 	arm_func_start func_ov61_0215e0e0
 func_ov61_0215e0e0: ; 0x0215e0e0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x20
-	ldr sb, [sp, #0x48]
+	ldr r9, [sp, #0x48]
 	ldr r8, [sp, #0x4c]
 	str r1, [sp, #4]
-	add r6, r8, sb, lsl #1
+	add r6, r8, r9, lsl #1
 	str r0, [sp]
 	mov r10, r2
 	mov r0, r6
-	mov r2, sb, lsl #0x2
+	mov r2, r9, lsl #0x2
 	mov r1, #0
 	str r3, [sp, #8]
-	add r7, r6, sb, lsl #1
+	add r7, r6, r9, lsl #1
 	bl func_02007a44
 	ldr r0, [sp, #4]
-	mov r1, sb
+	mov r1, r9
 	bl func_ov61_0215db28
 	mov r11, r0
 	mov r0, r10
-	mov r1, sb
+	mov r1, r9
 	bl func_ov61_0215db28
 	mov r5, r0
 	cmp r11, #0
 	cmpgt r5, #0
 	ble _0215e278
-	sub r0, sb, r11
+	sub r0, r9, r11
 	add r0, r5, r0
 	sub r4, r0, #1
-	cmp r4, sb
+	cmp r4, r9
 	blt _0215e16c
 	ldr r0, [sp, #4]
 	mov r1, r7
-	mov r2, sb, lsl #0x1
+	mov r2, r9, lsl #0x1
 	bl func_02007ad8
 	b _0215e278
 _0215e16c:
@@ -38840,9 +38840,9 @@ _0215e1c4:
 	str r0, [sp, #0x18]
 	str r1, [sp, #0x10]
 _0215e1d4:
-	cmp r4, sb
+	cmp r4, r9
 	bge _0215e278
-	mov r0, sb, lsl #0x1
+	mov r0, r9, lsl #0x1
 	sub r0, r0, #1
 	mov r0, r0, lsl #0x1
 	str r0, [sp, #0x14]
@@ -38865,11 +38865,11 @@ _0215e220:
 	mov r0, r8
 	mov r1, r10
 	mov r2, r2, lsr #0x10
-	mov r3, sb
+	mov r3, r9
 	bl func_ov61_0215dee8
 	mov r0, r7
 	mov r1, r8
-	mov r2, sb
+	mov r2, r9
 	bl func_ov61_0215ddd0
 	cmp r0, #0
 	sublt r5, r5, #1
@@ -38877,11 +38877,11 @@ _0215e220:
 	mov r0, r7
 	mov r1, r7
 	mov r2, r8
-	mov r3, sb
+	mov r3, r9
 	bl func_ov61_0215dcc0
 	strh r5, [r6]
 	add r4, r4, #1
-	cmp r4, sb
+	cmp r4, r9
 	blt _0215e1ec
 _0215e278:
 	ldr r0, [sp]
@@ -38889,19 +38889,19 @@ _0215e278:
 	beq _0215e294
 	ldr r1, [sp]
 	mov r0, r6
-	mov r2, sb, lsl #0x1
+	mov r2, r9, lsl #0x1
 	bl func_02007ad8
 _0215e294:
 	ldr r0, [sp, #8]
 	cmp r0, #0
 	addeq sp, sp, #0x20
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r1, [sp, #8]
 	mov r0, r7
-	mov r2, sb, lsl #0x1
+	mov r2, r9, lsl #0x1
 	bl func_02007ad8
 	add sp, sp, #0x20
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0215e0e0
 _0215e2bc: .word 0x0000ffff
@@ -38909,7 +38909,7 @@ _0215e2bc: .word 0x0000ffff
 	.global func_ov61_0215e2c0
 	arm_func_start func_ov61_0215e2c0
 func_ov61_0215e2c0: ; 0x0215e2c0
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0xc
 	ldr r4, _0215e44c ; =data_ov61_0217f428
 	mov r8, r3
@@ -38918,11 +38918,11 @@ func_ov61_0215e2c0: ; 0x0215e2c0
 	mov r0, r8, lsl #0x3
 	ldr r7, [sp, #0x30]
 	str r1, [sp, #8]
-	mov sb, r2
+	mov r9, r2
 	blx r3
 	movs r4, r0
 	addeq sp, sp, #0xc
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	sub r1, r8, #1
 	add r0, r10, #2
 	mov r2, r1, lsl #0x1
@@ -38930,7 +38930,7 @@ func_ov61_0215e2c0: ; 0x0215e2c0
 	add r5, r4, r8, lsl #1
 	bl func_02007a44
 	mov r2, #1
-	mov r0, sb
+	mov r0, r9
 	mov r1, r8
 	strh r2, [r10]
 	bl func_ov61_0215db28
@@ -38941,7 +38941,7 @@ func_ov61_0215e2c0: ; 0x0215e2c0
 	mov r2, #0x8000
 _0215e338:
 	sub r0, r8, r6, asr #4
-	add r0, sb, r0, lsl #1
+	add r0, r9, r0, lsl #1
 	ldrh r0, [r0, #-2]
 	and r1, r6, #0xf
 	tst r0, r2, lsr r1
@@ -38980,7 +38980,7 @@ _0215e380:
 	bl func_ov61_0215e0e0
 _0215e3c4:
 	sub r0, r8, r6, asr #4
-	add r0, sb, r0, lsl #1
+	add r0, r9, r0, lsl #1
 	ldrh r1, [r0, #-2]
 	and r2, r6, #0xf
 	mov r0, #0x8000
@@ -39014,7 +39014,7 @@ _0215e434:
 	ldr r1, [r1]
 	blx r1
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0215e2c0
 _0215e44c: .word data_ov61_0217f428
@@ -39023,11 +39023,11 @@ _0215e450: .word data_ov61_0217f454
 	.global func_ov61_0215e454
 	arm_func_start func_ov61_0215e454
 func_ov61_0215e454: ; 0x0215e454
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x14
-	ldr sb, [sp, #0x38]
+	ldr r9, [sp, #0x38]
 	mov r10, r3
-	add r11, sb, r10, lsl #1
+	add r11, r9, r10, lsl #1
 	add r4, r11, r10, lsl #1
 	add r5, r4, r10, lsl #1
 	add r6, r5, r10, lsl #1
@@ -39038,7 +39038,7 @@ func_ov61_0215e454: ; 0x0215e454
 	str r1, [sp, #0x10]
 	mov r8, r10, lsl #0x1
 	str r2, [sp, #0xc]
-	mov r1, sb
+	mov r1, r9
 	mov r2, r8
 	bl func_02007ad8
 	ldr r0, [sp, #0xc]
@@ -39047,7 +39047,7 @@ func_ov61_0215e454: ; 0x0215e454
 	bl func_02007ad8
 	mov r0, #1
 	strh r0, [r4, r8]
-	mov r0, sb
+	mov r0, r9
 	mov r1, r10
 	bl func_ov61_0215db50
 	cmp r0, #0
@@ -39058,15 +39058,15 @@ _0215e4c8:
 	str r3, [sp, #4]
 	mov r0, r11
 	mov r1, r4
-	mov r2, sb
+	mov r2, r9
 	mov r3, r7
 	bl func_ov61_0215e0e0
-	mov r0, sb
+	mov r0, r9
 	mov r1, r4
 	mov r2, r8
 	bl func_02007ad8
 	mov r0, r7
-	mov r1, sb
+	mov r1, r9
 	mov r2, r8
 	bl func_02007ad8
 	mov r0, r7
@@ -39087,7 +39087,7 @@ _0215e4c8:
 	mov r1, r5
 	mov r2, r8
 	bl func_02007ad8
-	mov r0, sb
+	mov r0, r9
 	mov r1, r10
 	bl func_ov61_0215db50
 	cmp r0, #0
@@ -39107,25 +39107,25 @@ _0215e564:
 	str r4, [sp, #4]
 	bl func_ov61_0215e0e0
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	arm_func_end func_ov61_0215e454
 
 	.global func_ov61_0215e5a0
 	arm_func_start func_ov61_0215e5a0
 func_ov61_0215e5a0: ; 0x0215e5a0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	mov r6, r3
 	mov r4, r6, lsl #0x1
 	mov r8, r2
 	mov r2, r4
 	mov r7, r0
-	mov sb, r1
+	mov r9, r1
 	ldr r5, [sp, #0x20]
 	bl func_02007ad8
 	cmp r8, #1
 	bne _0215e5e0
 	mov r0, r7
-	mov r1, sb
+	mov r1, r9
 	mov r2, r6
 	bl func_ov61_0215df60
 	b _0215e5fc
@@ -39133,7 +39133,7 @@ _0215e5e0:
 	cmp r8, #0
 	beq _0215e5fc
 	mov r0, r7
-	mov r1, sb
+	mov r1, r9
 	mov r2, r8
 	mov r3, r6
 	bl func_ov61_0215de3c
@@ -39177,26 +39177,26 @@ _0215e5fc:
 	beq _0215e69c
 	cmp r0, #1
 	beq _0215e6b0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _0215e69c:
 	mov r0, r7
 	mov r2, r4
 	mov r1, #0
 	bl func_02007a44
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _0215e6b0:
 	ldr r2, [sp, #0x24]
 	mov r0, r7
 	mov r1, r7
 	mov r3, r6
 	bl func_ov61_0215dcc0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	arm_func_end func_ov61_0215e5a0
 
 	.global func_ov61_0215e6c8
 	arm_func_start func_ov61_0215e6c8
 func_ov61_0215e6c8: ; 0x0215e6c8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x2c
 	mov r10, r3
 	mov r3, #0x16
@@ -39205,14 +39205,14 @@ func_ov61_0215e6c8: ; 0x0215e6c8
 	mov r11, r0
 	ldr r3, [r3]
 	mov r0, r4
-	ldr sb, [sp, #0x50]
+	ldr r9, [sp, #0x50]
 	str r1, [sp, #0x14]
 	str r2, [sp, #0x18]
 	blx r3
 	str r0, [sp, #0x28]
 	cmp r0, #0
 	addeq sp, sp, #0x2c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	mov r2, r4
 	mov r1, #0
 	bl func_02007a44
@@ -39226,7 +39226,7 @@ func_ov61_0215e6c8: ; 0x0215e6c8
 	add r0, r8, r10, lsl #1
 	str r0, [sp, #0x20]
 	add r5, r0, r10, lsl #1
-	mov r0, sb
+	mov r0, r9
 	bl func_ov61_0215db28
 	mov r4, r0
 	ldr r0, [sp, #0x28]
@@ -39237,7 +39237,7 @@ func_ov61_0215e6c8: ; 0x0215e6c8
 	ldr r1, [sp, #0x28]
 	str r0, [sp]
 	mov r0, r6
-	mov r2, sb
+	mov r2, r9
 	mov r3, r10
 	bl func_ov61_0215e454
 	ldr r1, [sp, #0x28]
@@ -39253,7 +39253,7 @@ func_ov61_0215e6c8: ; 0x0215e6c8
 	str r10, [sp]
 	mov r0, r6
 	mov r1, r6
-	mov r2, sb
+	mov r2, r9
 	mov r3, #0
 	str r5, [sp, #4]
 	bl func_ov61_0215e0e0
@@ -39265,14 +39265,14 @@ func_ov61_0215e6c8: ; 0x0215e6c8
 	ldr r1, [sp, #0x24]
 	str r10, [sp]
 	mov r0, #0
-	mov r2, sb
+	mov r2, r9
 	mov r3, r1
 	str r5, [sp, #4]
 	bl func_ov61_0215e0e0
 	str r10, [sp]
 	ldr r1, [sp, #0x28]
 	mov r0, #0
-	mov r2, sb
+	mov r2, r9
 	mov r3, r11
 	str r5, [sp, #4]
 	bl func_ov61_0215e0e0
@@ -39281,7 +39281,7 @@ func_ov61_0215e6c8: ; 0x0215e6c8
 	str r0, [sp, #0x1c]
 	beq _0215e890
 _0215e818:
-	stmia sp, {r4, sb}
+	stmia sp, {r4, r9}
 	str r6, [sp, #8]
 	str r7, [sp, #0xc]
 	ldr r1, [sp, #0x20]
@@ -39298,7 +39298,7 @@ _0215e818:
 	mov r1, #0x8000
 	tst r2, r1, lsr r0
 	beq _0215e880
-	stmia sp, {r4, sb}
+	stmia sp, {r4, r9}
 	str r6, [sp, #8]
 	str r7, [sp, #0xc]
 	ldr r1, [sp, #0x20]
@@ -39313,7 +39313,7 @@ _0215e880:
 	cmp r5, r0
 	blo _0215e818
 _0215e890:
-	stmia sp, {r4, sb}
+	stmia sp, {r4, r9}
 	str r6, [sp, #8]
 	str r7, [sp, #0xc]
 	ldr r1, [sp, #0x20]
@@ -39327,7 +39327,7 @@ _0215e890:
 	ldr r1, [r1]
 	blx r1
 	add sp, sp, #0x2c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0215e6c8
 _0215e8cc: .word data_ov61_0217f428
@@ -42768,23 +42768,23 @@ _021614e0: .word data_ov61_02181000
 	.global func_ov61_021614e4
 	arm_func_start func_ov61_021614e4
 func_ov61_021614e4: ; 0x021614e4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	ldr r7, [sp, #0x28]
 	ldr r6, [sp, #0x2c]
-	movs sb, r1
+	movs r9, r1
 	mov r10, r0
 	mov r11, r2
 	mov r8, r3
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
-	cmp sb, #1
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
+	cmp r9, #1
 	mov r4, #0
 	mov r5, #1
 	bls _02161528
 _02161518:
 	mov r0, r5, lsl #0x1
 	add r5, r0, #1
-	cmp r5, sb
+	cmp r5, r9
 	blo _02161518
 _02161528:
 	ldr r2, [r6]
@@ -42809,14 +42809,14 @@ _02161568:
 	cmp r4, #0xb
 	and r0, r5, r0
 	bls _02161588
-	mov r1, sb
+	mov r1, r9
 	bl FastDivide
 	mov r0, r1
 _02161588:
-	cmp r0, sb
+	cmp r0, r9
 	bhi _02161528
 	and r0, r0, #0xff
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	arm_func_end func_ov61_021614e4
 
 	.global func_ov61_02161598
@@ -42846,20 +42846,20 @@ _021615c8:
 	.global func_ov61_021615e0
 	arm_func_start func_ov61_021615e0
 func_ov61_021615e0: ; 0x021615e0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x10
 	mov r7, r2
-	mov sb, r0
+	mov r9, r0
 	mov r8, r1
 	cmp r7, #1
 	bhs _02161608
 	bl func_ov61_02161598
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _02161608:
 	mov r0, #0
 _0216160c:
-	strb r0, [sb, r0]
+	strb r0, [r9, r0]
 	add r0, r0, #1
 	cmp r0, #0x100
 	blt _0216160c
@@ -42871,34 +42871,34 @@ _0216160c:
 	add r4, sp, #0xc
 _02161634:
 	str r5, [sp]
-	mov r0, sb
+	mov r0, r9
 	mov r1, r6
 	mov r2, r8
 	mov r3, r7
 	str r4, [sp, #4]
 	bl func_ov61_021614e4
-	ldrb r2, [sb, r6]
-	ldrb r1, [sb, r0]
-	strb r1, [sb, r6]
-	strb r2, [sb, r0]
+	ldrb r2, [r9, r6]
+	ldrb r1, [r9, r0]
+	strb r1, [r9, r6]
+	strb r2, [r9, r0]
 	subs r6, r6, #1
 	bpl _02161634
-	ldrb r1, [sb, #1]
+	ldrb r1, [r9, #1]
 	mov r0, #0
-	strb r1, [sb, #0x100]
-	ldrb r1, [sb, #3]
-	strb r1, [sb, #0x101]
-	ldrb r1, [sb, #5]
-	strb r1, [sb, #0x102]
-	ldrb r1, [sb, #7]
-	strb r1, [sb, #0x103]
+	strb r1, [r9, #0x100]
+	ldrb r1, [r9, #3]
+	strb r1, [r9, #0x101]
+	ldrb r1, [r9, #5]
+	strb r1, [r9, #0x102]
+	ldrb r1, [r9, #7]
+	strb r1, [r9, #0x103]
 	ldrb r1, [sp, #8]
-	ldrb r1, [sb, r1]
-	strb r1, [sb, #0x104]
+	ldrb r1, [r9, r1]
+	strb r1, [r9, #0x104]
 	strb r0, [sp, #8]
 	str r0, [sp, #0xc]
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	arm_func_end func_ov61_021615e0
 
 	.global func_ov61_021616a8
@@ -43326,15 +43326,15 @@ _02161bd8:
 	.global func_ov61_02161be0
 	arm_func_start func_ov61_02161be0
 func_ov61_02161be0: ; 0x02161be0
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	mov r8, r2
 	ldrsb r2, [r8]
 	mov r10, r0
-	mov sb, r1
+	mov r9, r1
 	mov r7, r3
 	cmp r2, #0
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
-	ldrb r0, [sb, #0x14]
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
+	ldrb r0, [r9, #0x14]
 	add r8, r8, #5
 	sub r7, r7, #5
 	tst r0, #4
@@ -43352,7 +43352,7 @@ _02161c28:
 	bmi _02161c6c
 	add r0, r10, r6
 	ldrb r1, [r0, #0x2c]
-	mov r0, sb
+	mov r0, r9
 	mov r2, r8
 	ldr r1, [r4, r1, lsl #2]
 	bl func_ov61_0216218c
@@ -43363,36 +43363,36 @@ _02161c28:
 	sub r7, r7, r5
 	blt _02161c28
 _02161c6c:
-	ldrb r0, [sb, #0x14]
+	ldrb r0, [r9, #0x14]
 	orr r0, r0, #0x41
-	strb r0, [sb, #0x14]
+	strb r0, [r9, #0x14]
 	b _02161c98
 _02161c7c:
-	mov r0, sb
+	mov r0, r9
 	mov r1, r8
 	mov r2, r7
 	bl func_ov61_02162500
-	ldrb r0, [sb, #0x14]
+	ldrb r0, [r9, #0x14]
 	orr r0, r0, #0x43
-	strb r0, [sb, #0x14]
+	strb r0, [r9, #0x14]
 _02161c98:
-	ldrb r0, [sb, #0x14]
+	ldrb r0, [r9, #0x14]
 	and r0, r0, #0xf3
-	strb r0, [sb, #0x14]
+	strb r0, [r9, #0x14]
 	bl func_ov61_021665e8
-	ldr r2, [sb, #0x1c]
-	mov r1, sb
+	ldr r2, [r9, #0x1c]
+	mov r1, r9
 	sub r0, r0, r2
-	str r0, [sb, #0x1c]
+	str r0, [r9, #0x1c]
 	add r0, r10, #8
 	bl func_ov61_02161840
 	ldr r3, [r10, #0x48]
 	ldr r4, [r10, #0x44]
 	mov r0, r10
-	mov r2, sb
+	mov r2, r9
 	mov r1, #0
 	blx r4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02161be0
 _02161cdc: .word data_ov61_0217e4e8
@@ -43451,21 +43451,21 @@ func_ov61_02161d78: ; 0x02161d78
 	.global func_ov61_02161d80
 	arm_func_start func_ov61_02161d80
 func_ov61_02161d80: ; 0x02161d80
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x14
 	sub sp, sp, #0x800
 	movs r8, r1
 	mov r1, #8
-	mov sb, r0
+	mov r9, r0
 	str r1, [sp, #8]
-	ldrne r7, [sb, #0x24]
-	ldreq r7, [sb, #0x20]
+	ldrne r7, [r9, #0x24]
+	ldreq r7, [r9, #0x20]
 	mov r0, r7
 	bl func_ov61_02166914
 	cmp r0, #0
 	addeq sp, sp, #0x14
 	addeq sp, sp, #0x800
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _02161dbc:
 	add r0, sp, #0xc
 	str r0, [sp]
@@ -43481,11 +43481,11 @@ _02161dbc:
 	cmp r5, r0
 	addeq sp, sp, #0x14
 	addeq sp, sp, #0x800
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	add r4, sp, #0x14
 	mov r0, #0
 	strb r0, [r4, r5]
-	ldr r6, [sb, #8]
+	ldr r6, [r9, #8]
 	cmp r6, #0
 	beq _02161ef4
 _02161e10:
@@ -43510,7 +43510,7 @@ _02161e34:
 	cmp r8, #0
 	bne _02161e8c
 _02161e5c:
-	ldr r0, [sb, #0x28]
+	ldr r0, [r9, #0x28]
 	cmp r2, r0
 	bne _02161ee8
 	ldrb r0, [r6, #0x15]
@@ -43525,7 +43525,7 @@ _02161e5c:
 _02161e8c:
 	cmp r8, #0
 	beq _02161eb4
-	mov r0, sb
+	mov r0, r9
 	mov r1, r6
 	mov r2, r4
 	mov r3, r5
@@ -43534,10 +43534,10 @@ _02161e8c:
 	bne _02161ef4
 	b _02161ee8
 _02161eb4:
-	ldr r0, [sb]
+	ldr r0, [r9]
 	add r2, sp, #0x14
 	cmp r0, #1
-	mov r0, sb
+	mov r0, r9
 	bne _02161ed8
 	mov r1, r6
 	mov r3, r5
@@ -43559,7 +43559,7 @@ _02161ef4:
 	bne _02161dbc
 	add sp, sp, #0x14
 	add sp, sp, #0x800
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02161d80
 _02161f10: .word 0x000007ff
@@ -44071,13 +44071,13 @@ _0216247c: .word data_ov61_02181010
 	.global func_ov61_02162480
 	arm_func_start func_ov61_02162480
 func_ov61_02162480: ; 0x02162480
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	mov r10, r0
 	add r0, r1, #1
 	mov r1, #0x5c
 	bl func_ov61_0216241c
 	movs r8, r0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	mov r4, #0
 	mov r11, #0x5c
 	ldr r5, _021624fc ; =data_ov61_0217bf20
@@ -44087,15 +44087,15 @@ _021624b0:
 	mov r0, r7
 	mov r1, r6
 	bl func_ov61_0216241c
-	movs sb, r0
+	movs r9, r0
 	mov r0, r8
-	moveq sb, r5
+	moveq r9, r5
 	bl func_ov61_021623bc
 	cmp r0, #0
 	beq _021624e4
 	mov r0, r10
 	mov r1, r8
-	mov r2, sb
+	mov r2, r9
 	bl func_ov61_0216218c
 _021624e4:
 	mov r0, r4
@@ -44103,7 +44103,7 @@ _021624e4:
 	bl func_ov61_0216241c
 	movs r8, r0
 	bne _021624b0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02162480
 _021624fc: .word data_ov61_0217bf20
@@ -44111,34 +44111,34 @@ _021624fc: .word data_ov61_0217bf20
 	.global func_ov61_02162500
 	arm_func_start func_ov61_02162500
 func_ov61_02162500: ; 0x02162500
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x8c
 	mov r10, r1
 	ldrsb r1, [r10]
 	mov r11, r0
-	mov sb, r2
+	mov r9, r2
 	cmp r1, #0
 	beq _02162580
 _02162520:
 	mov r0, r10
-	mov r1, sb
+	mov r1, r9
 	bl func_ov61_02163490
 	cmp r0, #0
 	addlt sp, sp, #0x8c
-	ldmltia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmltia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	mov r4, r10
-	sub sb, sb, r0
+	sub r9, r9, r0
 	add r10, r10, r0
 	mov r0, r10
-	mov r1, sb
+	mov r1, r9
 	bl func_ov61_02163490
 	cmp r0, #0
 	addlt sp, sp, #0x8c
-	ldmltia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmltia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	mov r2, r10
 	mov r1, r4
 	add r10, r10, r0
-	sub sb, sb, r0
+	sub r9, r9, r0
 	mov r0, r11
 	bl func_ov61_0216218c
 	ldrsb r0, [r10]
@@ -44147,12 +44147,12 @@ _02162520:
 _02162580:
 	mov r0, #0
 	add r10, r10, #1
-	sub sb, sb, #1
+	sub r9, r9, #1
 	str r0, [sp]
 _02162590:
-	cmp sb, #2
+	cmp r9, #2
 	addlt sp, sp, #0x8c
-	ldmltia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmltia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldrb r1, [r10]
 	ldrb r0, [r10, #1]
 	add r2, sp, #8
@@ -44161,7 +44161,7 @@ _02162590:
 	strb r0, [r2, #1]
 	ldrh r0, [sp, #8]
 	str r10, [sp, #4]
-	sub sb, sb, #2
+	sub r9, r9, #2
 	mov r1, r0, asr #0x8
 	mov r0, r0, lsl #0x8
 	and r1, r1, #0xff
@@ -44174,23 +44174,23 @@ _02162590:
 	beq _02162620
 _021625e8:
 	mov r0, r10
-	mov r1, sb
+	mov r1, r9
 	bl func_ov61_02163490
 	cmp r0, #0
 	addlt sp, sp, #0x8c
-	ldmltia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmltia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	cmp r0, #0x64
 	addgt sp, sp, #0x8c
-	ldmgtia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmgtia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldrsb r1, [r10, r0]!
 	add r5, r5, #1
-	sub sb, sb, r0
+	sub r9, r9, r0
 	cmp r1, #0
 	bne _021625e8
 _02162620:
 	ldrh r0, [sp, #8]
 	add r10, r10, #1
-	sub sb, sb, #1
+	sub r9, r9, #1
 	cmp r0, #0
 	mov r6, #0
 	ble _021626b8
@@ -44201,11 +44201,11 @@ _02162638:
 	ble _021626a8
 _02162648:
 	mov r0, r10
-	mov r1, sb
+	mov r1, r9
 	bl func_ov61_02163490
 	movs r4, r0
 	addmi sp, sp, #0x8c
-	ldmmiia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmmiia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r1, _021626d4 ; =data_ov61_0217bf24
 	add r0, sp, #0xa
 	mov r2, r8
@@ -44217,7 +44217,7 @@ _02162648:
 	bl func_ov61_0216218c
 	mov r0, r8
 	add r10, r10, r4
-	sub sb, sb, r4
+	sub r9, r9, r4
 	bl strlen
 	add r0, r0, #1
 	add r7, r7, #1
@@ -44236,7 +44236,7 @@ _021626b8:
 	cmp r0, #2
 	blt _02162590
 	add sp, sp, #0x8c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02162500
 _021626d4: .word data_ov61_0217bf24
@@ -44668,13 +44668,13 @@ func_ov61_02162ba0: ; 0x02162ba0
 	.global func_ov61_02162bc4
 	arm_func_start func_ov61_02162bc4
 func_ov61_02162bc4: ; 0x02162bc4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x108
 	ldr r8, [sp, #0x130]
 	mov r10, r0
 	str r1, [sp, #4]
 	add r4, sp, #8
-	mov sb, r3
+	mov r9, r3
 	mov r1, #0x40
 	mov r0, #0
 _02162be8:
@@ -44694,7 +44694,7 @@ _02162be8:
 	ldr r4, _02162cec ; =data_ov61_0217e4e8
 	add r11, sp, #8
 _02162c24:
-	ldrb r0, [sb, r6]
+	ldrb r0, [r9, r6]
 	ldr r7, [r4, r0, lsl #2]
 	mov r0, r7
 	bl strlen
@@ -44707,7 +44707,7 @@ _02162c24:
 	add r0, r11, r5
 	bl func_020459b8
 	add r5, r5, r0
-	ldrb r1, [sb, r6]
+	ldrb r1, [r9, r6]
 	mov r0, r10
 	bl func_ov61_02162044
 	add r6, r6, #1
@@ -44723,11 +44723,11 @@ _02162c70:
 	bl func_ov61_02163aac
 	cmp r0, #0
 	addne sp, sp, #0x108
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r1, [sp, #4]
 	cmp r1, #0
 	addne sp, sp, #0x108
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	mov r4, #0xa
 	b _02162cc0
 _02162cb0:
@@ -44742,11 +44742,11 @@ _02162cc0:
 	ldr r1, [r10, #0x10]
 	cmp r1, #0
 	addle sp, sp, #0x108
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	cmp r0, #0
 	beq _02162cb0
 	add sp, sp, #0x108
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02162bc4
 _02162cec: .word data_ov61_0217e4e8
@@ -45173,9 +45173,9 @@ _021631b0:
 	.global func_ov61_021631b8
 	arm_func_start func_ov61_021631b8
 func_ov61_021631b8: ; 0x021631b8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
-	mov sb, r0
-	ldr r0, [sb, #4]
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
+	mov r9, r0
+	ldr r0, [r9, #4]
 	mov r8, r1
 	mov r7, r2
 	bl func_ov61_02165a68
@@ -45184,7 +45184,7 @@ func_ov61_021631b8: ; 0x021631b8
 	mov r6, #0
 	ble _02163220
 _021631e0:
-	ldr r0, [sb, #4]
+	ldr r0, [r9, #4]
 	mov r1, r6
 	bl func_ov61_02165a70
 	ldr r5, [r0]
@@ -45196,14 +45196,14 @@ _021631e0:
 	bl func_ov61_02162360
 	cmp r7, r0
 	moveq r0, r6
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _02163214:
 	add r6, r6, #1
 	cmp r6, r4
 	blt _021631e0
 _02163220:
 	mvn r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	arm_func_end func_ov61_021631b8
 
 	.global func_ov61_02163228
@@ -45775,7 +45775,7 @@ func_ov61_021638f4: ; 0x021638f4
 	.global func_ov61_02163928
 	arm_func_start func_ov61_02163928
 func_ov61_02163928: ; 0x02163928
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	mov r10, r0
 	bl func_02045b48
 	ldr r5, _02163a10 ; =0x2c0b02c1
@@ -45793,8 +45793,8 @@ func_ov61_02163928: ; 0x02163928
 	mov r6, r7
 	mov r4, r3
 _0216396c:
-	add sb, r10, r7
-	ldrsb r3, [sb, #0x73]
+	add r9, r10, r7
+	ldrsb r3, [r9, #0x73]
 	ldrsb r0, [r10, #0x74]
 	cmp r3, r0
 	eor r3, r7, r3
@@ -45817,26 +45817,26 @@ _0216396c:
 	sub r3, r0, r1
 	add r0, r3, #0x21
 	cmp r8, #0
-	strb r0, [sb, #0x74]
+	strb r0, [r9, #0x74]
 	beq _021639e0
-	ldrsb r0, [sb, #0x74]
+	ldrsb r0, [r9, #0x74]
 	tst r0, #1
 	beq _021639f4
 _021639e0:
 	cmp r8, #0
-	ldreqsb r0, [sb, #0x74]
+	ldreqsb r0, [r9, #0x74]
 	andeq r0, r0, #1
 	cmpeq r0, #1
 	bne _02163a00
 _021639f4:
-	ldrsb r0, [sb, #0x74]
+	ldrsb r0, [r9, #0x74]
 	add r0, r0, #1
-	strb r0, [sb, #0x74]
+	strb r0, [r9, #0x74]
 _02163a00:
 	add r7, r7, #1
 	cmp r7, #8
 	blt _0216396c
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02163928
 _02163a10: .word 0x2c0b02c1
@@ -45844,16 +45844,16 @@ _02163a10: .word 0x2c0b02c1
 	.global func_ov61_02163a14
 	arm_func_start func_ov61_02163a14
 func_ov61_02163a14: ; 0x02163a14
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	mov r10, r0
-	mov sb, r1
+	mov r9, r1
 	mov r8, r2
 	mov r7, #1
 	mov r11, #2
 	mov r5, #0
 _02163a30:
 	ldr r0, [r10, #0x4b0]
-	mov r1, sb
+	mov r1, r9
 	mov r2, r8
 	mov r3, r5
 	sub r7, r7, #1
@@ -45876,7 +45876,7 @@ _02163a30:
 	mov r0, r10
 	bl func_ov61_021635ec
 	mov r0, r4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02163a94:
 	cmp r7, #0
 	bge _02163a30
@@ -45884,7 +45884,7 @@ _02163a9c:
 	cmp r6, #0
 	movle r0, #3
 	movgt r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	arm_func_end func_ov61_02163a14
 
 	.global func_ov61_02163aac
@@ -46165,15 +46165,15 @@ _02163e54:
 	.global func_ov61_02163e60
 	arm_func_start func_ov61_02163e60
 func_ov61_02163e60: ; 0x02163e60
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
-	mov sb, r0
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
+	mov r9, r0
 	mov r7, r2
-	add r0, sb, #0x54
+	add r0, r9, #0x54
 	mov r8, r1
 	bl strlen
 	mov r5, r0
 	cmp r7, #0
-	add r6, sb, #0x54
+	add r6, r9, #0x54
 	mov r4, #0
 	ble _02163ee8
 _02163e8c:
@@ -46187,11 +46187,11 @@ _02163e8c:
 	mov r1, r3, lsr #0x1f
 	add r2, r2, r0, ror #29
 	rsb r0, r1, r3, lsl #29
-	add r2, sb, r2
+	add r2, r9, r2
 	add r3, r1, r0, ror #29
 	ldrsb r0, [r8, r4]
 	ldrsb r1, [r2, #0x74]
-	add r2, sb, r3
+	add r2, r9, r3
 	add r4, r4, #1
 	eor r0, r1, r0
 	ldrsb r1, [r2, #0x74]
@@ -46201,12 +46201,12 @@ _02163e8c:
 	strb r0, [r2, #0x74]
 	blt _02163e8c
 _02163ee8:
-	add r0, sb, #0xbc
+	add r0, r9, #0xbc
 	add r0, r0, #0x400
-	add r1, sb, #0x74
+	add r1, r9, #0x74
 	mov r2, #8
 	bl func_ov61_021615e0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	arm_func_end func_ov61_02163e60
 
 	.global func_ov61_02163f00
@@ -46269,7 +46269,7 @@ _02163f90:
 	.global func_ov61_02163fb0
 	arm_func_start func_ov61_02163fb0
 func_ov61_02163fb0: ; 0x02163fb0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	mov r8, r0
 	ldr r0, [r8, #8]
 	mov r7, r1
@@ -46279,7 +46279,7 @@ func_ov61_02163fb0: ; 0x02163fb0
 	cmp r4, #0
 	mov r5, #0
 	ble _02164094
-	mvn sb, #0
+	mvn r9, #0
 _02163fdc:
 	ldr r0, [r8, #8]
 	mov r1, r5
@@ -46303,7 +46303,7 @@ _02164014:
 _02164020:
 	cmp r6, #1
 	movlt r0, #0
-	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmltia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	ldrb r0, [r7], #1
 	sub r6, r6, #1
 	cmp r0, #0xff
@@ -46311,9 +46311,9 @@ _02164020:
 	mov r0, r7
 	mov r1, r6
 	bl func_ov61_02163490
-	cmp r0, sb
+	cmp r0, r9
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	add r7, r7, r0
 	sub r6, r6, r0
 	b _0216407c
@@ -46324,17 +46324,17 @@ _02164060:
 	ldr r3, _021640a8 ; =0x00000317
 	bl func_02042f80
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _0216407c:
 	cmp r6, #0
 	movlt r0, #0
-	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmltia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	add r5, r5, #1
 	cmp r5, r4
 	blt _02163fdc
 _02164094:
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02163fb0
 _0216409c: .word data_ov61_0217c03c
@@ -46379,15 +46379,15 @@ _02164108:
 	.global func_ov61_0216411c
 	arm_func_start func_ov61_0216411c
 func_ov61_0216411c: ; 0x0216411c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x10
 	mov r8, r2
 	ldrb r2, [r8], #5
-	mov sb, r1
+	mov r9, r1
 	mov r10, r0
 	mov r7, r3
 	str r2, [sp]
-	mov r0, sb
+	mov r0, r9
 	mov r1, r2
 	str r7, [sp, #4]
 	ldr r6, [sp, #0x38]
@@ -46430,7 +46430,7 @@ _021641a4:
 _021641d8:
 	ldrh r2, [sp, #8]
 	ldr r1, [sp, #0xc]
-	mov r0, sb
+	mov r0, r9
 	bl func_ov61_02162834
 	ldr r0, [sp]
 	tst r0, #8
@@ -46438,7 +46438,7 @@ _021641d8:
 	ldrb r2, [r8]
 	ldrb r1, [r8, #1]
 	add r3, sp, #0xc
-	mov r0, sb
+	mov r0, r9
 	strb r2, [r3]
 	strb r1, [r3, #1]
 	ldrb r2, [r8, #2]
@@ -46476,14 +46476,14 @@ _02164254:
 _02164284:
 	ldrb r2, [r8], #1
 	ldr r1, [r1]
-	mov r0, sb
+	mov r0, r9
 	bl func_ov61_021621cc
 	sub r7, r7, #1
 	b _02164338
 _0216429c:
 	ldrb r3, [r8]
 	ldrb r2, [r8, #1]
-	mov r0, sb
+	mov r0, r9
 	strb r3, [r11]
 	strb r2, [r11, #1]
 	ldrh r3, [sp, #0xa]
@@ -46507,7 +46507,7 @@ _021642e4:
 	cmp r0, #0xff
 	bne _02164324
 	ldr r1, [r1]
-	mov r0, sb
+	mov r0, r9
 	mov r2, r8
 	bl func_ov61_0216218c
 	mov r0, r8
@@ -46520,17 +46520,17 @@ _02164324:
 	add r0, r10, r0, lsl #2
 	ldr r1, [r1]
 	ldr r2, [r0, #0x84]
-	mov r0, sb
+	mov r0, r9
 	bl func_ov61_0216218c
 _02164338:
 	add r5, r5, #1
 	cmp r5, r4
 	blt _02164254
 _02164344:
-	mov r0, sb
+	mov r0, r9
 	bl func_ov61_02162850
 	orr r1, r0, #1
-	mov r0, sb
+	mov r0, r9
 	and r1, r1, #0xff
 	bl func_ov61_02162848
 _0216435c:
@@ -46544,7 +46544,7 @@ _0216436c:
 	bl strlen
 	add r3, r0, #1
 	add r8, r8, r3
-	mov r0, sb
+	mov r0, r9
 	mov r1, r4
 	mov r2, r8
 	sub r7, r7, r3
@@ -46561,18 +46561,18 @@ _021643a8:
 	cmp r7, #0
 	bgt _0216436c
 _021643bc:
-	mov r0, sb
+	mov r0, r9
 	sub r7, r7, #1
 	bl func_ov61_02162850
 	orr r1, r0, #2
-	mov r0, sb
+	mov r0, r9
 	and r1, r1, #0xff
 	bl func_ov61_02162848
 _021643d8:
 	ldr r0, [sp, #4]
 	sub r0, r0, r7
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	arm_func_end func_ov61_0216411c
 
 	.global func_ov61_021643e8
@@ -46669,7 +46669,7 @@ func_ov61_02164518: ; 0x02164518
 	.global func_ov61_02164520
 	arm_func_start func_ov61_02164520
 func_ov61_02164520: ; 0x02164520
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #8
 	mov r7, r0
 	ldr r1, [r7, #0x5c8]
@@ -46793,7 +46793,7 @@ _021646b8:
 	str r0, [r7, #8]
 	addeq sp, sp, #8
 	moveq r0, #5
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	add r5, r5, #1
 	sub r6, r6, #1
 _02164700:
@@ -46810,8 +46810,8 @@ _0216471c:
 	add r0, r5, #1
 	sub r1, r6, #1
 	bl func_ov61_02163490
-	mov sb, r0
-	cmp sb, r4
+	mov r9, r0
+	cmp r9, r4
 	beq _02164780
 	ldrb r2, [r5]
 	mov r0, r7
@@ -46822,7 +46822,7 @@ _0216471c:
 	ldr r0, [r7, #8]
 	mov r1, r8
 	bl func_ov61_02165ad8
-	add r1, sb, #1
+	add r1, r9, #1
 	ldr r0, [r7, #8]
 	add r5, r5, r1
 	sub r6, r6, r1
@@ -46892,7 +46892,7 @@ _02164850:
 	blt _021648e0
 	mvn r4, #0
 	sub r8, r4, #1
-	mov sb, #0
+	mov r9, #0
 _02164864:
 	mov r0, r7
 	mov r1, r5
@@ -46901,7 +46901,7 @@ _02164864:
 	cmp r0, r8
 	addeq sp, sp, #8
 	moveq r0, #5
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	cmp r0, r4
 	bne _021648c4
 	mov r0, #5
@@ -46923,7 +46923,7 @@ _021648c4:
 	add r5, r5, r0
 	cmp r1, #0
 	sub r6, r6, r0
-	moveq r0, sb
+	moveq r0, r9
 	cmp r0, #0
 	bne _02164864
 _021648e0:
@@ -46939,7 +46939,7 @@ _021648fc:
 	cmp r0, #0
 	addeq sp, sp, #8
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	cmp r6, #0
 	beq _02164924
 	mov r1, r5
@@ -46949,7 +46949,7 @@ _02164924:
 	str r6, [r7, #0x80]
 	mov r0, #0
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02164520
 _02164934: .word data_ov61_02181014
@@ -46962,15 +46962,15 @@ _02164948: .word 0x000004af
 	.global func_ov61_0216494c
 	arm_func_start func_ov61_0216494c
 func_ov61_0216494c: ; 0x0216494c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #8
 	mov r10, r0
 	ldr r3, [r10, #8]
-	mov sb, r1
+	mov r9, r1
 	mov r8, r2
 	cmp r3, #0
 	sub r8, r8, #1
-	ldrb r7, [sb], #1
+	ldrb r7, [r9], #1
 	beq _02164978
 	bl func_ov61_02163d60
 _02164978:
@@ -46982,7 +46982,7 @@ _02164978:
 	str r0, [r10, #8]
 	addeq sp, sp, #8
 	moveq r0, #5
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	cmp r7, #0
 	mov r6, #0
 	ble _02164a1c
@@ -46992,18 +46992,18 @@ _021649b0:
 	cmp r8, #2
 	addlt sp, sp, #8
 	movlt r0, #4
-	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
-	add r0, sb, #1
+	ldmltia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
+	add r0, r9, #1
 	sub r1, r8, #1
 	bl func_ov61_02163490
 	mov r5, r0
 	cmp r5, r4
 	addeq sp, sp, #8
 	moveq r0, #4
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
-	ldrb r2, [sb]
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
+	ldrb r2, [r9]
 	mov r0, r10
-	add r1, sb, #1
+	add r1, r9, #1
 	str r2, [sp, #4]
 	bl func_ov61_021633a4
 	str r0, [sp]
@@ -47013,32 +47013,32 @@ _021649b0:
 	add r0, r5, #1
 	add r6, r6, #1
 	cmp r6, r7
-	add sb, sb, r0
+	add r9, r9, r0
 	sub r8, r8, r0
 	blt _021649b0
 _02164a1c:
 	mov r0, #0
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	arm_func_end func_ov61_0216494c
 
 	.global func_ov61_02164a28
 	arm_func_start func_ov61_02164a28
 func_ov61_02164a28: ; 0x02164a28
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x24
 	mov r8, r2
 	cmp r8, #2
 	mov r10, r0
-	mov sb, r1
+	mov r9, r1
 	addlt sp, sp, #0x24
 	movlt r0, #4
-	ldmltia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
-	ldrb r0, [sb, #1]
+	ldmltia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
+	ldrb r0, [r9, #1]
 	sub r8, r8, #2
 	mov r11, #0
 	str r0, [sp, #0xc]
-	ldrb r0, [sb], #2
+	ldrb r0, [r9], #2
 	str r0, [sp, #0x14]
 	ldr r0, [sp, #0xc]
 	cmp r0, #0
@@ -47047,29 +47047,29 @@ func_ov61_02164a28: ; 0x02164a28
 	add r6, sp, #0x1c
 	mvn r4, #0
 _02164a7c:
-	mov r0, sb
+	mov r0, r9
 	mov r1, r8
-	str sb, [sp, #0x10]
+	str r9, [sp, #0x10]
 	bl func_ov61_02163490
 	cmp r0, r4
 	addeq sp, sp, #0x24
 	moveq r0, #4
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	sub r3, r8, r0
 	cmp r3, #0xb
-	add r2, sb, r0
+	add r2, r9, r0
 	addlt sp, sp, #0x24
 	movlt r0, #4
-	ldmltia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmltia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldrb r1, [r2]
 	ldrb r0, [r2, #1]
 	sub r8, r3, #0xa
-	add sb, r2, #0xa
+	add r9, r2, #0xa
 	strb r1, [r7]
 	strb r0, [r7, #1]
 	ldrb r5, [r2, #2]
 	ldrb r3, [r2, #3]
-	mov r0, sb
+	mov r0, r9
 	mov r1, r8
 	strb r3, [r7, #3]
 	strb r5, [r7, #2]
@@ -47104,10 +47104,10 @@ _02164a7c:
 	cmp r5, r4
 	addeq sp, sp, #0x24
 	moveq r0, #4
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r1, [sp, #0x1c]
 	mov r0, r10
-	stmia sp, {r1, sb}
+	stmia sp, {r1, r9}
 	ldr r2, [r10, #0x494]
 	ldr r1, [sp, #0x10]
 	str r2, [sp, #8]
@@ -47118,7 +47118,7 @@ _02164a7c:
 	ldr r0, [sp, #0xc]
 	add r11, r11, #1
 	cmp r11, r0
-	add sb, sb, r5
+	add r9, r9, r5
 	sub r8, r8, r5
 	blt _02164a7c
 _02164ba4:
@@ -47138,33 +47138,33 @@ _02164ba4:
 _02164bd8:
 	mov r0, #0
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	arm_func_end func_ov61_02164a28
 
 	.global func_ov61_02164be4
 	arm_func_start func_ov61_02164be4
 func_ov61_02164be4: ; 0x02164be4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x54
 	mov r8, r2
 	cmp r8, #0xb
 	mov r10, r0
-	mov sb, r1
+	mov r9, r1
 	addlt sp, sp, #0x54
 	movlt r0, #4
-	ldmltia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
-	ldrb r2, [sb]
-	ldrb r1, [sb, #1]
+	ldmltia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
+	ldrb r2, [r9]
+	ldrb r1, [r9, #1]
 	add r3, sp, #0xc
 	add r4, sp, #8
 	strb r2, [r3]
 	strb r1, [r3, #1]
-	ldrb r2, [sb, #2]
-	ldrb r1, [sb, #3]
+	ldrb r2, [r9, #2]
+	ldrb r1, [r9, #3]
 	strb r1, [r3, #3]
 	strb r2, [r3, #2]
-	ldrb r3, [sb, #4]
-	ldrb r2, [sb, #5]
+	ldrb r3, [r9, #4]
+	ldrb r2, [r9, #5]
 	ldr r1, [sp, #0xc]
 	strb r3, [r4]
 	strb r2, [r4, #1]
@@ -47175,17 +47175,17 @@ func_ov61_02164be4: ; 0x02164be4
 	cmp r1, r0
 	addeq sp, sp, #0x54
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	mov r0, r10
 	bl func_ov61_021632b8
-	ldrb r2, [sb, #6]
-	ldrb r1, [sb, #7]
+	ldrb r2, [r9, #6]
+	ldrb r1, [r9, #7]
 	add r3, sp, #0x10
 	mov r11, r0
 	strb r2, [r3]
 	strb r1, [r3, #1]
-	ldrb r1, [sb, #8]
-	ldrb r0, [sb, #9]
+	ldrb r1, [r9, #8]
+	ldrb r0, [r9, #9]
 	sub r8, r8, #0xb
 	mov r7, #0
 	strb r1, [r3, #2]
@@ -47204,22 +47204,22 @@ func_ov61_02164be4: ; 0x02164be4
 	orr r0, r2, r0
 	orr r0, r1, r0
 	str r0, [sp, #0x10]
-	ldrb r6, [sb, #0xa]
-	add sb, sb, #0xb
+	ldrb r6, [r9, #0xa]
+	add r9, r9, #0xb
 	mvn r4, #0
 	b _02164d18
 _02164ce4:
 	cmp r8, #1
 	blt _02164d24
-	mov r0, sb
+	mov r0, r9
 	mov r1, r8
 	bl func_ov61_02163490
 	cmp r0, r4
 	addeq sp, sp, #0x54
 	moveq r0, #4
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
-	str sb, [r5, r7, lsl #2]
-	add sb, sb, r0
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
+	str r9, [r5, r7, lsl #2]
+	add r9, r9, r0
 	sub r8, r8, r0
 	add r7, r7, #1
 _02164d18:
@@ -47231,7 +47231,7 @@ _02164d24:
 	cmp r4, #0
 	addeq sp, sp, #0x54
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r1, sp, #0x14
 	str r1, [sp]
 	ldr r2, [r10, #0x494]
@@ -47243,7 +47243,7 @@ _02164d24:
 	blx r4
 	mov r0, #0
 	add sp, sp, #0x54
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	arm_func_end func_ov61_02164be4
 
 	.global func_ov61_02164d68
@@ -47359,9 +47359,9 @@ _02164ec8:
 	.global func_ov61_02164eec
 	arm_func_start func_ov61_02164eec
 func_ov61_02164eec: ; 0x02164eec
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
-	mov sb, r0
-	ldr r0, [sb, #0x80]
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
+	mov r9, r0
+	ldr r0, [r9, #0x80]
 	mov r8, #0
 	cmp r0, #3
 	blt _02165088
@@ -47372,7 +47372,7 @@ func_ov61_02164eec: ; 0x02164eec
 	mov r6, r8
 	add r7, sp, #0
 _02164f1c:
-	ldr r0, [sb, #0x7c]
+	ldr r0, [r9, #0x7c]
 	ldrb r1, [r0]
 	ldrb r0, [r0, #1]
 	strb r1, [r7]
@@ -47388,11 +47388,11 @@ _02164f1c:
 	cmp r2, #0x1000
 	movhi r8, #4
 	bhi _02165088
-	ldr r0, [sb, #0x80]
+	ldr r0, [r9, #0x80]
 	cmp r0, r2
 	movlt r0, #0
-	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
-	ldr r1, [sb, #0x7c]
+	ldmltia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
+	ldr r1, [r9, #0x7c]
 	ldrsb r0, [r1, #2]
 	cmp r0, #6
 	addls pc, pc, r0, lsl #2
@@ -47406,52 +47406,52 @@ _02164f80: ; jump table
 	b _02165000 ; case 5
 	b _02165018 ; case 6
 _02164f9c:
-	mov r0, sb
+	mov r0, r9
 	add r1, r1, #3
 	sub r2, r2, #3
 	bl func_ov61_0216494c
 	mov r8, r0
 	b _0216502c
 _02164fb4:
-	mov r0, sb
+	mov r0, r9
 	add r1, r1, #3
 	sub r2, r2, #3
 	bl func_ov61_02164df4
 	mov r8, r0
 	b _0216502c
 _02164fcc:
-	ldr r0, [sb, #0x4b0]
+	ldr r0, [r9, #0x4b0]
 	mov r3, r6
 	bl func_ov61_02166bf0
 	cmp r0, #0
 	bgt _0216502c
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02164fe8:
-	mov r0, sb
+	mov r0, r9
 	add r1, r1, #3
 	sub r2, r2, #3
 	bl func_ov61_02164d68
 	mov r8, r0
 	b _0216502c
 _02165000:
-	mov r0, sb
+	mov r0, r9
 	add r1, r1, #3
 	sub r2, r2, #3
 	bl func_ov61_02164be4
 	mov r8, r0
 	b _0216502c
 _02165018:
-	mov r0, sb
+	mov r0, r9
 	add r1, r1, #3
 	sub r2, r2, #3
 	bl func_ov61_02164a28
 	mov r8, r0
 _0216502c:
 	ldrh r0, [sp]
-	ldr r1, [sb, #0x80]
+	ldr r1, [r9, #0x80]
 	subs r0, r1, r0
-	str r0, [sb, #0x80]
+	str r0, [r9, #0x80]
 	bpl _02165054
 	mov r0, r5
 	mov r1, r4
@@ -47459,9 +47459,9 @@ _0216502c:
 	mov r3, r11
 	bl func_02042f80
 _02165054:
-	ldr r2, [sb, #0x80]
+	ldr r2, [r9, #0x80]
 	cmp r2, #0
-	ldrne r0, [sb, #0x7c]
+	ldrne r0, [r9, #0x7c]
 	cmpne r0, #0
 	beq _02165074
 	ldrh r1, [sp]
@@ -47470,17 +47470,17 @@ _02165054:
 _02165074:
 	cmp r8, #0
 	bne _02165088
-	ldr r0, [sb, #0x80]
+	ldr r0, [r9, #0x80]
 	cmp r0, #3
 	bge _02164f1c
 _02165088:
 	cmp r8, #0
 	beq _02165098
-	mov r0, sb
+	mov r0, r9
 	bl func_ov61_021635ec
 _02165098:
 	mov r0, r8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02164eec
 _021650a0: .word data_ov61_0217c054
@@ -47560,7 +47560,7 @@ _02165190:
 	arm_func_start func_ov61_02165198
 func_ov61_02165198: ; 0x02165198
 	stmdb sp!, {r0, r1, r2, r3}
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x18
 	mov r5, r0
 	ldr r1, [r5]
@@ -47577,7 +47577,7 @@ _021651cc:
 	cmp r0, #1
 	addeq sp, sp, #0x18
 	moveq r0, #3
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	addeq sp, sp, #0x10
 	bxeq lr
 	ldr r0, [sp, #0x50]
@@ -47599,7 +47599,7 @@ _021651cc:
 	strb r3, [r1]
 	mov r11, #2
 	strb r2, [r1, #1]
-	ldrb sb, [r6]
+	ldrb r9, [r6]
 	add r10, sp, #9
 	ldrb r8, [r6, #1]
 	ldrb r7, [r6, #2]
@@ -47610,7 +47610,7 @@ _021651cc:
 	mov r0, r5
 	mov r2, #9
 	strb r11, [sp, #8]
-	strb sb, [r10]
+	strb r9, [r10]
 	strb r8, [r10, #1]
 	strb r7, [r10, #2]
 	strb r6, [r10, #3]
@@ -47619,7 +47619,7 @@ _021651cc:
 	bl func_ov61_02163a14
 	cmp r0, #0
 	addne sp, sp, #0x18
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	addne sp, sp, #0x10
 	bxne lr
 	ldr r0, [r5, #0x4b0]
@@ -47631,7 +47631,7 @@ _021651cc:
 	movlt r0, #3
 	movge r0, #0
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	add sp, sp, #0x10
 	bx lr
 	arm_func_end func_ov61_02165198
@@ -47640,7 +47640,7 @@ _021651cc:
 	arm_func_start func_ov61_021652c0
 func_ov61_021652c0: ; 0x021652c0
 	stmdb sp!, {r0, r1, r2, r3}
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x10
 	ldr r5, [sp, #0x44]
 	mov r7, #0xfd
@@ -47650,7 +47650,7 @@ func_ov61_021652c0: ; 0x021652c0
 	mov r6, r5, lsl #0x8
 	and r5, r4, #0xff
 	and r4, r3, #0xff00
-	orr sb, r5, r4
+	orr r9, r5, r4
 	and r3, r6, #0xff0000
 	mov r6, #0xfc
 	mov r5, #0x1e
@@ -47659,14 +47659,14 @@ func_ov61_021652c0: ; 0x021652c0
 	mov r11, #0xb2
 	strb r4, [sp, #7]
 	and r8, r8, #0xff000000
-	orr r3, r3, sb
+	orr r3, r3, r9
 	orr r8, r8, r3
 	add r3, sp, #0x44
 	str r8, [sp, #0x44]
 	strb r7, [sp, #4]
 	ldrb r10, [r3]
 	add ip, sp, #0xa
-	ldrb sb, [r3, #1]
+	ldrb r9, [r3, #1]
 	ldrb r8, [r3, #2]
 	ldrb r7, [r3, #3]
 	add r3, sp, #4
@@ -47675,14 +47675,14 @@ func_ov61_021652c0: ; 0x021652c0
 	strb lr, [sp, #8]
 	strb r11, [sp, #9]
 	strb r10, [ip]
-	strb sb, [ip, #1]
+	strb r9, [ip, #1]
 	strb r8, [ip, #2]
 	strb r7, [ip, #3]
 	mov r4, #0xa
 	str r4, [sp]
 	bl func_ov61_02165198
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	add sp, sp, #0x10
 	bx lr
 	arm_func_end func_ov61_021652c0
@@ -47690,7 +47690,7 @@ func_ov61_021652c0: ; 0x021652c0
 	.global func_ov61_02165378
 	arm_func_start func_ov61_02165378
 func_ov61_02165378: ; 0x02165378
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x5f0
 	mov r1, #8
 	mov r10, r0
@@ -47700,13 +47700,13 @@ func_ov61_02165378: ; 0x02165378
 	cmp r0, #0
 	beq _02165440
 	ldr r6, _02165494 ; =0x000005db
-	add sb, sp, #0xc
+	add r9, sp, #0xc
 	add r8, sp, #8
 	add r7, sp, #0x14
 	mov r11, #0
 	mvn r4, #0
 _021653b4:
-	str sb, [sp]
+	str r9, [sp]
 	str r8, [sp, #4]
 	ldr r0, [r10, #0x4b0]
 	mov r1, r7
@@ -47730,7 +47730,7 @@ _021653b4:
 	cmp r0, #0
 	addne sp, sp, #0x5f0
 	movne r0, #5
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	mov r0, r5
 	mov r1, #0x11
 	bl func_ov61_0216282c
@@ -47764,7 +47764,7 @@ _02165440:
 _02165488:
 	mov r0, #0
 	add sp, sp, #0x5f0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02165378
 _02165494: .word 0x000005db
@@ -48650,10 +48650,10 @@ _02165f68:
 	.global func_ov61_02165f80
 	arm_func_start func_ov61_02165f80
 func_ov61_02165f80: ; 0x02165f80
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	mov r8, r2
 	mov r10, r0
-	mov sb, r1
+	mov r9, r1
 	mov r7, r3
 	cmp r8, #0
 	ldr r6, [sp, #0x20]
@@ -48662,29 +48662,29 @@ func_ov61_02165f80: ; 0x02165f80
 	mov r5, r4
 _02165fa8:
 	mov r0, r10
-	add r1, sb, r5
+	add r1, r9, r5
 	blx r6
 	cmp r0, #0
-	mlaeq r0, r7, r4, sb
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	mlaeq r0, r7, r4, r9
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	add r4, r4, #1
 	cmp r4, r8
 	add r5, r5, r7
 	blt _02165fa8
 _02165fd0:
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	arm_func_end func_ov61_02165f80
 
 	.global func_ov61_02165fd8
 	arm_func_start func_ov61_02165fd8
 func_ov61_02165fd8: ; 0x02165fd8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	ldr r7, [sp, #0x2c]
 	mov r4, #0
 	mov r11, r0
 	mov r10, r1
-	mov sb, r3
+	mov r9, r3
 	str r4, [r7]
 	subs r5, r2, #1
 	ldr r8, [sp, #0x28]
@@ -48692,7 +48692,7 @@ func_ov61_02165fd8: ; 0x02165fd8
 _02166000:
 	add r0, r4, r5
 	mov r6, r0, asr #0x1
-	mla r0, r6, sb, r10
+	mla r0, r6, r9, r10
 	mov r1, r11
 	blx r8
 	cmp r0, #0
@@ -48704,8 +48704,8 @@ _02166000:
 	cmp r4, r5
 	ble _02166000
 _02166034:
-	mla r0, r4, sb, r10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	mla r0, r4, r9, r10
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	arm_func_end func_ov61_02165fd8
 
 	.global func_ov61_0216603c
@@ -48726,10 +48726,10 @@ func_ov61_0216603c: ; 0x0216603c
 	.global func_ov61_02166064
 	arm_func_start func_ov61_02166064
 func_ov61_02166064: ; 0x02166064
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	movs r7, r3
 	mov r10, r0
-	mov sb, r1
+	mov r9, r1
 	mov r8, r2
 	ldr r6, [sp, #0x24]
 	bne _02166094
@@ -48756,7 +48756,7 @@ _021660b4:
 	mov r3, #0x3a
 	bl func_02042f80
 _021660d0:
-	cmp sb, #0
+	cmp r9, #0
 	bne _021660ec
 	ldr r0, _02166198 ; =data_ov61_0217c258
 	ldr r1, _02166188 ; =data_ov61_0217c238
@@ -48774,7 +48774,7 @@ _021660ec:
 	mov r3, #0x3e
 	bl func_02042f80
 _02166110:
-	mov r0, sb, lsl #0x2
+	mov r0, r9, lsl #0x2
 	bl func_ov61_0213e10c
 	str r0, [r4]
 	cmp r0, #0
@@ -48785,7 +48785,7 @@ _02166110:
 	mov r3, #0x41
 	bl func_02042f80
 _02166138:
-	cmp sb, #0
+	cmp r9, #0
 	mov r5, #0
 	ble _02166168
 _02166144:
@@ -48796,16 +48796,16 @@ _02166144:
 	ldr r1, [r4]
 	str r0, [r1, r5, lsl #2]
 	add r5, r5, #1
-	cmp r5, sb
+	cmp r5, r9
 	blt _02166144
 _02166168:
-	str sb, [r4, #4]
+	str r9, [r4, #4]
 	ldr r0, [sp, #0x20]
 	str r6, [r4, #8]
 	str r0, [r4, #0x10]
 	mov r0, r4
 	str r7, [r4, #0xc]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02166064
 _02166184: .word data_ov61_0217c230
@@ -49947,12 +49947,12 @@ _02166e4c:
 	.global func_ov61_02166e98
 	arm_func_start func_ov61_02166e98
 func_ov61_02166e98: ; 0x02166e98
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	mov r7, r1
 	mov r6, r2
 	mov r10, r0
 	mov r5, r7
-	mov sb, r6
+	mov r9, r6
 	cmp r3, #1
 	beq _02166ec4
 	cmp r3, #2
@@ -49977,8 +49977,8 @@ _02166ee4:
 	mov r0, r10
 	mov r1, r7
 	bl func_ov61_02166e00
-	sub sb, sb, #3
-	cmp sb, #0
+	sub r9, r9, #3
+	cmp r9, #0
 	add r7, r7, #4
 	add r10, r10, #3
 	bgt _02166ee4
@@ -49999,7 +49999,7 @@ _02166f40:
 	mov r0, #0
 	strb r0, [r7]
 	cmp r7, r5
-	ldmlsia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmlsia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _02166f50:
 	sub r7, r7, #1
 	cmp r7, r1
@@ -50029,7 +50029,7 @@ _02166f50:
 _02166fb4:
 	cmp r7, r5
 	bhi _02166f50
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02166e98
 _02166fc0: .word data_ov61_0217a33c
@@ -51136,7 +51136,7 @@ _02167e3c: .word func_ov61_02167cfc
 	.global func_ov61_02167e40
 	arm_func_start func_ov61_02167e40
 func_ov61_02167e40: ; 0x02167e40
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x14
 	mov r1, #0
 	mov r4, r0
@@ -51157,7 +51157,7 @@ _02167e58:
 	bl func_ov61_021698fc
 	cmp r0, #0
 	addne sp, sp, #0x14
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r1, sp, #8
 	ldr r0, _0216812c ; =data_ov61_0217c460
 	str r1, [sp]
@@ -51171,7 +51171,7 @@ _02167e58:
 	beq _02167ef8
 	cmp r0, #3
 	addne sp, sp, #0x14
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r2, _02168130 ; =data_ov61_0217c464
 	mov r0, r4
 	mov r1, #5
@@ -51182,7 +51182,7 @@ _02167e58:
 	bl func_ov61_02169c10
 	add sp, sp, #0x14
 	mov r0, #3
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02167ef8:
 	ldr r0, [r10, #0x1dc]
 	ldr r1, _02168134 ; =data_ov61_0217c490
@@ -51193,9 +51193,9 @@ _02167ef8:
 	ldr r8, _0216813c ; =data_ov61_0217c498
 	add r11, sp, #0x10
 	mov r7, #0x800
-	mov sb, #0
+	mov r9, #0
 _02167f20:
-	strb sb, [r5]
+	strb r9, [r5]
 	mov r0, r4
 	mov r1, r8
 	ldr r2, [r10, #0x1dc]
@@ -51221,7 +51221,7 @@ _02167f20:
 	bl func_ov61_02171b10
 	add sp, sp, #0x14
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02167f8c:
 	str r0, [r10, #0x1ec]
 _02167f90:
@@ -51267,7 +51267,7 @@ _02168018:
 	cmp r0, #0
 	beq _021680b4
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02168038:
 	mov r1, r5
 	mov r0, r4
@@ -51276,7 +51276,7 @@ _02168038:
 	cmp r0, #0
 	addne sp, sp, #0x14
 	movne r0, #4
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r5, [r10, #0x1ec]
 	ldr r1, _02168148 ; =data_ov61_0217c4e4
 	mov r0, r5
@@ -51290,7 +51290,7 @@ _02168038:
 	cmp r0, #0
 	beq _021680b4
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02168090:
 	ldr r1, _0216814c ; =data_ov61_0217c4ec
 	mov r0, r5
@@ -51321,7 +51321,7 @@ _021680c8:
 	bl func_ov61_02169c10
 	add sp, sp, #0x14
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02168100:
 	mov r0, r4
 	bl func_ov61_0216d9ec
@@ -51334,7 +51334,7 @@ _02168118:
 	bne _02167e58
 	mov r0, #0
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02167e40
 _0216812c: .word data_ov61_0217c460
@@ -51352,10 +51352,10 @@ _02168154: .word data_ov61_0217c524
 	.global func_ov61_02168158
 	arm_func_start func_ov61_02168158
 func_ov61_02168158: ; 0x02168158
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	mov r10, r0
 	ldr r6, [r10]
-	mov sb, r1
+	mov r9, r1
 	ldr r0, [r6, #0x1d8]
 	mov r7, #0
 	cmp r0, #4
@@ -51377,7 +51377,7 @@ _021681a4:
 	bl func_ov61_0216b39c
 	movs r7, r0
 	bne _021681cc
-	cmp sb, #0
+	cmp r9, #0
 	beq _021681cc
 	ldr r0, [r6, #0x1d8]
 	cmp r0, #1
@@ -51457,10 +51457,10 @@ _021682b8:
 	bne _02168288
 _021682c4:
 	mov r0, r10
-	mov r1, sb
+	mov r1, r9
 	bl func_ov61_02169fa0
 	cmp r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, [r6, #0x41c]
 	cmp r0, #0
 	beq _021682f0
@@ -51469,7 +51469,7 @@ _021682c4:
 	bl func_ov61_0216b504
 _021682f0:
 	mov r0, r7
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02168158
 _021682f8: .word data_ov61_0217c54c
@@ -51529,7 +51529,7 @@ _021683b0: .word data_ov61_0217c690
 	.global func_ov61_021683b4
 	arm_func_start func_ov61_021683b4
 func_ov61_021683b4: ; 0x021683b4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x138
 	sub sp, sp, #0x1000
 	mov r7, r1
@@ -51553,7 +51553,7 @@ func_ov61_021683b4: ; 0x021683b4
 	add sp, sp, #0x138
 	add sp, sp, #0x1000
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02168418:
 	add r0, sp, #0x138
 	bl func_0204902c
@@ -51576,7 +51576,7 @@ _02168418:
 	add sp, sp, #0x138
 	add sp, sp, #0x1000
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02168470:
 	add r0, sp, #0x138
 	bl func_0204902c
@@ -51595,7 +51595,7 @@ _021684a4:
 	mov r0, #0
 	bl func_ov61_02166cf0
 _021684ac:
-	mov sb, r0
+	mov r9, r0
 	cmp r4, #0x64
 	bgt _021684dc
 	bge _021687c8
@@ -51633,7 +51633,7 @@ _021684fc:
 	add sp, sp, #0x138
 	add sp, sp, #0x1000
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02168540:
 	ldr r1, _02168d3c ; =data_ov61_0217c6ec
 	add r2, sp, #0x138
@@ -51653,7 +51653,7 @@ _02168540:
 	add sp, sp, #0x138
 	add sp, sp, #0x1000
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0216858c:
 	add r0, sp, #0x138
 	bl strlen
@@ -51668,11 +51668,11 @@ _0216858c:
 	add sp, sp, #0x138
 	add sp, sp, #0x1000
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _021685c4:
 	add r1, sp, #0x138
 	bl strcpy
-	stmia r4, {r6, sb}
+	stmia r4, {r6, r9}
 	mov r2, #0
 	str r2, [sp]
 	mov r2, #2
@@ -51686,7 +51686,7 @@ _021685c4:
 	beq _02168d18
 	add sp, sp, #0x138
 	add sp, sp, #0x1000
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02168608:
 	mov r0, r10
 	mov r1, r6
@@ -51699,7 +51699,7 @@ _02168608:
 	add sp, sp, #0x138
 	add sp, sp, #0x1000
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02168638:
 	ldr r1, _02168d3c ; =data_ov61_0217c6ec
 	add r2, sp, #0x138
@@ -51719,7 +51719,7 @@ _02168638:
 	add sp, sp, #0x138
 	add sp, sp, #0x1000
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02168684:
 	ldr r1, _02168d40 ; =data_ov61_0217c6f4
 	add r0, sp, #0x138
@@ -51737,7 +51737,7 @@ _02168684:
 	add sp, sp, #0x138
 	add sp, sp, #0x1000
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _021686c8:
 	mov r1, #0
 	add r0, r4, #8
@@ -51756,7 +51756,7 @@ _021686c8:
 	add sp, sp, #0x138
 	add sp, sp, #0x1000
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02168710:
 	ldr r0, [r5, #0x10]
 	bl func_ov61_0213e13c
@@ -51784,13 +51784,13 @@ _02168710:
 	add sp, sp, #0x138
 	add sp, sp, #0x1000
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0216877c:
 	ldr r2, _02168d48 ; =0x00000401
 	add r1, sp, #0x138
 	add r0, r4, #8
 	bl func_ov61_021715c8
-	stmia r4, {r6, sb}
+	stmia r4, {r6, r9}
 	mov r2, #0
 	str r2, [sp]
 	mov r2, #6
@@ -51804,7 +51804,7 @@ _0216877c:
 	beq _02168d18
 	add sp, sp, #0x138
 	add sp, sp, #0x1000
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _021687c8:
 	mov r0, r10
 	mov r1, r6
@@ -51817,7 +51817,7 @@ _021687c8:
 	add sp, sp, #0x138
 	add sp, sp, #0x1000
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _021687f8:
 	ldr r0, [r4, #8]
 	cmp r0, #0
@@ -51833,7 +51833,7 @@ _021687f8:
 	add sp, sp, #0x138
 	add sp, sp, #0x1000
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02168834:
 	mov r2, #6
 	mov r1, #0
@@ -51870,7 +51870,7 @@ _0216886c:
 	add sp, sp, #0x138
 	add sp, sp, #0x1000
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _021688bc:
 	ldr r1, _02168d4c ; =data_ov61_0217c700
 	add r0, sp, #0x138
@@ -51890,7 +51890,7 @@ _021688bc:
 	add sp, sp, #0x138
 	add sp, sp, #0x1000
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02168908:
 	add r0, sp, #0x28
 	bl func_0204902c
@@ -51918,7 +51918,7 @@ _02168908:
 	add sp, sp, #0x138
 	add sp, sp, #0x1000
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02168974:
 	ldr r0, [r7, #0xc]
 	bl func_ov61_0213e13c
@@ -51943,7 +51943,7 @@ _02168974:
 	add sp, sp, #0x138
 	add sp, sp, #0x1000
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _021689d4:
 	ldr r1, _02168d58 ; =data_ov61_0217c714
 	add r0, sp, #0x138
@@ -52014,13 +52014,13 @@ _02168a9c:
 	add sp, sp, #0x138
 	add sp, sp, #0x1000
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02168ae4:
 	str r6, [r3]
 	ldr r0, [r7]
 	mov r2, #0
 	str r0, [r3, #8]
-	str sb, [r3, #4]
+	str r9, [r3, #4]
 	str r2, [sp]
 	mov r2, #5
 	add r1, sp, #0x10
@@ -52032,7 +52032,7 @@ _02168ae4:
 	beq _02168d18
 	add sp, sp, #0x138
 	add sp, sp, #0x1000
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02168b28:
 	ldr r1, _02168d3c ; =data_ov61_0217c6ec
 	add r2, sp, #0x138
@@ -52052,7 +52052,7 @@ _02168b28:
 	add sp, sp, #0x138
 	add sp, sp, #0x1000
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02168b74:
 	ldr r1, _02168d5c ; =data_ov61_0217c71c
 	add r0, sp, #0x138
@@ -52070,7 +52070,7 @@ _02168b74:
 	add sp, sp, #0x138
 	add sp, sp, #0x1000
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02168bb8:
 	ldrsb r1, [r0, #3]
 	cmp r1, #0
@@ -52086,7 +52086,7 @@ _02168bb8:
 	add sp, sp, #0x138
 	add sp, sp, #0x1000
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02168bf4:
 	add r0, r0, #3
 	bl func_0204902c
@@ -52119,7 +52119,7 @@ _02168c2c:
 	add sp, sp, #0x138
 	add sp, sp, #0x1000
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02168c70:
 	str r6, [r5]
 	add r1, sp, #0x38
@@ -52138,7 +52138,7 @@ _02168c70:
 	beq _02168d18
 	add sp, sp, #0x138
 	add sp, sp, #0x1000
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02168cb8:
 	ldr r1, _02168d3c ; =data_ov61_0217c6ec
 	add r2, sp, #0x138
@@ -52158,7 +52158,7 @@ _02168cb8:
 	add sp, sp, #0x138
 	add sp, sp, #0x1000
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02168d04:
 	ldr r3, _02168d64 ; =data_ov61_0217c724
 	mov r0, r10
@@ -52169,7 +52169,7 @@ _02168d18:
 	mov r0, #0
 	add sp, sp, #0x138
 	add sp, sp, #0x1000
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_021683b4
 _02168d28: .word data_ov61_0217c698
@@ -52558,10 +52558,10 @@ _0216925c: .word data_ov61_0217c84c
 	.global func_ov61_02169260
 	arm_func_start func_ov61_02169260
 func_ov61_02169260: ; 0x02169260
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	movs r8, r2
 	mov r10, r0
-	mov sb, r1
+	mov r9, r1
 	mov r7, r3
 	bne _0216928c
 	ldr r0, _02169354 ; =data_ov61_0217c85c
@@ -52578,7 +52578,7 @@ _0216928c:
 	mov r3, #0x52
 	bl func_02042f80
 _021692a8:
-	cmp sb, #0
+	cmp r9, #0
 	bne _021692c4
 	ldr r0, _02169364 ; =data_ov61_0217c828
 	ldr r1, _02169358 ; =data_ov61_0217c840
@@ -52588,10 +52588,10 @@ _021692a8:
 _021692c4:
 	cmp r8, #0
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
-	ldr r4, [sb, #8]
-	ldr r5, [sb, #4]
-	ldr r6, [sb]
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
+	ldr r4, [r9, #8]
+	ldr r5, [r9, #4]
+	ldr r6, [r9]
 	sub r0, r5, r4
 	cmp r0, r7
 	bge _02169320
@@ -52608,7 +52608,7 @@ _021692c4:
 	mov r0, r10
 	bl func_ov61_02171b10
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _02169320:
 	mov r1, r8
 	mov r2, r7
@@ -52617,12 +52617,12 @@ _02169320:
 	add r1, r4, r7
 	mov r0, #0
 	strb r0, [r6, r1]
-	ldr r1, [sb, #8]
+	ldr r1, [r9, #8]
 	add r1, r1, r7
-	str r1, [sb, #8]
-	str r5, [sb, #4]
-	str r6, [sb]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	str r1, [r9, #8]
+	str r5, [r9, #4]
+	str r6, [r9]
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02169260
 _02169354: .word data_ov61_0217c85c
@@ -52805,10 +52805,10 @@ _021695a0: .word data_ov61_0217c8f0
 	.global func_ov61_021695a4
 	arm_func_start func_ov61_021695a4
 func_ov61_021695a4: ; 0x021695a4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x14
-	mov sb, r1
-	ldr r1, [sb, #0x28]
+	mov r9, r1
+	ldr r1, [r9, #0x28]
 	mov r10, r0
 	mov r8, r2
 	mov r7, r3
@@ -52824,12 +52824,12 @@ _021695dc:
 	mov r6, #0
 	addeq sp, sp, #0x14
 	moveq r0, r6
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
-	ldr r1, [sb, #0x30]
-	ldr r0, [sb, #0x34]
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
+	ldr r1, [r9, #0x30]
+	ldr r0, [r9, #0x34]
 	subs r0, r1, r0
 	bne _02169660
-	ldr r0, [sb, #0x38]
+	ldr r0, [r9, #0x38]
 	bl func_ov61_02165a68
 	cmp r0, #0
 	bne _02169660
@@ -52839,14 +52839,14 @@ _021695dc:
 _0216961c:
 	str r5, [sp]
 	stmib sp, {r4, r11}
-	ldr r1, [sb, #8]
+	ldr r1, [r9, #8]
 	mov r0, r10
 	mov r3, r7
 	add r2, r8, r6
 	bl func_ov61_021693d4
 	cmp r0, #0
 	addne sp, sp, #0x14
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, [sp, #0xc]
 	cmp r0, #0
 	subne r7, r7, r0
@@ -52859,16 +52859,16 @@ _02169660:
 	beq _02169688
 	mov r0, r10
 	mov r3, r7
-	add r1, sb, #0x28
+	add r1, r9, #0x28
 	add r2, r8, r6
 	bl func_ov61_02169260
 	cmp r0, #0
 	addne sp, sp, #0x14
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02169688:
 	mov r0, #0
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_021695a4
 _02169694: .word data_ov61_0217c8cc
@@ -52896,7 +52896,7 @@ func_ov61_021696a4: ; 0x021696a4
 	.global func_ov61_021696d4
 	arm_func_start func_ov61_021696d4
 func_ov61_021696d4: ; 0x021696d4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x18
 	str r0, [sp]
 	ldr r0, [sp, #0x44]
@@ -52947,10 +52947,10 @@ _02169774:
 	sub r0, r4, #0x4b
 	str r0, [sp, #0x14]
 	sub r0, r4, #0x19
-	mov sb, #0
+	mov r9, #0
 	str r0, [sp, #0x10]
 	sub r0, r4, #5
-	mov r11, sb
+	mov r11, r9
 	str r0, [sp, #0xc]
 _021697a4:
 	add r0, r6, #0x800
@@ -52967,7 +52967,7 @@ _021697a4:
 	bl func_ov61_02171b10
 	add sp, sp, #0x18
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _021697e0:
 	mov r0, r10
 	add r1, r5, r6
@@ -52991,11 +52991,11 @@ _021697e0:
 	bl func_ov61_02171b10
 	add sp, sp, #0x18
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0216983c:
 	cmp r8, #0
 	addne r6, r6, r8
-	addne sb, sb, r8
+	addne r9, r9, r8
 	bne _02169860
 	ldr r0, [sp]
 	ldr r1, _021698f4 ; =data_ov61_0217c974
@@ -53009,15 +53009,15 @@ _02169860:
 	beq _02169880
 	cmp r11, #0
 	bne _02169880
-	cmp sb, #0x20000
+	cmp r9, #0x20000
 	blt _021697a4
 _02169880:
-	cmp sb, #0
+	cmp r9, #0
 	beq _0216989c
 	ldr r1, _021698f8 ; =data_ov61_0217c998
 	ldr r0, [sp]
 	ldr r2, [sp, #0x44]
-	mov r3, sb
+	mov r3, r9
 	bl func_ov61_0217163c
 _0216989c:
 	ldr r0, [sp, #4]
@@ -53026,11 +53026,11 @@ _0216989c:
 	str r6, [r0, #8]
 	str r7, [r0, #4]
 	ldr r0, [sp, #8]
-	str sb, [r0]
+	str r9, [r0]
 	str r11, [r1]
 	mov r0, #0
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_021696d4
 _021698c8: .word data_ov61_0217c8f4
@@ -53050,11 +53050,11 @@ _021698f8: .word data_ov61_0217c998
 	.global func_ov61_021698fc
 	arm_func_start func_ov61_021698fc
 func_ov61_021698fc: ; 0x021698fc
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x1c
 	mov r10, r0
 	str r2, [sp, #0xc]
-	mov sb, r1
+	mov r9, r1
 	str r3, [sp, #0x10]
 	movs r0, r2
 	ldr r8, [sp, #0x44]
@@ -53073,7 +53073,7 @@ _02169934:
 	subs r5, r11, r7
 	addeq sp, sp, #0x1c
 	moveq r0, r4
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02169958:
 	add r0, sp, #0x18
 	str r0, [sp]
@@ -53082,13 +53082,13 @@ _02169958:
 	str r0, [sp, #4]
 	add r2, r6, r1
 	mov r0, r10
-	mov r1, sb
+	mov r1, r9
 	mov r3, r5
 	str r8, [sp, #8]
 	bl func_ov61_021693d4
 	cmp r0, #0
 	addne sp, sp, #0x1c
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, [sp, #0x14]
 	cmp r0, #0
 	subne r5, r5, r0
@@ -53143,7 +53143,7 @@ _02169a30:
 	strne r1, [r0]
 	mov r0, #0
 	add sp, sp, #0x1c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_021698fc
 _02169a58: .word data_ov61_0217c828
@@ -53537,9 +53537,9 @@ _02169f9c: .word data_ov61_0217caa8
 	.global func_ov61_02169fa0
 	arm_func_start func_ov61_02169fa0
 func_ov61_02169fa0: ; 0x02169fa0
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	mov r10, r0
-	movs sb, r1
+	movs r9, r1
 	ldr r4, [r10]
 	beq _0216a03c
 	ldr r5, [r4, #0x438]
@@ -53553,7 +53553,7 @@ func_ov61_02169fa0: ; 0x02169fa0
 _02169fd4:
 	ldr r0, [r1, #0x10]
 	ldr r8, [r1, #0x14]
-	cmp r0, sb
+	cmp r0, r9
 	ldrne r0, [r1, #0xc]
 	cmpne r0, #1
 	bne _0216a00c
@@ -53579,7 +53579,7 @@ _0216a01c:
 	streq r5, [r4, #0x438]
 	str r6, [r4, #0x43c]
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _0216a03c:
 	ldr r1, [r4, #0x438]
 	cmp r1, #0
@@ -53603,15 +53603,15 @@ _0216a074:
 	bne _0216a04c
 _0216a080:
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	arm_func_end func_ov61_02169fa0
 
 	.global func_ov61_0216a088
 	arm_func_start func_ov61_0216a088
 func_ov61_0216a088: ; 0x0216a088
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	mov r8, r1
-	mov sb, r0
+	mov r9, r0
 	cmp r8, #0
 	mov r7, #0
 	ble _0216a0dc
@@ -53627,14 +53627,14 @@ _0216a0ac:
 	umull r1, r2, r4, r2
 	sub r2, r0, r1
 	ldrsb r0, [r6, r2]
-	strb r0, [sb, r7]
+	strb r0, [r9, r7]
 	add r7, r7, #1
 	cmp r7, r8
 	blt _0216a0ac
 _0216a0dc:
 	mov r0, #0
-	strb r0, [sb, r7]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	strb r0, [r9, r7]
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0216a088
 _0216a0e8: .word data_ov61_0217cb1c
@@ -54290,11 +54290,11 @@ _0216aa48: .word data_ov61_0217cdf0
 	.global func_ov61_0216aa4c
 	arm_func_start func_ov61_0216aa4c
 func_ov61_0216aa4c: ; 0x0216aa4c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0xe8
 	mov r10, r0
 	ldr r5, [r10]
-	mov sb, r1
+	mov r9, r1
 	add r0, r5, #0x77
 	add r0, r0, #0x100
 	bl strlen
@@ -54389,11 +54389,11 @@ _0216aac0:
 	add r1, r5, #0x1f4
 	add r2, r2, #0x100
 	bl func_ov61_0216936c
-	add r0, sb, #0x200
+	add r0, r9, #0x200
 	ldrsb r0, [r0, #0xc2]
 	cmp r0, #0
 	beq _0216ac78
-	add r0, sb, #0xc2
+	add r0, r9, #0xc2
 	add r0, r0, #0x200
 	bl strlen
 	mov r6, r0
@@ -54408,7 +54408,7 @@ _0216ac0c:
 	mov r0, r4
 	mov r1, r11
 	bl func_ov61_02166ddc
-	add r1, sb, r8
+	add r1, r9, r8
 	add r1, r1, #0x200
 	add r8, r8, #1
 	ldrsb r1, [r1, #0xc2]
@@ -54444,7 +54444,7 @@ _0216ac78:
 	bl func_ov61_0216936c
 	mov r0, #0
 	add sp, sp, #0xe8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0216aa4c
 _0216aca4: .word 0x79707367
@@ -55267,13 +55267,13 @@ _0216b828: .word 0x0000076c
 	.global func_ov61_0216b82c
 	arm_func_start func_ov61_0216b82c
 func_ov61_0216b82c: ; 0x0216b82c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	mov lr, r1, asr #0x18
 	mov ip, r1, asr #0x10
 	mov r1, r1, lsl #0x10
 	and r5, ip, #0xff
 	and r4, lr, #0xff
-	mov sb, r0
+	mov r9, r0
 	mov r6, r1, lsr #0x10
 	mov r8, r2
 	mov r0, r4
@@ -55296,17 +55296,17 @@ _0216b880:
 	cmp r0, #0
 	bne _0216b8ac
 	ldr r1, _0216b8d0 ; =data_ov61_0217cf7c
-	mov r0, sb
+	mov r0, r9
 	bl func_ov61_02171b10
 	mov r0, #2
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _0216b8ac:
 	str r4, [r8]
 	ldr r0, [sp, #0x20]
 	str r5, [r7]
 	str r6, [r0]
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0216b82c
 _0216b8c4: .word data_ov61_0217cf8c
@@ -55456,7 +55456,7 @@ _0216ba40:
 	.global func_ov61_0216bacc
 	arm_func_start func_ov61_0216bacc
 func_ov61_0216bacc: ; 0x0216bacc
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x268
 	mov r4, r2
 	mov r10, r0
@@ -55468,7 +55468,7 @@ func_ov61_0216bacc: ; 0x0216bacc
 	cmp r0, #0
 	addne sp, sp, #0x268
 	movne r0, #4
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r1, _0216c254 ; =data_ov61_0217cfa4
 	mov r0, r4
 	mov r2, #4
@@ -55485,7 +55485,7 @@ func_ov61_0216bacc: ; 0x0216bacc
 	bl func_ov61_02169c10
 	add sp, sp, #0x268
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0216bb44:
 	ldr r1, _0216c25c ; =data_ov61_0217cfdc
 	add r2, sp, #0xec
@@ -55504,12 +55504,12 @@ _0216bb44:
 	bl func_ov61_02169c10
 	add sp, sp, #0x268
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0216bb8c:
 	add r0, sp, #0xec
 	bl func_0204902c
-	mov sb, r0
-	cmp sb, #0
+	mov r9, r0
+	cmp r9, #0
 	bgt _0216bbb4
 	ldr r0, _0216c260 ; =data_ov61_0217cfe8
 	ldr r1, _0216c264 ; =data_ov61_0217cf70
@@ -55519,7 +55519,7 @@ _0216bb8c:
 _0216bbb4:
 	add r2, sp, #0x10
 	mov r0, r10
-	mov r1, sb
+	mov r1, r9
 	bl func_ov61_0216f050
 	mov r0, #0
 	add r7, sp, #0x178
@@ -55690,7 +55690,7 @@ _0216be28:
 	bl func_ov61_0216b82c
 	cmp r0, #0
 	addne sp, sp, #0x268
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0216be58:
 	ldr r1, _0216c2a4 ; =data_ov61_0217d088
 	add r2, sp, #0xec
@@ -55868,7 +55868,7 @@ _0216c0a8:
 	bl func_ov61_02169c10
 	add sp, sp, #0x268
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0216c0f0:
 	ldr r7, [r6, #0x434]
 	ldr r8, [r6, #0x100]
@@ -55878,7 +55878,7 @@ _0216c0f0:
 	mov r4, #1
 _0216c108:
 	ldr r0, [r7, #0xc]
-	cmp r0, sb
+	cmp r0, r9
 	ldreq r0, [r7]
 	cmpeq r0, #0x65
 	bne _0216c140
@@ -55886,7 +55886,7 @@ _0216c108:
 	cmp r0, #0
 	bne _0216c138
 	mov r0, r10
-	mov r1, sb
+	mov r1, r9
 	bl func_ov61_0216ef6c
 	str r0, [sp, #0x10]
 _0216c138:
@@ -55904,7 +55904,7 @@ _0216c14c:
 	cmp r0, #0
 	beq _0216c174
 	mov r0, r10
-	mov r1, sb
+	mov r1, r9
 	bl func_ov61_0216ef6c
 	str r0, [sp, #0x10]
 _0216c174:
@@ -55944,13 +55944,13 @@ _0216c1c0:
 	bl func_ov61_02171b10
 	add sp, sp, #0x268
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0216c200:
 	add r0, sp, #0x178
 	mov r1, r4
 	bl func_ov61_0216b8d4
 	mov r2, #0
-	stmia r4, {r2, sb}
+	stmia r4, {r2, r9}
 	str r11, [sp]
 	add r1, sp, #8
 	str r2, [sp, #4]
@@ -55960,14 +55960,14 @@ _0216c200:
 	bl func_ov61_02169d04
 	cmp r0, #0
 	addne sp, sp, #0x268
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0216c23c:
 	mov r0, r10
 	mov r1, r11
 	bl func_ov61_0216d950
 	mov r0, #0
 	add sp, sp, #0x268
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0216bacc
 _0216c254: .word data_ov61_0217cfa4
@@ -58143,16 +58143,16 @@ _0216e080: .word data_ov61_0217d4ac
 	.global func_ov61_0216e084
 	arm_func_start func_ov61_0216e084
 func_ov61_0216e084: ; 0x0216e084
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0xc
-	mov sb, r1
-	ldr r1, [sb, #0x30]
+	mov r9, r1
+	ldr r1, [r9, #0x30]
 	mov r10, r0
 	cmp r1, #0
 	addne sp, sp, #0xc
 	movne r0, #0
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
-	ldr r0, [sb, #0x38]
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
+	ldr r0, [r9, #0x38]
 	bl func_ov61_02165a68
 	cmp r0, #0
 	beq _0216e148
@@ -58162,13 +58162,13 @@ func_ov61_0216e084: ; 0x0216e084
 	mov r6, r11
 	add r4, sp, #8
 _0216e0cc:
-	ldr r0, [sb, #0x38]
+	ldr r0, [r9, #0x38]
 	mov r1, r8
 	bl func_ov61_02165a70
 	mov r7, r0
 	str r6, [sp]
 	str r5, [sp, #4]
-	ldr r1, [sb, #8]
+	ldr r1, [r9, #8]
 	mov r0, r10
 	mov r2, r7
 	mov r3, r4
@@ -58178,26 +58178,26 @@ _0216e0cc:
 	cmpeq r0, #0
 	beq _0216e11c
 	mov r0, #0x6a
-	str r0, [sb]
+	str r0, [r9]
 	add sp, sp, #0xc
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0216e11c:
 	ldr r1, [r7, #0xc]
 	ldr r0, [r7, #8]
 	cmp r1, r0
 	bne _0216e148
-	ldr r0, [sb, #0x38]
+	ldr r0, [r9, #0x38]
 	mov r1, r11
 	bl func_ov61_02165cec
-	ldr r0, [sb, #0x38]
+	ldr r0, [r9, #0x38]
 	bl func_ov61_02165a68
 	cmp r0, #0
 	bne _0216e0cc
 _0216e148:
 	mov r0, #0
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0216e084
 _0216e154: .word data_ov61_0217d47c
@@ -58205,13 +58205,13 @@ _0216e154: .word data_ov61_0217d47c
 	.global func_ov61_0216e158
 	arm_func_start func_ov61_0216e158
 func_ov61_0216e158: ; 0x0216e158
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x24
 	mov r8, r1
 	ldr r1, [r8, #0x30]
-	mov sb, r0
+	mov r9, r0
 	cmp r1, #0
-	ldr r7, [sb]
+	ldr r7, [r9]
 	beq _0216e1bc
 	mov r2, #1
 	str r2, [sp]
@@ -58229,22 +58229,22 @@ func_ov61_0216e158: ; 0x0216e158
 	str r0, [r8]
 	add sp, sp, #0x24
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0216e1bc:
 	ldr r0, [r8, #0x30]
 	cmp r0, #0
 	bne _0216e1f4
-	mov r0, sb
+	mov r0, r9
 	mov r1, r8
 	bl func_ov61_0216e084
 	cmp r0, #0
 	addne sp, sp, #0x24
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, [r8]
 	cmp r0, #0x6a
 	addeq sp, sp, #0x24
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0216e1f4:
 	add r1, sp, #0x1c
 	ldr r0, _0216e3cc ; =data_ov61_0217d47c
@@ -58252,7 +58252,7 @@ _0216e1f4:
 	str r0, [sp, #4]
 	ldr r1, [r8, #8]
 	add r3, sp, #0x20
-	mov r0, sb
+	mov r0, r9
 	add r2, r8, #0x18
 	bl func_ov61_021696d4
 	cmp r0, #0
@@ -58261,7 +58261,7 @@ _0216e1f4:
 	str r0, [r8]
 	add sp, sp, #0x24
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0216e234:
 	ldr r0, [sp, #0x20]
 	cmp r0, #0
@@ -58276,7 +58276,7 @@ _0216e250:
 	add r11, sp, #0x14
 	add r6, sp, #8
 _0216e260:
-	mov r0, sb
+	mov r0, r9
 	add r1, r8, #0x18
 	add r2, sp, #0x10
 	add r3, sp, #0xc
@@ -58284,7 +58284,7 @@ _0216e260:
 	bl func_ov61_02169a7c
 	cmp r0, #0
 	addne sp, sp, #0x24
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r1, [sp, #0x10]
 	cmp r1, #0
 	beq _0216e3a4
@@ -58322,11 +58322,11 @@ _0216e2e0:
 	movs r5, r0
 	bne _0216e320
 	ldr r1, _0216e3d0 ; =data_ov61_0217d50c
-	mov r0, sb
+	mov r0, r9
 	bl func_ov61_02171b10
 	add sp, sp, #0x24
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0216e320:
 	ldr r0, [r8, #0xc]
 	str r0, [r5]
@@ -58337,31 +58337,31 @@ _0216e320:
 	bl func_ov61_02166cf0
 	str r0, [r5, #4]
 	mov r3, r5
-	mov r0, sb
+	mov r0, r9
 	stmia sp, {r4, r10}
 	ldmia r11, {r1, r2}
 	bl func_ov61_02169d04
 	cmp r0, #0
 	beq _0216e398
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0216e364:
 	ldr r1, [r8, #0xc]
 	ldr r3, _0216e3d4 ; =data_ov61_0217d51c
-	mov r0, sb
+	mov r0, r9
 	mov r2, #0x67
 	bl func_ov61_02168e44
 	b _0216e398
 _0216e37c:
 	str r1, [sp]
 	ldr r1, [sp, #8]
-	mov r0, sb
+	mov r0, r9
 	str r1, [sp, #4]
 	mov r1, r8
 	ldr r3, [r8, #0x18]
 	bl func_ov61_02171440
 _0216e398:
-	mov r0, sb
+	mov r0, r9
 	add r1, r8, #0x18
 	bl func_ov61_02169bb8
 _0216e3a4:
@@ -58374,7 +58374,7 @@ _0216e3a4:
 	strne r0, [r8]
 	mov r0, #0
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0216e158
 _0216e3cc: .word data_ov61_0217d47c
@@ -58972,9 +58972,9 @@ _0216eba8: .word data_ov61_0217d61c
 	.global func_ov61_0216ebac
 	arm_func_start func_ov61_0216ebac
 func_ov61_0216ebac: ; 0x0216ebac
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x48
-	mov sb, r0
+	mov r9, r0
 	mov r8, r1
 	mov r7, r2
 	cmp r3, #0
@@ -58994,11 +58994,11 @@ _0216ebe4:
 	stmia sp, {r4, r6}
 	bl func_020459b8
 	add r2, sp, #8
-	mov r0, sb
+	mov r0, r9
 	mov r1, r8
 	bl func_ov61_021696a4
 	add sp, sp, #0x48
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0216ebac
 _0216ec14: .word data_ov61_0217d624
@@ -59750,10 +59750,10 @@ _0216f5a4:
 	.global func_ov61_0216f5b0
 	arm_func_start func_ov61_0216f5b0
 func_ov61_0216f5b0: ; 0x0216f5b0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #8
 	movs r8, r1
-	mov sb, r0
+	mov r9, r0
 	ldrnesb r0, [r8]
 	mov r7, r2
 	mov r6, r3
@@ -59781,19 +59781,19 @@ func_ov61_0216f5b0: ; 0x0216f5b0
 	cmpne r0, #0
 	bne _0216f640
 	ldr r1, _0216f798 ; =data_ov61_0217d848
-	mov r0, sb
+	mov r0, r9
 	bl func_ov61_02171b10
 	add sp, sp, #8
 	mov r0, #2
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _0216f640:
 	add r1, sp, #4
-	mov r0, sb
+	mov r0, r9
 	mov r2, #1
 	bl func_ov61_0216f470
 	cmp r0, #0
 	addne sp, sp, #8
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	cmp r8, #0
 	bne _0216f674
 	ldr r0, [sp, #4]
@@ -59877,12 +59877,12 @@ _0216f744:
 	ldr r1, [sp, #4]
 	ldr r2, [sp, #0x38]
 	ldr r3, [sp, #0x3c]
-	mov r0, sb
+	mov r0, r9
 	bl func_ov61_0216f520
 	cmp r0, #0
 	moveq r0, #0
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0216f5b0
 _0216f798: .word data_ov61_0217d848
@@ -59890,7 +59890,7 @@ _0216f798: .word data_ov61_0217d848
 	.global func_ov61_0216f79c
 	arm_func_start func_ov61_0216f79c
 func_ov61_0216f79c: ; 0x0216f79c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x490
 	mov r10, r0
 	ldr r0, [r10]
@@ -59914,7 +59914,7 @@ _0216f7cc:
 	bl func_ov61_021698fc
 	cmp r0, #0
 	addne sp, sp, #0x490
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, [sp, #0x1c]
 	ldr r0, [r0, #0x14]
 	cmp r0, #1
@@ -59925,7 +59925,7 @@ _0216f7cc:
 	bl func_ov61_02171828
 	cmp r0, #0
 	addne sp, sp, #0x490
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, [sp, #0x7c]
 	cmp r0, #4
 	bne _0216f860
@@ -59939,7 +59939,7 @@ _0216f7cc:
 	bl func_ov61_02169c10
 	add sp, sp, #0x490
 	mov r0, #4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0216f860:
 	cmp r0, #3
 	bne _021711ec
@@ -60344,7 +60344,7 @@ _0216fe30:
 	beq _0216fe9c
 	cmp r0, #3
 	addne sp, sp, #0x490
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r1, _021705d8 ; =0x00000d01
 	ldr r2, _02170658 ; =data_ov61_0217d9a8
 	mov r0, r10
@@ -60355,7 +60355,7 @@ _0216fe30:
 	bl func_ov61_02169c10
 	add sp, sp, #0x490
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0216fe9c:
 	ldr r0, [r6, #8]
 	ldr r1, _02170654 ; =data_ov61_0217d9a0
@@ -60377,7 +60377,7 @@ _0216fe9c:
 	str r0, [r6, #0x140]
 	add sp, sp, #0x490
 	mov r0, #4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0216fef0:
 	ldr r0, [r6]
 	cmp r0, #1
@@ -60401,7 +60401,7 @@ _0216ff24:
 	bl func_ov61_0217191c
 	cmp r0, #0
 	addne sp, sp, #0x490
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r1, _02170660 ; =data_ov61_0217d9d4
 	mov r0, r4
 	bl strcmp
@@ -60415,7 +60415,7 @@ _0216ff24:
 	bl func_ov61_0217191c
 	cmp r0, #0
 	addne sp, sp, #0x490
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r1, _02170664 ; =data_ov61_0217d9dc
 	mov r0, r4
 	bl strcmp
@@ -60452,15 +60452,15 @@ _0216ffb8:
 	bl func_ov61_02171b10
 	add sp, sp, #0x490
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0217000c:
 	ldr r0, [sp, #0x84]
 	mov r1, #0
 	sub r2, r0, #1
 	mov r0, #0xac
 	mul r8, r2, r0
-	add sb, r7, r8
-	mov r0, sb
+	add r9, r7, r8
+	mov r0, r9
 	mov r2, #0xac
 	bl func_02043600
 	mov r0, r5
@@ -60477,13 +60477,13 @@ _02170040:
 	bl func_ov61_0217191c
 	cmp r0, #0
 	addne sp, sp, #0x490
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r1, _02170670 ; =data_ov61_0217d9e8
 	mov r0, r4
 	bl strcmp
 	cmp r0, #0
 	bne _02170090
-	add r0, sb, #4
+	add r0, r9, #4
 	mov r1, r5
 	mov r2, #0x1f
 	bl func_ov61_021715c8
@@ -60494,7 +60494,7 @@ _02170090:
 	bl strcmp
 	cmp r0, #0
 	bne _021700b8
-	add r0, sb, #0x23
+	add r0, r9, #0x23
 	mov r1, r5
 	mov r2, #0x15
 	bl func_ov61_021715c8
@@ -60505,7 +60505,7 @@ _021700b8:
 	bl strcmp
 	cmp r0, #0
 	bne _021700e0
-	add r0, sb, #0x38
+	add r0, r9, #0x38
 	mov r1, r5
 	mov r2, #0x1f
 	bl func_ov61_021715c8
@@ -60516,7 +60516,7 @@ _021700e0:
 	bl strcmp
 	cmp r0, #0
 	bne _02170108
-	add r0, sb, #0x57
+	add r0, r9, #0x57
 	mov r1, r5
 	mov r2, #0x1f
 	bl func_ov61_021715c8
@@ -60527,7 +60527,7 @@ _02170108:
 	bl strcmp
 	cmp r0, #0
 	bne _02170130
-	add r0, sb, #0x76
+	add r0, r9, #0x76
 	mov r1, r5
 	mov r2, #0x33
 	bl func_ov61_021715c8
@@ -60561,7 +60561,7 @@ _0217016c:
 	bl func_ov61_02169c10
 	add sp, sp, #0x490
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02170198:
 	ldr r0, [sp, #0x2c]
 	cmp r0, #0
@@ -60608,7 +60608,7 @@ _021701d0:
 	bl func_ov61_0216f5b0
 	cmp r0, #0
 	addne sp, sp, #0x490
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0217024c:
 	ldr r0, [sp, #0x8c]
 	bl func_ov61_0213e13c
@@ -60634,7 +60634,7 @@ _02170260:
 	bl func_ov61_0217191c
 	cmp r0, #0
 	addne sp, sp, #0x490
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r1, _02170688 ; =data_ov61_0217da44
 	add r0, sp, #0x290
 	bl strcmp
@@ -60650,7 +60650,7 @@ _02170260:
 	bl func_ov61_02169c10
 	add sp, sp, #0x490
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _021702ec:
 	mov r0, #0x3c
 	bl func_ov61_0213e10c
@@ -60661,7 +60661,7 @@ _021702ec:
 	bl func_ov61_02171b10
 	add sp, sp, #0x490
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02170314:
 	mov r0, #0
 	str r0, [r4]
@@ -60686,7 +60686,7 @@ _02170314:
 	cmp r0, #0
 	beq _021711e0
 	add sp, sp, #0x490
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02170374:
 	cmp r0, #3
 	bne _0217071c
@@ -60706,7 +60706,7 @@ _02170374:
 	bl func_ov61_02171b10
 	add sp, sp, #0x490
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _021703c0:
 	mov r2, #0
 	add r0, r8, #4
@@ -60726,7 +60726,7 @@ _021703c0:
 	bl func_ov61_0217191c
 	cmp r0, #0
 	addne sp, sp, #0x490
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r1, _0217068c ; =data_ov61_0217da48
 	add r0, sp, #0x290
 	bl strcmp
@@ -60742,10 +60742,10 @@ _021703c0:
 	bl func_ov61_02169c10
 	add sp, sp, #0x490
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0217044c:
 	ldr r11, _02170670 ; =data_ov61_0217d9e8
-	mov sb, #0
+	mov r9, #0
 	add r4, sp, #0x290
 	add r7, sp, #0x90
 	add r5, sp, #0x78
@@ -60758,7 +60758,7 @@ _02170460:
 	bl func_ov61_0217191c
 	cmp r0, #0
 	addne sp, sp, #0x490
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	mov r0, r4
 	mov r1, r11
 	bl strcmp
@@ -60776,7 +60776,7 @@ _02170460:
 	bl func_ov61_02171b10
 	add sp, sp, #0x490
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _021704cc:
 	str r0, [r8, #0x3c]
 	mov r0, #0x1f
@@ -60788,7 +60788,7 @@ _021704cc:
 	bl func_ov61_02171b10
 	add sp, sp, #0x490
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _021704f8:
 	ldr r3, [r8, #0x3c]
 	ldr r2, [r8, #0x38]
@@ -60822,7 +60822,7 @@ _0217052c:
 	bl func_ov61_02171b10
 	add sp, sp, #0x490
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02170578:
 	str r0, [r8, #0x40]
 	mov r0, #0x15
@@ -60834,7 +60834,7 @@ _02170578:
 	bl func_ov61_02171b10
 	add sp, sp, #0x490
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _021705a4:
 	ldr r3, [r8, #0x40]
 	ldr r2, [r8, #0x38]
@@ -60905,7 +60905,7 @@ _0217069c:
 	mov r0, r4
 	bl strcmp
 	cmp r0, #0
-	moveq sb, #1
+	moveq r9, #1
 	beq _021706e0
 	ldr r2, _02170684 ; =data_ov61_0217da1c
 	mov r0, r10
@@ -60917,9 +60917,9 @@ _0217069c:
 	bl func_ov61_02169c10
 	add sp, sp, #0x490
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _021706e0:
-	cmp sb, #0
+	cmp r9, #0
 	beq _02170460
 	ldr r1, [sp, #0x1c]
 	add r2, sp, #0x38
@@ -60933,7 +60933,7 @@ _021706e0:
 	cmp r0, #0
 	beq _021711e0
 	add sp, sp, #0x490
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0217071c:
 	cmp r0, #4
 	bne _02170998
@@ -60953,7 +60953,7 @@ _0217071c:
 	bl func_ov61_02171b10
 	add sp, sp, #0x490
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02170768:
 	ldr r1, [r6, #0x138]
 	mov r0, #0
@@ -60972,7 +60972,7 @@ _02170788:
 	bl func_ov61_0217191c
 	cmp r0, #0
 	addne sp, sp, #0x490
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r1, _02170694 ; =data_ov61_0217da54
 	mov r0, r4
 	bl strcmp
@@ -61000,14 +61000,14 @@ _02170788:
 	bl func_ov61_02171b10
 	add sp, sp, #0x490
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0217081c:
 	ldr r0, [r11, #8]
 	mov r1, #0
 	sub r2, r0, #1
 	mov r0, #0x128
-	mul sb, r2, r0
-	add r7, r8, sb
+	mul r9, r2, r0
+	add r7, r8, r9
 	mov r0, r7
 	mov r2, #0x128
 	bl func_02043600
@@ -61015,10 +61015,10 @@ _0217081c:
 	str r0, [r7, #0x24]
 	mov r0, r5
 	bl func_0204902c
-	str r0, [r8, sb]
+	str r0, [r8, r9]
 	mov r8, #0
 _02170858:
-	ldr sb, [sp, #0x78]
+	ldr r9, [sp, #0x78]
 	mov r0, r10
 	str r5, [sp]
 	ldr r1, [r6, #8]
@@ -61027,7 +61027,7 @@ _02170858:
 	bl func_ov61_0217191c
 	cmp r0, #0
 	addne sp, sp, #0x490
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r1, _02171210 ; =data_ov61_0217da60
 	mov r0, r4
 	bl strcmp
@@ -61070,7 +61070,7 @@ _021708f0:
 	cmp r0, #0
 	bne _02170920
 _02170918:
-	str sb, [sp, #0x78]
+	str r9, [sp, #0x78]
 	mov r8, #1
 _02170920:
 	cmp r8, #0
@@ -61087,7 +61087,7 @@ _0217092c:
 	bl func_ov61_02169c10
 	add sp, sp, #0x490
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02170958:
 	ldr r0, [sp, #0x20]
 	cmp r0, #0
@@ -61104,7 +61104,7 @@ _02170958:
 	cmp r0, #0
 	beq _021711e0
 	add sp, sp, #0x490
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02170998:
 	cmp r0, #5
 	bne _02170af4
@@ -61124,7 +61124,7 @@ _02170998:
 	bl func_ov61_0217191c
 	cmp r0, #0
 	addne sp, sp, #0x490
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r1, _02171218 ; =data_ov61_0217da74
 	add r0, sp, #0x290
 	bl strcmp
@@ -61140,7 +61140,7 @@ _02170998:
 	bl func_ov61_02169c10
 	add sp, sp, #0x490
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02170a24:
 	add r0, sp, #0x90
 	bl func_0204902c
@@ -61168,7 +61168,7 @@ _02170a44:
 	bl func_ov61_02169c10
 	add sp, sp, #0x490
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02170a8c:
 	add r0, sp, #0x90
 	bl func_0204902c
@@ -61183,7 +61183,7 @@ _02170a98:
 	bl func_ov61_02171b10
 	add sp, sp, #0x490
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02170ac0:
 	stmia r3, {r4, r5}
 	ldr r1, [sp, #0x1c]
@@ -61197,7 +61197,7 @@ _02170ac0:
 	cmp r0, #0
 	beq _021711e0
 	add sp, sp, #0x490
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02170af4:
 	cmp r0, #6
 	bne _02170c54
@@ -61217,7 +61217,7 @@ _02170af4:
 	bl func_ov61_0217191c
 	cmp r0, #0
 	addne sp, sp, #0x490
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r1, _02171220 ; =data_ov61_0217da80
 	add r0, sp, #0x290
 	bl strcmp
@@ -61233,7 +61233,7 @@ _02170af4:
 	bl func_ov61_02169c10
 	add sp, sp, #0x490
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02170b80:
 	add r0, sp, #0x90
 	bl func_0204902c
@@ -61259,7 +61259,7 @@ _02170b80:
 	bl func_ov61_02169c10
 	add sp, sp, #0x490
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02170be4:
 	mov r5, #0
 	b _02170bf8
@@ -61277,7 +61277,7 @@ _02170bf8:
 	bl func_ov61_02171b10
 	add sp, sp, #0x490
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02170c20:
 	stmia r3, {r4, r5}
 	ldr r1, [sp, #0x1c]
@@ -61291,7 +61291,7 @@ _02170c20:
 	cmp r0, #0
 	beq _021711e0
 	add sp, sp, #0x490
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02170c54:
 	cmp r0, #7
 	bne _02170f90
@@ -61311,7 +61311,7 @@ _02170c54:
 	bl func_ov61_02171b10
 	add sp, sp, #0x490
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02170ca0:
 	mov r1, #0
 	str r1, [r11]
@@ -61326,7 +61326,7 @@ _02170ca0:
 	bl func_ov61_0217191c
 	cmp r0, #0
 	addne sp, sp, #0x490
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r1, _02171224 ; =data_ov61_0217da84
 	add r0, sp, #0x290
 	bl strcmp
@@ -61342,7 +61342,7 @@ _02170ca0:
 	bl func_ov61_02169c10
 	add sp, sp, #0x490
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02170d18:
 	mov r0, #0
 	str r0, [sp, #0x24]
@@ -61357,7 +61357,7 @@ _02170d28:
 	bl func_ov61_0217191c
 	cmp r0, #0
 	addne sp, sp, #0x490
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r1, _02171228 ; =data_ov61_0217da8c
 	mov r0, r4
 	bl strcmp
@@ -61383,14 +61383,14 @@ _02170d28:
 	bl func_ov61_02171b10
 	add sp, sp, #0x490
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02170db4:
 	str r0, [r11, #8]
 	ldr r2, [r11, #4]
 	mov r8, r0
 	mov r0, #0xac
-	mul sb, r2, r0
-	add r7, r8, sb
+	mul r9, r2, r0
+	add r7, r8, r9
 	mov r1, #0
 	mov r0, r7
 	mov r2, #0xac
@@ -61400,10 +61400,10 @@ _02170db4:
 	add r1, r1, #1
 	str r1, [r11, #4]
 	bl func_0204902c
-	str r0, [r8, sb]
+	str r0, [r8, r9]
 	mov r8, #0
 _02170df8:
-	ldr sb, [sp, #0x78]
+	ldr r9, [sp, #0x78]
 	mov r0, r10
 	str r5, [sp]
 	ldr r1, [r6, #8]
@@ -61412,7 +61412,7 @@ _02170df8:
 	bl func_ov61_0217191c
 	cmp r0, #0
 	addne sp, sp, #0x490
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r1, _02170670 ; =data_ov61_0217d9e8
 	mov r0, r4
 	bl strcmp
@@ -61479,7 +61479,7 @@ _02170ee8:
 	cmp r0, #0
 	bne _02170f18
 _02170f10:
-	str sb, [sp, #0x78]
+	str r9, [sp, #0x78]
 	mov r8, #1
 _02170f18:
 	cmp r8, #0
@@ -61496,7 +61496,7 @@ _02170f24:
 	bl func_ov61_02169c10
 	add sp, sp, #0x490
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02170f50:
 	ldr r0, [sp, #0x24]
 	cmp r0, #0
@@ -61513,7 +61513,7 @@ _02170f50:
 	cmp r0, #0
 	beq _021711e0
 	add sp, sp, #0x490
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02170f90:
 	cmp r0, #8
 	bne _021711cc
@@ -61534,7 +61534,7 @@ _02170f90:
 	bl func_ov61_02171b10
 	add sp, sp, #0x490
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02170fe0:
 	mov r1, r7
 	str r1, [r8]
@@ -61549,7 +61549,7 @@ _02170fe0:
 	bl func_ov61_0217191c
 	cmp r0, #0
 	addne sp, sp, #0x490
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r1, _02171238 ; =data_ov61_0217daa8
 	add r0, sp, #0x290
 	bl strcmp
@@ -61565,7 +61565,7 @@ _02170fe0:
 	bl func_ov61_02169c10
 	add sp, sp, #0x490
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02171058:
 	add r0, sp, #0x90
 	bl func_0204902c
@@ -61580,9 +61580,9 @@ _02171058:
 	bl func_ov61_02171b10
 	add sp, sp, #0x490
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02171090:
-	mov sb, r7
+	mov r9, r7
 	add r4, sp, #0x290
 	add r5, sp, #0x90
 	add r11, sp, #0x78
@@ -61595,7 +61595,7 @@ _021710a0:
 	bl func_ov61_0217191c
 	cmp r0, #0
 	addne sp, sp, #0x490
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r1, _02170670 ; =data_ov61_0217d9e8
 	mov r0, r4
 	bl strcmp
@@ -61614,7 +61614,7 @@ _021710a0:
 	bl func_ov61_02171b10
 	add sp, sp, #0x490
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02171110:
 	mov r1, r5
 	mov r2, #0x15
@@ -61637,7 +61637,7 @@ _02171124:
 	bl func_02042f80
 _02171158:
 	str r7, [r8, #4]
-	mov sb, #1
+	mov r9, #1
 	b _02171190
 _02171164:
 	ldr r2, _02170684 ; =data_ov61_0217da1c
@@ -61650,9 +61650,9 @@ _02171164:
 	bl func_ov61_02169c10
 	add sp, sp, #0x490
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02171190:
-	cmp sb, #0
+	cmp r9, #0
 	beq _021710a0
 	ldr r1, [sp, #0x1c]
 	add r2, sp, #0x60
@@ -61666,7 +61666,7 @@ _02171190:
 	cmp r0, #0
 	beq _021711e0
 	add sp, sp, #0x490
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _021711cc:
 	ldr r0, _0217063c ; =data_ov61_0217d990
 	ldr r1, _02170640 ; =data_ov61_0217d814
@@ -61687,7 +61687,7 @@ _021711fc:
 	bne _0216f7cc
 	mov r0, #0
 	add sp, sp, #0x490
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 _02171210: .word data_ov61_0217da60
 _02171214: .word data_ov61_0217da68
@@ -61708,10 +61708,10 @@ _02171248: .word 0x0000052a
 	.global func_ov61_0217124c
 	arm_func_start func_ov61_0217124c
 func_ov61_0217124c: ; 0x0217124c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	mov r10, r0
 	ldr r6, [r10]
-	mov sb, #0
+	mov r9, #0
 	ldr r0, [r6, #0x210]
 	cmp r0, #0
 	ble _02171380
@@ -61723,7 +61723,7 @@ func_ov61_0217124c: ; 0x0217124c
 	mov r0, r10
 	bl func_ov61_02171b10
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _0217128c:
 	ldr r8, [r6, #0x424]
 	cmp r8, #0
@@ -61743,7 +61743,7 @@ _021712a4:
 	cmp r0, #0
 	bne _021712fc
 	ldr r0, [r6, #0x210]
-	cmp sb, r0
+	cmp r9, r0
 	blt _021712ec
 	ldr r2, _02171394 ; =data_ov61_0217d6ec
 	ldr r3, _02171398 ; =0x00000563
@@ -61751,16 +61751,16 @@ _021712a4:
 	mov r1, r11
 	bl func_02042f80
 _021712ec:
-	str r8, [r7, sb, lsl #2]
+	str r8, [r7, r9, lsl #2]
 	ldr r0, [r8, #4]
-	add sb, sb, #1
+	add r9, r9, #1
 	str r4, [r0, #0x13c]
 _021712fc:
 	ldr r8, [r8, #0x20]
 	cmp r8, #0
 	bne _021712a4
 _02171308:
-	cmp sb, #0
+	cmp r9, #0
 	mov r4, #0
 	ble _02171338
 _02171314:
@@ -61771,10 +61771,10 @@ _02171314:
 	ldrne r1, [r7, r4, lsl #2]
 	add r4, r4, #1
 	strne r0, [r1, #0x1c]
-	cmp r4, sb
+	cmp r4, r9
 	blt _02171314
 _02171338:
-	cmp sb, #0
+	cmp r9, #0
 	mov r4, #0
 	ble _02171378
 	mov r5, r4
@@ -61790,14 +61790,14 @@ _02171348:
 	bl func_ov61_0216d950
 _0217136c:
 	add r4, r4, #1
-	cmp r4, sb
+	cmp r4, r9
 	blt _02171348
 _02171378:
 	mov r0, r7
 	bl func_ov61_0213e13c
 _02171380:
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0217124c
 _02171388: .word data_ov61_0217d758
@@ -62894,24 +62894,24 @@ _0217216c: .word data_ov61_0217dd08
 	.global func_ov61_02172170
 	arm_func_start func_ov61_02172170
 func_ov61_02172170: ; 0x02172170
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	ldr r0, _021722b8 ; =data_ov61_0217dd08
 	mvn r1, #0
 	ldr r0, [r0]
 	cmp r0, r1
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	ldr r1, _021722bc ; =data_ov61_02181154
 	ldr r1, [r1, #0x10]
 	cmp r1, #5
 	movne r0, #0
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	bl func_ov61_021723f4
 	cmp r0, #0
 	beq _0217229c
 	mov r7, #0
 	ldr r10, _021722bc ; =data_ov61_02181154
-	ldr sb, _021722b8 ; =data_ov61_0217dd08
+	ldr r9, _021722b8 ; =data_ov61_0217dd08
 	mov r8, #0x100
 	mov r6, r7
 	mov r4, r7
@@ -62932,12 +62932,12 @@ _021721c4:
 	str r0, [r10, #0xc]
 	cmp r0, #0
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _02172208:
 	ldr r5, [r10]
 	ldr r1, [r10, #0xc]
 	ldr r2, [r10, #0x2c]
-	ldr r0, [sb]
+	ldr r0, [r9]
 	mov r3, r7
 	add r1, r1, r5
 	sub r2, r2, r5
@@ -62946,7 +62946,7 @@ _02172208:
 	bgt _0217223c
 	bl func_ov61_021720e0
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _0217223c:
 	ldr r1, [r10]
 	add r1, r1, r0
@@ -62969,7 +62969,7 @@ _0217223c:
 	sub r0, r0, r5
 	str r0, [r10]
 _0217228c:
-	ldr r0, [sb]
+	ldr r0, [r9]
 	bl func_ov61_021723f4
 	cmp r0, #0
 	bne _021721c4
@@ -62980,7 +62980,7 @@ _0217229c:
 	cmp r1, r0
 	moveq r0, #0
 	movne r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02172170
 _021722b8: .word data_ov61_0217dd08
@@ -63437,10 +63437,10 @@ _02172888: .word data_ov61_0217dde4
 	.global func_ov61_0217288c
 	arm_func_start func_ov61_0217288c
 func_ov61_0217288c: ; 0x0217288c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
-	mov sb, r1
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
+	mov r9, r1
 	mov r10, r0
-	mov r7, sb
+	mov r7, r9
 	bl func_ov61_02172400
 	mov r6, r0
 	ldr r5, _0217290c ; =data_ov61_0217dd54
@@ -63456,22 +63456,22 @@ _021728b0:
 	mov r1, r8
 	bl func_ov61_021727a4
 	add r0, r8, #7
-	sub sb, sb, r0
-	cmp sb, #0
+	sub r9, r9, r0
+	cmp r9, #0
 	add r10, r6, #7
 	ble _021728f4
 	mov r0, r10
-	mov r1, sb
+	mov r1, r9
 	bl func_ov61_02172400
 	mov r6, r0
 _021728f4:
-	cmp sb, #0
+	cmp r9, #0
 	ble _02172904
 	cmp r6, #0
 	bne _021728b0
 _02172904:
-	sub r0, r7, sb
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	sub r0, r7, r9
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0217288c
 _0217290c: .word data_ov61_0217dd54
@@ -63557,13 +63557,13 @@ _02172a14: .word data_ov61_02181154
 	.global func_ov61_02172a18
 	arm_func_start func_ov61_02172a18
 func_ov61_02172a18: ; 0x02172a18
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x24
 	ldr r0, _02172afc ; =data_ov61_02181154
 	ldr r0, [r0, #4]
 	cmp r0, #0
 	addeq sp, sp, #0x24
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	bl func_ov61_02165a68
 	subs r4, r0, #1
 	bmi _02172adc
@@ -63579,7 +63579,7 @@ _02172a4c:
 	add r3, r3, #2
 	subs r2, r2, #1
 	bne _02172a4c
-	ldr sb, _02172b04 ; =data_ov61_0217dd64
+	ldr r9, _02172b04 ; =data_ov61_0217dd64
 	ldr r5, _02172b08 ; =data_ov61_0217dd08
 	add r8, sp, #0x14
 	mov r7, #0xf
@@ -63599,7 +63599,7 @@ _02172a8c:
 	bne _02172a8c
 	mov r0, r8
 	mov r1, r7
-	str sb, [r5, #8]
+	str r9, [r5, #8]
 	bl func_ov61_021722c0
 	mov r0, r4
 	mov r1, r6
@@ -63617,7 +63617,7 @@ _02172adc:
 	mov r1, #0
 	str r1, [r0, #4]
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02172a18
 _02172afc: .word data_ov61_02181154
@@ -63937,7 +63937,7 @@ _02172ecc: .word data_ov61_0217ddf8
 	.global func_ov61_02172ed0
 	arm_func_start func_ov61_02172ed0
 func_ov61_02172ed0: ; 0x02172ed0
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	ldrb r5, [r0]
 	mov lr, #0
 	mov r4, #1
@@ -63955,12 +63955,12 @@ _02172ef4:
 	and r10, r10, #1
 	movhs r8, r3
 	cmp r5, #0x4f
-	movlo sb, r2
+	movlo r9, r2
 	eor r10, lr, r10
-	movhs sb, r1
+	movhs r9, r1
 	eor r10, r6, r10
-	eor sb, r10, sb
-	eors lr, sb, r8
+	eor r9, r10, r9
+	eors lr, r9, r8
 	beq _02172f3c
 	ldrb r8, [r7]
 	tst r8, #1
@@ -63973,19 +63973,19 @@ _02172f3c:
 	bne _02172f58
 _02172f50:
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _02172f58:
 	add r4, r4, #1
 	cmp r4, #0x20
 	blt _02172ef4
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	arm_func_end func_ov61_02172ed0
 
 	.global func_ov61_02172f6c
 	arm_func_start func_ov61_02172f6c
 func_ov61_02172f6c: ; 0x02172f6c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	movs r10, r0
 	bne _02172f8c
 	ldr r0, _02173078 ; =data_ov61_0217de38
@@ -64012,8 +64012,8 @@ _02172f8c:
 	mov r6, r7
 	mov r4, r3
 _02172fd0:
-	add sb, r10, r7
-	ldrb r3, [sb, #-1]
+	add r9, r10, r7
+	ldrb r3, [r9, #-1]
 	ldrb r0, [r10]
 	cmp r3, r0
 	eor r3, r7, r3
@@ -64036,27 +64036,27 @@ _02172fd0:
 	sub r3, r0, r1
 	add r0, r3, #0x21
 	cmp r8, #0
-	strb r0, [sb]
+	strb r0, [r9]
 	beq _02173044
-	ldrb r0, [sb]
+	ldrb r0, [r9]
 	tst r0, #1
 	beq _02173058
 _02173044:
 	cmp r8, #0
-	ldreqb r0, [sb]
+	ldreqb r0, [r9]
 	andeq r0, r0, #1
 	cmpeq r0, #1
 	bne _02173064
 _02173058:
-	ldrb r0, [sb]
+	ldrb r0, [r9]
 	add r0, r0, #1
-	strb r0, [sb]
+	strb r0, [r9]
 _02173064:
 	add r7, r7, #1
 	cmp r7, #0x20
 	blt _02172fd0
 	mov r0, r10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02172f6c
 _02173078: .word data_ov61_0217de38
@@ -64067,7 +64067,7 @@ _02173084: .word 0x2c0b02c1
 	.global func_ov61_02173088
 	arm_func_start func_ov61_02173088
 func_ov61_02173088: ; 0x02173088
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	mov r5, r0
 	ldr r0, _02173188 ; =data_ov61_0217de14
 	mov r4, r1
@@ -64098,10 +64098,10 @@ _021730ec:
 	cmpne r10, #0xe
 	ldreqsb r6, [r4, r10]
 	addne r0, r4, r10
-	ldrb sb, [r4, r10]
+	ldrb r9, [r4, r10]
 	ldrnesb r6, [r0, #-1]
 	mov r1, r7
-	add r0, r10, sb
+	add r0, r10, r9
 	bl func_02002c14
 	mul r0, r6, r8
 	mov r6, r1
@@ -64110,7 +64110,7 @@ _021730ec:
 	ldr r0, _02173188 ; =data_ov61_0217de14
 	ldrsb r3, [r0, r6]
 	ldrsb r2, [r0, r1]
-	mla r0, r10, sb, r3
+	mla r0, r10, r9, r3
 	mov r1, r0, lsr #0x1f
 	rsb r0, r1, r0, lsl #27
 	add r0, r1, r0, ror #27
@@ -64133,7 +64133,7 @@ _02173168:
 	add r8, r0, #0x4600
 	blt _021730b4
 	mov r0, r5
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02173088
 _02173188: .word data_ov61_0217de14
@@ -65480,7 +65480,7 @@ _02174294: .word func_ov61_02173e60
 	.global func_ov61_02174298
 	arm_func_start func_ov61_02174298
 func_ov61_02174298: ; 0x02174298
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0xc
 	mov r6, r0
 	mov r5, r1
@@ -65496,7 +65496,7 @@ func_ov61_02174298: ; 0x02174298
 	cmpne r3, #0
 	addeq sp, sp, #0xc
 	moveq r0, #4
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	mov r1, r2, lsr #0x18
 	mov r0, r2, lsr #0x8
 	mov r7, r2, lsl #0x8
@@ -65512,13 +65512,13 @@ func_ov61_02174298: ; 0x02174298
 	cmp r0, #0xe0000000
 	addeq sp, sp, #0xc
 	moveq r0, #4
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	add r1, sp, #8
 	mov r0, r6
 	bl func_ov61_02173cfc
 	cmp r0, #0
 	addne sp, sp, #0xc
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	ldr r1, [sp, #0x2c]
 	ldr r0, [sp, #8]
 	ldr r2, [sp, #0x28]
@@ -65533,7 +65533,7 @@ func_ov61_02174298: ; 0x02174298
 	bl func_ov61_02176630
 	add sp, sp, #0xc
 	mov r0, r4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _02174370:
 	ldr r0, [sp, #0x34]
 	cmp r0, #0
@@ -65543,7 +65543,7 @@ _02174370:
 	add sp, sp, #0xc
 	strne r0, [r5]
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _02174394:
 	ldr r1, [sp, #8]
 	mov r8, #1
@@ -65558,14 +65558,14 @@ _021743b0:
 	ldr r0, [sp, #8]
 	ldr r0, [r0, #0xc]
 	cmp r0, #5
-	movge sb, r8
-	movlt sb, r7
-	cmp sb, #0
+	movge r9, r8
+	movlt r9, r7
+	cmp r9, #0
 	bne _021743dc
 	mov r0, r4
 	bl func_ov61_02166640
 _021743dc:
-	cmp sb, #0
+	cmp r9, #0
 	beq _021743b0
 	ldr r1, [sp, #8]
 	ldr r0, [r1, #0x24]
@@ -65578,7 +65578,7 @@ _021743dc:
 	ldr r0, [sp, #8]
 	ldr r0, [r0, #0x18]
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	arm_func_end func_ov61_02174298
 
 	.global func_ov61_02174414
@@ -66364,10 +66364,10 @@ _02174d78: .word func_ov61_021745cc
 	.global func_ov61_02174d7c
 	arm_func_start func_ov61_02174d7c
 func_ov61_02174d7c: ; 0x02174d7c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #0x10
-	mov sb, r0
-	ldr r0, [sb, #0x5c]
+	mov r9, r0
+	ldr r0, [r9, #0x5c]
 	mov r8, r1
 	mov r7, r2
 	mov r6, r3
@@ -66378,7 +66378,7 @@ func_ov61_02174d7c: ; 0x02174d7c
 	mov r10, #0
 	ble _02174df8
 _02174db0:
-	ldr r0, [sb, #0x5c]
+	ldr r0, [r9, #0x5c]
 	mov r1, r10
 	bl func_ov61_02165a70
 	ldrh r0, [r0, #0xc]
@@ -66388,7 +66388,7 @@ _02174db0:
 	str r0, [r5]
 	add sp, sp, #0x10
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _02174ddc:
 	mov r1, r7
 	bl func_ov61_021745cc
@@ -66398,56 +66398,56 @@ _02174ddc:
 	cmp r10, r4
 	blt _02174db0
 _02174df8:
-	add r0, sb, #0x44
+	add r0, r9, #0x44
 	bl func_ov61_021731f0
 	ldr r2, [sp, #0x30]
 	cmp r0, r2
 	movlt r0, #1
 	addlt sp, sp, #0x10
 	strlt r0, [r5]
-	ldmltia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
-	ldr r0, [sb, #0x4c]
+	ldmltia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
+	ldr r0, [r9, #0x4c]
 	add r1, sp, #0
 	str r2, [sp, #4]
 	str r8, [sp, #8]
 	strh r7, [sp, #0xc]
 	str r0, [sp]
-	ldr r0, [sb, #0x5c]
+	ldr r0, [r9, #0x5c]
 	ldr r2, _02174f2c ; =func_ov61_02174d68
 	bl func_ov61_02165bdc
-	ldr r0, [sb, #0x5c]
+	ldr r0, [r9, #0x5c]
 	bl func_ov61_02165a68
 	add r1, r4, #1
 	cmp r1, r0
 	movne r0, #1
 	addne sp, sp, #0x10
 	strne r0, [r5]
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	ldr r2, [sp, #0x30]
 	mov r1, r6
-	add r0, sb, #0x44
+	add r0, r9, #0x44
 	bl func_ov61_021732bc
 	cmp r4, #0
 	bne _02174ea0
 	sub r0, r7, #1
 	mov r2, r0, lsl #0x10
-	ldrh r1, [sb, #0x66]
-	mov r0, sb
+	ldrh r1, [r9, #0x66]
+	mov r0, r9
 	mov r2, r2, lsr #0x10
 	bl func_ov61_02175f78
 	cmp r0, #0
 	bne _02174f18
 	add sp, sp, #0x10
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _02174ea0:
-	ldr r0, [sb, #0x5c]
+	ldr r0, [r9, #0x5c]
 	mov r1, r4
 	bl func_ov61_02165a70
 	ldrh r0, [r0, #0xc]
 	cmp r0, r7
 	bne _02174f18
-	ldr r0, [sb, #0x5c]
+	ldr r0, [r9, #0x5c]
 	sub r1, r4, #1
 	bl func_ov61_02165a70
 	mov r4, r0
@@ -66463,20 +66463,20 @@ _02174ea0:
 	mov r2, r0, lsl #0x10
 	add r0, r1, #1
 	mov r1, r0, lsl #0x10
-	mov r0, sb
+	mov r0, r9
 	mov r1, r1, lsr #0x10
 	mov r2, r2, lsr #0x10
 	bl func_ov61_02175f78
 	cmp r0, #0
 	addeq sp, sp, #0x10
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 _02174f18:
 	mov r0, #0
 	str r0, [r5]
 	mov r0, #1
 	add sp, sp, #0x10
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02174d7c
 _02174f2c: .word func_ov61_02174d68
@@ -66484,21 +66484,21 @@ _02174f2c: .word func_ov61_02174d68
 	.global func_ov61_02174f30
 	arm_func_start func_ov61_02174f30
 func_ov61_02174f30: ; 0x02174f30
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
-	mov sb, r0
-	ldr r0, [sb, #0x5c]
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
+	mov r9, r0
+	ldr r0, [r9, #0x5c]
 	ldmia r1, {r4, r5}
 	mov r1, r2
 	mov r8, #0
 	bl func_ov61_02165cec
-	ldr r0, [sb, #0x5c]
+	ldr r0, [r9, #0x5c]
 	bl func_ov61_02165a68
 	mov r6, r0
 	cmp r6, #0
 	mov r7, r8
 	ble _02174fa0
 _02174f64:
-	ldr r0, [sb, #0x5c]
+	ldr r0, [r9, #0x5c]
 	mov r1, r7
 	bl func_ov61_02165a70
 	ldr r1, [r0]
@@ -66517,9 +66517,9 @@ _02174f94:
 _02174fa0:
 	mov r1, r4
 	mov r2, r5
-	add r0, sb, #0x44
+	add r0, r9, #0x44
 	bl func_ov61_02173344
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	arm_func_end func_ov61_02174f30
 
 	.global func_ov61_02174fb4
@@ -66698,7 +66698,7 @@ _021751cc:
 	.global func_ov61_021751f4
 	arm_func_start func_ov61_021751f4
 func_ov61_021751f4: ; 0x021751f4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	mov r7, r1
 	mov r4, r0
 	mov r0, r7
@@ -66722,17 +66722,17 @@ _0217523c:
 	cmp r0, #0
 	movne r0, #1
 	moveq r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _02175254:
 	ldr r0, [r4, #0x60]
 	bl func_ov61_02165a68
 	mov r8, r0
 	cmp r8, #0
-	mov sb, #0
+	mov r9, #0
 	ble _021752c8
 _0217526c:
 	ldr r0, [r4, #0x60]
-	mov r1, sb
+	mov r1, r9
 	bl func_ov61_02165a70
 	mov r5, r0
 	ldrh r0, [r5, #8]
@@ -66750,14 +66750,14 @@ _0217526c:
 	bl func_ov61_02176080
 	cmp r0, #0
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _021752bc:
-	add sb, sb, #1
-	cmp sb, r8
+	add r9, r9, #1
+	cmp r9, r8
 	blt _0217526c
 _021752c8:
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	arm_func_end func_ov61_021751f4
 
 	.global func_ov61_021752d0
@@ -66890,7 +66890,7 @@ _02175458:
 	.global func_ov61_02175460
 	arm_func_start func_ov61_02175460
 func_ov61_02175460: ; 0x02175460
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x18
 	ldr r5, [sp, #0x38]
 	mov r6, r3
@@ -66898,10 +66898,10 @@ func_ov61_02175460: ; 0x02175460
 	mov r7, r2
 	mov r1, r6
 	mov r2, r5
-	mov sb, r0
+	mov r9, r0
 	bl func_ov61_0217616c
 	str r0, [sp, #0x14]
-	ldr r0, [sb, #0x2c]
+	ldr r0, [r9, #0x2c]
 	cmp r0, #0
 	beq _021754cc
 	mov r0, #0
@@ -66909,14 +66909,14 @@ func_ov61_02175460: ; 0x02175460
 	str r7, [sp, #8]
 	str r0, [sp, #0xc]
 	ldr r1, [sp, #0x14]
-	mov r0, sb
+	mov r0, r9
 	mov r2, r6
 	mov r3, r5
 	bl func_ov61_02173ae0
 	cmp r0, #0
 	addeq sp, sp, #0x18
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _021754cc:
 	cmp r7, #2
 	ble _021754f0
@@ -66934,7 +66934,7 @@ _021754f4:
 	cmp r0, #0
 	bne _021755f8
 	add ip, sp, #0x10
-	mov r0, sb
+	mov r0, r9
 	mov r1, r6
 	mov r2, r5
 	mov r3, r8
@@ -66943,12 +66943,12 @@ _021754f4:
 	cmp r0, #0
 	addeq sp, sp, #0x18
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	ldr r0, [sp, #0x10]
 	cmp r0, #0
 	addne sp, sp, #0x18
 	movne r0, #1
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	cmp r4, #0
 	beq _02175554
 	ldrb r0, [r8, #2]
@@ -66961,26 +66961,26 @@ _02175554:
 	cmp r0, #0x68
 	beq _02175588
 _02175568:
-	mov r0, sb
+	mov r0, r9
 	mov r1, r6
 	mov r2, r5
 	bl func_ov61_02176034
 	cmp r0, #0
 	addeq sp, sp, #0x18
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _02175588:
 	add sp, sp, #0x18
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _02175594:
-	ldr r0, [sb, #0x20]
+	ldr r0, [r9, #0x20]
 	cmp r0, #0
 	addeq sp, sp, #0x18
 	moveq r0, #1
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	add r1, sp, #0x14
-	mov r0, sb
+	mov r0, r9
 	mov r2, r6
 	mov r3, r5
 	bl func_ov61_02173d2c
@@ -66988,18 +66988,18 @@ _02175594:
 	beq _021755f8
 	cmp r0, #5
 	beq _021755ec
-	mov r0, sb
+	mov r0, r9
 	mov r1, r6
 	mov r2, r5
 	bl func_ov61_02176034
 	cmp r0, #0
 	addeq sp, sp, #0x18
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _021755ec:
 	add sp, sp, #0x18
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _021755f8:
 	ldr r5, [sp, #0x14]
 	ldr r0, [r5, #0xc]
@@ -67016,11 +67016,11 @@ _0217561c:
 	cmp r0, #0
 	addeq sp, sp, #0x18
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _02175634:
 	add sp, sp, #0x18
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _02175640:
 	cmp r4, #0
 	beq _02175670
@@ -67045,7 +67045,7 @@ _02175670:
 	movne r0, #1
 	add sp, sp, #0x18
 	moveq r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _0217569c:
 	ldrb r1, [r8, #2]
 	cmp r1, #0
@@ -67056,7 +67056,7 @@ _0217569c:
 	movne r0, #1
 	add sp, sp, #0x18
 	moveq r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _021756c4:
 	cmp r1, #8
 	mov r0, r5
@@ -67068,7 +67068,7 @@ _021756c4:
 	movne r0, #1
 	add sp, sp, #0x18
 	moveq r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _021756f0:
 	mov r3, r7
 	bl func_ov61_021753a8
@@ -67076,7 +67076,7 @@ _021756f0:
 	movne r0, #1
 	moveq r0, #0
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02175460
 _0217570c: .word data_ov61_0217e0e4
@@ -67158,7 +67158,7 @@ _02175804:
 	.global func_ov61_02175810
 	arm_func_start func_ov61_02175810
 func_ov61_02175810: ; 0x02175810
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x5f0
 	mov r10, r0
 	ldr r0, [r10]
@@ -67169,11 +67169,11 @@ func_ov61_02175810: ; 0x02175810
 	sub r4, r5, #0x14
 	add r6, r5, #0xe
 	add r7, sp, #0x14
-	mov sb, #8
+	mov r9, #8
 	add r8, sp, #0xc
 	add r11, sp, #8
 _02175848:
-	str sb, [sp, #8]
+	str r9, [sp, #8]
 	stmia sp, {r8, r11}
 	ldr r0, [r10]
 	ldr r2, _0217593c ; =0x000005dc
@@ -67202,7 +67202,7 @@ _02175848:
 	bne _02175920
 	add sp, sp, #0x5f0
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _021758c0:
 	cmp r0, r4
 	beq _02175920
@@ -67210,7 +67210,7 @@ _021758c0:
 	bl func_ov61_02176968
 	add sp, sp, #0x5f0
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _021758dc:
 	ldrh ip, [sp, #0xe]
 	mov r0, r10
@@ -67228,7 +67228,7 @@ _021758dc:
 	cmp r0, #0
 	addeq sp, sp, #0x5f0
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02175920:
 	ldr r0, [r10]
 	bl func_ov61_02166914
@@ -67237,7 +67237,7 @@ _02175920:
 _02175930:
 	mov r0, #1
 	add sp, sp, #0x5f0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02175810
 _0217593c: .word 0x000005dc
@@ -67628,9 +67628,9 @@ func_ov61_02175df0: ; 0x02175df0
 	.global func_ov61_02175e4c
 	arm_func_start func_ov61_02175e4c
 func_ov61_02175e4c: ; 0x02175e4c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	mov r7, r2
-	mov sb, r0
+	mov r9, r0
 	mov r8, r1
 	cmp r7, #2
 	blt _02175e7c
@@ -67641,44 +67641,44 @@ func_ov61_02175e4c: ; 0x02175e4c
 	cmp r0, #0
 	beq _02175e9c
 _02175e7c:
-	mov r0, sb
+	mov r0, r9
 	mov r1, r8
 	mov r2, r7
 	bl func_ov61_02173eb8
 	cmp r0, #0
 	moveq r0, #0
 	movne r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _02175e9c:
 	add r6, r7, #2
-	add r0, sb, #0x50
+	add r0, r9, #0x50
 	bl func_ov61_021731f0
 	cmp r0, r6
 	movlt r0, #1
-	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmltia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	ldr r1, _02175f10 ; =data_ov61_0217e0e4
-	add r0, sb, #0x50
-	ldr r5, [sb, #0x50]
-	ldr r4, [sb, #0x58]
+	add r0, r9, #0x50
+	ldr r5, [r9, #0x50]
+	ldr r4, [r9, #0x58]
 	mov r2, #2
 	bl func_ov61_021732bc
 	mov r1, r8
 	mov r2, r7
-	add r0, sb, #0x50
+	add r0, r9, #0x50
 	bl func_ov61_021732bc
-	mov r0, sb
+	mov r0, r9
 	mov r2, r6
 	add r1, r5, r4
 	bl func_ov61_02173eb8
 	cmp r0, #0
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	mov r2, r6
-	add r0, sb, #0x50
+	add r0, r9, #0x50
 	mvn r1, #0
 	bl func_ov61_02173344
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02175e4c
 _02175f10: .word data_ov61_0217e0e4
@@ -68556,7 +68556,7 @@ _02176a50: .word data_ov61_0217e120
 	.global func_ov61_02176a54
 	arm_func_start func_ov61_02176a54
 func_ov61_02176a54: ; 0x02176a54
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x104
 	movs r8, r0
 	mov r7, r1
@@ -68575,8 +68575,8 @@ func_ov61_02176a54: ; 0x02176a54
 	moveq r8, #0
 	moveq r4, r8
 	beq _02176adc
-	sub sb, r5, r8
-	cmp sb, #0x100
+	sub r9, r5, r8
+	cmp r9, #0x100
 	blt _02176ac0
 	ldr r0, _02176bc4 ; =data_ov61_0217e124
 	ldr r1, _02176bc8 ; =data_ov61_0217e144
@@ -68586,11 +68586,11 @@ func_ov61_02176a54: ; 0x02176a54
 _02176ac0:
 	add r0, sp, #0
 	mov r1, r8
-	mov r2, sb
+	mov r2, r9
 	bl func_02043594
 	add r8, sp, #0
 	mov r0, #0
-	strb r0, [r8, sb]
+	strb r0, [r8, r9]
 _02176adc:
 	ldrsb r0, [r5, #1]
 	add r3, r5, #1
@@ -68614,7 +68614,7 @@ _02176b18:
 	cmp r0, #0
 	addeq sp, sp, #0x104
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	ldrsb r0, [r3, #1]!
 	cmp r0, #0
 	bne _02176af4
@@ -68629,7 +68629,7 @@ _02176b34:
 _02176b50:
 	add sp, sp, #0x104
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 _02176b5c:
 	mov r0, r0, lsl #0x10
 	mov r5, r0, lsr #0x10
@@ -68647,7 +68647,7 @@ _02176b64:
 	cmp r0, #0
 	addeq sp, sp, #0x104
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	ldr r0, [r0, #0xc]
 	ldr r0, [r0]
 	ldr r4, [r0]
@@ -68658,7 +68658,7 @@ _02176ba8:
 	strneh r5, [r6]
 	mov r0, #1
 	add sp, sp, #0x104
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02176a54
 _02176bc4: .word data_ov61_0217e124
@@ -69328,19 +69328,19 @@ _02177440:
 	.global func_ov61_02177454
 	arm_func_start func_ov61_02177454
 func_ov61_02177454: ; 0x02177454
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, lr}
 	sub sp, sp, #0x1c
 	mov r2, #8
-	mov sb, r0
+	mov r9, r0
 	str r2, [sp, #0x10]
-	ldr r1, [sb, #0x10]
+	ldr r1, [r9, #0x10]
 	cmp r1, #4
 	bne _02177480
 	bl func_ov61_02176d58
 	add sp, sp, #0x1c
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 _02177480:
-	ldr r0, [sb]
+	ldr r0, [r9]
 	sub r1, r2, #9
 	cmp r0, r1
 	beq _021774fc
@@ -69356,7 +69356,7 @@ _021774a8:
 	beq _021774fc
 	str r8, [sp]
 	str r7, [sp, #4]
-	ldr r0, [sb]
+	ldr r0, [r9]
 	mov r1, r6
 	mov r2, r5
 	mov r3, r4
@@ -69367,59 +69367,59 @@ _021774a8:
 	mov r0, r6
 	mov r2, r8
 	bl func_ov61_021779dc
-	ldr r0, [sb, #0x10]
+	ldr r0, [r9, #0x10]
 	cmp r0, #4
-	ldrne r0, [sb]
+	ldrne r0, [r9]
 	cmpne r0, r10
 	bne _021774a8
 _021774fc:
-	ldr r0, [sb, #0x10]
+	ldr r0, [r9, #0x10]
 	cmp r0, #0
 	cmpne r0, #2
 	bne _02177574
 	bl func_ov61_021665e8
-	ldr r1, [sb, #0x28]
+	ldr r1, [r9, #0x28]
 	cmp r0, r1
 	bls _02177574
-	ldr r1, [sb, #0x20]
-	ldr r0, [sb, #0x24]
+	ldr r1, [r9, #0x20]
+	ldr r0, [r9, #0x24]
 	cmp r1, r0
 	ble _02177550
 	mov r0, #2
-	ldr r3, [sb, #0x3c]
-	ldr r4, [sb, #0x38]
+	ldr r3, [r9, #0x3c]
+	ldr r4, [r9, #0x38]
 	sub r1, r0, #3
 	mov r2, #0
 	blx r4
-	ldr r0, [sb, #8]
+	ldr r0, [r9, #8]
 	bl func_ov61_0217741c
 	b _02177574
 _02177550:
 	add r0, r1, #1
-	str r0, [sb, #0x20]
-	ldr r0, [sb, #0x10]
+	str r0, [r9, #0x20]
+	ldr r0, [r9, #0x10]
 	cmp r0, #0
-	mov r0, sb
+	mov r0, r9
 	bne _02177570
 	bl func_ov61_02176efc
 	b _02177574
 _02177570:
 	bl func_ov61_02177144
 _02177574:
-	ldr r0, [sb, #0x10]
+	ldr r0, [r9, #0x10]
 	cmp r0, #3
 	bne _021775f4
 	bl func_ov61_021665e8
-	ldr r1, [sb, #0x28]
+	ldr r1, [r9, #0x28]
 	cmp r0, r1
 	bls _021775f4
-	ldr r1, [sb, #4]
+	ldr r1, [r9, #4]
 	mvn r0, #0
 	cmp r1, r0
 	bne _021775ec
 	mov r0, #2
 	strb r0, [sp, #9]
-	ldrh r1, [sb, #0x30]
+	ldrh r1, [r9, #0x30]
 	add r2, sp, #8
 	mov r0, #0
 	mov r3, r1, asr #0x8
@@ -69428,37 +69428,37 @@ _02177574:
 	and r1, r1, #0xff00
 	orr r1, r3, r1
 	strh r1, [sp, #0xa]
-	ldr r1, [sb, #0x2c]
+	ldr r1, [r9, #0x2c]
 	str r1, [sp, #0xc]
-	ldr r1, [sb]
-	ldr r3, [sb, #0x3c]
-	ldr r4, [sb, #0x38]
+	ldr r1, [r9]
+	ldr r3, [r9, #0x3c]
+	ldr r4, [r9, #0x38]
 	blx r4
 	mvn r0, #0
-	str r0, [sb]
+	str r0, [r9]
 _021775ec:
-	ldr r0, [sb, #8]
+	ldr r0, [r9, #8]
 	bl func_ov61_0217741c
 _021775f4:
-	ldr r0, [sb, #0x10]
+	ldr r0, [r9, #0x10]
 	cmp r0, #1
 	addne sp, sp, #0x1c
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	bl func_ov61_021665e8
-	ldr r1, [sb, #0x28]
+	ldr r1, [r9, #0x28]
 	cmp r0, r1
 	addls sp, sp, #0x1c
-	ldmlsia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmlsia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	mov r0, #1
-	ldr r3, [sb, #0x3c]
-	ldr r4, [sb, #0x38]
+	ldr r3, [r9, #0x3c]
+	ldr r4, [r9, #0x38]
 	sub r1, r0, #2
 	mov r2, #0
 	blx r4
-	ldr r0, [sb, #8]
+	ldr r0, [r9, #8]
 	bl func_ov61_0217741c
 	add sp, sp, #0x1c
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02177454
 _02177640: .word data_ov61_021815cc
@@ -70012,7 +70012,7 @@ _02177d78: .word data_ov61_0217e1a0
 	.global func_ov61_02177d7c
 	arm_func_start func_ov61_02177d7c
 func_ov61_02177d7c: ; 0x02177d7c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x14
 	mov r1, #8
 	mov r10, r0
@@ -70020,21 +70020,21 @@ func_ov61_02177d7c: ; 0x02177d7c
 	ldr r0, [r10, #0xc4]
 	cmp r0, #0
 	addeq sp, sp, #0x14
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r0, [r10]
 	bl func_ov61_02166914
 	cmp r0, #0
 	addeq sp, sp, #0x14
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	mov r5, #0
 	ldr r7, _02177e24 ; =data_ov61_02181824
-	add sb, sp, #0xc
+	add r9, sp, #0xc
 	add r8, sp, #8
 	mov r6, #0xff
 	mov r11, r5
 	mvn r4, #0
 _02177dd0:
-	str sb, [sp]
+	str r9, [sp]
 	str r8, [sp, #4]
 	ldr r0, [r10]
 	mov r1, r7
@@ -70046,7 +70046,7 @@ _02177dd0:
 	beq _02177e0c
 	mov r0, r10
 	mov r1, r7
-	mov r3, sb
+	mov r3, r9
 	strb r5, [r7, r2]
 	bl func_ov61_02178d08
 _02177e0c:
@@ -70055,7 +70055,7 @@ _02177e0c:
 	cmp r0, #0
 	bne _02177dd0
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02177d7c
 _02177e24: .word data_ov61_02181824
@@ -70396,7 +70396,7 @@ func_ov61_02178208: ; 0x02178208
 	.global func_ov61_02178250
 	arm_func_start func_ov61_02178250
 func_ov61_02178250: ; 0x02178250
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #8
 	mov r7, r1
 	mov r8, r0
@@ -70434,12 +70434,12 @@ _0217827c:
 	strb ip, [sp, #1]
 	strb r2, [sp, #2]
 	strb r1, [sp, #3]
-	mov sb, #0
+	mov r9, #0
 _021782e4:
 	ldrb r0, [r5], #1
 	bl func_ov61_02178208
-	add sb, sb, #1
-	cmp sb, #3
+	add r9, r9, #1
+	cmp r9, #3
 	strb r0, [r6], #1
 	ble _021782e4
 	cmp r4, r7
@@ -70448,18 +70448,18 @@ _02178304:
 	mov r0, #0
 	strb r0, [r6]
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	arm_func_end func_ov61_02178250
 
 	.global func_ov61_02178314
 	arm_func_start func_ov61_02178314
 func_ov61_02178314: ; 0x02178314
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x104
 	str r1, [sp]
 	add r4, sp, #4
 	mov r10, r0
-	mov sb, r2
+	mov r9, r2
 	mov r8, r3
 	mov r1, #0
 _02178334:
@@ -70501,10 +70501,10 @@ _02178360:
 	mov r7, r6
 	mov r5, r6
 	addle sp, sp, #0x104
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r4, sp, #4
 _021783d0:
-	ldrb r0, [sb, r5]
+	ldrb r0, [r9, r5]
 	add r0, r6, r0
 	add r0, r0, #1
 	mov r1, r0, lsr #0x1f
@@ -70529,15 +70529,15 @@ _021783d0:
 	rsb r0, r1, r0, lsl #24
 	add r0, r1, r0, ror #24
 	and r0, r0, #0xff
-	ldrb r1, [sb, r5]
+	ldrb r1, [r9, r5]
 	ldrb r0, [r4, r0]
 	cmp r8, r2, asr #16
 	eor r0, r1, r0
-	strb r0, [sb, r5]
+	strb r0, [r9, r5]
 	mov r5, r2, asr #0x10
 	bgt _021783d0
 	add sp, sp, #0x104
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	arm_func_end func_ov61_02178314
 
 	.global func_ov61_02178458
@@ -70655,25 +70655,25 @@ _021785d4: .word data_ov61_0217e320
 	.global func_ov61_021785d8
 	arm_func_start func_ov61_021785d8
 func_ov61_021785d8: ; 0x021785d8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x10c
 	movs r11, r3
 	mov r3, #0
 	ldr r7, [sp, #0x130]
 	str r3, [sp, #0x108]
 	mov r10, r0
-	mov sb, r1
+	mov r9, r1
 	mov r8, r2
 	addeq sp, sp, #0x10c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	sub r0, r8, #1
 	cmp r0, #1
 	bhi _02178684
-	ldr r0, [sb, #0x800]
+	ldr r0, [r9, #0x800]
 	rsb r0, r0, #0x800
 	cmp r0, #2
 	addlo sp, sp, #0x10c
-	ldmloia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmloia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	ldr r1, [r10, #0x10c]
 	ldr r2, [r10, #0x98]
 	mov r0, r8
@@ -70689,14 +70689,14 @@ func_ov61_021785d8: ; 0x021785d8
 	strh r0, [sp, #4]
 	add r0, sp, #4
 	ldrb r1, [r0]
-	ldr r2, [sb, #0x800]
+	ldr r2, [r9, #0x800]
 	ldrb r0, [r0, #1]
-	add r3, sb, r2
-	strb r1, [sb, r2]
+	add r3, r9, r2
+	strb r1, [r9, r2]
 	strb r0, [r3, #1]
-	ldr r0, [sb, #0x800]
+	ldr r0, [r9, #0x800]
 	add r0, r0, #2
-	str r0, [sb, #0x800]
+	str r0, [r9, #0x800]
 	b _0217868c
 _02178684:
 	mov r0, #1
@@ -70719,7 +70719,7 @@ _0217868c:
 _021786c4:
 	ldrb r0, [r7]
 	ldr r1, [r4, r0, lsl #2]
-	mov r0, sb
+	mov r0, r9
 	cmp r1, #0
 	moveq r1, r11
 	bl func_ov61_0217807c
@@ -70728,14 +70728,14 @@ _021786c4:
 	ldrb r0, [r7]
 	ldr r2, [r10, #0x10c]
 	ldr r3, [r10, #0x88]
-	mov r1, sb
-	ldr r6, [sb, #0x800]
+	mov r1, r9
+	ldr r6, [r9, #0x800]
 	blx r3
-	ldr r0, [sb, #0x800]
+	ldr r0, [r9, #0x800]
 	cmp r6, r0
 	bne _02178714
 	ldr r1, _0217882c ; =data_ov61_0217e334
-	mov r0, sb
+	mov r0, r9
 	bl func_ov61_0217807c
 _02178714:
 	ldr r0, [sp, #0x108]
@@ -70744,38 +70744,38 @@ _02178714:
 	add r7, r7, #1
 	blt _021786c4
 _02178728:
-	ldr r1, [sb, #0x800]
+	ldr r1, [r9, #0x800]
 	rsb r0, r1, #0x800
 	cmp r0, #1
 	addlt sp, sp, #0x10c
-	ldmltia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmltia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r0, r1, #1
-	str r0, [sb, #0x800]
+	str r0, [r9, #0x800]
 	mov r0, #0
-	strb r0, [sb, r1]
+	strb r0, [r9, r1]
 	ldr r11, [sp, #0x108]
 	cmp r8, #0
 	add r7, sp, #8
 	addeq sp, sp, #0x10c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02178760:
 	ldr r0, [sp]
 	mov r4, #0
 	cmp r0, #0
 	addle sp, sp, #0x10c
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 _02178774:
 	mov r5, #0
 	cmp r11, #0
 	ble _0217880c
 _02178780:
 	cmp r8, #0
-	ldr r6, [sb, #0x800]
+	ldr r6, [r9, #0x800]
 	bne _021787a4
 	ldrb r0, [r7, r5]
 	ldr r2, [r10, #0x10c]
 	ldr r3, [r10, #0x88]
-	mov r1, sb
+	mov r1, r9
 	blx r3
 	b _021787e8
 _021787a4:
@@ -70785,7 +70785,7 @@ _021787a4:
 	ldr r3, [r10, #0x10c]
 	ldr ip, [r10, #0x8c]
 	mov r1, r4
-	mov r2, sb
+	mov r2, r9
 	blx ip
 	b _021787e8
 _021787c8:
@@ -70795,14 +70795,14 @@ _021787c8:
 	ldr r3, [r10, #0x10c]
 	ldr ip, [r10, #0x90]
 	mov r1, r4
-	mov r2, sb
+	mov r2, r9
 	blx ip
 _021787e8:
-	ldr r0, [sb, #0x800]
+	ldr r0, [r9, #0x800]
 	cmp r6, r0
 	bne _02178800
 	ldr r1, _0217882c ; =data_ov61_0217e334
-	mov r0, sb
+	mov r0, r9
 	bl func_ov61_0217807c
 _02178800:
 	add r5, r5, #1
@@ -70814,7 +70814,7 @@ _0217880c:
 	cmp r4, r0
 	blt _02178774
 	add sp, sp, #0x10c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_021785d8
 _02178824: .word data_ov61_0217e32c
@@ -70902,14 +70902,14 @@ func_ov61_02178888: ; 0x02178888
 	.global func_ov61_02178940
 	arm_func_start func_ov61_02178940
 func_ov61_02178940: ; 0x02178940
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x188
 	mov r8, r2
 	sub r2, r8, #1
 	mov r3, #0
 	cmp r2, #1
 	mov r10, r0
-	mov sb, r1
+	mov r9, r1
 	str r3, [sp, #0x104]
 	movhi r11, #1
 	bhi _02178980
@@ -70929,7 +70929,7 @@ _02178980:
 	str r0, [sp]
 	cmp r1, #0
 	addle sp, sp, #0x188
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	add r6, sp, #4
 _021789b0:
 	ldrb r1, [r6]
@@ -70939,29 +70939,29 @@ _021789b0:
 	ldreq r5, _02178b0c ; =data_ov61_0217e32c
 	cmp r8, #0
 	bne _02178a2c
-	mov r0, sb
+	mov r0, r9
 	mov r1, r5
 	bl func_ov61_0217807c
-	ldr r0, [sb, #0x800]
+	ldr r0, [r9, #0x800]
 	mov r1, #0x5c
-	add r0, sb, r0
+	add r0, r9, r0
 	strb r1, [r0, #-1]
 	ldrb r0, [r6]
 	ldr r2, [r10, #0x10c]
 	ldr r3, [r10, #0x88]
-	mov r1, sb
-	ldr r4, [sb, #0x800]
+	mov r1, r9
+	ldr r4, [r9, #0x800]
 	blx r3
-	ldr r0, [sb, #0x800]
+	ldr r0, [r9, #0x800]
 	cmp r4, r0
 	bne _02178a18
 	ldr r1, _02178b10 ; =data_ov61_0217e334
-	mov r0, sb
+	mov r0, r9
 	bl func_ov61_0217807c
 _02178a18:
-	ldr r0, [sb, #0x800]
+	ldr r0, [r9, #0x800]
 	mov r1, #0x5c
-	add r0, sb, r0
+	add r0, r9, r0
 	strb r1, [r0, #-1]
 	b _02178ae4
 _02178a2c:
@@ -70974,19 +70974,19 @@ _02178a38:
 	mov r2, r5
 	mov r3, r4
 	bl func_020459b8
-	mov r0, sb
+	mov r0, r9
 	add r1, sp, #0x108
 	bl func_ov61_0217807c
-	ldr r0, [sb, #0x800]
+	ldr r0, [r9, #0x800]
 	cmp r8, #1
-	add r1, sb, r0
+	add r1, r9, r0
 	mov r0, #0x5c
 	strb r0, [r1, #-1]
-	ldr r7, [sb, #0x800]
+	ldr r7, [r9, #0x800]
 	bne _02178a90
 	ldrb r0, [r6]
 	mov r1, r4
-	mov r2, sb
+	mov r2, r9
 	ldr r3, [r10, #0x10c]
 	ldr ip, [r10, #0x8c]
 	blx ip
@@ -70996,21 +70996,21 @@ _02178a90:
 	bne _02178ab0
 	ldrb r0, [r6]
 	mov r1, r4
-	mov r2, sb
+	mov r2, r9
 	ldr r3, [r10, #0x10c]
 	ldr ip, [r10, #0x90]
 	blx ip
 _02178ab0:
-	ldr r0, [sb, #0x800]
+	ldr r0, [r9, #0x800]
 	cmp r7, r0
 	bne _02178ac8
 	ldr r1, _02178b10 ; =data_ov61_0217e334
-	mov r0, sb
+	mov r0, r9
 	bl func_ov61_0217807c
 _02178ac8:
-	ldr r0, [sb, #0x800]
+	ldr r0, [r9, #0x800]
 	add r4, r4, #1
-	add r1, sb, r0
+	add r1, r9, r0
 	mov r0, #0x5c
 	strb r0, [r1, #-1]
 	cmp r4, r11
@@ -71024,7 +71024,7 @@ _02178ae4:
 	add r6, r6, #1
 	blt _021789b0
 	add sp, sp, #0x188
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02178940
 _02178b08: .word data_ov61_0217e4e8
@@ -71182,7 +71182,7 @@ _02178d04: .word 0x66666667
 	.global func_ov61_02178d08
 	arm_func_start func_ov61_02178d08
 func_ov61_02178d08: ; 0x02178d08
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	sub sp, sp, #0x810
 	movs r8, r0
 	mov r0, #0
@@ -71197,13 +71197,13 @@ func_ov61_02178d08: ; 0x02178d08
 	ldr r3, [r8, #0xd4]
 	cmp r3, #0
 	addeq sp, sp, #0x810
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	mov r0, r1
 	mov r1, r7
 	mov r2, r6
 	blx r3
 	add sp, sp, #0x810
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _02178d60:
 	cmp r0, #0x5c
 	bne _02178d9c
@@ -71219,31 +71219,31 @@ _02178d60:
 	mov r3, #0
 	bl func_ov61_02166c04
 	add sp, sp, #0x810
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _02178d9c:
 	cmp r7, #7
 	addlt sp, sp, #0x810
-	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmltia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	and r0, r0, #0xff
 	cmp r0, #0xfe
 	ldreqb r0, [r1, #1]
 	cmpeq r0, #0xfd
 	addne sp, sp, #0x810
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	ldr r0, [r8, #0xb8]
 	add r4, r1, #3
 	cmp r0, #0
 	movgt r0, #0
 	strgt r0, [r8, #0xb8]
-	ldrsb sb, [r1, #2]
+	ldrsb r9, [r1, #2]
 	add r5, r1, #7
 	add r0, sp, #0xc
-	mov r1, sb
+	mov r1, r9
 	mov r2, r4
 	sub r7, r7, #7
 	bl func_ov61_02178458
-	cmp sb, #8
-	addls pc, pc, sb, lsl #2
+	cmp r9, #8
+	addls pc, pc, r9, lsl #2
 	b _02178fe8
 _02178dfc: ; jump table
 	b _02178e20 ; case 0
@@ -71299,7 +71299,7 @@ _02178eac:
 	mvn r0, #0
 	cmp r1, r0
 	addeq sp, sp, #0x810
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	mov r2, #0
 	str r2, [sp, #8]
 _02178ec8:
@@ -71308,14 +71308,14 @@ _02178ec8:
 	ldrsb r0, [r0, #0x84]
 	cmp r1, r0
 	addne sp, sp, #0x810
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	add r2, r2, #1
 	str r2, [sp, #8]
 	cmp r2, #4
 	blt _02178ec8
 	cmp r7, #2
 	addlt sp, sp, #0x810
-	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmltia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	mvn r0, #0
 	str r0, [r8, #0xb8]
 	ldrsb r0, [r5]
@@ -71324,7 +71324,7 @@ _02178ec8:
 	add r1, r5, #1
 	blx r3
 	add sp, sp, #0x810
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _02178f20:
 	mov r2, #0
 	str r2, [sp, #8]
@@ -71334,14 +71334,14 @@ _02178f28:
 	ldrsb r0, [r0, #0x84]
 	cmp r1, r0
 	addne sp, sp, #0x810
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	add r2, r2, #1
 	str r2, [sp, #8]
 	cmp r2, #4
 	blt _02178f28
 	cmp r7, #4
 	addlt sp, sp, #0x810
-	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmltia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	mov r0, #7
 	strb r0, [sp, #0xc]
 	ldrb r1, [r5]
@@ -71379,7 +71379,7 @@ _02178f28:
 	b _02178ff0
 _02178fe8:
 	add sp, sp, #0x810
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _02178ff0:
 	str r6, [sp]
 	mov r0, #8
@@ -71390,7 +71390,7 @@ _02178ff0:
 	mov r3, #0
 	bl func_ov61_02166c04
 	add sp, sp, #0x810
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02178d08
 _02179018: .word data_ov61_0217e1a0
@@ -71427,11 +71427,11 @@ func_ov61_0217901c: ; 0x0217901c
 	.global func_ov61_0217907c
 	arm_func_start func_ov61_0217907c
 func_ov61_0217907c: ; 0x0217907c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	sub sp, sp, #0x28
 	sub sp, sp, #0x800
 	mov r10, r0
-	mov sb, r1
+	mov r9, r1
 	mov r3, #0
 	add r0, sp, #0x24
 	add r2, r10, #0x84
@@ -71480,13 +71480,13 @@ _0217910c:
 	add r0, sp, #0x24
 	ldreq r1, _02179274 ; =data_ov61_0217e378
 	bl func_ov61_0217807c
-	cmp sb, #0
+	cmp r9, #0
 	beq _02179168
 	ldr r1, _02179278 ; =data_ov61_0217e37c
 	add r0, sp, #0x24
 	bl func_ov61_0217807c
 	add r0, sp, #0x24
-	mov r1, sb
+	mov r1, r9
 	bl func_ov61_02178048
 _02179168:
 	ldr r1, _0217927c ; =data_ov61_0217e38c
@@ -71512,7 +71512,7 @@ _02179168:
 	add r0, sp, #0x24
 	bl func_ov61_02178048
 _021791c0:
-	cmp sb, #2
+	cmp r9, #2
 	beq _021791f0
 	mov r2, #0xff
 	str r2, [sp]
@@ -71547,12 +71547,12 @@ _02179214:
 	bl func_ov61_021665e8
 	str r0, [r10, #0xac]
 	str r0, [r10, #0xb0]
-	cmp sb, #0
+	cmp r9, #0
 	movne r0, #0
 	strne r0, [r10, #0xb4]
 	add sp, sp, #0x28
 	add sp, sp, #0x800
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0217907c
 _0217925c: .word data_ov61_021817cc
@@ -71725,17 +71725,17 @@ func_ov61_02179424: ; 0x02179424
 	.global func_ov61_02179428
 	arm_func_start func_ov61_02179428
 func_ov61_02179428: ; 0x02179428
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	ldr r1, _0217953c ; =data_ov61_0217a5ec
 	mvn r2, #0
 	ldr r1, [r1, #8]
-	mov sb, r0
+	mov r9, r0
 	bl func_ov61_0214231c
 	movs r4, r0
 	mvnmi r0, #0
-	ldmmiia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmmiia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	ldr r1, _0217953c ; =data_ov61_0217a5ec
-	mov r0, sb
+	mov r0, r9
 	ldr r1, [r1, #0xc]
 	mvn r2, #0
 	bl func_ov61_0214231c
@@ -71745,13 +71745,13 @@ func_ov61_02179428: ; 0x02179428
 	ble _02179478
 _02179470:
 	mvn r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _02179478:
 	bl func_ov61_021792ec
 	ldr r1, _0217953c ; =data_ov61_0217a5ec
 	mov r6, r0
 	ldr r1, [r1, #0x14]
-	mov r0, sb
+	mov r0, r9
 	mov r2, #0
 	bl func_ov61_0214231c
 	ldr r1, [r6, #0xe30]
@@ -71759,9 +71759,9 @@ _02179478:
 	rsbmi r0, r0, #0
 	cmp r0, #1
 	mvngt r0, #0
-	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	ldr r1, _0217953c ; =data_ov61_0217a5ec
-	mov r0, sb
+	mov r0, r9
 	ldr r1, [r1, #0x10]
 	mov r2, #4
 	bl func_ov61_0214231c
@@ -71771,14 +71771,14 @@ _02179478:
 	cmpne r7, #1
 	bne _021794f8
 	ldr r1, _0217953c ; =data_ov61_0217a5ec
-	mov r0, sb
+	mov r0, r9
 	ldr r1, [r1, #4]
 	mvn r2, #0
 	bl func_ov61_0214231c
 	ldr r1, [r6, #0xe24]
 	cmp r1, r0
 	mvnne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _021794f8:
 	ldr r0, [r6, #0xe2c]
 	cmp r5, r0
@@ -71791,14 +71791,14 @@ _021794f8:
 	bhi _02179524
 _0217951c:
 	mvn r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 _02179524:
 	ldr r0, [r6, #0xe28]
 	subs r1, r4, r0
 	ldr r0, _02179540 ; =0x00002711
 	rsbmi r1, r1, #0
 	sub r0, r0, r1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02179428
 _0217953c: .word data_ov61_0217a5ec
@@ -71807,39 +71807,39 @@ _02179540: .word 0x00002711
 	.global func_ov61_02179544
 	arm_func_start func_ov61_02179544
 func_ov61_02179544: ; 0x02179544
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, r9, lr}
 	mov r6, r0
 	mov r5, r1
 	bl func_ov61_021792ec
 	mov r4, r0
 	cmp r6, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	cmp r5, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	mov r0, #0x88
-	mov sb, #0
-	mul r7, sb, r0
+	mov r9, #0
+	mul r7, r9, r0
 	ldr r8, _021795ec ; =data_ov61_02181940
 	mov r6, r0
 	ldr r5, _021795f0 ; =0x00002710
 	b _021795b8
 _02179584:
-	mov r0, sb
+	mov r0, r9
 	bl func_ov61_0213f4ac
 	cmp r0, #0
 	beq _021795b0
-	mov r0, sb
+	mov r0, r9
 	mov r2, r6
 	add r1, r8, r7
 	bl func_ov61_0214a578
-	mov r0, sb
+	mov r0, r9
 	mov r1, r5
 	bl func_ov61_0214a6d0
 _021795b0:
-	add r0, sb, #1
-	and sb, r0, #0xff
+	add r0, r9, #1
+	and r9, r0, #0xff
 _021795b8:
-	cmp sb, #2
+	cmp r9, #2
 	blo _02179584
 	ldr r0, _021795f4 ; =func_ov61_0217968c
 	bl func_ov61_0214a604
@@ -71852,7 +71852,7 @@ _021795b8:
 _021795e0:
 	mov r0, #7
 	str r0, [r4, #0xe3c]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, r9, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02179544
 _021795ec: .word data_ov61_02181940

--- a/asm/ov61.s
+++ b/asm/ov61.s
@@ -1444,10 +1444,10 @@ _0213f0dc: .word func_ov61_0213fa98
 	.global func_ov61_0213f0e0
 	arm_func_start func_ov61_0213f0e0
 func_ov61_0213f0e0: ; 0x0213f0e0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x90
 	mov r4, r0
-	mov sl, r1
+	mov r10, r1
 	mov sb, r2
 	mov r11, r3
 	bl func_ov61_0213dfec
@@ -1461,7 +1461,7 @@ func_ov61_0213f0e0: ; 0x0213f0e0
 _0213f118:
 	add sp, sp, #0x90
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0213f124:
 	bl func_ov61_0213f678
 	ldr r0, _0213f284 ; =data_ov61_0217ea4c
@@ -1484,15 +1484,15 @@ _0213f124:
 	ldr r5, [sp, #0xc4]
 	str r0, [sp, #8]
 	mov r0, r4
-	mov r1, sl
+	mov r1, r10
 	mov r3, r11
 	and r2, r2, #0xff
 	str r5, [sp, #0xc]
 	bl func_ov61_02142880
 	b _0213f278
 _0213f190:
-	mov sl, #0
-	mov r5, sl
+	mov r10, #0
+	mov r5, r10
 	bl func_ov61_0214114c
 	cmp r0, #0
 	ble _0213f1c0
@@ -1518,7 +1518,7 @@ _0213f1d8:
 	mov r6, r0
 	ldrb r0, [r5, r6]
 	add r7, r5, r6
-	add sl, sl, #1
+	add r10, r10, #1
 	strb r0, [r4, r8]
 	bl func_ov61_0214114c
 	sub r0, r0, r8
@@ -1550,7 +1550,7 @@ _0213f240:
 	ldr r4, [sp, #0xc4]
 	str r0, [sp, #8]
 	add r0, sp, #0x50
-	mov r1, sl
+	mov r1, r10
 	mov r3, r11
 	and r2, r2, #0xff
 	str r4, [sp, #0xc]
@@ -1558,7 +1558,7 @@ _0213f240:
 _0213f278:
 	mov r0, #1
 	add sp, sp, #0x90
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0213f0e0
 _0213f284: .word data_ov61_0217ea4c
@@ -2514,16 +2514,16 @@ _0213fdb8: .word func_ov61_0214a758
 	.global func_ov61_0213fdbc
 	arm_func_start func_ov61_0213fdbc
 func_ov61_0213fdbc: ; 0x0213fdbc
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #8
 	mov r5, #0
 	mov r11, r0
 	mov sb, r1
-	mov sl, r5
+	mov r10, r5
 	bl func_ov61_02144534
 	cmp r0, #0
 	addne sp, sp, #8
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	cmp sb, #4
 	addls pc, pc, sb, lsl #2
 	b _0213fe20
@@ -2550,7 +2550,7 @@ _0213fe20:
 	bl func_ov61_02174560
 	movs r5, r0
 	addeq sp, sp, #8
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, _02140100 ; =data_ov61_0217ea4c
 	ldrb r4, [r5, #1]
 	ldr r0, [r0]
@@ -2571,7 +2571,7 @@ _0213fe20:
 	cmpeq r4, #0
 	bne _0213fe8c
 _0213fe88:
-	mov sl, #1
+	mov r10, #1
 _0213fe8c:
 	mov r0, r4
 	bl func_ov61_0213f79c
@@ -2602,12 +2602,12 @@ _0213fecc:
 	cmp r0, #2
 	cmpeq r8, #0
 	addne sp, sp, #8
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	bl func_ov61_021443ec
 	mov r0, r5
 	bl func_ov61_02144040
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0213ff14:
 	mov r0, r8
 	mov r1, r6
@@ -2615,14 +2615,14 @@ _0213ff14:
 	bl func_ov61_02143ec4
 	cmp r0, #0
 	addne sp, sp, #8
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	cmp r8, #0
 	beq _0213ff4c
 	mov r0, r8
 	mov r1, r6
 	bl func_ov61_0213e008
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0213ff4c:
 	ldr r0, _02140100 ; =data_ov61_0217ea4c
 	ldr r1, [r0]
@@ -2715,7 +2715,7 @@ _02140058:
 	mov r0, r8
 	ldr r5, [r1, #0x90]
 	mov r1, r7
-	mov r2, sl
+	mov r2, r10
 	mov r3, r4
 	blx r5
 _021400b0:
@@ -2726,17 +2726,17 @@ _021400b0:
 	ldreqb r0, [r1, #0x369]
 	cmpeq r0, #2
 	addeq sp, sp, #8
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldrb r0, [r1, #0x361]
 	cmp r0, #0
 	addne sp, sp, #8
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	bl func_ov61_02176dc0
 	bl func_ov61_02143cd0
 	mov r0, #3
 	bl func_ov61_0213f77c
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0213fdbc
 _021400f8: .word 0xffffe250
@@ -4244,7 +4244,7 @@ _02141450: .word data_ov61_0217ebe0
 	.global func_ov61_02141454
 	arm_func_start func_ov61_02141454
 func_ov61_02141454: ; 0x02141454
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #0x248
 	ldr r2, _021416b8 ; =data_ov61_0217ebe0
 	mov r7, r0
@@ -4327,12 +4327,12 @@ _02141574:
 	ldr r0, [r0]
 	strb r1, [r0, #0x1e]
 _02141584:
-	ldr sl, _021416b8 ; =data_ov61_0217ebe0
-	ldr r0, [sl]
+	ldr r10, _021416b8 ; =data_ov61_0217ebe0
+	ldr r0, [r10]
 	ldrb r0, [r0, #0x1c]
 	cmp r0, r6
 	addge sp, sp, #0x248
-	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmgeia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	add r4, sp, #0x18
 	mov r8, #0xc
 	mvn sb, #0
@@ -4340,14 +4340,14 @@ _021415a8:
 	bl func_ov61_02141168
 	movs r5, r0
 	beq _02141600
-	ldr r1, [sl]
+	ldr r1, [r10]
 	mov r0, r7
 	ldrb r1, [r1, #0x1c]
 	mov r2, r5
 	bl func_ov61_02141750
 	cmp r0, #0
 	bne _02141690
-	ldr r0, [sl]
+	ldr r0, [r10]
 	mov r1, r5
 	ldr r0, [r0, #4]
 	mov r2, r4
@@ -4361,7 +4361,7 @@ _021415a8:
 	b _02141690
 _02141600:
 	bl func_ov61_02140308
-	ldr r1, [sl]
+	ldr r1, [r10]
 	ldrb r2, [r1, #0x1c]
 	mla r1, r2, r8, r7
 	blx func_ov00_02077948
@@ -4395,18 +4395,18 @@ _02141600:
 	ldr r0, [r0]
 	add sp, sp, #0x248
 	strb r1, [r0, #0x1e]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _02141690:
-	ldr r1, [sl]
+	ldr r1, [r10]
 	ldrb r0, [r1, #0x1c]
 	add r0, r0, #1
 	strb r0, [r1, #0x1c]
-	ldr r0, [sl]
+	ldr r0, [r10]
 	ldrb r0, [r0, #0x1c]
 	cmp r0, r6
 	blt _021415a8
 	add sp, sp, #0x248
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02141454
 _021416b8: .word data_ov61_0217ebe0
@@ -4517,13 +4517,13 @@ _021417f8: .word data_ov61_0217ebe0
 	.global func_ov61_021417fc
 	arm_func_start func_ov61_021417fc
 func_ov61_021417fc: ; 0x021417fc
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #8
-	mov sl, r1
+	mov r10, r1
 	mov r11, r0
 	mvn r0, #0
 	str r2, [sp]
-	cmp sl, #0
+	cmp r10, #0
 	str r0, [sp, #4]
 	mov r5, #0
 	ble _021418f4
@@ -4538,7 +4538,7 @@ _0214182c:
 	add r6, r5, #1
 	cmp r4, r0
 	streq r5, [sp, #4]
-	cmp r6, sl
+	cmp r6, r10
 	bge _021418e0
 	mov r0, #0xc
 	mla sb, r6, r0, r11
@@ -4576,19 +4576,19 @@ _021418b0:
 	strb r0, [r1, #0x1d]
 _021418d0:
 	add r6, r6, #1
-	cmp r6, sl
+	cmp r6, r10
 	add sb, sb, #0xc
 	blt _0214185c
 _021418e0:
 	add r5, r5, #1
-	cmp r5, sl
+	cmp r5, r10
 	add r7, r7, #0xc
 	add r8, r8, #0xc
 	blt _0214182c
 _021418f4:
 	ldr r0, [sp, #4]
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_021417fc
 _02141900: .word data_ov61_0217ebe0
@@ -4714,10 +4714,10 @@ _02141a64: .word 0xfffeeaa8
 	.global func_ov61_02141a68
 	arm_func_start func_ov61_02141a68
 func_ov61_02141a68: ; 0x02141a68
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	mov sb, r1
 	ldr r1, [sb]
-	mov sl, r0
+	mov r10, r0
 	mov r8, r2
 	cmp r1, #0
 	bne _02141c38
@@ -4737,7 +4737,7 @@ func_ov61_02141a68: ; 0x02141a68
 	ldr r0, [r7]
 	ldr r0, [r0]
 	cmp r0, #1
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, [sb, #4]
 	mov r4, #0
 	cmp r0, #0
@@ -4762,7 +4762,7 @@ _02141adc:
 	ldr r0, [r0]
 	strb r2, [r0, #0x1e]
 	str r1, [sb, #8]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02141b28:
 	ldr r0, [sb, #4]
 	add r4, r4, #1
@@ -4778,7 +4778,7 @@ _02141b3c:
 	mvn r4, #0
 _02141b54:
 	ldr r1, [sb, #0xc]
-	mov r0, sl
+	mov r0, r10
 	ldr r1, [r1, r5]
 	mov r2, r11
 	bl func_ov61_021677c0
@@ -4817,7 +4817,7 @@ _02141b88:
 	str r1, [sb, #8]
 	ldr r0, [r0]
 	strb r3, [r0, #0x1d]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02141bf4:
 	ldr r0, [sb, #4]
 	add r7, r7, #1
@@ -4827,7 +4827,7 @@ _02141bf4:
 _02141c08:
 	ldr r0, [sb, #8]
 	cmp r0, #0x600
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, _02141ca0 ; =data_ov61_0217ebe0
 	mov r1, #1
 	ldr r3, [r0]
@@ -4836,14 +4836,14 @@ _02141c08:
 	strb r2, [r3, #0x1c]
 	ldr r0, [r0]
 	strb r1, [r0, #0x1e]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02141c38:
 	ldr r0, [sb]
 	cmp r0, #0
 	beq _02141c50
 	bl func_ov61_021419f4
 	cmp r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02141c50:
 	ldr r0, _02141ca0 ; =data_ov61_0217ebe0
 	ldr r1, [r0]
@@ -4855,7 +4855,7 @@ _02141c50:
 	mla r0, r8, r0, r1
 	blx func_ov00_020774c4
 	cmp r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02141c7c:
 	ldr r0, _02141ca0 ; =data_ov61_0217ebe0
 	mov r1, #1
@@ -4865,7 +4865,7 @@ _02141c7c:
 	strb r2, [r3, #0x1c]
 	ldr r0, [r0]
 	strb r1, [r0, #0x1e]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02141a68
 _02141ca0: .word data_ov61_0217ebe0
@@ -4873,15 +4873,15 @@ _02141ca0: .word data_ov61_0217ebe0
 	.global func_ov61_02141ca4
 	arm_func_start func_ov61_02141ca4
 func_ov61_02141ca4: ; 0x02141ca4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x28
 	mov sb, r1
 	ldr r1, [sb]
-	mov sl, r0
+	mov r10, r0
 	cmp r1, #0
 	mov r6, #0
 	addne sp, sp, #0x28
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r4, _02141e4c ; =data_ov61_0217ebe0
 	mov r5, r6
 	ldr r1, [r4]
@@ -4908,7 +4908,7 @@ _02141ce8:
 	cmp r0, #0
 	bne _02141e08
 	ldr r1, [sb, #4]
-	mov r0, sl
+	mov r0, r10
 	bl func_ov61_02167540
 	ldr r0, [r4]
 	ldr r1, [sb, #4]
@@ -4961,7 +4961,7 @@ _02141d80:
 	bl func_0204366c
 	cmp r0, #0
 	bne _02141e08
-	mov r0, sl
+	mov r0, r10
 	mov r1, r8
 	bl func_ov61_02167540
 	mov r6, #1
@@ -4978,13 +4978,13 @@ _02141e20:
 	ldr r0, [sb, #4]
 	bl func_ov61_02141904
 	add sp, sp, #0x28
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02141e38:
 	ldr r1, [sb, #4]
-	mov r0, sl
+	mov r0, r10
 	bl func_ov61_02167590
 	add sp, sp, #0x28
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02141ca4
 _02141e4c: .word data_ov61_0217ebe0
@@ -4993,15 +4993,15 @@ _02141e50: .word data_ov61_0217a6f0
 	.global func_ov61_02141e54
 	arm_func_start func_ov61_02141e54
 func_ov61_02141e54: ; 0x02141e54
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x18
-	mov sl, r1
-	ldr r0, [sl]
+	mov r10, r1
+	ldr r0, [r10]
 	mov r7, #0
 	cmp r0, #0
 	mov r11, #1
 	addne sp, sp, #0x18
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r4, _02141fec ; =data_ov61_0217ebe0
 	mov r6, r7
 	ldr r0, [r4]
@@ -5023,12 +5023,12 @@ _02141e98:
 	add r1, r1, r8
 	blx func_ov00_02077a30
 	mov r0, r5
-	add r1, sl, #0x8e
+	add r1, r10, #0x8e
 	bl strcmp
 	cmp r0, #0
 	bne _02141f98
 	ldr r0, [r4]
-	ldr r1, [sl, #4]
+	ldr r1, [r10, #4]
 	ldr r0, [r0, #0x18]
 	add r0, r0, r8
 	blx func_ov00_02077a10
@@ -5059,7 +5059,7 @@ _02141f34:
 	cmp r0, #1
 	moveq r11, #0
 	beq _02141f98
-	ldr sb, [sl, #4]
+	ldr sb, [r10, #4]
 	bl func_ov61_02140308
 	ldr r1, [r4]
 	ldr r1, [r1, #0x18]
@@ -5087,9 +5087,9 @@ _02141f98:
 _02141fb0:
 	cmp r7, #0
 	addeq sp, sp, #0x18
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, [r0, #0x18]
-	ldr r2, [sl, #4]
+	ldr r2, [r10, #4]
 	bl func_ov61_021417fc
 	cmp r11, #0
 	beq _02141fd4
@@ -5100,7 +5100,7 @@ _02141fd4:
 	ldr r0, [r0]
 	strb r1, [r0, #0x1d]
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02141e54
 _02141fec: .word data_ov61_0217ebe0
@@ -5489,7 +5489,7 @@ _021424f4: .word data_ov61_0217ebe8
 	.global func_ov61_021424f8
 	arm_func_start func_ov61_021424f8
 func_ov61_021424f8: ; 0x021424f8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x28
 	mov r4, r0
 	bl func_ov61_0214a214
@@ -5497,12 +5497,12 @@ func_ov61_021424f8: ; 0x021424f8
 	cmp r0, #0
 	addne sp, sp, #0x28
 	movne r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	bl func_ov61_0214a214
 	str r4, [r0, #0x200]
 	ldr r4, _02142670 ; =func_ov61_021499d0
 	ldr r11, _02142674 ; =func_ov61_02149b18
-	mov sl, #0
+	mov r10, #0
 	mov r5, #1
 _02142534:
 	bl func_ov61_0214a214
@@ -5550,17 +5550,17 @@ _02142534:
 	str r1, [r0, #0x10]
 	cmp r6, #3
 	bne _021425f0
-	cmp sl, #4
+	cmp r10, #4
 	bne _02142604
 _021425f0:
 	mov r0, r6
 	bl func_ov61_02149060
 	add sp, sp, #0x28
 	mov r0, r6
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02142604:
-	add sl, sl, #1
-	cmp sl, #5
+	add r10, r10, #1
+	cmp r10, #5
 	blt _02142534
 _02142610:
 	bl func_ov61_0214a214
@@ -5586,7 +5586,7 @@ _02142610:
 	bl func_ov61_02177f3c
 	mov r0, r6
 	add sp, sp, #0x28
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_021424f8
 _02142670: .word func_ov61_021499d0
@@ -7039,11 +7039,11 @@ _02143b6c: .word 0xfffeabc4
 	.global func_ov61_02143b70
 	arm_func_start func_ov61_02143b70
 func_ov61_02143b70: ; 0x02143b70
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x218
 	mov sb, #0
 	mov r11, r1
-	mov sl, r2
+	mov r10, r2
 	add r8, sp, #8
 	mov r7, sb
 	mov r6, #0xa
@@ -7052,7 +7052,7 @@ func_ov61_02143b70: ; 0x02143b70
 _02143b98:
 	mov r0, r8
 	mov r2, sb
-	add r1, sl, #1
+	add r1, r10, #1
 	bl func_ov61_02145384
 	cmp r0, r4
 	beq _02143bd0
@@ -7068,12 +7068,12 @@ _02143bd0:
 	add r0, sp, #0x18
 	stmia sp, {r0, sb}
 	mov r2, #0
-	ldrb r0, [sl]
+	ldrb r0, [r10]
 	mov r1, r11
 	mov r3, r2
 	bl func_ov61_02145420
 	add sp, sp, #0x218
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	arm_func_end func_ov61_02143b70
 
 	.global func_ov61_02143bf4
@@ -7448,13 +7448,13 @@ _021440c0:
 	.global func_ov61_021440c8
 	arm_func_start func_ov61_021440c8
 func_ov61_021440c8: ; 0x021440c8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	mov sb, r0
 	mov r8, r1
 	bl func_ov61_0214a214
 	cmp r0, #0
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	bl func_ov61_0214a214
 	add r0, r0, sb, lsl #2
 	ldr r11, [r0, #0xf4]
@@ -7481,37 +7481,37 @@ _0214413c:
 	add r7, sb, r4
 	add r6, r7, #1
 	bl func_ov61_0214a214
-	mov sl, r0
+	mov r10, r0
 	bl func_ov61_0214a214
 	add r0, r0, r6, lsl #2
 	ldr r1, [r0, #0x24]
-	add r0, sl, r7, lsl #2
+	add r0, r10, r7, lsl #2
 	str r1, [r0, #0x24]
 	bl func_ov61_0214a214
-	mov sl, r0
+	mov r10, r0
 	bl func_ov61_0214a214
 	add r0, r0, r6, lsl #1
 	ldrh r1, [r0, #0xa4]
-	add r0, sl, r7, lsl #1
+	add r0, r10, r7, lsl #1
 	strh r1, [r0, #0xa4]
 	bl func_ov61_0214a214
-	mov sl, r0
+	mov r10, r0
 	bl func_ov61_0214a214
-	add r1, sl, r7, lsl #2
+	add r1, r10, r7, lsl #2
 	add r0, r0, r6, lsl #2
 	ldr r0, [r0, #0xf4]
 	str r0, [r1, #0xf4]
 	bl func_ov61_0214a214
-	mov sl, r0
+	mov r10, r0
 	bl func_ov61_0214a214
-	add r1, sl, r7, lsl #2
+	add r1, r10, r7, lsl #2
 	add r0, r0, r6, lsl #2
 	ldr r0, [r0, #0x210]
 	str r0, [r1, #0x210]
 	bl func_ov61_0214a214
-	mov sl, r0
+	mov r10, r0
 	bl func_ov61_0214a214
-	add r1, sl, r7, lsl #1
+	add r1, r10, r7, lsl #1
 	add r0, r0, r6, lsl #1
 	add r0, r0, #0x200
 	ldrh r2, [r0, #0x90]
@@ -7560,7 +7560,7 @@ _02144208:
 	strb r1, [r0, #0x2d0]
 _02144278:
 	mov r0, r11
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	arm_func_end func_ov61_021440c8
 
 	.global func_ov61_02144280
@@ -8122,7 +8122,7 @@ _02144a0c: .word data_ov61_0217ebe8
 	.global func_ov61_02144a10
 	arm_func_start func_ov61_02144a10
 func_ov61_02144a10: ; 0x02144a10
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x1b0
 	mov r7, #8
 	mov r6, #0xa
@@ -8216,11 +8216,11 @@ _02144b5c:
 	bl func_ov61_0214a214
 	ldr r0, [r0, #0xe4]
 	bl func_ov61_02162e28
-	mov sl, #0
+	mov r10, #0
 	add r7, sp, #0xad
 	mov r6, #6
 	mov r5, #1
-	mov r4, sl
+	mov r4, r10
 	add r11, sp, #0xc
 _02144b80:
 	bl func_ov61_0214a214
@@ -8236,8 +8236,8 @@ _02144b80:
 	beq _02144bc0
 	cmp sb, #2
 	bne _02144bc0
-	add sl, sl, #1
-	cmp sl, #5
+	add r10, r10, #1
+	cmp r10, #5
 	blt _02144b80
 _02144bc0:
 	cmp sb, #0
@@ -8253,7 +8253,7 @@ _02144bc0:
 _02144be8:
 	mov r0, sb
 	add sp, sp, #0x1b0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02144a10
 _02144bf4: .word data_ov61_0217ebf8
@@ -8557,10 +8557,10 @@ _02145018: .word func_ov61_02149db8
 	.global func_ov61_0214501c
 	arm_func_start func_ov61_0214501c
 func_ov61_0214501c: ; 0x0214501c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x220
 	str r3, [sp, #0xc]
-	mov sl, r0
+	mov r10, r0
 	str r1, [sp, #4]
 	str r2, [sp, #8]
 	ldr sb, [sp, #0x248]
@@ -8579,12 +8579,12 @@ func_ov61_0214501c: ; 0x0214501c
 	cmp r0, #0
 	beq _02145098
 _02145070:
-	cmp sl, #6
+	cmp r10, #6
 	bne _02145098
 _02145078:
 	ldr r2, [sp, #0xc]
 	ldr r1, [sp, #8]
-	mov r0, sl
+	mov r0, r10
 	mov r3, sb
 	str r8, [sp]
 	bl func_ov61_021451d0
@@ -8628,20 +8628,20 @@ _02145108:
 	ldr r0, [r0]
 	ldr r2, [sp, #4]
 	add r3, sp, #0x20
-	mov r1, sl
+	mov r1, r10
 	bl func_ov61_021452e0
 	mov r4, r0
 _02145130:
-	cmp sl, #2
-	cmpne sl, #6
+	cmp r10, #2
+	cmpne r10, #6
 	beq _0214514c
-	add r0, sl, #0xf8
+	add r0, r10, #0xf8
 	and r0, r0, #0xff
 	cmp r0, #1
 	bhi _021451bc
 _0214514c:
 	bl func_ov61_0214a214
-	strb sl, [r0, #0x3cc]
+	strb r10, [r0, #0x3cc]
 	bl func_ov61_0214a214
 	add r1, r0, #0x300
 	ldr r0, [sp, #0xc]
@@ -8671,7 +8671,7 @@ _0214514c:
 _021451bc:
 	mov r0, r4
 	add sp, sp, #0x220
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0214501c
 _021451c8: .word data_ov61_0217a708
@@ -8850,12 +8850,12 @@ _021453dc:
 	.global func_ov61_02145420
 	arm_func_start func_ov61_02145420
 func_ov61_02145420: ; 0x02145420
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #0x118
 	mov sb, r0
 	mov r8, r1
 	mov r7, r2
-	mov sl, r3
+	mov r10, r3
 	ldr r6, [sp, #0x138]
 	ldr r5, [sp, #0x13c]
 	mov r4, #0
@@ -8869,7 +8869,7 @@ func_ov61_02145420: ; 0x02145420
 _02145460:
 	add sp, sp, #0x118
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _0214546c:
 	bl func_ov61_0213f4e4
 	cmp r0, #5
@@ -8935,7 +8935,7 @@ _02145540:
 	ldr r0, [r6, #8]
 	ldr r7, [r6, #4]
 	mov r0, r0, lsl #0x10
-	mov sl, r0, lsr #0x10
+	mov r10, r0, lsr #0x10
 _02145560:
 	cmp sb, #0xb
 	moveq r0, #1
@@ -8944,7 +8944,7 @@ _02145560:
 	ldr r3, [r6]
 	mov r0, r8
 	mov r1, r7
-	mov r2, sl
+	mov r2, r10
 	bl func_ov61_02146304
 	mov r5, r0
 	cmp r5, #2
@@ -8954,13 +8954,13 @@ _02145560:
 	str r1, [r0, #0x1dc]
 	mov r0, r8
 	mov r1, r7
-	mov r2, sl
+	mov r2, r10
 	bl func_ov61_02146600
 	bl func_ov61_02146810
 	cmp r0, #0
 	addne sp, sp, #0x118
 	movne r0, #0
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	bl func_ov61_0214a214
 	ldrb r0, [r0, #0x15]
 	cmp r0, #2
@@ -9041,7 +9041,7 @@ _021456d0:
 	mov r0, r5
 	mov r1, r8
 	mov r2, r7
-	mov r3, sl
+	mov r3, r10
 	str r4, [sp, #4]
 	bl func_ov61_0214501c
 	bl func_ov61_02146810
@@ -9049,7 +9049,7 @@ _021456d0:
 	beq _021462f0
 	add sp, sp, #0x118
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _02145710:
 	bl func_ov61_0214a214
 	ldr r0, [r0, #0x1a0]
@@ -9116,7 +9116,7 @@ _021457f8:
 	cmp r0, #0
 	addne sp, sp, #0x118
 	mov r0, #0
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	mov r1, r0
 	mov r2, r8
 	bl func_ov61_021469ec
@@ -9125,7 +9125,7 @@ _021457f8:
 	beq _021462f0
 	add sp, sp, #0x118
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _02145838:
 	bl func_ov61_0214a214
 	ldrb r0, [r0, #0x15]
@@ -9143,7 +9143,7 @@ _02145838:
 	cmp r0, #0
 	addne sp, sp, #0x118
 	movne r0, #0
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _0214587c:
 	mov r0, #6
 	bl func_ov61_0214a224
@@ -9160,7 +9160,7 @@ _0214587c:
 	beq _021462f0
 	add sp, sp, #0x118
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _021458bc:
 	mov r0, #5
 	bl func_ov61_0214a224
@@ -9171,7 +9171,7 @@ _021458bc:
 	beq _021462f0
 	add sp, sp, #0x118
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _021458e4:
 	bl func_ov61_0214a214
 	ldr r0, [r0, #0x1a0]
@@ -9191,13 +9191,13 @@ _021458e4:
 	bl func_ov61_02143c14
 	add sp, sp, #0x118
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _02145930:
 	bl func_ov61_0214a214
 	ldr r0, [r0, #0x204]
 	bl func_ov61_02146cb4
 	add sp, sp, #0x118
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _02145944:
 	bl func_ov61_0214a214
 	ldr r0, [r0, #0x1a0]
@@ -9307,7 +9307,7 @@ _02145ac4:
 	bne _021462f0
 	add sp, sp, #0x118
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _02145ae0:
 	ldr r0, [r6, #4]
 	ldr r5, [r6]
@@ -9410,7 +9410,7 @@ _02145bf0:
 	mov r5, #1
 	mov r1, r8
 	mov r2, r7
-	mov r3, sl
+	mov r3, r10
 	mov r0, #0x20
 	str r5, [sp, #4]
 	bl func_ov61_0214501c
@@ -9418,7 +9418,7 @@ _02145bf0:
 	cmp r0, #0
 	addne sp, sp, #0x118
 	movne r0, #0
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _02145c84:
 	bl func_ov61_0214a214
 	mov r5, r0
@@ -9512,7 +9512,7 @@ _02145d70:
 	beq _021462f0
 	add sp, sp, #0x118
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _02145df0:
 	bl func_ov61_0214a214
 	ldr r1, [sp, #0x10]
@@ -9544,7 +9544,7 @@ _02145df0:
 	cmp r0, #0
 	addne sp, sp, #0x118
 	movne r0, #0
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	bl func_ov61_0214a214
 	mov r1, #0
 	str r1, [r0, #0x1c8]
@@ -9621,7 +9621,7 @@ _02145f6c:
 	beq _021462f0
 	add sp, sp, #0x118
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _02145f84:
 	bl func_ov61_0214a214
 	ldr r0, [r0, #0xf4]
@@ -9642,7 +9642,7 @@ _02145fb4:
 	bne _021462f0
 	add sp, sp, #0x118
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _02145fd0:
 	bl func_ov61_0214a214
 	ldrb r0, [r0, #0x15]
@@ -9663,14 +9663,14 @@ _02145ff8:
 	bne _021462f0
 	add sp, sp, #0x118
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _0214601c:
 	bl func_ov61_0214a214
 	ldr r0, [r0, #0xf4]
 	cmp r8, r0
 	addne sp, sp, #0x118
 	movne r0, #1
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	cmp r5, #0
 	mov r7, #0
 	ble _021462f0
@@ -9720,7 +9720,7 @@ _021460d0:
 	mov r4, #1
 	mov r1, r8
 	mov r2, r7
-	mov r3, sl
+	mov r3, r10
 	mov r0, #0x12
 	str r4, [sp, #4]
 	bl func_ov61_0214501c
@@ -9729,7 +9729,7 @@ _021460d0:
 	beq _021462f0
 	add sp, sp, #0x118
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _0214610c:
 	bl func_ov61_0214a214
 	ldr r0, [r0, #0x1a0]
@@ -9760,7 +9760,7 @@ _02146168:
 	bl func_ov61_02143c14
 	add sp, sp, #0x118
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _02146180:
 	bl func_ov61_0214a214
 	ldrb r0, [r0, #0x15]
@@ -9798,7 +9798,7 @@ _021461f4:
 	cmp r0, #0
 	addne sp, sp, #0x118
 	movne r0, #0
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _0214620c:
 	bl func_ov61_0214a214
 	ldr r0, [r0, #0x19c]
@@ -9847,7 +9847,7 @@ _02146290:
 	str r4, [sp]
 	mov r1, r8
 	mov r2, r7
-	mov r3, sl
+	mov r3, r10
 	mov r0, #0x41
 	str r4, [sp, #4]
 	bl func_ov61_0214501c
@@ -9856,7 +9856,7 @@ _02146290:
 	beq _021462f0
 	add sp, sp, #0x118
 	mov r0, r4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _021462dc:
 	add r4, r4, #1
 	bl func_ov61_0214a214
@@ -9866,7 +9866,7 @@ _021462dc:
 _021462f0:
 	mov r0, #1
 	add sp, sp, #0x118
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02145420
 _021462fc: .word data_ov61_0217ebe8
@@ -10375,7 +10375,7 @@ _021469e8: .word 0x00001770
 	.global func_ov61_021469ec
 	arm_func_start func_ov61_021469ec
 func_ov61_021469ec: ; 0x021469ec
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x228
 	movs r4, r1
 	mov r8, r0
@@ -10440,11 +10440,11 @@ _02146a94:
 	str r1, [r0, #0x1bc]
 	add sp, sp, #0x228
 	mov r0, r1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02146ae4:
 	mov r5, #1
 	bl func_ov61_02140308
-	mov sl, r0
+	mov r10, r0
 	bl func_ov61_0214a214
 	mov sb, r0
 	bl func_ov61_0214a214
@@ -10456,7 +10456,7 @@ _02146ae4:
 	mov r1, #0xc
 	add r2, r4, r2
 	ldrb r2, [r2, #0x304]
-	mov r0, sl
+	mov r0, r10
 	mla r1, r2, r1, r3
 	blx func_ov00_02077948
 	movs r4, r0
@@ -10464,12 +10464,12 @@ _02146ae4:
 	cmpne r4, r0
 	beq _02146a50
 	bl func_ov61_0214a214
-	mov sl, r0
+	mov r10, r0
 	bl func_ov61_0214a214
 	mov sb, r0
 	bl func_ov61_0214a214
 	ldrb r1, [r0, #0x1a5]
-	ldr r2, [sl, #0x2fc]
+	ldr r2, [r10, #0x2fc]
 	mov r0, #0xc
 	add r1, sb, r1
 	ldrb r1, [r1, #0x304]
@@ -10518,7 +10518,7 @@ _02146bac:
 	add r2, sp, #0x20
 	mov r3, #0x2f
 	bl func_ov61_0213e5f8
-	mov sl, r0
+	mov r10, r0
 	ldr r0, _02146cac ; =data_ov61_0217a70c
 	add r1, sp, #8
 	add r2, sp, #0x20
@@ -10530,7 +10530,7 @@ _02146bac:
 	add r2, sp, #0x20
 	mov r3, #0x2f
 	bl func_ov61_0213e5f8
-	cmp sl, #0
+	cmp r10, #0
 	cmpgt sb, #0
 	cmpgt r0, #0
 	ble _02146a50
@@ -10555,7 +10555,7 @@ _02146bac:
 	mov r1, r8
 	bl func_ov61_0214683c
 	add sp, sp, #0x228
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_021469ec
 _02146ca4: .word 0x00000bb8
@@ -10929,7 +10929,7 @@ _02147154:
 	.global func_ov61_021471a0
 	arm_func_start func_ov61_021471a0
 func_ov61_021471a0: ; 0x021471a0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #0x1c
 	cmp r0, #4
 	mov r4, #3
@@ -11155,7 +11155,7 @@ _021474dc:
 	cmp r0, #0x10
 	beq _021477c4
 	bl func_ov61_0214a214
-	mov sl, r0
+	mov r10, r0
 	bl func_ov61_0214a214
 	mov sb, r0
 	bl func_ov61_0214a214
@@ -11171,7 +11171,7 @@ _021474dc:
 	ldrb r3, [sb, #0xd]
 	ldrb r2, [r7, #0xd]
 	ldrb r1, [ip, #0xd]
-	add r4, sl, r3, lsl #2
+	add r4, r10, r3, lsl #2
 	add r2, r8, r2, lsl #2
 	add r3, r6, r1, lsl #1
 	ldrh r3, [r3, #0xa4]
@@ -11182,7 +11182,7 @@ _021474dc:
 	bl func_ov61_02146810
 	cmp r0, #0
 	addne sp, sp, #0x1c
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	bl func_ov61_0214a214
 	mov r1, #0
 	strb r1, [r0, #0x3cd]
@@ -11257,7 +11257,7 @@ _021475fc:
 	cmp r0, #0
 	beq _021477c4
 	add sp, sp, #0x1c
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 _02147678:
 	mov r0, #1
 	bl func_ov61_0214a224
@@ -11330,7 +11330,7 @@ _0214775c:
 	bl func_ov61_02148f58
 	cmp r0, #0
 	addne sp, sp, #0x1c
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	ldr r0, _021477fc ; =data_ov61_0217ebe8
 	ldrb r1, [r0, #8]
 	cmp r1, #1
@@ -11353,17 +11353,17 @@ _021477b8:
 _021477c4:
 	cmp r5, #0
 	addeq sp, sp, #0x1c
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	bl func_ov61_0214a214
 	ldrb r0, [r0, #0x15]
 	cmp r0, #3
 	addeq sp, sp, #0x1c
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	bl func_ov61_0214a214
 	ldr r0, [r0, #0xe4]
 	bl func_ov61_02162e28
 	add sp, sp, #0x1c
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov61_021471a0
 _021477f8: .word data_ov61_0217a704
@@ -11839,10 +11839,10 @@ func_ov61_02147e08: ; 0x02147e08
 	.global func_ov61_02147e38
 	arm_func_start func_ov61_02147e38
 func_ov61_02147e38: ; 0x02147e38
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #0x108
 	mov r7, #0
-	mov sl, r0
+	mov r10, r0
 	mov r8, r7
 	mov sb, #1
 	bl func_ov61_0214a214
@@ -11856,7 +11856,7 @@ _02147e6c:
 	bl func_ov61_0214a214
 	add r0, r0, sb
 	ldrb r0, [r0, #0x2d0]
-	tst sl, r6, lsl r0
+	tst r10, r6, lsl r0
 	beq _02147e98
 	bl func_ov61_0214a214
 	add r0, r0, sb, lsl #2
@@ -11878,14 +11878,14 @@ _02147eac:
 	ble _02147e6c
 _02147ec0:
 	cmp r8, #0
-	mov sl, #0
+	mov r10, #0
 	ble _02147f18
 	add sb, sp, #0x88
 	mov r6, #0x10
 	add r5, sp, #8
-	mov r4, sl
+	mov r4, r10
 _02147edc:
-	ldr r1, [r5, sl, lsl #2]
+	ldr r1, [r5, r10, lsl #2]
 	str sb, [sp]
 	mov r0, r6
 	mov r2, r4
@@ -11896,9 +11896,9 @@ _02147edc:
 	cmp r0, #0
 	addne sp, sp, #0x108
 	movne r0, #0
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
-	add sl, sl, #1
-	cmp sl, r8
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
+	add r10, r10, #1
+	cmp r10, r8
 	blt _02147edc
 _02147f18:
 	bl func_ov61_0214a214
@@ -11926,7 +11926,7 @@ _02147f5c:
 	strb r1, [r0, #0x1a8]
 	mov r0, #1
 	add sp, sp, #0x108
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	arm_func_end func_ov61_02147e38
 
 	.global func_ov61_02147f74
@@ -12816,7 +12816,7 @@ _02148b28: .word data_ov61_0217ebe8
 	.global func_ov61_02148b2c
 	arm_func_start func_ov61_02148b2c
 func_ov61_02148b2c: ; 0x02148b2c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #8
 	ldr r0, _02148f4c ; =data_ov61_0217ebe8
 	ldr r0, [r0]
@@ -12824,17 +12824,17 @@ func_ov61_02148b2c: ; 0x02148b2c
 	ldrneb r0, [r0]
 	cmpne r0, #0
 	addeq sp, sp, #8
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	bl func_ov61_0214a214
 	ldrb r0, [r0, #0x15]
 	cmp r0, #2
 	addeq sp, sp, #8
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	bl func_ov61_0214a214
 	ldrb r0, [r0, #0x15]
 	cmp r0, #3
 	addeq sp, sp, #8
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	bl func_ov61_0214a214
 	ldr r0, [r0, #0x1a0]
 	cmp r0, #0x13
@@ -12863,7 +12863,7 @@ func_ov61_02148b2c: ; 0x02148b2c
 	strb r1, [r4, #0x1a4]
 	bl func_ov61_021471a0
 	add sp, sp, #8
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _02148bec:
 	bl func_0200e8f8
 	str r0, [r5, #0x18]
@@ -12885,7 +12885,7 @@ _02148bec:
 	str r0, [r4, #0xec]
 	add sp, sp, #8
 	str r1, [r4, #0xf0]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _02148c40:
 	mov r0, #4
 	bl func_ov61_0214a224
@@ -12894,7 +12894,7 @@ _02148c40:
 	mov r0, #1
 	bl func_ov61_021469ec
 	add sp, sp, #8
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _02148c60:
 	ldrb r4, [r5, #2]
 	bl func_0200e8f8
@@ -12913,7 +12913,7 @@ _02148c60:
 	cmp r1, r2, asr #31
 	cmpeq r0, r2
 	addlo sp, sp, #8
-	ldmloia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmloia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	cmp r4, #5
 	bls _02148ccc
 	mov r0, #1
@@ -12922,7 +12922,7 @@ _02148c60:
 	mov r0, #1
 	bl func_ov61_02147ba4
 	add sp, sp, #8
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _02148ccc:
 	mov r7, #1
 	bl func_ov61_0214a214
@@ -12942,14 +12942,14 @@ _02148cf0:
 	tst r1, r6, lsl r0
 	bne _02148d58
 	bl func_ov61_0214a214
-	mov sl, r0
+	mov r10, r0
 	bl func_ov61_0214a214
 	mov sb, r0
 	bl func_ov61_0214a214
 	str r5, [sp]
 	str r5, [sp, #4]
 	add r0, r0, r7, lsl #1
-	add r1, sl, r7, lsl #2
+	add r1, r10, r7, lsl #2
 	add r2, sb, r7, lsl #2
 	ldrh r3, [r0, #0xa4]
 	ldr r1, [r1, #0xf4]
@@ -12959,7 +12959,7 @@ _02148cf0:
 	bl func_ov61_02146810
 	cmp r0, #0
 	addne sp, sp, #8
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _02148d58:
 	add r7, r7, #1
 	bl func_ov61_0214a214
@@ -12973,7 +12973,7 @@ _02148d6c:
 	ldrb r0, [r1, #2]
 	add r0, r0, #1
 	strb r0, [r1, #2]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _02148d88:
 	bl func_ov61_0214a214
 	ldr r0, [r0, #0x1a0]
@@ -12983,7 +12983,7 @@ _02148d88:
 	ldr r0, [r0, #0x1a0]
 	cmp r0, #3
 	addne sp, sp, #8
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _02148dac:
 	ldr r0, _02148f4c ; =data_ov61_0217ebe8
 	ldr r4, [r0]
@@ -12993,7 +12993,7 @@ _02148dac:
 	sub r0, r1, #1
 	cmp r2, r0
 	addlt sp, sp, #8
-	ldmltia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmltia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	ldrb r0, [r4, #2]
 	cmp r0, #0
 	bne _02148e20
@@ -13018,7 +13018,7 @@ _02148e20:
 	ldrb r0, [r4, #2]
 	cmp r0, #0
 	addeq sp, sp, #8
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	ldr r0, _02148f4c ; =data_ov61_0217ebe8
 	ldr r4, [r0]
 	bl func_0200e8f8
@@ -13036,7 +13036,7 @@ _02148e20:
 	cmp r1, #0
 	cmpeq r0, r2, lsr #2
 	addlo sp, sp, #8
-	ldmloia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmloia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _02148e78:
 	bl func_ov61_0214a214
 	ldr r0, [r0, #0x204]
@@ -13048,7 +13048,7 @@ _02148e78:
 	bl func_ov61_02146810
 	cmp r0, #0
 	addne sp, sp, #8
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _02148ea4:
 	mov r0, #0x13
 	bl func_ov61_0214a224
@@ -13078,7 +13078,7 @@ _02148ec8:
 	bl func_ov61_02146810
 	cmp r0, #0
 	addne sp, sp, #8
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	add r4, r4, #1
 	bl func_ov61_0214a214
 	ldrb r0, [r0, #0xd]
@@ -13093,7 +13093,7 @@ _02148f28:
 	mov r0, #1
 	strb r0, [r4, #2]
 	add sp, sp, #8
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02148b2c
 _02148f4c: .word data_ov61_0217ebe8
@@ -13672,9 +13672,9 @@ func_ov61_02149684: ; 0x02149684
 	.global func_ov61_02149688
 	arm_func_start func_ov61_02149688
 func_ov61_02149688: ; 0x02149688
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	mov r4, #0
-	mov sl, r0
+	mov r10, r0
 	mov r7, r4
 	bl func_ov61_0214a214
 	ldr r0, [r0, #0xe4]
@@ -13773,7 +13773,7 @@ _021497e0:
 	cmp r7, r0
 	blt _021496ac
 _021497f8:
-	cmp sl, #0
+	cmp r10, #0
 	beq _0214982c
 	bl func_ov61_0214a214
 	ldr r0, [r0, #0xe4]
@@ -13794,10 +13794,10 @@ _0214982c:
 	bl func_ov61_02162e84
 	cmp r0, #0
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _0214984c:
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02149688
 _02149854: .word data_ov61_0217a758
@@ -13807,7 +13807,7 @@ _0214985c: .word data_ov61_0217a784
 	.global func_ov61_02149860
 	arm_func_start func_ov61_02149860
 func_ov61_02149860: ; 0x02149860
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x18
 	mov r7, #0
 	mov r8, r7
@@ -13816,7 +13816,7 @@ func_ov61_02149860: ; 0x02149860
 	bl func_ov61_02162e84
 	cmp r0, #1
 	addle sp, sp, #0x18
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	mov sb, r7
 	bl func_ov61_0214a214
 	ldr r0, [r0, #0xe4]
@@ -13867,12 +13867,12 @@ _02149920:
 	ldr r2, [r4, sb, lsl #2]
 	cmp sb, #0
 	addgt r0, r5, sb, lsl #2
-	ldrgt sl, [r0, #-4]
+	ldrgt r10, [r0, #-4]
 	mul r0, r2, r11
-	movle sl, #0
+	movle r10, #0
 	mov r1, r8
 	bl func_02002c14
-	add r0, r0, sl
+	add r0, r0, r10
 	str r0, [r5, sb, lsl #2]
 	cmp r6, r0
 	blo _02149980
@@ -13900,7 +13900,7 @@ _02149980:
 	mov r3, r1
 	bl func_ov61_02162e94
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02149860
 _021499c8: .word data_ov61_0217a210
@@ -14153,9 +14153,9 @@ _02149c74:
 	.global func_ov61_02149cac
 	arm_func_start func_ov61_02149cac
 func_ov61_02149cac: ; 0x02149cac
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x9c
-	mov sl, r0
+	mov r10, r0
 	mov sb, r1
 	mov r8, #0
 	bl func_ov61_0213f4e4
@@ -14164,7 +14164,7 @@ func_ov61_02149cac: ; 0x02149cac
 	bl func_ov61_0213f4e4
 	cmp r0, #6
 	addne sp, sp, #0x9c
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	bl func_ov61_0214a214
 	ldrb r0, [r0, #0x15]
 	cmp r0, #2
@@ -14173,18 +14173,18 @@ func_ov61_02149cac: ; 0x02149cac
 	ldrb r0, [r0, #0x15]
 	cmp r0, #3
 	addne sp, sp, #0x9c
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02149d00:
 	cmp sb, #0x14
 	addlo sp, sp, #0x9c
-	ldmloia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmloia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r5, _02149db4 ; =data_ov61_0217a800
 	add r4, sp, #0x1c
 	add r7, sp, #8
 	mov r6, #0x14
 	mov r11, #4
 _02149d20:
-	mov r0, sl
+	mov r0, r10
 	mov r1, r7
 	mov r2, r6
 	bl func_02007ad8
@@ -14196,10 +14196,10 @@ _02149d20:
 	ldreq r0, [sp, #0xc]
 	cmpeq r0, #3
 	addne sp, sp, #0x9c
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldrb r2, [sp, #0x11]
 	mov r1, r4
-	add r0, sl, #0x14
+	add r0, r10, #0x14
 	bl func_02007ad8
 	str r4, [sp]
 	ldrb r0, [sp, #0x11]
@@ -14212,7 +14212,7 @@ _02149d20:
 	bl func_ov61_02145420
 	cmp r0, #0
 	addeq sp, sp, #0x9c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldrb r0, [sp, #0x11]
 	add r0, r0, #0x14
 	add r8, r8, r0
@@ -14220,7 +14220,7 @@ _02149d20:
 	cmp r0, sb
 	bls _02149d20
 	add sp, sp, #0x9c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02149cac
 _02149db4: .word data_ov61_0217a800
@@ -14710,7 +14710,7 @@ _0214a404: .word data_ov61_0217f350
 	.global func_ov61_0214a408
 	arm_func_start func_ov61_0214a408
 func_ov61_0214a408: ; 0x0214a408
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	mov r7, #1
 	mov r6, r0
 	mov r5, r1
@@ -14719,9 +14719,9 @@ func_ov61_0214a408: ; 0x0214a408
 	mov r8, r7
 _0214a424:
 	cmp sb, #0
-	movne sl, r8, lsl sb
-	moveq sl, r7
-	tst r6, sl
+	movne r10, r8, lsl sb
+	moveq r10, r7
+	tst r6, r10
 	beq _0214a460
 	bl func_ov61_0213f40c
 	cmp sb, r0
@@ -14731,7 +14731,7 @@ _0214a424:
 	mov r2, r4
 	bl func_ov61_0214a2c8
 	cmp r0, #0
-	mvneq r0, sl
+	mvneq r0, r10
 	andeq r6, r6, r0
 _0214a460:
 	add r0, sb, #1
@@ -14739,7 +14739,7 @@ _0214a460:
 	cmp sb, #0x20
 	blo _0214a424
 	mov r0, r6
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	arm_func_end func_ov61_0214a408
 
 	.global func_ov61_0214a478
@@ -14788,7 +14788,7 @@ _0214a504: .word data_ov61_0217f350
 	.global func_ov61_0214a508
 	arm_func_start func_ov61_0214a508
 func_ov61_0214a508: ; 0x0214a508
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	mov r7, #1
 	mov r6, r0
 	mov r5, r1
@@ -14797,9 +14797,9 @@ func_ov61_0214a508: ; 0x0214a508
 	mov r8, r7
 _0214a524:
 	cmp sb, #0
-	movne sl, r8, lsl sb
-	moveq sl, r7
-	tst r6, sl
+	movne r10, r8, lsl sb
+	moveq r10, r7
+	tst r6, r10
 	beq _0214a560
 	bl func_ov61_0213f40c
 	cmp sb, r0
@@ -14809,7 +14809,7 @@ _0214a524:
 	mov r2, r4
 	bl func_ov61_0214a478
 	cmp r0, #0
-	mvneq r0, sl
+	mvneq r0, r10
 	andeq r6, r6, r0
 _0214a560:
 	add r0, sb, #1
@@ -14817,7 +14817,7 @@ _0214a560:
 	cmp sb, #0x20
 	blo _0214a524
 	mov r0, r6
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	arm_func_end func_ov61_0214a508
 
 	.global func_ov61_0214a578
@@ -15046,17 +15046,17 @@ _0214a7d0: .word data_ov61_0217f350
 	.global func_ov61_0214a7d4
 	arm_func_start func_ov61_0214a7d4
 func_ov61_0214a7d4: ; 0x0214a7d4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	ldr r0, _0214a960 ; =data_ov61_0217f350
 	ldr r0, [r0]
 	cmp r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	add r0, sp, #0
 	bl func_ov61_0213f428
 	mov r7, r0
 	mov r8, #0
 	cmp r7, #0
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r4, _0214a960 ; =data_ov61_0217f350
 	mov r11, r8
 _0214a808:
@@ -15076,13 +15076,13 @@ _0214a808:
 	cmpne r0, #0
 	beq _0214a89c
 	bl func_0200e8f8
-	mov sl, r1
+	mov r10, r1
 	ldr r2, [r6, #0x24]
 	mov r5, r0
 	subs r2, r5, r2
 	ldr r1, [r6, #0x28]
 	mov r0, r2, lsl #0x6
-	sbc r1, sl, r1
+	sbc r1, r10, r1
 	mov r1, r1, lsl #0x6
 	orr r1, r1, r2, lsr #26
 	ldr r2, _0214a964 ; =0x000082ea
@@ -15096,7 +15096,7 @@ _0214a808:
 	ldr r1, [r1, #0x608]
 	blx r1
 	str r5, [r6, #0x24]
-	str sl, [r6, #0x28]
+	str r10, [r6, #0x28]
 _0214a89c:
 	bl func_ov61_0213f40c
 	cmp sb, r0
@@ -15147,7 +15147,7 @@ _0214a950:
 	add r8, r8, #1
 	cmp r8, r7
 	blt _0214a808
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0214a7d4
 _0214a960: .word data_ov61_0217f350
@@ -16070,7 +16070,7 @@ _0214b4a4: .word 0x00000d18
 	.global func_ov61_0214b4a8
 	arm_func_start func_ov61_0214b4a8
 func_ov61_0214b4a8: ; 0x0214b4a8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	ldr r0, _0214b544 ; =data_ov61_0217f354
 	mov r1, #0xc0
 	ldr r8, [r0]
@@ -16081,12 +16081,12 @@ func_ov61_0214b4a8: ; 0x0214b4a8
 	add r5, r0, #0x400
 	cmp r2, #6
 	movhs r0, #1
-	ldmhsia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmhsia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	ldrb sb, [r8, #0xd12]
 	mov r6, #0
 	cmp sb, #0
 	bls _0214b53c
-	mov sl, r1
+	mov r10, r1
 _0214b4ec:
 	cmp r6, r7
 	beq _0214b52c
@@ -16094,7 +16094,7 @@ _0214b4ec:
 	ldrb r0, [r0, #0x445]
 	cmp r0, #6
 	bhs _0214b52c
-	mul r1, r6, sl
+	mul r1, r6, r10
 	add r0, r8, r1
 	add r0, r0, #0x400
 	ldrh r2, [r0, #0x7a]
@@ -16103,7 +16103,7 @@ _0214b4ec:
 	bl strncmp
 	cmp r0, #0
 	moveq r0, #2
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _0214b52c:
 	add r0, r6, #1
 	and r6, r0, #0xff
@@ -16111,7 +16111,7 @@ _0214b52c:
 	blo _0214b4ec
 _0214b53c:
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0214b4a8
 _0214b544: .word data_ov61_0217f354
@@ -16305,21 +16305,21 @@ _0214b7bc:
 	.global func_ov61_0214b7c4
 	arm_func_start func_ov61_0214b7c4
 func_ov61_0214b7c4: ; 0x0214b7c4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
-	mov sl, r0
-	ldrh r2, [sl, #0xa]
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	mov r10, r0
+	ldrh r2, [r10, #0xa]
 	mov sb, r1
 	cmp r2, #0x20
 	bne _0214b7e8
 	bl func_ov61_0214b6b4
 	cmp r0, #0
-	ldmgtia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmgtia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _0214b7e8:
 	ldrb r8, [sb, #0xd12]
 	mov r4, #0
 	cmp r8, #0
 	ble _0214b84c
-	ldrh r7, [sl, #0xa]
+	ldrh r7, [r10, #0xa]
 	add r0, sb, #0x7c
 	mov r5, sb
 	add r6, r0, #0x400
@@ -16330,12 +16330,12 @@ _0214b808:
 	bne _0214b838
 	mov r1, r6
 	mov r2, r7
-	add r0, sl, #0xc
+	add r0, r10, #0xc
 	bl strncmp
 	cmp r0, #0
 	addeq r0, sb, r4, lsl #2
 	ldreqb r0, [r0, #0x445]
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _0214b838:
 	add r4, r4, #1
 	cmp r4, r8
@@ -16344,7 +16344,7 @@ _0214b838:
 	blt _0214b808
 _0214b84c:
 	mvn r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	arm_func_end func_ov61_0214b7c4
 
 	.global func_ov61_0214b854
@@ -16466,7 +16466,7 @@ _0214b9c0:
 	.global func_ov61_0214b9d4
 	arm_func_start func_ov61_0214b9d4
 func_ov61_0214b9d4: ; 0x0214b9d4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0xc4
 	mov r4, r0
 	add r0, r1, #0x44
@@ -16475,7 +16475,7 @@ func_ov61_0214b9d4: ; 0x0214b9d4
 	subs r6, r4, #1
 	bmi _0214ba9c
 	mov r0, #0xc0
-	mla sl, r6, r0, r8
+	mla r10, r6, r0, r8
 	add sb, r7, r6, lsl #2
 	add r11, sp, #0
 _0214ba04:
@@ -16498,14 +16498,14 @@ _0214ba04:
 	mov r0, r11
 	mov r2, #4
 	bl func_02007908
-	mov r0, sl
+	mov r0, r10
 	add r1, sp, #4
 	mov r2, #0xc0
 	bl func_02007908
 	mov r0, #0xc0
 	mul r5, r4, r0
 	add r0, r8, r5
-	mov r1, sl
+	mov r1, r10
 	mov r2, #0xc0
 	bl func_02007908
 	add r1, r8, r5
@@ -16514,7 +16514,7 @@ _0214ba04:
 	bl func_02007908
 	mov r4, r6
 	sub sb, sb, #4
-	sub sl, sl, #0xc0
+	sub r10, r10, #0xc0
 	subs r6, r6, #1
 	bpl _0214ba04
 _0214ba9c:
@@ -16527,7 +16527,7 @@ _0214ba9c:
 	mov r2, #0xc0
 	bl func_020078f4
 	add sp, sp, #0xc4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	arm_func_end func_ov61_0214b9d4
 
 	.global func_ov61_0214bac4
@@ -16764,11 +16764,11 @@ _0214bdc0:
 	.global func_ov61_0214bdc8
 	arm_func_start func_ov61_0214bdc8
 func_ov61_0214bdc8: ; 0x0214bdc8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
-	mov sl, r0
-	ldrb r2, [sl, #0xd13]
-	ldrb r1, [sl, #0xd0c]
-	add r3, sl, #0x470
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	mov r10, r0
+	ldrb r2, [r10, #0xd13]
+	ldrb r1, [r10, #0xd0c]
+	add r3, r10, #0x470
 	mov r0, #0xc0
 	mla r4, r2, r0, r3
 	mov r0, r1, lsl #0x18
@@ -16799,14 +16799,14 @@ _0214be28:
 	addne r6, r6, #1
 	streq r0, [sp]
 _0214be4c:
-	ldrb r0, [sl, #0xd10]
+	ldrb r0, [r10, #0xd10]
 	mov r5, #0
 	cmp r0, #0
 	ble _0214bf58
-	mov r7, sl
-	add r8, sl, #0x304
-	add sb, sl, #0x300
-	add r11, sl, #0x10c
+	mov r7, r10
+	add r8, r10, #0x304
+	add sb, r10, #0x300
+	add r11, r10, #0x10c
 _0214be6c:
 	ldrh r2, [r4, #0xa]
 	ldrb r0, [r7, #0x303]
@@ -16832,7 +16832,7 @@ _0214be6c:
 _0214bec0:
 	add r6, r6, #1
 _0214bec4:
-	ldrb r0, [sl, #0xd10]
+	ldrb r0, [r10, #0xd10]
 	add r5, r5, #1
 	add r7, r7, #0x24
 	cmp r5, r0
@@ -16841,13 +16841,13 @@ _0214bec4:
 	blt _0214be6c
 	b _0214bf58
 _0214bee4:
-	ldrb r0, [sl, #0xd10]
+	ldrb r0, [r10, #0xd10]
 	ldr r5, [sp]
 	mov r4, r5
 	cmp r0, #0
 	ble _0214bf48
-	mov r3, sl
-	add r2, sl, #0x300
+	mov r3, r10
+	add r2, r10, #0x300
 _0214bf00:
 	ldrb r0, [r2]
 	mov r1, r0, lsl #0x18
@@ -16863,7 +16863,7 @@ _0214bf00:
 _0214bf2c:
 	add r4, r4, #1
 _0214bf30:
-	ldrb r0, [sl, #0xd10]
+	ldrb r0, [r10, #0xd10]
 	add r5, r5, #1
 	add r2, r2, #0x24
 	cmp r5, r0
@@ -16871,13 +16871,13 @@ _0214bf30:
 	blt _0214bf00
 _0214bf48:
 	cmp r4, #1
-	ldreqb r0, [sl, #0xd0c]
+	ldreqb r0, [r10, #0xd0c]
 	biceq r0, r0, #0xc0
-	streqb r0, [sl, #0xd0c]
+	streqb r0, [r10, #0xd0c]
 _0214bf58:
 	ldr r0, [sp]
 	and r0, r0, #0xff
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	arm_func_end func_ov61_0214bdc8
 
 	.global func_ov61_0214bf64
@@ -19039,7 +19039,7 @@ _0214da20:
 	.global func_ov61_0214da4c
 	arm_func_start func_ov61_0214da4c
 func_ov61_0214da4c: ; 0x0214da4c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x18
 	add r4, r2, r2, lsl #1
 	str r0, [sp]
@@ -19055,7 +19055,7 @@ func_ov61_0214da4c: ; 0x0214da4c
 _0214da80:
 	add sp, sp, #0x18
 	mvn r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0214da8c:
 	cmp r0, #0
 	mov r7, #0
@@ -19067,9 +19067,9 @@ _0214daa4:
 	ldr r0, [sp]
 	mov r6, #0
 	mov r8, r6
-	add sl, r0, r7
+	add r10, r0, r7
 _0214dab4:
-	ldrb r0, [sl], #1
+	ldrb r0, [r10], #1
 	bl func_ov61_0214d9dc
 	rsb r1, r8, #3
 	mul r2, r1, r4
@@ -19138,7 +19138,7 @@ _0214db90:
 _0214dba8:
 	ldr r0, [sp, #8]
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	arm_func_end func_ov61_0214da4c
 
 	.global func_ov61_0214dbb4
@@ -19520,7 +19520,7 @@ _0214e098: .word data_027e02a0
 	.global func_ov61_0214e09c
 	arm_func_start func_ov61_0214e09c
 func_ov61_0214e09c: ; 0x0214e09c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	mov r8, #0
 _0214e0a4:
 	ldr r0, _0214e340 ; =data_ov61_0217f368
@@ -19554,7 +19554,7 @@ _0214e0d0:
 	bne _0214e120
 	mov r0, #0x14
 	bl func_ov61_0214e994
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0214e120:
 	cmp r8, #2
 	ble _0214e15c
@@ -19562,17 +19562,17 @@ _0214e120:
 	bne _0214e13c
 	mov r0, #9
 	bl func_ov61_0214e994
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0214e13c:
 	cmp r0, #3
 	bne _0214e150
 	mov r0, #0xb
 	bl func_ov61_0214e994
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0214e150:
 	mov r0, #0xd
 	bl func_ov61_0214e994
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0214e15c:
 	mov r0, #1
 	add r8, r8, #1
@@ -19588,13 +19588,13 @@ _0214e16c:
 	bne _0214e1c0
 	mov r0, #0x15
 	bl func_ov61_0214e994
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0214e194:
 	cmp r8, #2
 	ble _0214e1a8
 	mov r0, #0x10
 	bl func_ov61_0214e994
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0214e1a8:
 	mov r0, #0
 	add r8, r8, #1
@@ -19602,12 +19602,12 @@ _0214e1a8:
 	b _0214e1dc
 _0214e1b8:
 	bl func_ov61_0214e994
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0214e1c0:
 	cmp r8, #2
 	blt _0214e1d0
 	bl func_ov61_0214e994
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0214e1d0:
 	mov r0, #1
 	add r8, r8, #1
@@ -19615,10 +19615,10 @@ _0214e1d0:
 _0214e1dc:
 	bl func_0200e8f8
 	mov sb, r0
-	mov sl, r1
+	mov r10, r1
 	bl func_0200e8f8
 	subs r2, r0, sb
-	sbc r0, r1, sl
+	sbc r0, r1, r10
 	mov r1, r0, lsl #0x6
 	orr r1, r1, r2, lsr #26
 	mov r0, r2, lsl #0x6
@@ -19652,7 +19652,7 @@ _0214e22c:
 	bl func_0200e0c8
 	mov r0, #0x14
 	bl func_ov61_0214e994
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0214e278:
 	add r0, r2, #0x3d8
 	add r0, r0, #0x1000
@@ -19661,7 +19661,7 @@ _0214e278:
 	bl func_0200db28
 	bl func_0200e8f8
 	subs r2, r0, sb
-	sbc r0, r1, sl
+	sbc r0, r1, r10
 	mov r1, r0, lsl #0x6
 	orr r1, r1, r2, lsr #26
 	mov r0, r2, lsl #0x6
@@ -19699,14 +19699,14 @@ _0214e2bc:
 	add r0, r0, #0x3d8
 	add r0, r0, #0x1000
 	bl func_0200e0c8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0214e32c:
 	add r0, r3, #0x3d8
 	add r0, r0, #0x1000
 	bl func_0200e0c8
 	b _0214e0a4
 _0214e33c:
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	arm_func_end func_ov61_0214e09c
 _0214e340: .word data_ov61_0217f368
 _0214e344: .word 0x00004e84
@@ -20944,33 +20944,33 @@ _0214f490: .word data_ov61_0217aba0
 	.global func_ov61_0214f494
 	arm_func_start func_ov61_0214f494
 func_ov61_0214f494: ; 0x0214f494
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x14
-	mov sl, r0
-	add r0, sl, #0x1000
+	mov r10, r0
+	add r0, r10, #0x1000
 	ldr r8, [r0, #0x1c]
-	add r0, sl, #0x138
-	add r1, sl, #0x19c
-	add r2, sl, #0x208
+	add r0, r10, #0x138
+	add r1, r10, #0x19c
+	add r2, r10, #0x208
 	add r4, r0, #0x1000
 	cmp r8, #0
-	mov r0, sl
+	mov r0, r10
 	add r5, r1, #0x1000
 	add r7, r2, #0x1800
 	mov r11, #0
 	ldrle r8, _0214f79c ; =0x0000ea60
 	bl func_ov61_0214f340
-	mov r0, sl
+	mov r0, r10
 	bl func_ov61_0214f398
 	movs r6, r0
-	add r0, sl, #0x1000
+	add r0, r10, #0x1000
 	moveq r1, #2
 	streq r1, [r0, #0x20]
 	addeq sp, sp, #0x14
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	str r6, [r0, #0x12c]
 	bl func_ov61_02154bc0
-	add r0, sl, #0x1000
+	add r0, r10, #0x1000
 	ldr r0, [r0, #0x130]
 	cmp r0, #1
 	bne _0214f548
@@ -20979,7 +20979,7 @@ func_ov61_0214f494: ; 0x0214f494
 	mov r2, #0x830
 	bl func_02007a44
 	ldr r1, _0214f7a0 ; =func_ov61_0214fb94
-	add r0, sl, #0x1000
+	add r0, r10, #0x1000
 	str r1, [r5, #0x810]
 	ldr r1, [r0, #0x124]
 	ldr r0, _0214f7a4 ; =data_ov61_0217ab00
@@ -20990,21 +20990,21 @@ func_ov61_0214f494: ; 0x0214f494
 	mov r0, #1
 	bl func_ov61_0215ca6c
 _0214f548:
-	add r0, sl, #0x1100
+	add r0, r10, #0x1100
 	ldrh r1, [r0, #0x34]
 	mov r2, r6
 	mov r0, #0
 	bl func_ov61_02154b60
 	bl func_ov61_02154d64
 	cmp r0, #0
-	add r0, sl, #0x1000
+	add r0, r10, #0x1000
 	beq _0214f584
 	mov r1, #3
 	str r1, [r0, #0x20]
 	bl func_ov61_02154bf4
 	bl func_ov61_02154b1c
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0214f584:
 	ldr r4, [r0, #0x9f8]
 	mov r0, r4
@@ -21015,17 +21015,17 @@ _0214f584:
 	str r0, [sp, #0x10]
 	cmp r0, #0
 	bgt _0214f5b8
-	add r0, sl, #0x1000
+	add r0, r10, #0x1000
 	mov r1, #5
 	str r1, [r0, #0x20]
 	b _0214f784
 _0214f5b8:
 	bl func_ov61_021555d4
-	mov r0, sl
+	mov r0, r10
 	bl func_ov61_0214f2c8
 	cmp r0, #0
 	bne _0214f5dc
-	add r0, sl, #0x1000
+	add r0, r10, #0x1000
 	mov r1, #7
 	str r1, [r0, #0x20]
 	b _0214f784
@@ -21038,17 +21038,17 @@ _0214f5dc:
 	str r0, [r7, #8]
 	bl func_0200e8f8
 	str r0, [sp, #8]
-	add r0, sl, #0x234
+	add r0, r10, #0x234
 	str r1, [sp, #4]
-	add r5, sl, #0x218
+	add r5, r10, #0x218
 	add r6, r0, #0x1800
-	add r4, sl, #0x1000
+	add r4, r10, #0x1000
 _0214f610:
 	ldr r0, _0214f7a8 ; =data_ov61_0217f464
 	ldr r0, [r0]
 	cmp r0, #0
 	bne _0214f630
-	add r0, sl, #0x1000
+	add r0, r10, #0x1000
 	mov r1, #5
 	str r1, [r0, #0x20]
 	b _0214f784
@@ -21089,7 +21089,7 @@ _0214f630:
 	bl func_0200e0c8
 	b _0214f6c8
 _0214f6bc:
-	mov r0, sl
+	mov r0, r10
 	bl func_ov61_0214f3ac
 	mov r11, r0
 _0214f6c8:
@@ -21121,16 +21121,16 @@ _0214f6e4:
 	cmp r1, r8, asr #31
 	cmpeq r0, r8
 	bls _0214f740
-	add r0, sl, #0x1000
+	add r0, r10, #0x1000
 	mov r1, #6
 	str r1, [r0, #0x20]
 	b _0214f784
 _0214f740:
-	mov r0, sl
+	mov r0, r10
 	bl func_ov61_0214f2c8
 	cmp r0, #0
 	bne _0214f610
-	add r0, sl, #0x1000
+	add r0, r10, #0x1000
 	mov r1, #7
 	str r1, [r0, #0x20]
 	b _0214f784
@@ -21139,18 +21139,18 @@ _0214f760:
 	bl func_ov61_02154e80
 	bl func_ov61_02154bf4
 	bl func_ov61_02154b1c
-	add r0, sl, #0x1000
+	add r0, r10, #0x1000
 	mov r1, #8
 	str r1, [r0, #0x20]
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0214f784:
 	bl func_ov61_02154e44
 	bl func_ov61_02154e80
 	bl func_ov61_02154bf4
 	bl func_ov61_02154b1c
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0214f494
 _0214f79c: .word 0x0000ea60
@@ -21331,15 +21331,15 @@ _0214f9fc: .word data_ov61_0217ab70
 	.global func_ov61_0214fa00
 	arm_func_start func_ov61_0214fa00
 func_ov61_0214fa00: ; 0x0214fa00
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
-	mov sl, r0
-	add r0, sl, #0x1000
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	mov r10, r0
+	add r0, r10, #0x1000
 	ldr r4, [r0, #0x9f4]
-	add r0, sl, #0x1f8
+	add r0, r10, #0x1f8
 	cmp r4, #0
 	ldreq r6, _0214fb04 ; =data_ov61_0217ac54
 	mov r8, r2
-	add r4, sl, #0x1000
+	add r4, r10, #0x1000
 	add r5, r0, #0x1800
 	ldr r0, [r4, #0x9f4]
 	mov r7, r3
@@ -21366,13 +21366,13 @@ func_ov61_0214fa00: ; 0x0214fa00
 	cmp r2, r1
 	ble _0214fab0
 	sub r2, r2, r1
-	mov r0, sl
+	mov r0, r10
 	mov r1, r5
 	add r2, r2, #1
 	bl func_ov61_0214fc38
 	cmp r0, #0
 	moveq r0, #1
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldmib r5, {r0, r1}
 	sub r1, r1, r0
 _0214fab0:
@@ -21390,13 +21390,13 @@ _0214fab0:
 	bl func_ov61_02151810
 	cmp r0, #0
 	movlt r0, #1
-	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r1, [r5, #4]
 	mov r0, #0
 	add r1, r1, r4
 	str r1, [r5, #4]
 	strb r0, [r1]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0214fa00
 _0214fb04: .word data_ov61_0217ac54
@@ -21741,7 +21741,7 @@ _0214ff84: .word data_ov61_0217ad14
 	.global func_ov61_0214ff88
 	arm_func_start func_ov61_0214ff88
 func_ov61_0214ff88: ; 0x0214ff88
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x10
 	mov r4, r0
 	add r0, r4, #0x238
@@ -21763,7 +21763,7 @@ func_ov61_0214ff88: ; 0x0214ff88
 	cmp r0, #0
 	addeq sp, sp, #0x10
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	add r0, r0, #4
 	bl strlen
 	ldr r1, [sp]
@@ -21775,7 +21775,7 @@ func_ov61_0214ff88: ; 0x0214ff88
 	movs r7, r0
 	addeq sp, sp, #0x10
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldrsb sb, [r7, #4]
 	ldr r2, _02150210 ; =data_ov61_0217ad34
 	mov r5, #0
@@ -21788,7 +21788,7 @@ func_ov61_0214ff88: ; 0x0214ff88
 	addne sp, sp, #0x10
 	strb sb, [r7, #4]
 	movne r0, r5
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	cmp r6, #1
 	beq _02150068
 	ldr r1, _02150214 ; =data_ov61_0217ad40
@@ -21800,7 +21800,7 @@ func_ov61_0214ff88: ; 0x0214ff88
 _02150068:
 	add sp, sp, #0x10
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02150074:
 	ldr r1, _02150218 ; =data_ov61_0217aba0
 	add r0, r7, #5
@@ -21808,7 +21808,7 @@ _02150074:
 	cmp r0, #0
 	addeq sp, sp, #0x10
 	moveq r0, r5
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	add sb, r0, #2
 	b _02150128
 _02150098:
@@ -21819,10 +21819,10 @@ _02150098:
 	beq _0215013c
 	ldrsb r7, [r6]
 	mov r1, #0
-	add sl, r6, #2
+	add r10, r6, #2
 	strb r1, [r6]
 	ldr r1, _02150218 ; =data_ov61_0217aba0
-	mov r0, sl
+	mov r0, r10
 	bl strstr
 	movs r5, r0
 	streqb r7, [r6]
@@ -21833,7 +21833,7 @@ _02150098:
 	strb r1, [r5]
 	mov r0, r4
 	add r1, sp, #4
-	mov r3, sl
+	mov r3, r10
 	bl func_ov61_0214fe34
 	cmp r0, #1
 	beq _02150110
@@ -21841,12 +21841,12 @@ _02150098:
 	add sp, sp, #0x10
 	strb r8, [r5]
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02150110:
-	mov r0, sl
+	mov r0, r10
 	bl strlen
 	strb r7, [r6]
-	add r0, sl, r0
+	add r0, r10, r0
 	strb r8, [r5]
 	add sb, r0, #2
 _02150128:
@@ -21873,18 +21873,18 @@ _0215014c:
 	ldr r1, _02150224 ; =data_ov61_0217ad4c
 	mov r0, r6
 	bl strstr
-	movs sl, r0
+	movs r10, r0
 	bne _02150194
 	ldr r1, _02150218 ; =data_ov61_0217aba0
 	mov r0, r6
 	bl strstr
-	mov sl, r0
+	mov r10, r0
 _02150194:
-	cmp sl, #0
-	ldrnesb r8, [sl]
+	cmp r10, #0
+	ldrnesb r8, [r10]
 	movne r0, #0
 	mov r2, r7
-	strneb r0, [sl]
+	strneb r0, [r10]
 	mov r0, r4
 	add r1, sp, #4
 	mov r3, r6
@@ -21892,25 +21892,25 @@ _02150194:
 	cmp r0, #1
 	beq _021501d8
 	strb sb, [r5]
-	cmp sl, #0
+	cmp r10, #0
 	add sp, sp, #0x10
-	strneb r8, [sl]
+	strneb r8, [r10]
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _021501d8:
 	mov r0, r6
 	bl strlen
 	add r0, r6, r0
 	strb sb, [r5]
-	cmp sl, #0
+	cmp r10, #0
 	add r7, r0, #1
-	strneb r8, [sl]
+	strneb r8, [r10]
 	cmp r7, r11
 	blo _0215014c
 _021501fc:
 	mov r0, #1
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0214ff88
 _02150208: .word data_ov61_0217ab70
@@ -22002,41 +22002,41 @@ func_ov61_021502d4: ; 0x021502d4
 	.global func_ov61_02150314
 	arm_func_start func_ov61_02150314
 func_ov61_02150314: ; 0x02150314
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	add r0, r0, #0x1000
 	ldr r6, [r0, #0x14]
 	mov sb, r2
-	mov sl, r1
+	mov r10, r1
 	mov r8, #0
 	cmp sb, #0
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r11, _02150394 ; =data_ov61_0217ad50
 	ldr r7, _02150398 ; =data_ov61_0217ad6c
 	mov r5, r8
 	mov r4, r8
 _02150344:
-	ldr r1, [sl, r8, lsl #3]
+	ldr r1, [r10, r8, lsl #3]
 	cmp r1, #0
 	beq _02150360
 	mov r0, r11
 	mov r2, #0
 	blx r6
-	str r5, [sl, r8, lsl #3]
+	str r5, [r10, r8, lsl #3]
 _02150360:
-	add r0, sl, r8, lsl #3
+	add r0, r10, r8, lsl #3
 	ldr r1, [r0, #4]
 	cmp r1, #0
 	beq _02150384
 	mov r0, r7
 	mov r2, #0
 	blx r6
-	add r0, sl, r8, lsl #3
+	add r0, r10, r8, lsl #3
 	str r4, [r0, #4]
 _02150384:
 	add r8, r8, #1
 	cmp r8, sb
 	blt _02150344
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02150314
 _02150394: .word data_ov61_0217ad50
@@ -22287,7 +22287,7 @@ _021506b8: .word func_ov61_021506bc
 	.global func_ov61_021506bc
 	arm_func_start func_ov61_021506bc
 func_ov61_021506bc: ; 0x021506bc
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x290
 	ldr r4, _02151520 ; =data_ov61_0217f38c
 	mov r8, #0
@@ -22301,7 +22301,7 @@ func_ov61_021506bc: ; 0x021506bc
 	sub r0, r0, #1
 	str r0, [sp, #0x18]
 	ldr r0, [sp, #0x14]
-	mov sl, r8
+	mov r10, r8
 	sub r0, r0, #2
 	str r0, [sp, #0x1c]
 	ldr r0, _02151524 ; =0x00009c40
@@ -23041,7 +23041,7 @@ _02151188:
 	ldr r0, _0215158c ; =data_ov61_0217ae6c
 	add r1, r5, #1
 	blx r6
-	movs sl, r0
+	movs r10, r0
 	bne _021511bc
 	ldr r0, _02151520 ; =data_ov61_0217f38c
 	ldr r0, [r0, #0x14]
@@ -23089,7 +23089,7 @@ _02151230:
 	ldr r0, [r4, #0x14]
 	ldr r1, _02151580 ; =data_ov61_0217af10
 	add r3, r5, #1
-	mov r2, sl
+	mov r2, r10
 	bl func_ov61_02150280
 	cmp r0, #0
 	bge _02151278
@@ -23101,8 +23101,8 @@ _02151230:
 	b _021514cc
 _02151278:
 	mov r1, r11
-	strb r1, [sl, r0]
-	mov r0, sl
+	strb r1, [r10, r0]
+	mov r0, r10
 	bl func_0204902c
 	ldr r1, _02151538 ; =data_02076d88
 	ldr r1, [r1]
@@ -23276,15 +23276,15 @@ _021514e4:
 	mov r2, #0
 	blx r7
 _021514fc:
-	cmp sl, #0
+	cmp r10, #0
 	addeq sp, sp, #0x290
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, _021515a4 ; =data_ov61_0217af30
-	mov r1, sl
+	mov r1, r10
 	mov r2, #0
 	blx r7
 	add sp, sp, #0x290
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_021506bc
 _02151520: .word data_ov61_0217f38c
@@ -23494,7 +23494,7 @@ _0215180c: .word data_ov61_0217f408
 	.global func_ov61_02151810
 	arm_func_start func_ov61_02151810
 func_ov61_02151810: ; 0x02151810
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #8
 	ldr r4, _02151990 ; =0xaaaaaaab
 	str r2, [sp]
@@ -23502,7 +23502,7 @@ func_ov61_02151810: ; 0x02151810
 	mov r6, #3
 	mov r5, r5, lsr #0x1
 	umull r4, r5, r6, r5
-	mov sl, r0
+	mov r10, r0
 	subs r5, r1, r4
 	movne r5, #4
 	ldr r2, _02151990 ; =0xaaaaaaab
@@ -23513,20 +23513,20 @@ func_ov61_02151810: ; 0x02151810
 	mov r4, r4, lsr #0x1
 	addeq sp, sp, #8
 	add r0, r5, r4, lsl #2
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	cmp r3, r0
 	addlo sp, sp, #8
 	mvnlo r0, #0
-	ldmloia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
-	add r7, sl, r1
+	ldmloia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	add r7, r10, r1
 	ldr r8, [sp]
-	cmp sl, r7
+	cmp r10, r7
 	beq _02151980
 	sub r11, r2, #0x80000000
 	ldr r5, _02151994 ; =data_ov61_0217afbc
 	mov r4, r11
 _0215188c:
-	sub sb, r7, sl
+	sub sb, r7, r10
 	mov r0, sb, lsl #0x3
 	smull r1, r2, r4, r0
 	add r2, r2, r0, lsr #31
@@ -23544,7 +23544,7 @@ _0215188c:
 	mov r1, #0
 	mov r2, #3
 	bl func_02007a44
-	mov r0, sl
+	mov r0, r10
 	add r1, sp, #4
 	mov r2, sb
 	bl func_02007ad8
@@ -23585,16 +23585,16 @@ _0215194c:
 	and r0, r0, #0x3f
 	ldrsb r0, [r1, r0]
 _0215196c:
-	add sl, sl, sb
+	add r10, r10, sb
 	strb r0, [r8, #3]
-	cmp sl, r7
+	cmp r10, r7
 	add r8, r8, #4
 	bne _0215188c
 _02151980:
 	ldr r0, [sp]
 	sub r0, r8, r0
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02151810
 _02151990: .word 0xaaaaaaab
@@ -24961,14 +24961,14 @@ _02152b1c: .word data_ov61_0217f8fc
 	.global func_ov61_02152b20
 	arm_func_start func_ov61_02152b20
 func_ov61_02152b20: ; 0x02152b20
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #8
-	mov sl, r0
+	mov r10, r0
 	mov r0, #0x45
-	strb r0, [sl, #-0x14]
+	strb r0, [r10, #-0x14]
 	mov r4, #0
 	ldr r7, _02152d10 ; =data_ov61_0217f414
-	strb r4, [sl, #-0x13]
+	strb r4, [r10, #-0x13]
 	ldrh r0, [r7, #6]
 	ldr r6, [sp, #0x30]
 	ldrb r5, [sp, #0x34]
@@ -24979,9 +24979,9 @@ func_ov61_02152b20: ; 0x02152b20
 	mov r8, #0x80
 	mov sb, r11, lsl #0x8
 	orr sb, sb, r11, asr #8
-	strh sb, [sl, #-0x10]
-	strb r8, [sl, #-0xc]
-	strb r5, [sl, #-0xb]
+	strh sb, [r10, #-0x10]
+	strb r8, [r10, #-0xc]
+	strb r5, [r10, #-0xb]
 	ldr r8, [r7, #0x50]
 	mov r5, r0, lsl #0x10
 	mov r0, r8, lsr #0x10
@@ -24989,7 +24989,7 @@ func_ov61_02152b20: ; 0x02152b20
 	mov r8, r0, lsr #0x10
 	mov r0, r8, lsl #0x8
 	orr r0, r0, r8, asr #8
-	strh r0, [sl, #-8]
+	strh r0, [r10, #-8]
 	ldr r0, [r7, #0x50]
 	mov r8, r5, lsr #0x10
 	mov r0, r0, lsl #0x10
@@ -25000,21 +25000,21 @@ func_ov61_02152b20: ; 0x02152b20
 	mov r7, r8, lsl #0x8
 	mov r5, r0, lsr #0x10
 	mov r0, r5, lsl #0x8
-	strh sb, [sl, #-6]
+	strh sb, [r10, #-6]
 	orr r7, r7, r8, asr #8
 	ldr r11, _02152d14 ; =0x000005c8
 	mov sb, r1
-	strh r7, [sl, #-4]
+	strh r7, [r10, #-4]
 	orr r0, r0, r5, asr #8
 	mov r8, r2
 	mov r7, r3
-	strh r0, [sl, #-2]
+	strh r0, [r10, #-2]
 	cmp sb, r11
 	bls _02152c8c
-	mov r5, sl
+	mov r5, r10
 	bls _02152c30
 _02152bf0:
-	mov r0, sl
+	mov r0, r10
 	mov r1, #0
 	mov r2, r5
 	mov r3, r11
@@ -25037,7 +25037,7 @@ _02152c30:
 	mov r1, #0
 	beq _02152c64
 	mov r2, r5
-	mov r0, sl
+	mov r0, r10
 	mov r3, sb
 	str r6, [sp]
 	orr r5, r4, #0x2000
@@ -25046,7 +25046,7 @@ _02152c30:
 	b _02152c7c
 _02152c64:
 	str r6, [sp]
-	mov r0, sl
+	mov r0, r10
 	mov r2, r5
 	mov r3, sb
 	str r4, [sp, #4]
@@ -25064,7 +25064,7 @@ _02152c8c:
 _02152c9c:
 	sub r5, r11, sb
 	mov r1, sb
-	mov r0, sl
+	mov r0, r10
 	mov r2, r8
 	mov r3, r5
 	str r6, [sp]
@@ -25082,16 +25082,16 @@ _02152c9c:
 _02152ce0:
 	adds r0, sb, r7
 	addeq sp, sp, #8
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	str r6, [sp]
-	mov r0, sl
+	mov r0, r10
 	mov r1, sb
 	mov r2, r8
 	mov r3, r7
 	str r4, [sp, #4]
 	bl func_ov61_021529f8
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02152b20
 _02152d10: .word data_ov61_0217f414
@@ -25235,7 +25235,7 @@ _02152f00: .word data_ov61_0217f414
 	.global func_ov61_02152f04
 	arm_func_start func_ov61_02152f04
 func_ov61_02152f04: ; 0x02152f04
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #8
 	mov r7, r2
 	ldrb r2, [r7, #8]
@@ -25244,7 +25244,7 @@ func_ov61_02152f04: ; 0x02152f04
 	cmp r2, #0
 	mov r6, r3
 	addeq sp, sp, #8
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	ldr r0, _02153168 ; =data_027e02a0
 	ldr r1, _0215316c ; =data_ov61_0217f67c
 	ldr r0, [r0, #4]
@@ -25257,36 +25257,36 @@ func_ov61_02152f04: ; 0x02152f04
 	movne r5, #0x18
 	moveq r5, #0x14
 	add r1, r5, r8
-	ldr sl, [r0, #0x50]
+	ldr r10, [r0, #0x50]
 	mov r3, r1, lsl #0x10
-	mov r1, sl, lsr #0x10
+	mov r1, r10, lsr #0x10
 	mov r1, r1, lsl #0x10
-	mov sl, r1, lsr #0x10
-	mov r1, sl, lsl #0x8
-	orr r1, r1, sl, asr #8
+	mov r10, r1, lsr #0x10
+	mov r1, r10, lsl #0x8
+	orr r1, r1, r10, asr #8
 	strh r1, [r4, #-0xc]
 	mov r1, r3, lsr #0x10
-	ldr sl, [r0, #0x50]
+	ldr r10, [r0, #0x50]
 	mov lr, r1, lsl #0x8
-	mov r3, sl, lsl #0x10
-	mov sl, r3, lsr #0x10
-	mov r3, sl, lsl #0x8
-	orr r3, r3, sl, asr #8
+	mov r3, r10, lsl #0x10
+	mov r10, r3, lsr #0x10
+	mov r3, r10, lsl #0x8
+	orr r3, r3, r10, asr #8
 	strh r3, [r4, #-0xa]
 	ldr r3, [r7, #0x1c]
 	orr r1, lr, r1, asr #8
 	mov r3, r3, lsr #0x10
 	mov r3, r3, lsl #0x10
-	mov sl, r3, lsr #0x10
-	mov r3, sl, lsl #0x8
-	orr r3, r3, sl, asr #8
+	mov r10, r3, lsr #0x10
+	mov r3, r10, lsl #0x8
+	orr r3, r3, r10, asr #8
 	strh r3, [r4, #-8]
 	ldr r3, [r7, #0x1c]
 	mov ip, r5, lsr #0x2
 	mov r3, r3, lsl #0x10
-	mov sl, r3, lsr #0x10
-	mov r3, sl, lsl #0x8
-	orr r3, r3, sl, asr #8
+	mov r10, r3, lsr #0x10
+	mov r3, r10, lsl #0x8
+	orr r3, r3, r10, asr #8
 	strh r3, [r4, #-6]
 	mov r3, #0x600
 	strh r3, [r4, #-4]
@@ -25388,7 +25388,7 @@ _021530e8:
 	addne r0, r0, #1
 	strne r0, [r7, #0x28]
 	add sp, sp, #8
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02152f04
 _02153168: .word data_027e02a0
@@ -26853,12 +26853,12 @@ _02154518: .word data_027e02a0
 	.global func_ov61_0215451c
 	arm_func_start func_ov61_0215451c
 func_ov61_0215451c: ; 0x0215451c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0xc
 	mov r6, #0
-	mov sl, r0
+	mov r10, r0
 	str r6, [r1]
-	ldrh r3, [sl, #6]
+	ldrh r3, [r10, #6]
 	str r1, [sp]
 	ldr r2, _021547d8 ; =0x00003fff
 	mov r1, r3, lsl #0x8
@@ -26868,10 +26868,10 @@ func_ov61_0215451c: ; 0x0215451c
 	str r1, [sp, #8]
 	tst r1, r2
 	addeq sp, sp, #0xc
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
-	ldrh r3, [sl, #0xe]
-	ldrh r2, [sl, #0xc]
-	ldrb r4, [sl]
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldrh r3, [r10, #0xe]
+	ldrh r2, [r10, #0xc]
+	ldrb r4, [r10]
 	mov r0, r3, lsl #0x8
 	mov r1, r2, lsl #0x8
 	orr r2, r1, r2, asr #8
@@ -26881,7 +26881,7 @@ func_ov61_0215451c: ; 0x0215451c
 	mov r1, r1, lsl #0x10
 	mov r2, r0, lsr #0x10
 	mov r1, r1, lsr #0x10
-	ldrh r4, [sl, #4]
+	ldrh r4, [r10, #4]
 	ldr r7, _021547dc ; =data_ov61_0217f73c
 	mov r0, r6
 	mov r5, r3, lsr #0x1a
@@ -26904,7 +26904,7 @@ _021545c0:
 	add r7, r7, #0x38
 	blo _021545a0
 _021545dc:
-	ldrh r2, [sl, #2]
+	ldrh r2, [r10, #2]
 	cmp r0, #8
 	ldr r1, _021547e0 ; =0x00001fff
 	mov r0, r2, lsl #0x8
@@ -26924,7 +26924,7 @@ _021545dc:
 _02154620:
 	add sp, sp, #0xc
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0215462c:
 	ldr r1, _021547e4 ; =data_ov61_0217f414
 	add r0, r5, #0xe
@@ -26936,7 +26936,7 @@ _0215462c:
 	str r0, [r6, #0x34]
 	addeq sp, sp, #0xc
 	mov r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	str sb, [r6]
 	strh r4, [r6, #6]
 	strh r0, [r6, #8]
@@ -26945,7 +26945,7 @@ _0215462c:
 	orr r0, r0, r1, lsl #16
 	str r0, [r6, #0x2c]
 	ldr r1, [r6, #0x34]
-	mov r0, sl
+	mov r0, r10
 	add r1, r1, #0xe
 	add r1, r1, r5
 	str r1, [r6, #0x30]
@@ -26968,7 +26968,7 @@ _021546ac:
 	blx r1
 	add sp, sp, #0xc
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _021546d0:
 	ldr r0, [sp, #4]
 	ldr r2, [sp, #4]
@@ -26979,7 +26979,7 @@ _021546d0:
 	streqh r8, [r7, #0xa]
 	streqh r3, [r7, #8]
 	ldrh r1, [r7, #4]
-	add r0, sl, r5
+	add r0, r10, r5
 	add r1, r7, r1, lsl #1
 	strh r11, [r1, #0xc]
 	ldrh r1, [r7, #4]
@@ -26995,7 +26995,7 @@ _021546d0:
 	cmp r4, #0
 	addeq sp, sp, #0xc
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldrh r3, [r7, #4]
 	mov r6, #0
 	mov r5, r6
@@ -27021,7 +27021,7 @@ _02154780:
 	cmp r6, r4
 	addlo sp, sp, #0xc
 	movlo r0, #0
-	ldmloia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmloia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r4, [r7, #0x34]
 	ldrh r3, [r7, #0xa]
 	ldrb r0, [r4, #0xe]
@@ -27039,7 +27039,7 @@ _02154780:
 	str r1, [r0]
 	add r0, r4, #0xe
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0215451c
 _021547d8: .word 0x00003fff
@@ -27457,8 +27457,8 @@ _02154cb8: .word data_027e02a0
 	.global func_ov61_02154cbc
 	arm_func_start func_ov61_02154cbc
 func_ov61_02154cbc: ; 0x02154cbc
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
-	mov sl, r0
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	mov r10, r0
 	bl func_ov61_02154ac4
 	mov r6, #2
 	ldr r4, _02154d60 ; =data_ov61_0217f414
@@ -27467,13 +27467,13 @@ func_ov61_02154cbc: ; 0x02154cbc
 	mov r5, #1
 	mov r11, r6
 _02154ce0:
-	str r8, [sl, #0x28]
-	strb r6, [sl, #8]
+	str r8, [r10, #0x28]
+	strb r6, [r10, #8]
 	bl func_0200e8f8
 	mov r0, r0, lsr #0x10
 	orr r0, r0, r1, lsl #16
-	str r0, [sl, #0x10]
-	mov r0, sl
+	str r0, [r10, #0x10]
+	mov r0, r10
 	mov r1, r11
 	mov r2, #0x18
 	bl func_ov61_021538c4
@@ -27483,15 +27483,15 @@ _02154ce0:
 	cmp r0, #0
 	beq _02154d28
 	mov r0, #0
-	str r5, [sl, #4]
+	str r5, [r10, #4]
 	bl func_0200d880
 _02154d28:
 	mov r0, sb
 	bl func_0200ee60
-	ldrb r0, [sl, #8]
+	ldrb r0, [r10, #8]
 	cmp r0, #4
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, [r4, #0x50]
 	cmp r0, #0
 	beq _02154d58
@@ -27500,7 +27500,7 @@ _02154d28:
 	blo _02154ce0
 _02154d58:
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02154cbc
 _02154d60: .word data_ov61_0217f414
@@ -27818,11 +27818,11 @@ _02155100: .word data_027e02a0
 	.global func_ov61_02155104
 	arm_func_start func_ov61_02155104
 func_ov61_02155104: ; 0x02155104
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	mov r8, r2
 	ldr r6, [r8, #0x34]
 	movs r11, r3
-	mov sl, r0
+	mov r10, r0
 	movne r5, #1
 	mov r0, r6, lsl #0x1
 	mov sb, r1
@@ -27851,14 +27851,14 @@ _02155130:
 	beq _021551bc
 	mov r2, #0
 	str r2, [sp]
-	mov r0, sl
+	mov r0, r10
 	mov r1, r4
 	mov r2, r8
 	mov r3, #0x18
 	sub r5, r5, r4
 	bl func_ov61_02152f04
 	bl func_0200d9a4
-	add sl, sl, r4
+	add r10, r10, r4
 	sub sb, sb, r4
 _021551a8:
 	cmp sb, #0
@@ -27868,7 +27868,7 @@ _021551a8:
 	beq _02155130
 _021551bc:
 	mov r0, r4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02155104
 _021551c4: .word data_ov61_0217f414
@@ -27896,14 +27896,14 @@ func_ov61_021551c8: ; 0x021551c8
 	.global func_ov61_02155204
 	arm_func_start func_ov61_02155204
 func_ov61_02155204: ; 0x02155204
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x14
 	mov r4, #0
 	mov r11, r0
 	ldr r8, [sp, #0x38]
 	mov r0, r4
 	str r4, [sp, #0x10]
-	mov sl, r1
+	mov r10, r1
 	mov sb, r2
 	str r3, [sp, #8]
 	mov r6, r4
@@ -27918,7 +27918,7 @@ _02155248:
 	ldr r3, [sp, #8]
 	str r8, [sp]
 	mov r0, r11
-	mov r1, sl
+	mov r1, r10
 	mov r2, sb
 	str r6, [sp, #4]
 	bl func_ov61_021551c8
@@ -28000,22 +28000,22 @@ _0215536c:
 _0215537c:
 	mov r6, #0
 _02155380:
-	cmp r5, sl
+	cmp r5, r10
 	addlo r11, r11, r5
-	sublo sl, sl, r5
+	sublo r10, r10, r5
 	blo _021553a8
-	sub r1, r5, sl
+	sub r1, r5, r10
 	ldr r0, [sp, #8]
 	add r11, sb, r1
 	mov sb, #0
-	sub sl, r0, r1
+	sub r10, r0, r1
 	str sb, [sp, #8]
 _021553a8:
 	ldr r0, _021553f4 ; =data_ov61_0217f414
 	ldr r0, [r0, #0x48]
 	blx r0
 	cmp r0, #0
-	cmpne sl, #0
+	cmpne r10, #0
 	beq _021553e8
 	ldrb r0, [r8, #8]
 	cmp r0, #4
@@ -28030,7 +28030,7 @@ _021553a8:
 _021553e8:
 	ldr r0, [sp, #0x10]
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02155204
 _021553f4: .word data_ov61_0217f414
@@ -28262,7 +28262,7 @@ _021556b0: .word data_ov61_0217f414
 	.global func_ov61_021556b4
 	arm_func_start func_ov61_021556b4
 func_ov61_021556b4: ; 0x021556b4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	ldr r3, _02155a04 ; =data_ov61_0217f414
 	mov r1, #0
 	ldr r0, _02155a08 ; =data_ov61_0217f4f4
@@ -28279,11 +28279,11 @@ func_ov61_021556b4: ; 0x021556b4
 	ldr r0, _02155a08 ; =data_ov61_0217f4f4
 	str r2, [r1, #0x12c]
 	bl func_ov61_02154b08
-	mov sl, #1
+	mov r10, #1
 	ldr r0, _02155a04 ; =data_ov61_0217f414
-	mov r11, sl
-	str sl, [sp]
-	str sl, [r0, #0xc]
+	mov r11, r10
+	str r10, [sp]
+	str r10, [r0, #0xc]
 	mov r4, #0
 _02155710:
 	mov r0, #0x3e8
@@ -28364,15 +28364,15 @@ _02155800:
 	bhs _02155850
 	mov r0, #3
 	bl func_ov61_02151b04
-	mov sl, #1
-	str sl, [sp]
+	mov r10, #1
+	str r10, [sp]
 	mov r4, #0
 	b _02155850
 _0215583c:
 	mov r0, #1
 	bl func_ov61_02151b04
-	mov sl, #1
-	str sl, [sp]
+	mov r10, #1
+	str r10, [sp]
 	mov r4, #0
 _02155850:
 	mov r3, #0
@@ -28397,10 +28397,10 @@ _02155880:
 	ldr r0, [r0, #0x2c]
 	cmp r0, #0
 	beq _021558b0
-	subs sl, sl, #1
+	subs r10, r10, #1
 	bne _021558b0
 	bl func_ov61_02152680
-	mov sl, #0x69
+	mov r10, #0x69
 _021558b0:
 	ldr r0, _02155a1c ; =data_027e02a0
 	ldr sb, [r0, #8]
@@ -28495,7 +28495,7 @@ _021559e4:
 	bl func_ov61_02156254
 _021559fc:
 	bl func_ov61_02154b1c
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_021556b4
 _02155a04: .word data_ov61_0217f414
@@ -28763,7 +28763,7 @@ _02155dac: .word data_ov61_0217f414
 	.global func_ov61_02155db0
 	arm_func_start func_ov61_02155db0
 func_ov61_02155db0: ; 0x02155db0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #8
 	add r1, r1, #1
 	str r0, [sp]
@@ -28834,7 +28834,7 @@ _02155dec:
 	bne _021560b0
 	mov r0, #0
 	mov sb, #2
-	mov sl, #1
+	mov r10, #1
 	ldr ip, _021560fc ; =data_ov61_0217f414
 	b _0215609c
 _02155ed0:
@@ -28944,7 +28944,7 @@ _02156038:
 	streq r2, [ip, #0x50]
 	b _02156090
 _02156054:
-	mov r5, sl
+	mov r5, r10
 	str r2, [ip, #0x34]
 	b _02156090
 _02156060:
@@ -28990,7 +28990,7 @@ _021560b8:
 _021560ec:
 	mov r0, r5
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02155db0
 _021560f8: .word data_ov61_0217f8fc
@@ -29156,14 +29156,14 @@ _021562cc:
 	.global func_ov61_021562f0
 	arm_func_start func_ov61_021562f0
 func_ov61_021562f0: ; 0x021562f0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x40
 	mov sb, r2
 	mov r2, sb, lsl #0x8
-	mov sl, r1
+	mov r10, r1
 	orr r1, r2, sb, asr #8
 	strh r1, [sp, #4]
-	cmp sl, #0x20
+	cmp r10, #0x20
 	mov r6, #0
 	movne r1, #1
 	strneh r1, [sp, #6]
@@ -29192,7 +29192,7 @@ _02156364:
 	cmp r6, #0x3c
 	addge sp, sp, #0x40
 	mvnge r0, #0
-	ldmgeia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmgeia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	add r6, r4, #1
 	mov r4, r6
 	str r6, [sp]
@@ -29214,9 +29214,9 @@ _021563b8:
 	mov r3, #0
 	strb r0, [r1]
 	strb r3, [r2]
-	mov r0, sl, lsr #0x8
+	mov r0, r10, lsr #0x8
 	strb r0, [r2, #1]
-	strb sl, [r2, #2]
+	strb r10, [r2, #2]
 	strb r3, [r2, #3]
 	mov r3, #1
 	add r0, sp, #4
@@ -29282,10 +29282,10 @@ _021564a0:
 	mov r1, r1, lsl #0x10
 	orr r2, r2, r3, lsl #8
 	mov r2, r2, lsl #0x10
-	cmp sl, r2, lsr #16
+	cmp r10, r2, lsr #16
 	mov r2, r1, lsr #0x10
 	bne _02156538
-	cmp sl, #0xc
+	cmp r10, #0xc
 	beq _02156518
 	add r4, r0, #8
 	add r0, r0, #6
@@ -29337,7 +29337,7 @@ _02156550:
 _02156584:
 	mov r0, r4
 	add sp, sp, #0x40
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_021562f0
 _02156590: .word 0x00001001
@@ -29442,7 +29442,7 @@ func_ov61_02156668: ; 0x02156668
 	.global func_ov61_021566cc
 	arm_func_start func_ov61_021566cc
 func_ov61_021566cc: ; 0x021566cc
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0xc
 	ldr r2, _021567fc ; =data_ov61_0217f414
 	mov r6, #0
@@ -29457,20 +29457,20 @@ func_ov61_021566cc: ; 0x021566cc
 	mla r7, r4, r3, r7
 	ldr r8, [r2, #0x7c]
 	umull r3, r1, r5, r11
-	adc sl, r8, r7
-	mla r1, r5, sl, r1
+	adc r10, r8, r7
+	mla r1, r5, r10, r1
 	str r11, [r2, #0x68]
 	mov r7, r6, lsl #0x10
 	adds r5, sb, r3
 	mla r1, r4, r11, r1
-	str sl, [r2, #0x6c]
-	orr r7, r7, sl, lsr #16
+	str r10, [r2, #0x6c]
+	orr r7, r7, r10, lsr #16
 	adc r4, r8, r1
 	mov r3, r6, lsl #0x10
 	str r5, [r2, #0x68]
 	orr r3, r3, r4, lsr #16
 	add r1, sp, #8
-	mov sl, r0
+	mov r10, r0
 	strh r7, [sp, #2]
 	str r4, [r2, #0x6c]
 	strh r3, [sp, #4]
@@ -29478,7 +29478,7 @@ func_ov61_021566cc: ; 0x021566cc
 	cmp r0, #0
 	ldrne r0, [sp, #8]
 	addne sp, sp, #0xc
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	mov r0, #1
 	mov r11, r6
 	ldr r7, _02156800 ; =data_ov61_0217f474
@@ -29497,7 +29497,7 @@ _02156788:
 	mov r0, r8, lsl #0x1
 	ldrh r2, [r6, r0]
 	ldr r1, [r7, r8, lsl #2]
-	mov r0, sl
+	mov r0, r10
 	bl func_ov61_02156668
 	cmp r0, #0
 	str r0, [sp, #8]
@@ -29521,7 +29521,7 @@ _021567dc:
 	streq r0, [sp, #8]
 	ldr r0, [sp, #8]
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_021566cc
 _021567fc: .word data_ov61_0217f414
@@ -29961,11 +29961,11 @@ func_ov61_02156ce4: ; 0x02156ce4
 	.global func_ov61_02156cfc
 	arm_func_start func_ov61_02156cfc
 func_ov61_02156cfc: ; 0x02156cfc
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #4
 	mov r4, #0
 	mov sb, r0
-	mov sl, r4
+	mov r10, r4
 	add r6, sp, #0
 	mov r5, #1
 _02156d18:
@@ -29976,7 +29976,7 @@ _02156d18:
 	ldr r0, [sp]
 	cmp r0, #0
 	addeq sp, sp, #4
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	ldr r1, [r0]
 	blx r1
 	mov r8, r0
@@ -29996,7 +29996,7 @@ _02156d18:
 	cmp r0, #0
 	beq _02156d8c
 	mov r1, r8
-	mov r2, sl
+	mov r2, r10
 	bl func_0200dddc
 _02156d8c:
 	ldr r0, [sp]
@@ -30008,7 +30008,7 @@ _02156d8c:
 	arm_func_end func_ov61_02156cfc
 _02156da4:
     add sp, sp, #4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 
 	.global func_ov61_02156dac
 	arm_func_start func_ov61_02156dac
@@ -30955,14 +30955,14 @@ _021579e0: .word func_ov61_021579e4
 	.global func_ov61_021579e4
 	arm_func_start func_ov61_021579e4
 func_ov61_021579e4: ; 0x021579e4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x14
 	ldr r7, [r0, #4]
 	ldr r1, [r0, #0x10]
 	ldr r8, [r7, #0x64]
 	str r1, [sp, #0xc]
 	ldr r1, [r0, #0x18]
-	ldr sl, [r0, #0x14]
+	ldr r10, [r0, #0x14]
 	ldr r0, [r0, #0x1c]
 	ldr sb, [r8, #0xf8]
 	str r1, [sp, #8]
@@ -31000,18 +31000,18 @@ _02157a78:
 	cmp r0, #0
 	addeq sp, sp, #0x14
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r1, [sp, #0x10]
-	cmp sl, r1
-	movhi sl, r1
+	cmp r10, r1
+	movhi r10, r1
 	ldr r1, [sp, #0xc]
-	mov r2, sl
+	mov r2, r10
 	bl func_02007ad8
-	mov r0, sl
+	mov r0, r10
 	bl func_ov61_021550cc
 	add sp, sp, #0x14
-	mov r0, sl
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	mov r0, r10
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02157ac0:
 	cmp r0, #0
 	moveq r4, #0
@@ -31020,7 +31020,7 @@ _02157ac0:
 	ldr r1, [sp, #0xc]
 	ldr r3, [sp, #8]
 	mov r0, r7
-	mov r2, sl
+	mov r2, r10
 	str r4, [sp]
 	bl func_ov61_0215781c
 	mov r4, r0
@@ -31028,7 +31028,7 @@ _02157aec:
 	cmp r4, #0
 	addle sp, sp, #0x14
 	movle r0, r4
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldrh r0, [r8, #0xfc]
 	ldr r1, [r8, #0xf8]
 	cmp r1, r0
@@ -31038,7 +31038,7 @@ _02157aec:
 _02157b14:
 	mov r0, r4
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	arm_func_end func_ov61_021579e4
 
 	.global func_ov61_02157b20
@@ -31100,10 +31100,10 @@ _02157ba8:
 	.global func_ov61_02157bb8
 	arm_func_start func_ov61_02157bb8
 func_ov61_02157bb8: ; 0x02157bb8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0xc
-	mov sl, r0
-	ldr r6, [sl, #0x64]
+	mov r10, r0
+	ldr r6, [r10, #0x64]
 	str r1, [sp]
 	ldr r0, [r6, #0x104]
 	str r2, [sp, #4]
@@ -31123,14 +31123,14 @@ _02157bfc:
 	beq _02157c54
 	add r0, r6, #0x10c
 	bl func_0200d880
-	mov r0, sl
+	mov r0, r10
 	bl func_ov61_02158e2c
 	cmp r0, #0
 	bne _02157c40
 	mov r1, r5
-	cmp sl, #0
+	cmp r10, #0
 	beq _02157c38
-	ldrsh r0, [sl, #0x70]
+	ldrsh r0, [r10, #0x70]
 	tst r0, #1
 	movne r1, r4
 _02157c38:
@@ -31185,7 +31185,7 @@ _02157ce4:
 	bl func_0200ee60
 	mov r0, r8
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02157bb8
 _02157cf8: .word data_ov61_0217bc28
@@ -31351,11 +31351,11 @@ _02157eec:
 	.global func_ov61_02157f24
 	arm_func_start func_ov61_02157f24
 func_ov61_02157f24: ; 0x02157f24
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x18
-	mov sl, r0
-	ldr r4, [sl, #0x68]
-	ldrsb r0, [sl, #0x73]
+	mov r10, r0
+	ldr r4, [r10, #0x68]
+	ldrsb r0, [r10, #0x73]
 	ldr r4, [r4, #0x10c]
 	mov sb, r1
 	str r3, [sp, #0xc]
@@ -31370,7 +31370,7 @@ func_ov61_02157f24: ; 0x02157f24
 	cmp r8, r0
 	addgt sp, sp, #0x18
 	subgt r0, r5, #0x23
-	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmgtia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	str r8, [sp, #0x10]
 	b _02157f8c
 _02157f7c:
@@ -31384,7 +31384,7 @@ _02157f8c:
 	and r11, r6, #1
 _02157f98:
 	ldr r2, [sp, #0x10]
-	mov r0, sl
+	mov r0, r10
 	mov r1, r8
 	add r3, sp, #0x14
 	str r6, [sp]
@@ -31397,13 +31397,13 @@ _02157f98:
 	stmia sp, {r0, r7}
 	str r6, [sp, #8]
 	ldr r3, [sp, #0x14]
-	mov r0, sl
+	mov r0, r10
 	mov r2, r4
 	bl func_ov61_021580d0
 	cmp r0, #0
 	addle sp, sp, #0x18
 	mvnle r0, #5
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	add sb, sb, r4
 	sub r8, r8, r4
 	add r5, r5, r4
@@ -31414,33 +31414,33 @@ _02157ff8:
 	bgt _0215801c
 	add sp, sp, #0x18
 	mvn r0, #5
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02158014:
 	cmp r8, #0
 	bgt _02157f98
 _0215801c:
 	mov r0, r5
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	arm_func_end func_ov61_02157f24
 
 	.global func_ov61_02158028
 	arm_func_start func_ov61_02158028
 func_ov61_02158028: ; 0x02158028
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
-	mov sl, r0
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	mov r10, r0
 	mov sb, r1
 	mov r8, r2
 	cmp r8, sb
 	mov r7, r3
-	ldr r4, [sl, #0x68]
+	ldr r4, [r10, #0x68]
 	movgt r8, sb
 	bl func_0200ee4c
 	ldr r1, [sp, #0x28]
 	mov r11, r0
 	and r6, r1, #1
 _02158058:
-	mov r0, sl
+	mov r0, r10
 	bl func_ov61_021580ac
 	mov r5, r0
 	cmp r5, r8
@@ -31462,7 +31462,7 @@ _0215809c:
 	mov r0, r11
 	bl func_0200ee60
 	mov r0, r5
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	arm_func_end func_ov61_02158028
 
 	.global func_ov61_021580ac
@@ -31588,7 +31588,7 @@ _02158240: .word func_ov61_02158244
 	.global func_ov61_02158244
 	arm_func_start func_ov61_02158244
 func_ov61_02158244: ; 0x02158244
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	mov sb, r0
 	ldr r5, [sb, #4]
 	mov r7, #0
@@ -31623,14 +31623,14 @@ _02158298:
 	cmp r1, #0
 	cmpne r1, #4
 	ldrne r0, [r5, #0x48]
-	subne sl, r0, r8
+	subne r10, r0, r8
 	bne _021582e0
 	ldr r0, [r5, #0x48]
 	sub r0, r0, r8
 	bl func_ov61_02158360
-	mov sl, r0
+	mov r10, r0
 _021582e0:
-	mov r1, sl
+	mov r1, r10
 	mov r2, sb
 	add r0, r4, r8
 	bl func_ov61_02158404
@@ -31664,7 +31664,7 @@ _02158344:
 	strh r2, [r1, #2]
 	bl func_0200d8d0
 	mov r0, r7
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	arm_func_end func_ov61_02158244
 
 	.global func_ov61_02158360
@@ -33245,7 +33245,7 @@ func_ov61_02159658: ; 0x02159658
 	.global func_ov61_02159678
 	arm_func_start func_ov61_02159678
 func_ov61_02159678: ; 0x02159678
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	mov sb, r2
 	mov r8, r3
 	mvn r2, #0
@@ -33253,13 +33253,13 @@ func_ov61_02159678: ; 0x02159678
 	cmpeq sb, r2
 	movne r11, #1
 	str r0, [sp]
-	mov sl, r1
+	mov r10, r1
 	moveq r11, #0
 _021596a0:
 	mov r6, #0
 	ldr r4, [sp]
 	mov r5, r6
-	cmp sl, #0
+	cmp r10, #0
 	bls _021596e0
 _021596b4:
 	ldrsh r1, [r4, #4]
@@ -33271,7 +33271,7 @@ _021596b4:
 	add r5, r5, #1
 	addne r6, r6, #1
 	add r4, r4, #8
-	cmp r5, sl
+	cmp r5, r10
 	blo _021596b4
 _021596e0:
 	cmp r6, #0
@@ -33293,7 +33293,7 @@ _02159704:
 	b _021596a0
 _02159720:
 	mov r0, r6
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02159678
 _02159728: .word 0x0000020b
@@ -33714,7 +33714,7 @@ _02159be8:
 	.global func_ov61_02159c1c
 	arm_func_start func_ov61_02159c1c
 func_ov61_02159c1c: ; 0x02159c1c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #8
 	mov r11, r1
 	ldr r1, [r11]
@@ -33734,7 +33734,7 @@ func_ov61_02159c1c: ; 0x02159c1c
 _02159c60:
 	add sp, sp, #8
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02159c6c:
 	and r1, r5, #0x1f
 	cmp r1, #0x18
@@ -33864,7 +33864,7 @@ _02159dfc:
 	cmp r0, #0
 	addne sp, sp, #8
 	movne r0, #1
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	mov r0, #0
 	strb r0, [sb, #0x5ad]
 	b _0215a0f4
@@ -33875,10 +33875,10 @@ _02159e48:
 	b _0215a0f4
 _02159e58:
 	ldr r6, [sp, #4]
-	ldr sl, _0215a108 ; =data_ov61_0217bc8c
+	ldr r10, _0215a108 ; =data_ov61_0217bc8c
 	mov r5, #0
 _02159e64:
-	ldr r7, [sl, r5, lsl #2]
+	ldr r7, [r10, r5, lsl #2]
 	mov r0, r7
 	bl strlen
 	mov r2, r0
@@ -33987,8 +33987,8 @@ _02159fc0:
 _02159fd8:
 	ldr r0, [sp, #4]
 	mov r5, #0
-	add sl, r0, r4
-	cmp r0, sl
+	add r10, r0, r4
+	cmp r0, r10
 	bhs _0215a028
 	add r4, sp, #4
 _02159ff0:
@@ -34002,9 +34002,9 @@ _02159ff0:
 	add r5, r5, #1
 	addne sp, sp, #8
 	movne r0, #1
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, [sp, #4]
-	cmp r0, sl
+	cmp r0, r10
 	blo _02159ff0
 _0215a028:
 	cmp r7, #1
@@ -34030,7 +34030,7 @@ _0215a058:
 	cmp r0, #0
 	addne sp, sp, #8
 	movne r0, #1
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, [sp, #4]
 	cmp r0, r6
 	blo _0215a058
@@ -34054,7 +34054,7 @@ _0215a0b0:
 	cmp r0, #0
 	addne sp, sp, #8
 	movne r0, #1
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, [sp, #4]
 	cmp r0, r6
 	blo _0215a0b0
@@ -34068,7 +34068,7 @@ _0215a0f4:
 	mov r0, #0
 	str r1, [r11]
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02159c1c
 _0215a108: .word data_ov61_0217bc8c
@@ -34076,7 +34076,7 @@ _0215a108: .word data_ov61_0217bc8c
 	.global func_ov61_0215a10c
 	arm_func_start func_ov61_0215a10c
 func_ov61_0215a10c: ; 0x0215a10c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #4
 	mov r8, r0
 	ldr r0, [r8, #0x5a4]
@@ -34094,7 +34094,7 @@ func_ov61_0215a10c: ; 0x0215a10c
 	cmpne r0, #0
 	addeq sp, sp, #4
 	moveq r0, #2
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	mov r0, r0, lsl #0x1
 	ldr r1, _0215a2ac ; =data_ov61_0217f428
 	add r0, r0, r0, lsr #31
@@ -34105,14 +34105,14 @@ func_ov61_0215a10c: ; 0x0215a10c
 	movs r4, r0
 	addeq sp, sp, #4
 	moveq r0, #2
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	add r6, r4, r5, lsl #1
 	add sb, r6, r5, lsl #1
 	ldr r1, [r8, #0x5a4]
 	ldr r2, [r8, #0x5a8]
 	mov r0, r6
 	mov r3, r5
-	add sl, sb, r5, lsl #1
+	add r10, sb, r5, lsl #1
 	bl func_ov61_0215e8d4
 	ldr r1, [r7, #0x10]
 	ldr r2, [r7, #0xc]
@@ -34121,7 +34121,7 @@ func_ov61_0215a10c: ; 0x0215a10c
 	bl func_ov61_0215e8d4
 	ldr r1, [r7, #8]
 	ldr r2, [r7, #4]
-	mov r0, sl
+	mov r0, r10
 	mov r3, r5
 	bl func_ov61_0215e8d4
 	bl func_ov61_021599fc
@@ -34130,7 +34130,7 @@ func_ov61_0215a10c: ; 0x0215a10c
 	mov r0, r4
 	mov r1, r6
 	mov r3, r5
-	str sl, [sp]
+	str r10, [sp]
 	bl func_ov61_0215e2c0
 	mov r0, sb
 	bl func_ov61_02159a48
@@ -34183,7 +34183,7 @@ _0215a290:
 	blx r1
 	mov r0, r5
 	add sp, sp, #4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0215a10c
 _0215a2ac: .word data_ov61_0217f428
@@ -34310,10 +34310,10 @@ _0215a424:
 	arm_func_start func_ov61_0215a428
 func_ov61_0215a428: ; 0x0215a428
 	stmdb sp!, {r0, r1, r2, r3}
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x18
 	ldr r1, [sp, #0x44]
-	mov sl, r0
+	mov r10, r0
 	ldrb r4, [r1, #2]
 	ldrb r3, [r1]
 	ldrb r2, [r1, #1]
@@ -34322,7 +34322,7 @@ func_ov61_0215a428: ; 0x0215a428
 	str r0, [sp, #0x44]
 	add r2, r2, r3, lsl #8
 	add r0, sp, #8
-	str r1, [sl, #0x45c]
+	str r1, [r10, #0x45c]
 	add r8, r4, r2, lsl #8
 	blx func_02042668
 	mov r6, #0
@@ -34333,36 +34333,36 @@ func_ov61_0215a428: ; 0x0215a428
 	ldr r2, [sp, #0x10]
 	add r0, r0, r1, lsl #16
 	add r0, r2, r0
-	str r0, [sl, #0x80c]
-	strb r6, [sl, #0x6b0]
-	str r6, [sl, #0x5a0]
+	str r0, [r10, #0x80c]
+	strb r6, [r10, #0x6b0]
+	str r6, [r10, #0x5a0]
 	mov sb, r6
-	str r6, [sl, #0x594]
+	str r6, [r10, #0x594]
 	mov r11, #2
 	mvn r5, #0
 	mov r4, r6
 _0215a4a8:
 	ldr r1, [sp, #0x44]
-	mov r0, sl
+	mov r0, r10
 	ldrb r2, [r1, #2]
 	ldrb ip, [r1]
 	ldrb r3, [r1, #1]
 	add r7, r1, #3
 	add r1, sp, #0x44
 	str r7, [sp, #0x44]
-	str r5, [sl, #0x458]
-	strb r4, [sl, #0x5ad]
-	strb r4, [sl, #0x5ac]
-	strb r4, [sl, #0x5af]
-	strb r4, [sl, #0x6b0]
-	strb r4, [sl, #0x5b0]
-	strb r4, [sl, #0x7b0]
+	str r5, [r10, #0x458]
+	strb r4, [r10, #0x5ad]
+	strb r4, [r10, #0x5ac]
+	strb r4, [r10, #0x5af]
+	strb r4, [r10, #0x6b0]
+	strb r4, [r10, #0x5b0]
+	strb r4, [r10, #0x7b0]
 	add r3, r3, ip, lsl #8
 	ldr r7, [sp, #0x44]
 	add r3, r2, r3, lsl #8
 	add r2, r3, #3
-	str r7, [sl, #0x804]
-	str r3, [sl, #0x808]
+	str r7, [r10, #0x804]
+	str r3, [r10, #0x808]
 	sub r8, r8, r2
 	mov r2, r4
 	mov r3, r4
@@ -34370,29 +34370,29 @@ _0215a4a8:
 	bl func_ov61_02159c1c
 	cmp r0, #0
 	bne _0215a530
-	ldr r0, [sl, #0x594]
+	ldr r0, [r10, #0x594]
 	cmp r0, #0x33
 	blo _0215a530
-	ldr r0, [sl, #0x5a0]
+	ldr r0, [r10, #0x5a0]
 	cmp r0, #0
 	bne _0215a548
 _0215a530:
 	mov r0, #9
 	add sp, sp, #0x18
-	strb r0, [sl, #0x455]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	strb r0, [r10, #0x455]
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	add sp, sp, #0x10
 	bx lr
 _0215a548:
-	mov r0, sl
+	mov r0, r10
 	bl func_ov61_0215a2b4
 	mov r7, r0
 	cmp sb, #0
 	bne _0215a578
-	ldr r0, [sl, #0x800]
+	ldr r0, [r10, #0x800]
 	cmp r0, #0
 	beq _0215a578
-	add r1, sl, #0x7b0
+	add r1, r10, #0x7b0
 	bl func_ov61_0215a3bc
 	cmp r0, #0
 	orrne r7, r7, #0x4000
@@ -34407,8 +34407,8 @@ _0215a578:
 	add r1, r1, #3
 	str r1, [sp, #4]
 	mov r1, #0
-	strb r1, [sl, #0x5ad]
-	mov r0, sl
+	strb r1, [r10, #0x5ad]
+	mov r0, r10
 	add r1, sp, #4
 	mov r3, r2
 	str r11, [sp]
@@ -34416,21 +34416,21 @@ _0215a578:
 	cmp r0, #0
 	movne r0, #9
 	addne sp, sp, #0x18
-	strneb r0, [sl, #0x455]
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	strneb r0, [r10, #0x455]
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	addne sp, sp, #0x10
 	bxne lr
-	mov r0, sl
-	add r1, sl, #0x480
+	mov r0, r10
+	add r1, r10, #0x480
 	bl func_ov61_0215a10c
 	bic r1, r7, #0xff
 	orr r7, r1, r0
 _0215a5e8:
-	ldr r3, [sl, #0x810]
+	ldr r3, [r10, #0x810]
 	cmp r3, #0
 	beq _0215a608
 	mov r0, r7
-	mov r1, sl
+	mov r1, r10
 	mov r2, sb
 	blx r3
 	mov r7, r0
@@ -34446,11 +34446,11 @@ _0215a608:
 _0215a628:
 	cmp r7, #0
 	moveq r0, #3
-	streqb r0, [sl, #0x455]
+	streqb r0, [r10, #0x455]
 	movne r0, #9
-	strneb r0, [sl, #0x455]
+	strneb r0, [r10, #0x455]
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	add sp, sp, #0x10
 	bx lr
 	arm_func_end func_ov61_0215a428
@@ -34682,15 +34682,15 @@ _0215a8e4:
 	.global func_ov61_0215a920
 	arm_func_start func_ov61_0215a920
 func_ov61_0215a920: ; 0x0215a920
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x18
-	movs sl, r2
+	movs r10, r2
 	str r0, [sp, #8]
-	ldrne r0, [sl]
+	ldrne r0, [r10]
 	mov r11, r1
 	cmpne r0, #0
 	addeq sp, sp, #0x18
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	mov r0, r0, lsl #0x1
 	add r0, r0, r0, lsr #31
 	mov r0, r0, asr #0x1
@@ -34702,7 +34702,7 @@ func_ov61_0215a920: ; 0x0215a920
 	blx r1
 	movs r5, r0
 	addeq sp, sp, #0x18
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	add r6, r5, r4, lsl #1
 	add r7, r6, r4, lsl #1
 	add r1, r7, r4, lsl #1
@@ -34710,19 +34710,19 @@ func_ov61_0215a920: ; 0x0215a920
 	add r1, r1, r4, lsl #1
 	add r8, r1, r4, lsl #1
 	str r1, [sp, #0xc]
-	ldr r2, [sl]
+	ldr r2, [r10]
 	add sb, r8, r4, lsl #1
 	mov r1, r11
 	mov r3, r4
 	add r11, sb, r4, lsl #1
 	bl func_ov61_0215e8d4
-	ldr r1, [sl, #0x1c]
-	ldr r2, [sl, #0x18]
+	ldr r1, [r10, #0x1c]
+	ldr r2, [r10, #0x18]
 	mov r0, r6
 	mov r3, r4
 	bl func_ov61_0215e8d4
-	ldr r1, [sl, #0xc]
-	ldr r2, [sl, #8]
+	ldr r1, [r10, #0xc]
+	ldr r2, [r10, #8]
 	mov r0, r8
 	mov r3, r4
 	bl func_ov61_0215e8d4
@@ -34734,13 +34734,13 @@ func_ov61_0215a920: ; 0x0215a920
 	mov r2, r6
 	mov r3, r4
 	bl func_ov61_0215e6c8
-	ldr r1, [sl, #0x24]
-	ldr r2, [sl, #0x20]
+	ldr r1, [r10, #0x24]
+	ldr r2, [r10, #0x20]
 	mov r0, r6
 	mov r3, r4
 	bl func_ov61_0215e8d4
-	ldr r1, [sl, #0x14]
-	ldr r2, [sl, #0x10]
+	ldr r1, [r10, #0x14]
+	ldr r2, [r10, #0x10]
 	mov r0, r8
 	mov r3, r4
 	bl func_ov61_0215e8d4
@@ -34757,8 +34757,8 @@ func_ov61_0215a920: ; 0x0215a920
 	mov r0, r5
 	mov r3, r4
 	bl func_ov61_0215dcc0
-	ldr r1, [sl, #0x2c]
-	ldr r2, [sl, #0x28]
+	ldr r1, [r10, #0x2c]
+	ldr r2, [r10, #0x28]
 	mov r0, r6
 	mov r3, r4
 	bl func_ov61_0215e8d4
@@ -34767,8 +34767,8 @@ func_ov61_0215a920: ; 0x0215a920
 	mov r2, r6
 	mov r3, r4
 	bl func_ov61_0215de3c
-	ldr r1, [sl, #0x14]
-	ldr r2, [sl, #0x10]
+	ldr r1, [r10, #0x14]
+	ldr r2, [r10, #0x10]
 	mov r0, r6
 	mov r3, r4
 	bl func_ov61_0215e8d4
@@ -34782,8 +34782,8 @@ func_ov61_0215a920: ; 0x0215a920
 	mov r1, r5
 	mov r3, r4
 	bl func_ov61_0215db80
-	ldr r1, [sl, #4]
-	ldr r2, [sl]
+	ldr r1, [r10, #4]
+	ldr r2, [r10]
 	mov r0, r6
 	mov r3, r4
 	bl func_ov61_0215e8d4
@@ -34825,7 +34825,7 @@ _0215ab2c:
 	ldr r1, [r1]
 	blx r1
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0215a920
 _0215ab58: .word data_ov61_0217f428
@@ -34908,10 +34908,10 @@ _0215ac58: .word data_ov61_0217bce0
 	.global func_ov61_0215ac5c
 	arm_func_start func_ov61_0215ac5c
 func_ov61_0215ac5c: ; 0x0215ac5c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x24
-	mov sl, r0
-	ldrh r0, [sl, #0x32]
+	mov r10, r0
+	ldrh r0, [r10, #0x32]
 	cmp r0, #4
 	beq _0215ac80
 	cmp r0, #5
@@ -34938,13 +34938,13 @@ _0215aca8:
 	mov r11, r0, lsl #0x1
 	cmp r11, #0
 	ble _0215ad9c
-	add r0, sl, #0x74
+	add r0, r10, #0x74
 	mov sb, r7
 	str r0, [sp, #8]
 	add r5, sp, #0xc
 	mov r4, #1
 _0215acdc:
-	add r0, sl, #0x348
+	add r0, r10, #0x348
 	bl func_ov61_0215d8a4
 	add r0, r7, #0x41
 	add r6, r7, #1
@@ -34953,7 +34953,7 @@ _0215acdc:
 	cmp r6, #0
 	ble _0215ad18
 _0215acfc:
-	add r0, sl, #0x348
+	add r0, r10, #0x348
 	mov r1, r5
 	mov r2, r4
 	bl func_ov61_0215d8f8
@@ -34961,33 +34961,33 @@ _0215acfc:
 	cmp r8, r6
 	blt _0215acfc
 _0215ad18:
-	add r0, sl, #0x348
-	mov r1, sl
+	add r0, r10, #0x348
+	mov r1, r10
 	mov r2, #0x30
 	bl func_ov61_0215d8f8
-	add r0, sl, #0x348
-	add r1, sl, #0x54
+	add r0, r10, #0x348
+	add r1, r10, #0x54
 	mov r2, #0x20
 	bl func_ov61_0215d8f8
-	add r0, sl, #0x348
-	add r1, sl, #0x34
+	add r0, r10, #0x348
+	add r1, r10, #0x34
 	mov r2, #0x20
 	bl func_ov61_0215d8f8
-	add r0, sl, #0x348
+	add r0, r10, #0x348
 	add r1, sp, #0xd
 	bl func_ov61_0215d9b0
-	add r0, sl, #0x3fc
+	add r0, r10, #0x3fc
 	bl func_ov61_0215cfe4
-	add r0, sl, #0x3fc
-	mov r1, sl
+	add r0, r10, #0x3fc
+	mov r1, r10
 	mov r2, #0x30
 	bl func_ov61_0215d02c
-	add r0, sl, #0x3fc
+	add r0, r10, #0x3fc
 	add r1, sp, #0xd
 	mov r2, #0x14
 	bl func_ov61_0215d02c
 	ldr r1, [sp, #8]
-	add r0, sl, #0x3fc
+	add r0, r10, #0x3fc
 	add r1, r1, sb
 	bl func_ov61_0215d0e4
 	add sb, sb, #0x10
@@ -34995,43 +34995,43 @@ _0215ad18:
 	add r7, r7, #1
 	blt _0215acdc
 _0215ad9c:
-	ldrb r0, [sl, #0x454]
-	add r3, sl, #0x74
+	ldrb r0, [r10, #0x454]
+	add r3, r10, #0x74
 	cmp r0, #0
 	beq _0215add8
 	ldr r0, [sp, #4]
-	str r3, [sl, #0x1d4]
+	str r3, [r10, #0x1d4]
 	add r2, r3, r0
 	add r1, r2, r0
 	add r0, r3, r0, lsl #1
-	str r0, [sl, #0x1d8]
+	str r0, [r10, #0x1d8]
 	ldr r0, [sp]
-	str r2, [sl, #0xbc]
+	str r2, [r10, #0xbc]
 	add r0, r1, r0
-	str r0, [sl, #0xc0]
+	str r0, [r10, #0xc0]
 	b _0215ae00
 _0215add8:
 	ldr r0, [sp, #4]
-	str r3, [sl, #0xbc]
+	str r3, [r10, #0xbc]
 	add r2, r3, r0
 	add r1, r2, r0
 	add r0, r3, r0, lsl #1
-	str r0, [sl, #0xc0]
+	str r0, [r10, #0xc0]
 	ldr r0, [sp]
-	str r2, [sl, #0x1d4]
+	str r2, [r10, #0x1d4]
 	add r0, r1, r0
-	str r0, [sl, #0x1d8]
+	str r0, [r10, #0x1d8]
 _0215ae00:
-	ldr r1, [sl, #0x1d8]
-	add r0, sl, #0x1e0
+	ldr r1, [r10, #0x1d8]
+	add r0, r10, #0x1e0
 	mov r2, #0x10
 	bl func_ov61_0215da48
-	ldr r1, [sl, #0xc0]
-	add r0, sl, #0xc8
+	ldr r1, [r10, #0xc0]
+	add r0, r10, #0xc8
 	mov r2, #0x10
 	bl func_ov61_0215da48
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	arm_func_end func_ov61_0215ac5c
 
 	.global func_ov61_0215ae28
@@ -35596,7 +35596,7 @@ func_ov61_0215b5b8: ; 0x0215b5b8
 	.global func_ov61_0215b5e4
 	arm_func_start func_ov61_0215b5e4
 func_ov61_0215b5e4: ; 0x0215b5e4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	mov r5, r0
 	ldrb r0, [r5, #0x455]
 	mov r4, r1
@@ -35606,7 +35606,7 @@ func_ov61_0215b5e4: ; 0x0215b5e4
 	mov r0, r4
 	ldr r1, [r1]
 	blx r1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _0215b610:
 	ldrb r2, [r4, #3]
 	ldrb r1, [r4, #4]
@@ -35671,7 +35671,7 @@ _0215b6d0:
 	mov r0, r0, lsl #0x8
 	add r0, r0, r1, lsl #16
 	cmp r3, #0xb
-	add sl, r2, r0
+	add r10, r2, r0
 	add r8, r8, #4
 	bgt _0215b720
 	cmp r3, #0xb
@@ -35734,10 +35734,10 @@ _0215b7b8:
 _0215b7bc:
 	mov r0, r5
 	sub r1, r8, #4
-	add r2, sl, #4
+	add r2, r10, #4
 	bl func_ov61_0215b5b8
-	add r0, sl, #4
-	add r8, r8, sl
+	add r0, r10, #4
+	add r8, r8, r10
 	subs sb, sb, r0
 	beq _0215b814
 	ldrb r0, [r5, #0x455]
@@ -35752,7 +35752,7 @@ _0215b7ec:
 	str r0, [r5, #0x828]
 	mov r0, #1
 	strb r0, [r5, #0x456]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _0215b80c:
 	mov r0, #9
 	strb r0, [r5, #0x455]
@@ -35761,7 +35761,7 @@ _0215b814:
 	mov r0, r4
 	ldr r1, [r1]
 	blx r1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0215b5e4
 _0215b828: .word data_ov61_0217f454
@@ -35885,10 +35885,10 @@ _0215b9c8: .word 0x00004805
 	.global func_ov61_0215b9cc
 	arm_func_start func_ov61_0215b9cc
 func_ov61_0215b9cc: ; 0x0215b9cc
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x74
 	ldr r2, _0215baec ; =data_ov61_02180e40
-	mov sl, r0
+	mov r10, r0
 	ldrb r0, [r2]
 	mov sb, r1
 	cmp r0, #0
@@ -35915,7 +35915,7 @@ _0215ba30:
 	mov r8, #0
 	addle sp, sp, #0x74
 	mov r1, #0x14
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r5, _0215baf4 ; =data_ov61_02180fb8
 	add r6, sp, #0x18
 	mov r11, r1
@@ -35955,12 +35955,12 @@ _0215bac8:
 	ldrb r0, [r4, r1]
 	add r1, r1, #1
 	cmp r0, #0
-	strneb r0, [sl, r8]
+	strneb r0, [r10, r8]
 	addne r8, r8, #1
 	cmp r8, sb
 	blt _0215ba54
 	add sp, sp, #0x74
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0215b9cc
 _0215baec: .word data_ov61_02180e40
@@ -36369,7 +36369,7 @@ _0215c0b4: .word data_ov61_0217f454
 	.global func_ov61_0215c0b8
 	arm_func_start func_ov61_0215c0b8
 func_ov61_0215c0b8: ; 0x0215c0b8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #8
 	mov r11, r0
 	ldr r4, [r11, #0xc]
@@ -36380,29 +36380,29 @@ func_ov61_0215c0b8: ; 0x0215c0b8
 	add r0, r4, #2
 	mov r1, #0x2e
 	bl func_ov61_0215b9cc
-	ldr sl, [r4, #0x594]
+	ldr r10, [r4, #0x594]
 	ldr r0, _0215c348 ; =data_ov61_0217f428
-	mov r1, sl, lsl #0x1
+	mov r1, r10, lsl #0x1
 	ldr r2, [r0]
 	add r1, r1, r1, lsr #31
-	mov r0, sl
+	mov r0, r10
 	mov r8, r1, asr #0x1
 	blx r2
 	movs sb, r0
 	moveq r0, #9
 	addeq sp, sp, #8
 	streqb r0, [r4, #0x455]
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	mov r0, #0
 	strb r0, [sb]
 	mov r2, #2
 	add r0, sb, #2
-	sub r1, sl, #0x33
+	sub r1, r10, #0x33
 	strb r2, [sb, #1]
 	bl func_ov61_0215b9cc
-	add r1, sb, sl
+	add r1, sb, r10
 	mov r0, r4
-	sub r3, sl, #0x31
+	sub r3, r10, #0x31
 	mov r5, #0
 	sub r1, r1, #0x30
 	mov r2, #0x30
@@ -36421,12 +36421,12 @@ func_ov61_0215c0b8: ; 0x0215c0b8
 	mov r0, #9
 	add sp, sp, #8
 	strb r0, [r4, #0x455]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0215c18c:
 	add r0, r5, r8, lsl #1
 	add r6, r0, r8, lsl #1
 	mov r1, sb
-	mov r2, sl
+	mov r2, r10
 	mov r3, r8
 	str r0, [sp, #4]
 	add r7, r6, r8, lsl #1
@@ -36440,7 +36440,7 @@ _0215c18c:
 	add r1, r4, #0x94
 	mov r0, r7
 	add r1, r1, #0x400
-	mov r2, sl
+	mov r2, r10
 	mov r3, r8
 	bl func_ov61_0215e8d4
 	bl func_ov61_021599fc
@@ -36454,7 +36454,7 @@ _0215c18c:
 	mov r0, r6
 	bl func_ov61_02159a48
 	ldr r1, _0215c348 ; =data_ov61_0217f428
-	add r0, sl, #0x49
+	add r0, r10, #0x49
 	ldr r1, [r1]
 	blx r1
 	movs r6, r0
@@ -36470,12 +36470,12 @@ _0215c18c:
 	mov r0, #9
 	add sp, sp, #8
 	strb r0, [r4, #0x455]
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0215c24c:
 	mov r0, #0x16
 	strb r0, [r6]
 	mov r1, #3
-	add r0, sl, #4
+	add r0, r10, #4
 	strb r1, [r6, #1]
 	mov r1, #0
 	strb r1, [r6, #2]
@@ -36484,22 +36484,22 @@ _0215c24c:
 	strb r0, [r6, #4]
 	mov r0, #0x10
 	strb r0, [r6, #5]
-	mov r0, sl, asr #0x10
+	mov r0, r10, asr #0x10
 	strb r0, [r6, #6]
-	mov r0, sl, asr #0x8
+	mov r0, r10, asr #0x8
 	strb r0, [r6, #7]
-	strb sl, [r6, #8]
-	tst sl, #1
+	strb r10, [r6, #8]
+	tst r10, #1
 	add r0, r6, #9
 	beq _0215c2b4
-	add r0, sl, sl, lsr #31
+	add r0, r10, r10, lsr #31
 	mov r0, r0, asr #0x1
 	mov r0, r0, lsl #0x1
 	ldrh r1, [r5, r0]
 	add r0, r6, #0xa
 	strb r1, [r6, #9]
 _0215c2b4:
-	add r1, sl, sl, lsr #31
+	add r1, r10, r10, lsr #31
 	mov r1, r1, asr #0x1
 	subs r3, r1, #1
 	bmi _0215c2e8
@@ -36517,12 +36517,12 @@ _0215c2e8:
 	mov r2, #0
 	mov r0, r6
 	mov r3, r2
-	add r1, sl, #9
+	add r1, r10, #9
 	str r11, [sp]
 	bl func_ov61_02155204
 	mov r0, r4
 	add r1, r6, #5
-	add r2, sl, #4
+	add r2, r10, #4
 	bl func_ov61_0215b5b8
 	ldr r1, _0215c34c ; =data_ov61_0217f454
 	mov r0, r6
@@ -36537,7 +36537,7 @@ _0215c2e8:
 	ldr r1, [r1]
 	blx r1
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0215c0b8
 _0215c348: .word data_ov61_0217f428
@@ -36949,13 +36949,13 @@ _0215c878:
 	.global func_ov61_0215c880
 	arm_func_start func_ov61_0215c880
 func_ov61_0215c880: ; 0x0215c880
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0xc
 	ldr r4, [sp, #0x30]
 	mov sb, r1
 	mov r1, r4
 	ldr r1, [r1, #0xc]
-	mov sl, r0
+	mov r10, r0
 	mov r0, #0
 	str r4, [sp, #0x30]
 	str r1, [sp, #8]
@@ -36976,7 +36976,7 @@ _0215c8b4:
 	cmp sb, r6
 	movhs r7, r6
 	movlo r7, sb
-	mov r0, sl
+	mov r0, r10
 	add r1, r4, #5
 	mov r2, r7
 	sub r11, r6, r7
@@ -36985,7 +36985,7 @@ _0215c8b4:
 	mov r0, r8
 	add r1, r1, r7
 	mov r2, r11
-	add sl, sl, r7
+	add r10, r10, r7
 	sub sb, sb, r7
 	bl func_02007ad8
 	mov r0, #0x17
@@ -37024,7 +37024,7 @@ _0215c8b4:
 _0215c99c:
 	ldr r0, [sp, #4]
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0215c880
 _0215c9a8: .word 0x00000b4f
@@ -37214,7 +37214,7 @@ _0215cbc4: .word func_02007ad8
 	.global func_ov61_0215cbc8
 	arm_func_start func_ov61_0215cbc8
 func_ov61_0215cbc8: ; 0x0215cbc8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x44
 	str r0, [sp]
 	ldr r3, [sp]
@@ -37234,10 +37234,10 @@ _0215cbf8:
 	and r8, r5, r1
 	ldr r1, _0215cfe0 ; =data_ov61_0217bd74
 	ldr r0, [r2, r0, lsl #2]
-	ldr sl, [r1, r3, lsl #2]
+	ldr r10, [r1, r3, lsl #2]
 	eor r1, r7, r8
 	add r0, r1, r0
-	add r0, sl, r0
+	add r0, r10, r0
 	add r1, r4, r0
 	mov r0, r1, lsr #0x19
 	orr r0, r0, r1, lsl #7
@@ -37245,11 +37245,11 @@ _0215cbf8:
 	add r4, r5, r0
 	eor r0, r5, r6
 	and r0, r4, r0
-	ldr sl, [r2, r1, lsl #2]
+	ldr r10, [r2, r1, lsl #2]
 	eor r0, r6, r0
-	add r0, r0, sl
+	add r0, r0, r10
 	ldr r8, [sb, #4]
-	ldrb sl, [lr, #2]
+	ldrb r10, [lr, #2]
 	add r0, r8, r0
 	add r7, r7, r0
 	mov r0, r7, lsr #0x14
@@ -37259,9 +37259,9 @@ _0215cbf8:
 	and r0, r7, r0
 	ldr r1, [sb, #8]
 	ldrb r11, [lr, #3]
-	ldr sl, [r2, sl, lsl #2]
+	ldr r10, [r2, r10, lsl #2]
 	eor r0, r5, r0
-	add r0, r0, sl
+	add r0, r0, r10
 	add r0, r1, r0
 	add r6, r6, r0
 	mov r1, r6, lsr #0xf
@@ -37286,10 +37286,10 @@ _0215cbf8:
 	ldr r0, _0215cfdc ; =data_ov61_0217bcf4
 	ldr lr, _0215cfe0 ; =data_ov61_0217bd74
 	mov r11, #0
-	add sl, r0, r3
+	add r10, r0, r3
 	add sb, sp, #4
 _0215ccec:
-	ldrb r0, [sl]
+	ldrb r0, [r10]
 	add ip, lr, r3, lsl #2
 	eor r1, r5, r6
 	and r1, r7, r1
@@ -37302,7 +37302,7 @@ _0215ccec:
 	add r1, r4, r0
 	mov r0, r1, lsr #0x1b
 	orr r1, r0, r1, lsl #5
-	ldrb r0, [sl, #1]
+	ldrb r0, [r10, #1]
 	add r4, r5, r1
 	eor r1, r4, r5
 	and r1, r6, r1
@@ -37319,9 +37319,9 @@ _0215ccec:
 	eor r1, r7, r4
 	and r1, r5, r1
 	eor r2, r4, r1
-	ldrb r1, [sl, #2]
-	ldrb ip, [sl, #3]
-	add sl, sl, #4
+	ldrb r1, [r10, #2]
+	ldrb ip, [r10, #3]
+	add r10, r10, #4
 	ldr r1, [sb, r1, lsl #2]
 	ldr ip, [sb, ip, lsl #2]
 	add r1, r2, r1
@@ -37352,47 +37352,47 @@ _0215cdd8:
 	ldrb sb, [r2]
 	add r11, r1, r3, lsl #2
 	eor ip, r5, r6
-	ldr sl, [r0, sb, lsl #2]
+	ldr r10, [r0, sb, lsl #2]
 	eor ip, r7, ip
 	ldr sb, [r1, r3, lsl #2]
-	add sl, ip, sl
-	add sb, sb, sl
+	add r10, ip, r10
+	add sb, sb, r10
 	add sb, r4, sb
 	mov r4, sb, lsr #0x1c
-	ldrb sl, [r2, #1]
+	ldrb r10, [r2, #1]
 	orr r4, r4, sb, lsl #4
 	add r4, r5, r4
 	eor sb, r4, r5
 	eor sb, r6, sb
-	ldr ip, [r0, sl, lsl #2]
-	ldr sl, [r11, #4]
+	ldr ip, [r0, r10, lsl #2]
+	ldr r10, [r11, #4]
 	add sb, sb, ip
-	add sb, sl, sb
+	add sb, r10, sb
 	add sb, r7, sb
 	mov r7, sb, lsr #0x15
 	orr r7, r7, sb, lsl #11
 	ldrb sb, [r2, #2]
 	add r7, r4, r7
-	ldr sl, [r11, #8]
+	ldr r10, [r11, #8]
 	ldr ip, [r0, sb, lsl #2]
 	ldr sb, [r11, #0xc]
 	eor r11, r7, r4
 	eor r11, r5, r11
 	add r11, r11, ip
-	add sl, sl, r11
-	add sl, r6, sl
-	mov r6, sl, lsr #0x10
-	orr r6, r6, sl, lsl #16
+	add r10, r10, r11
+	add r10, r6, r10
+	mov r6, r10, lsr #0x10
+	orr r6, r6, r10, lsl #16
 	add r6, r7, r6
-	eor sl, r6, r7
-	eor r11, r4, sl
-	ldrb sl, [r2, #3]
+	eor r10, r6, r7
+	eor r11, r4, r10
+	ldrb r10, [r2, #3]
 	add r2, r2, #4
 	add r3, r3, #4
-	ldr sl, [r0, sl, lsl #2]
+	ldr r10, [r0, r10, lsl #2]
 	add r8, r8, #1
-	add sl, r11, sl
-	add sb, sb, sl
+	add r10, r11, r10
+	add sb, sb, r10
 	add sb, r5, sb
 	cmp r8, #4
 	mov r5, sb, lsr #0x9
@@ -37408,11 +37408,11 @@ _0215ceb0:
 	ldrb r0, [r8]
 	add r11, r1, r3, lsl #2
 	mvn r1, r7
-	orr sl, r5, r1
+	orr r10, r5, r1
 	ldr r1, _0215cfe0 ; =data_ov61_0217bd74
 	ldr r0, [r2, r0, lsl #2]
 	ldr ip, [r1, r3, lsl #2]
-	eor r1, r6, sl
+	eor r1, r6, r10
 	add r0, r1, r0
 	add r0, ip, r0
 	add r1, r4, r0
@@ -37425,9 +37425,9 @@ _0215ceb0:
 	ldr ip, [r2, r1, lsl #2]
 	eor r0, r5, r0
 	add r0, r0, ip
-	ldr sl, [r11, #4]
+	ldr r10, [r11, #4]
 	ldrb ip, [r8, #2]
-	add r0, sl, r0
+	add r0, r10, r0
 	add r7, r7, r0
 	mov r0, r7, lsr #0x16
 	orr r0, r0, r7, lsl #10
@@ -37444,9 +37444,9 @@ _0215ceb0:
 	mov r1, r6, lsr #0x11
 	orr r1, r1, r6, lsl #15
 	add sb, sb, #1
-	mvn sl, r4
+	mvn r10, r4
 	add r6, r7, r1
-	orr r1, r6, sl
+	orr r1, r6, r10
 	ldr r0, [r2, lr, lsl #2]
 	eor r1, r7, r1
 	ldr r11, [r11, #0xc]
@@ -37478,7 +37478,7 @@ _0215ceb0:
 	ldr r0, [sp]
 	str r1, [r0, #0xc]
 	add sp, sp, #0x44
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0215cbc8
 _0215cfdc: .word data_ov61_0217bcf4
@@ -37666,7 +37666,7 @@ _0215d1e4:
 	.global func_ov61_0215d21c
 	arm_func_start func_ov61_0215d21c
 func_ov61_0215d21c: ; 0x0215d21c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x50
 	str r0, [sp]
 	ldr r3, [sp]
@@ -37680,12 +37680,12 @@ func_ov61_0215d21c: ; 0x0215d21c
 	add r1, sp, #0x10
 _0215d24c:
 	eor r6, r7, r8
-	mov sl, r4, lsr #0x1b
+	mov r10, r4, lsr #0x1b
 	and r6, r5, r6
-	orr r11, sl, r4, lsl #5
+	orr r11, r10, r4, lsl #5
 	eor r6, r8, r6
-	mov sl, r5, lsr #0x2
-	orr sl, sl, r5, lsl #30
+	mov r10, r5, lsr #0x2
+	orr r10, r10, r5, lsl #30
 	add r5, r1, r0, lsl #2
 	add r6, r11, r6
 	ldr ip, [r1, r0, lsl #2]
@@ -37695,7 +37695,7 @@ _0215d24c:
 	add sb, sb, r6
 	mov r6, sb, lsr #0x1b
 	orr r6, r6, sb, lsl #5
-	eor ip, sl, r7
+	eor ip, r10, r7
 	and ip, r4, ip
 	eor ip, r7, ip
 	add r6, r6, ip
@@ -37707,9 +37707,9 @@ _0215d24c:
 	ldr r11, [r5, #8]
 	mov r6, r8, lsr #0x1b
 	orr r6, r6, r8, lsl #5
-	eor ip, r4, sl
+	eor ip, r4, r10
 	and ip, sb, ip
-	eor ip, sl, ip
+	eor ip, r10, ip
 	add r6, r6, ip
 	add r6, r11, r6
 	add r6, r6, r3
@@ -37726,15 +37726,15 @@ _0215d24c:
 	add r5, r5, ip
 	add r5, r7, r5
 	add r5, r5, r3
-	add r5, sl, r5
+	add r5, r10, r5
 	mov r7, r8, lsr #0x2
 	orr r8, r7, r8, lsl #30
 	mov r7, r5, lsr #0x1b
 	orr r7, r7, r5, lsl #5
-	eor sl, r8, sb
-	and sl, r6, sl
-	eor sl, sb, sl
-	add r7, r7, sl
+	eor r10, r8, sb
+	and r10, r6, r10
+	eor r10, sb, r10
+	add r7, r7, r10
 	add r7, r11, r7
 	add r7, r7, r3
 	add r4, r4, r7
@@ -37818,11 +37818,11 @@ _0215d24c:
 	mov r0, #0
 	ldr r4, _0215d898 ; =0x6ed9eba1
 	orr r7, r1, r7, lsl #30
-	mov sl, #4
+	mov r10, #4
 	str r0, [sp, #4]
 	add r11, sp, #0x10
 _0215d484:
-	mov r0, sl
+	mov r0, r10
 	mov r1, r11
 	bl func_ov61_0215d14c
 	mov r2, r5, lsr #0x1b
@@ -37835,7 +37835,7 @@ _0215d484:
 	mov r0, r6, lsr #0x2
 	add sb, sb, r1
 	orr r6, r0, r6, lsl #30
-	add r0, sl, #1
+	add r0, r10, #1
 	mov r1, r11
 	bl func_ov61_0215d14c
 	mov r1, sb, lsr #0x1b
@@ -37848,9 +37848,9 @@ _0215d484:
 	add r8, r8, r0
 	mov r0, r5, lsr #0x2
 	orr r5, r0, r5, lsl #30
-	add r0, sl, #2
-	and sl, r0, #0xf
-	mov r0, sl
+	add r0, r10, #2
+	and r10, r0, #0xf
+	mov r0, r10
 	mov r1, r11
 	bl func_ov61_0215d14c
 	mov r1, r8, lsr #0x1b
@@ -37863,7 +37863,7 @@ _0215d484:
 	add r7, r7, r0
 	mov r0, sb, lsr #0x2
 	orr sb, r0, sb, lsl #30
-	add r0, sl, #1
+	add r0, r10, #1
 	mov r1, r11
 	bl func_ov61_0215d14c
 	mov r1, r7, lsr #0x1b
@@ -37876,7 +37876,7 @@ _0215d484:
 	add r6, r6, r0
 	mov r0, r8, lsr #0x2
 	orr r8, r0, r8, lsl #30
-	add r0, sl, #2
+	add r0, r10, #2
 	mov r1, r11
 	bl func_ov61_0215d14c
 	mov r1, r6, lsr #0x1b
@@ -37893,14 +37893,14 @@ _0215d484:
 	str r0, [sp, #4]
 	cmp r0, #4
 	orr r7, r1, r7, lsl #30
-	add sl, sl, #3
+	add r10, r10, #3
 	blt _0215d484
 	mov r0, #0
 	ldr r4, _0215d89c ; =0x8f1bbcdc
 	str r0, [sp, #8]
 	add r11, sp, #0x10
 _0215d5b8:
-	mov r0, sl
+	mov r0, r10
 	mov r1, r11
 	bl func_ov61_0215d14c
 	orr r2, r7, r8
@@ -37915,7 +37915,7 @@ _0215d5b8:
 	add r1, r1, r4
 	add sb, sb, r1
 	orr r6, r0, r6, lsl #30
-	add r0, sl, #1
+	add r0, r10, #1
 	mov r1, r11
 	bl func_ov61_0215d14c
 	mov r1, sb, lsr #0x1b
@@ -37930,7 +37930,7 @@ _0215d5b8:
 	add r8, r8, r0
 	mov r0, r5, lsr #0x2
 	orr r5, r0, r5, lsl #30
-	add r0, sl, #2
+	add r0, r10, #2
 	mov r1, r11
 	bl func_ov61_0215d14c
 	mov r1, r8, lsr #0x1b
@@ -37945,9 +37945,9 @@ _0215d5b8:
 	add r7, r7, r0
 	mov r0, sb, lsr #0x2
 	orr sb, r0, sb, lsl #30
-	add r0, sl, #3
-	and sl, r0, #0xf
-	mov r0, sl
+	add r0, r10, #3
+	and r10, r0, #0xf
+	mov r0, r10
 	mov r1, r11
 	bl func_ov61_0215d14c
 	mov r1, r7, lsr #0x1b
@@ -37962,7 +37962,7 @@ _0215d5b8:
 	add r6, r6, r0
 	mov r0, r8, lsr #0x2
 	orr r8, r0, r8, lsl #30
-	add r0, sl, #1
+	add r0, r10, #1
 	mov r1, r11
 	bl func_ov61_0215d14c
 	mov r1, r6, lsr #0x1b
@@ -37981,14 +37981,14 @@ _0215d5b8:
 	str r0, [sp, #8]
 	cmp r0, #4
 	orr r7, r1, r7, lsl #30
-	add sl, sl, #2
+	add r10, r10, #2
 	blt _0215d5b8
 	mov r0, #0
 	ldr r4, _0215d8a0 ; =0xca62c1d6
 	str r0, [sp, #0xc]
 	add r11, sp, #0x10
 _0215d714:
-	mov r0, sl
+	mov r0, r10
 	mov r1, r11
 	bl func_ov61_0215d14c
 	mov r2, r5, lsr #0x1b
@@ -38001,7 +38001,7 @@ _0215d714:
 	mov r0, r6, lsr #0x2
 	add sb, sb, r1
 	orr r6, r0, r6, lsl #30
-	add r0, sl, #1
+	add r0, r10, #1
 	mov r1, r11
 	bl func_ov61_0215d14c
 	mov r1, sb, lsr #0x1b
@@ -38014,7 +38014,7 @@ _0215d714:
 	add r8, r8, r0
 	mov r0, r5, lsr #0x2
 	orr r5, r0, r5, lsl #30
-	add r0, sl, #2
+	add r0, r10, #2
 	mov r1, r11
 	bl func_ov61_0215d14c
 	mov r1, r8, lsr #0x1b
@@ -38027,7 +38027,7 @@ _0215d714:
 	add r7, r7, r0
 	mov r0, sb, lsr #0x2
 	orr sb, r0, sb, lsl #30
-	add r0, sl, #3
+	add r0, r10, #3
 	mov r1, r11
 	bl func_ov61_0215d14c
 	mov r1, r7, lsr #0x1b
@@ -38040,9 +38040,9 @@ _0215d714:
 	add r6, r6, r0
 	mov r0, r8, lsr #0x2
 	orr r8, r0, r8, lsl #30
-	add r0, sl, #4
-	and sl, r0, #0xf
-	mov r0, sl
+	add r0, r10, #4
+	and r10, r0, #0xf
+	mov r0, r10
 	mov r1, r11
 	bl func_ov61_0215d14c
 	mov r1, r6, lsr #0x1b
@@ -38059,7 +38059,7 @@ _0215d714:
 	str r0, [sp, #0xc]
 	cmp r0, #4
 	orr r7, r1, r7, lsl #30
-	add sl, sl, #1
+	add r10, r10, #1
 	blt _0215d714
 	ldr r0, [sp]
 	ldr r0, [r0]
@@ -38083,7 +38083,7 @@ _0215d714:
 	ldr r0, [sp]
 	str r1, [r0, #0x10]
 	add sp, sp, #0x50
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0215d21c
 _0215d894: .word 0x5a827999
@@ -38557,16 +38557,16 @@ _0215de28:
 	.global func_ov61_0215de3c
 	arm_func_start func_ov61_0215de3c
 func_ov61_0215de3c: ; 0x0215de3c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #8
 	mov r8, r3
-	mov sl, r1
+	mov r10, r1
 	mov sb, r2
 	mov r2, r8, lsl #0x1
 	mov r1, #0
 	str r0, [sp]
 	bl func_02007a44
-	mov r0, sl
+	mov r0, r10
 	mov r1, r8
 	bl func_ov61_0215db28
 	mov r11, r0
@@ -38577,7 +38577,7 @@ func_ov61_0215de3c: ; 0x0215de3c
 	cmp r0, #0
 	mov r5, #0
 	addle sp, sp, #8
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0215de90:
 	mov r6, #0
 	sub r7, r8, r5
@@ -38585,7 +38585,7 @@ _0215de90:
 	b _0215dec4
 _0215dea0:
 	mov r0, r6, lsl #0x1
-	ldrh r3, [sl, r0]
+	ldrh r3, [r10, r0]
 	ldrh r1, [sb, r4]
 	ldr r0, [sp]
 	add r2, r5, r6
@@ -38602,7 +38602,7 @@ _0215dec4:
 	cmp r5, r0
 	blt _0215de90
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	arm_func_end func_ov61_0215de3c
 
 	.global func_ov61_0215dee8
@@ -38645,10 +38645,10 @@ _0215df38:
 	.global func_ov61_0215df60
 	arm_func_start func_ov61_0215df60
 func_ov61_0215df60: ; 0x0215df60
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	mov sb, r1
 	mov r8, r2
-	mov sl, r0
+	mov r10, r0
 	mov r0, sb
 	mov r1, r8
 	bl func_ov61_0215db28
@@ -38657,7 +38657,7 @@ func_ov61_0215df60: ; 0x0215df60
 	mov r0, r11, lsl #0x1
 	ble _0215dfa0
 	sub r1, r8, r0
-	add r0, sl, r0, lsl #1
+	add r0, r10, r0, lsl #1
 	mov r2, r1, lsl #0x1
 	mov r1, #0
 	bl func_02007a44
@@ -38675,11 +38675,11 @@ _0215dfb4:
 	mov r0, r5, lsl #0x1
 	cmp r5, r2
 	mul r1, r3, r3
-	strh r1, [sl, r0]
+	strh r1, [r10, r0]
 	beq _0215dff4
 	add r4, r4, #1
 	mov r1, r1, lsr #0x10
-	add r0, sl, r0
+	add r0, r10, r0
 	strh r1, [r0, #2]
 	cmp r4, r11
 	add r5, r5, #2
@@ -38687,7 +38687,7 @@ _0215dfb4:
 _0215dff4:
 	mov r6, #0
 	cmp r11, #0
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0215e000:
 	mov r0, r6, lsl #0x1
 	add r4, r6, #1
@@ -38701,7 +38701,7 @@ _0215e010:
 	mul r7, r1, r0
 	ldr r0, _0215e090 ; =0x7fff8000
 	cmp r7, r0
-	mov r0, sl
+	mov r0, r10
 	bhi _0215e048
 	mov r2, r5
 	mov r3, r8
@@ -38715,7 +38715,7 @@ _0215e048:
 	bl func_ov61_0215de08
 	mov r1, r7
 	mov r2, r5
-	mov r0, sl
+	mov r0, r10
 	mov r3, r8
 	bl func_ov61_0215de08
 _0215e06c:
@@ -38728,7 +38728,7 @@ _0215e070:
 	add r6, r6, #1
 	cmp r6, r11
 	blt _0215e000
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0215df60
 _0215e090: .word 0x7fff8000
@@ -38775,14 +38775,14 @@ func_ov61_0215e0c4: ; 0x0215e0c4
 	.global func_ov61_0215e0e0
 	arm_func_start func_ov61_0215e0e0
 func_ov61_0215e0e0: ; 0x0215e0e0
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x20
 	ldr sb, [sp, #0x48]
 	ldr r8, [sp, #0x4c]
 	str r1, [sp, #4]
 	add r6, r8, sb, lsl #1
 	str r0, [sp]
-	mov sl, r2
+	mov r10, r2
 	mov r0, r6
 	mov r2, sb, lsl #0x2
 	mov r1, #0
@@ -38793,7 +38793,7 @@ func_ov61_0215e0e0: ; 0x0215e0e0
 	mov r1, sb
 	bl func_ov61_0215db28
 	mov r11, r0
-	mov r0, sl
+	mov r0, r10
 	mov r1, sb
 	bl func_ov61_0215db28
 	mov r5, r0
@@ -38817,7 +38817,7 @@ _0215e16c:
 	bl func_02007ad8
 	cmp r5, #2
 	ble _0215e1a0
-	add r0, sl, r5, lsl #1
+	add r0, r10, r5, lsl #1
 	sub r0, r0, #2
 	mov r11, r5, lsl #0x1
 	bl func_ov61_0215e0b0
@@ -38825,7 +38825,7 @@ _0215e16c:
 	str r1, [sp, #0x10]
 	b _0215e1d4
 _0215e1a0:
-	add r0, sl, r5, lsl #1
+	add r0, r10, r5, lsl #1
 	cmp r5, #1
 	sub r0, r0, #2
 	ble _0215e1c4
@@ -38863,7 +38863,7 @@ _0215e1ec:
 _0215e220:
 	mov r2, r5, lsl #0x10
 	mov r0, r8
-	mov r1, sl
+	mov r1, r10
 	mov r2, r2, lsr #0x10
 	mov r3, sb
 	bl func_ov61_0215dee8
@@ -38895,13 +38895,13 @@ _0215e294:
 	ldr r0, [sp, #8]
 	cmp r0, #0
 	addeq sp, sp, #0x20
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r1, [sp, #8]
 	mov r0, r7
 	mov r2, sb, lsl #0x1
 	bl func_02007ad8
 	add sp, sp, #0x20
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0215e0e0
 _0215e2bc: .word 0x0000ffff
@@ -38909,12 +38909,12 @@ _0215e2bc: .word 0x0000ffff
 	.global func_ov61_0215e2c0
 	arm_func_start func_ov61_0215e2c0
 func_ov61_0215e2c0: ; 0x0215e2c0
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0xc
 	ldr r4, _0215e44c ; =data_ov61_0217f428
 	mov r8, r3
 	ldr r3, [r4]
-	mov sl, r0
+	mov r10, r0
 	mov r0, r8, lsl #0x3
 	ldr r7, [sp, #0x30]
 	str r1, [sp, #8]
@@ -38922,9 +38922,9 @@ func_ov61_0215e2c0: ; 0x0215e2c0
 	blx r3
 	movs r4, r0
 	addeq sp, sp, #0xc
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	sub r1, r8, #1
-	add r0, sl, #2
+	add r0, r10, #2
 	mov r2, r1, lsl #0x1
 	mov r1, #0
 	add r5, r4, r8, lsl #1
@@ -38932,7 +38932,7 @@ func_ov61_0215e2c0: ; 0x0215e2c0
 	mov r2, #1
 	mov r0, sb
 	mov r1, r8
-	strh r2, [sl]
+	strh r2, [r10]
 	bl func_ov61_0215db28
 	sub r0, r8, r0
 	mov r6, r0, lsl #0x4
@@ -38947,7 +38947,7 @@ _0215e338:
 	tst r0, r2, lsr r1
 	beq _0215e368
 	ldr r0, [sp, #8]
-	mov r1, sl
+	mov r1, r10
 	mov r2, r8, lsl #0x1
 	bl func_02007ad8
 	add r6, r6, #1
@@ -38962,20 +38962,20 @@ _0215e374:
 	mov r11, r8, lsl #0x1
 _0215e380:
 	mov r0, r4
-	mov r1, sl
+	mov r1, r10
 	mov r2, r8
 	bl func_ov61_0215df60
 	mov r0, r4
-	mov r1, sl
+	mov r1, r10
 	mov r2, r11
 	bl func_02007ad8
 	cmp r7, #0
 	beq _0215e3c4
 	str r8, [sp]
 	mov r0, #0
-	mov r1, sl
+	mov r1, r10
 	mov r2, r7
-	mov r3, sl
+	mov r3, r10
 	str r5, [sp, #4]
 	bl func_ov61_0215e0e0
 _0215e3c4:
@@ -38988,20 +38988,20 @@ _0215e3c4:
 	beq _0215e428
 	ldr r2, [sp, #8]
 	mov r0, r4
-	mov r1, sl
+	mov r1, r10
 	mov r3, r8
 	bl func_ov61_0215de3c
 	mov r0, r4
-	mov r1, sl
+	mov r1, r10
 	mov r2, r11
 	bl func_02007ad8
 	cmp r7, #0
 	beq _0215e428
 	str r8, [sp]
 	mov r0, #0
-	mov r1, sl
+	mov r1, r10
 	mov r2, r7
-	mov r3, sl
+	mov r3, r10
 	str r5, [sp, #4]
 	bl func_ov61_0215e0e0
 _0215e428:
@@ -39014,7 +39014,7 @@ _0215e434:
 	ldr r1, [r1]
 	blx r1
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0215e2c0
 _0215e44c: .word data_ov61_0217f428
@@ -39023,20 +39023,20 @@ _0215e450: .word data_ov61_0217f454
 	.global func_ov61_0215e454
 	arm_func_start func_ov61_0215e454
 func_ov61_0215e454: ; 0x0215e454
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x14
 	ldr sb, [sp, #0x38]
-	mov sl, r3
-	add r11, sb, sl, lsl #1
-	add r4, r11, sl, lsl #1
-	add r5, r4, sl, lsl #1
-	add r6, r5, sl, lsl #1
-	add r7, r6, sl, lsl #1
+	mov r10, r3
+	add r11, sb, r10, lsl #1
+	add r4, r11, r10, lsl #1
+	add r5, r4, r10, lsl #1
+	add r6, r5, r10, lsl #1
+	add r7, r6, r10, lsl #1
 	str r0, [sp, #8]
 	mov r0, r1
-	add r1, r7, sl, lsl #1
+	add r1, r7, r10, lsl #1
 	str r1, [sp, #0x10]
-	mov r8, sl, lsl #0x1
+	mov r8, r10, lsl #0x1
 	str r2, [sp, #0xc]
 	mov r1, sb
 	mov r2, r8
@@ -39048,13 +39048,13 @@ func_ov61_0215e454: ; 0x0215e454
 	mov r0, #1
 	strh r0, [r4, r8]
 	mov r0, sb
-	mov r1, sl
+	mov r1, r10
 	bl func_ov61_0215db50
 	cmp r0, #0
 	ble _0215e564
 _0215e4c8:
 	ldr r3, [sp, #0x10]
-	str sl, [sp]
+	str r10, [sp]
 	str r3, [sp, #4]
 	mov r0, r11
 	mov r1, r4
@@ -39072,12 +39072,12 @@ _0215e4c8:
 	mov r0, r7
 	mov r1, r11
 	mov r2, r5
-	mov r3, sl
+	mov r3, r10
 	bl func_ov61_0215de3c
 	mov r0, r7
 	mov r1, r6
 	mov r2, r7
-	mov r3, sl
+	mov r3, r10
 	bl func_ov61_0215dcc0
 	mov r0, r5
 	mov r1, r6
@@ -39088,7 +39088,7 @@ _0215e4c8:
 	mov r2, r8
 	bl func_02007ad8
 	mov r0, sb
-	mov r1, sl
+	mov r1, r10
 	bl func_ov61_0215db50
 	cmp r0, #0
 	bgt _0215e4c8
@@ -39096,18 +39096,18 @@ _0215e564:
 	ldr r2, [sp, #0xc]
 	mov r0, r6
 	mov r1, r6
-	mov r3, sl
+	mov r3, r10
 	bl func_ov61_0215db80
 	ldr r2, [sp, #0xc]
 	ldr r3, [sp, #8]
 	ldr r4, [sp, #0x10]
-	str sl, [sp]
+	str r10, [sp]
 	mov r1, r6
 	mov r0, #0
 	str r4, [sp, #4]
 	bl func_ov61_0215e0e0
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	arm_func_end func_ov61_0215e454
 
 	.global func_ov61_0215e5a0
@@ -39196,11 +39196,11 @@ _0215e6b0:
 	.global func_ov61_0215e6c8
 	arm_func_start func_ov61_0215e6c8
 func_ov61_0215e6c8: ; 0x0215e6c8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x2c
-	mov sl, r3
+	mov r10, r3
 	mov r3, #0x16
-	mul r4, sl, r3
+	mul r4, r10, r3
 	ldr r3, _0215e8cc ; =data_ov61_0217f428
 	mov r11, r0
 	ldr r3, [r3]
@@ -39212,20 +39212,20 @@ func_ov61_0215e6c8: ; 0x0215e6c8
 	str r0, [sp, #0x28]
 	cmp r0, #0
 	addeq sp, sp, #0x2c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	mov r2, r4
 	mov r1, #0
 	bl func_02007a44
 	ldr r0, [sp, #0x28]
-	mov r1, sl
-	add r6, r0, sl, lsl #1
-	add r0, r6, sl, lsl #1
-	add r7, r0, sl, lsl #1
-	add r8, r7, sl, lsl #1
+	mov r1, r10
+	add r6, r0, r10, lsl #1
+	add r0, r6, r10, lsl #1
+	add r7, r0, r10, lsl #1
+	add r8, r7, r10, lsl #1
 	str r0, [sp, #0x24]
-	add r0, r8, sl, lsl #1
+	add r0, r8, r10, lsl #1
 	str r0, [sp, #0x20]
-	add r5, r0, sl, lsl #1
+	add r5, r0, r10, lsl #1
 	mov r0, sb
 	bl func_ov61_0215db28
 	mov r4, r0
@@ -39238,19 +39238,19 @@ func_ov61_0215e6c8: ; 0x0215e6c8
 	str r0, [sp]
 	mov r0, r6
 	mov r2, sb
-	mov r3, sl
+	mov r3, r10
 	bl func_ov61_0215e454
 	ldr r1, [sp, #0x28]
 	mov r0, r7
 	mov r2, r6
-	mov r3, sl
+	mov r3, r10
 	bl func_ov61_0215de3c
 	mov r0, r6
 	mov r1, r7
 	mov r2, #1
-	mov r3, sl
+	mov r3, r10
 	bl func_ov61_0215dd68
-	str sl, [sp]
+	str r10, [sp]
 	mov r0, r6
 	mov r1, r6
 	mov r2, sb
@@ -39260,16 +39260,16 @@ func_ov61_0215e6c8: ; 0x0215e6c8
 	ldr r1, [sp, #0x14]
 	ldr r0, [sp, #0x24]
 	ldr r2, [sp, #0x28]
-	mov r3, sl
+	mov r3, r10
 	bl func_ov61_0215de3c
 	ldr r1, [sp, #0x24]
-	str sl, [sp]
+	str r10, [sp]
 	mov r0, #0
 	mov r2, sb
 	mov r3, r1
 	str r5, [sp, #4]
 	bl func_ov61_0215e0e0
-	str sl, [sp]
+	str r10, [sp]
 	ldr r1, [sp, #0x28]
 	mov r0, #0
 	mov r2, sb
@@ -39287,7 +39287,7 @@ _0215e818:
 	ldr r1, [sp, #0x20]
 	mov r0, r11
 	mov r2, #1
-	mov r3, sl
+	mov r3, r10
 	str r8, [sp, #0x10]
 	bl func_ov61_0215e5a0
 	ldr r1, [sp, #0x18]
@@ -39304,7 +39304,7 @@ _0215e818:
 	ldr r1, [sp, #0x20]
 	ldr r2, [sp, #0x24]
 	mov r0, r11
-	mov r3, sl
+	mov r3, r10
 	str r8, [sp, #0x10]
 	bl func_ov61_0215e5a0
 _0215e880:
@@ -39318,7 +39318,7 @@ _0215e890:
 	str r7, [sp, #0xc]
 	ldr r1, [sp, #0x20]
 	mov r0, r11
-	mov r3, sl
+	mov r3, r10
 	mov r2, #0
 	str r8, [sp, #0x10]
 	bl func_ov61_0215e5a0
@@ -39327,7 +39327,7 @@ _0215e890:
 	ldr r1, [r1]
 	blx r1
 	add sp, sp, #0x2c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0215e6c8
 _0215e8cc: .word data_ov61_0217f428
@@ -42768,15 +42768,15 @@ _021614e0: .word data_ov61_02181000
 	.global func_ov61_021614e4
 	arm_func_start func_ov61_021614e4
 func_ov61_021614e4: ; 0x021614e4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	ldr r7, [sp, #0x28]
 	ldr r6, [sp, #0x2c]
 	movs sb, r1
-	mov sl, r0
+	mov r10, r0
 	mov r11, r2
 	mov r8, r3
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	cmp sb, #1
 	mov r4, #0
 	mov r5, #1
@@ -42792,7 +42792,7 @@ _02161528:
 	str r0, [r6]
 	ldrb r1, [r7]
 	ldrb r0, [r11, r2]
-	ldrb r1, [sl, r1]
+	ldrb r1, [r10, r1]
 	add r0, r1, r0
 	strb r0, [r7]
 	ldr r0, [r6]
@@ -42816,7 +42816,7 @@ _02161588:
 	cmp r0, sb
 	bhi _02161528
 	and r0, r0, #0xff
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	arm_func_end func_ov61_021614e4
 
 	.global func_ov61_02161598
@@ -43326,20 +43326,20 @@ _02161bd8:
 	.global func_ov61_02161be0
 	arm_func_start func_ov61_02161be0
 func_ov61_02161be0: ; 0x02161be0
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	mov r8, r2
 	ldrsb r2, [r8]
-	mov sl, r0
+	mov r10, r0
 	mov sb, r1
 	mov r7, r3
 	cmp r2, #0
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	ldrb r0, [sb, #0x14]
 	add r8, r8, #5
 	sub r7, r7, #5
 	tst r0, #4
 	beq _02161c7c
-	ldr r0, [sl, #0x40]
+	ldr r0, [r10, #0x40]
 	mov r6, #0
 	cmp r0, #0
 	ble _02161c6c
@@ -43350,13 +43350,13 @@ _02161c28:
 	bl func_ov61_02163490
 	movs r5, r0
 	bmi _02161c6c
-	add r0, sl, r6
+	add r0, r10, r6
 	ldrb r1, [r0, #0x2c]
 	mov r0, sb
 	mov r2, r8
 	ldr r1, [r4, r1, lsl #2]
 	bl func_ov61_0216218c
-	ldr r0, [sl, #0x40]
+	ldr r0, [r10, #0x40]
 	add r6, r6, #1
 	cmp r6, r0
 	add r8, r8, r5
@@ -43384,15 +43384,15 @@ _02161c98:
 	mov r1, sb
 	sub r0, r0, r2
 	str r0, [sb, #0x1c]
-	add r0, sl, #8
+	add r0, r10, #8
 	bl func_ov61_02161840
-	ldr r3, [sl, #0x48]
-	ldr r4, [sl, #0x44]
-	mov r0, sl
+	ldr r3, [r10, #0x48]
+	ldr r4, [r10, #0x44]
+	mov r0, r10
 	mov r2, sb
 	mov r1, #0
 	blx r4
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02161be0
 _02161cdc: .word data_ov61_0217e4e8
@@ -44071,13 +44071,13 @@ _0216247c: .word data_ov61_02181010
 	.global func_ov61_02162480
 	arm_func_start func_ov61_02162480
 func_ov61_02162480: ; 0x02162480
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
-	mov sl, r0
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	mov r10, r0
 	add r0, r1, #1
 	mov r1, #0x5c
 	bl func_ov61_0216241c
 	movs r8, r0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	mov r4, #0
 	mov r11, #0x5c
 	ldr r5, _021624fc ; =data_ov61_0217bf20
@@ -44093,7 +44093,7 @@ _021624b0:
 	bl func_ov61_021623bc
 	cmp r0, #0
 	beq _021624e4
-	mov r0, sl
+	mov r0, r10
 	mov r1, r8
 	mov r2, sb
 	bl func_ov61_0216218c
@@ -44103,7 +44103,7 @@ _021624e4:
 	bl func_ov61_0216241c
 	movs r8, r0
 	bne _021624b0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02162480
 _021624fc: .word data_ov61_0217bf20
@@ -44111,56 +44111,56 @@ _021624fc: .word data_ov61_0217bf20
 	.global func_ov61_02162500
 	arm_func_start func_ov61_02162500
 func_ov61_02162500: ; 0x02162500
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x8c
-	mov sl, r1
-	ldrsb r1, [sl]
+	mov r10, r1
+	ldrsb r1, [r10]
 	mov r11, r0
 	mov sb, r2
 	cmp r1, #0
 	beq _02162580
 _02162520:
-	mov r0, sl
+	mov r0, r10
 	mov r1, sb
 	bl func_ov61_02163490
 	cmp r0, #0
 	addlt sp, sp, #0x8c
-	ldmltia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
-	mov r4, sl
+	ldmltia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	mov r4, r10
 	sub sb, sb, r0
-	add sl, sl, r0
-	mov r0, sl
+	add r10, r10, r0
+	mov r0, r10
 	mov r1, sb
 	bl func_ov61_02163490
 	cmp r0, #0
 	addlt sp, sp, #0x8c
-	ldmltia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
-	mov r2, sl
+	ldmltia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	mov r2, r10
 	mov r1, r4
-	add sl, sl, r0
+	add r10, r10, r0
 	sub sb, sb, r0
 	mov r0, r11
 	bl func_ov61_0216218c
-	ldrsb r0, [sl]
+	ldrsb r0, [r10]
 	cmp r0, #0
 	bne _02162520
 _02162580:
 	mov r0, #0
-	add sl, sl, #1
+	add r10, r10, #1
 	sub sb, sb, #1
 	str r0, [sp]
 _02162590:
 	cmp sb, #2
 	addlt sp, sp, #0x8c
-	ldmltia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
-	ldrb r1, [sl]
-	ldrb r0, [sl, #1]
+	ldmltia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldrb r1, [r10]
+	ldrb r0, [r10, #1]
 	add r2, sp, #8
-	add sl, sl, #2
+	add r10, r10, #2
 	strb r1, [r2]
 	strb r0, [r2, #1]
 	ldrh r0, [sp, #8]
-	str sl, [sp, #4]
+	str r10, [sp, #4]
 	sub sb, sb, #2
 	mov r1, r0, asr #0x8
 	mov r0, r0, lsl #0x8
@@ -44168,28 +44168,28 @@ _02162590:
 	and r0, r0, #0xff00
 	orr r0, r1, r0
 	strh r0, [sp, #8]
-	ldrsb r0, [sl]
+	ldrsb r0, [r10]
 	mov r5, #0
 	cmp r0, #0
 	beq _02162620
 _021625e8:
-	mov r0, sl
+	mov r0, r10
 	mov r1, sb
 	bl func_ov61_02163490
 	cmp r0, #0
 	addlt sp, sp, #0x8c
-	ldmltia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmltia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	cmp r0, #0x64
 	addgt sp, sp, #0x8c
-	ldmgtia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
-	ldrsb r1, [sl, r0]!
+	ldmgtia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldrsb r1, [r10, r0]!
 	add r5, r5, #1
 	sub sb, sb, r0
 	cmp r1, #0
 	bne _021625e8
 _02162620:
 	ldrh r0, [sp, #8]
-	add sl, sl, #1
+	add r10, r10, #1
 	sub sb, sb, #1
 	cmp r0, #0
 	mov r6, #0
@@ -44200,12 +44200,12 @@ _02162638:
 	cmp r5, #0
 	ble _021626a8
 _02162648:
-	mov r0, sl
+	mov r0, r10
 	mov r1, sb
 	bl func_ov61_02163490
 	movs r4, r0
 	addmi sp, sp, #0x8c
-	ldmmiia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmmiia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r1, _021626d4 ; =data_ov61_0217bf24
 	add r0, sp, #0xa
 	mov r2, r8
@@ -44213,10 +44213,10 @@ _02162648:
 	bl func_020459b8
 	mov r0, r11
 	add r1, sp, #0xa
-	mov r2, sl
+	mov r2, r10
 	bl func_ov61_0216218c
 	mov r0, r8
-	add sl, sl, r4
+	add r10, r10, r4
 	sub sb, sb, r4
 	bl strlen
 	add r0, r0, #1
@@ -44236,7 +44236,7 @@ _021626b8:
 	cmp r0, #2
 	blt _02162590
 	add sp, sp, #0x8c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02162500
 _021626d4: .word data_ov61_0217bf24
@@ -44668,10 +44668,10 @@ func_ov61_02162ba0: ; 0x02162ba0
 	.global func_ov61_02162bc4
 	arm_func_start func_ov61_02162bc4
 func_ov61_02162bc4: ; 0x02162bc4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x108
 	ldr r8, [sp, #0x130]
-	mov sl, r0
+	mov r10, r0
 	str r1, [sp, #4]
 	add r4, sp, #8
 	mov sb, r3
@@ -44686,9 +44686,9 @@ _02162be8:
 	subs r1, r1, #1
 	bne _02162be8
 	mov r5, #0
-	str r2, [sl, #0x620]
+	str r2, [r10, #0x620]
 	mov r6, r5
-	str r5, [sl, #0x40]
+	str r5, [r10, #0x40]
 	cmp r8, #0
 	ble _02162c70
 	ldr r4, _02162cec ; =data_ov61_0217e4e8
@@ -44708,7 +44708,7 @@ _02162c24:
 	bl func_020459b8
 	add r5, r5, r0
 	ldrb r1, [sb, r6]
-	mov r0, sl
+	mov r0, r10
 	bl func_ov61_02162044
 	add r6, r6, #1
 	cmp r6, r8
@@ -44718,35 +44718,35 @@ _02162c70:
 	ldr r2, [sp, #0x134]
 	ldr r3, [sp, #0x138]
 	add r1, sp, #8
-	add r0, sl, #0x4c
+	add r0, r10, #0x4c
 	str r4, [sp]
 	bl func_ov61_02163aac
 	cmp r0, #0
 	addne sp, sp, #0x108
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r1, [sp, #4]
 	cmp r1, #0
 	addne sp, sp, #0x108
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	mov r4, #0xa
 	b _02162cc0
 _02162cb0:
 	mov r0, r4
 	bl func_ov61_02166640
-	mov r0, sl
+	mov r0, r10
 	bl func_ov61_02162df4
 _02162cc0:
-	ldr r1, [sl, #0x4c]
+	ldr r1, [r10, #0x4c]
 	cmp r1, #3
 	beq _02162cb0
-	ldr r1, [sl, #0x10]
+	ldr r1, [r10, #0x10]
 	cmp r1, #0
 	addle sp, sp, #0x108
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	cmp r0, #0
 	beq _02162cb0
 	add sp, sp, #0x108
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02162bc4
 _02162cec: .word data_ov61_0217e4e8
@@ -45775,8 +45775,8 @@ func_ov61_021638f4: ; 0x021638f4
 	.global func_ov61_02163928
 	arm_func_start func_ov61_02163928
 func_ov61_02163928: ; 0x02163928
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
-	mov sl, r0
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	mov r10, r0
 	bl func_02045b48
 	ldr r5, _02163a10 ; =0x2c0b02c1
 	mov r8, #0
@@ -45788,14 +45788,14 @@ func_ov61_02163928: ; 0x02163928
 	sub r4, r0, r1
 	add r0, r4, #0x21
 	mov r7, #1
-	strb r0, [sl, #0x74]
+	strb r0, [r10, #0x74]
 	mov r11, r8
 	mov r6, r7
 	mov r4, r3
 _0216396c:
-	add sb, sl, r7
+	add sb, r10, r7
 	ldrsb r3, [sb, #0x73]
-	ldrsb r0, [sl, #0x74]
+	ldrsb r0, [r10, #0x74]
 	cmp r3, r0
 	eor r3, r7, r3
 	movlt r1, r6
@@ -45836,7 +45836,7 @@ _02163a00:
 	add r7, r7, #1
 	cmp r7, #8
 	blt _0216396c
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02163928
 _02163a10: .word 0x2c0b02c1
@@ -45844,15 +45844,15 @@ _02163a10: .word 0x2c0b02c1
 	.global func_ov61_02163a14
 	arm_func_start func_ov61_02163a14
 func_ov61_02163a14: ; 0x02163a14
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
-	mov sl, r0
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	mov r10, r0
 	mov sb, r1
 	mov r8, r2
 	mov r7, #1
 	mov r11, #2
 	mov r5, #0
 _02163a30:
-	ldr r0, [sl, #0x4b0]
+	ldr r0, [r10, #0x4b0]
 	mov r1, sb
 	mov r2, r8
 	mov r3, r5
@@ -45863,20 +45863,20 @@ _02163a30:
 	bgt _02163a9c
 	cmp r7, #0
 	blt _02163a9c
-	mov r0, sl
+	mov r0, r10
 	bl func_ov61_02163dc4
 	mov r1, #0
 	mov r2, r1
-	mov r0, sl
+	mov r0, r10
 	mov r3, r11
 	str r2, [sp]
 	bl func_ov61_02163aac
 	movs r4, r0
 	beq _02163a94
-	mov r0, sl
+	mov r0, r10
 	bl func_ov61_021635ec
 	mov r0, r4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02163a94:
 	cmp r7, #0
 	bge _02163a30
@@ -45884,7 +45884,7 @@ _02163a9c:
 	cmp r6, #0
 	movle r0, #3
 	movgt r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	arm_func_end func_ov61_02163a14
 
 	.global func_ov61_02163aac
@@ -46379,12 +46379,12 @@ _02164108:
 	.global func_ov61_0216411c
 	arm_func_start func_ov61_0216411c
 func_ov61_0216411c: ; 0x0216411c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x10
 	mov r8, r2
 	ldrb r2, [r8], #5
 	mov sb, r1
-	mov sl, r0
+	mov r10, r0
 	mov r7, r3
 	str r2, [sp]
 	mov r0, sb
@@ -46416,7 +46416,7 @@ func_ov61_0216411c: ; 0x0216411c
 _021641a4:
 	ldr r0, [sp]
 	tst r0, #0x20
-	addeq r0, sl, #0x400
+	addeq r0, r10, #0x400
 	ldreqh r0, [r0, #0xa8]
 	streqh r0, [sp, #8]
 	beq _021641d8
@@ -46453,7 +46453,7 @@ _0216422c:
 	ldr r0, [sp]
 	tst r0, #0x40
 	beq _0216435c
-	ldr r0, [sl, #8]
+	ldr r0, [r10, #8]
 	bl func_ov61_02165a68
 	mov r4, r0
 	cmp r4, #0
@@ -46461,7 +46461,7 @@ _0216422c:
 	ble _02164344
 	add r11, sp, #0xa
 _02164254:
-	ldr r0, [sl, #8]
+	ldr r0, [r10, #8]
 	mov r1, r5
 	bl func_ov61_02165a70
 	mov r1, r0
@@ -46517,7 +46517,7 @@ _021642e4:
 	sub r7, r7, r0
 	b _02164338
 _02164324:
-	add r0, sl, r0, lsl #2
+	add r0, r10, r0, lsl #2
 	ldr r1, [r1]
 	ldr r2, [r0, #0x84]
 	mov r0, sb
@@ -46572,7 +46572,7 @@ _021643d8:
 	ldr r0, [sp, #4]
 	sub r0, r0, r7
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	arm_func_end func_ov61_0216411c
 
 	.global func_ov61_021643e8
@@ -46962,10 +46962,10 @@ _02164948: .word 0x000004af
 	.global func_ov61_0216494c
 	arm_func_start func_ov61_0216494c
 func_ov61_0216494c: ; 0x0216494c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #8
-	mov sl, r0
-	ldr r3, [sl, #8]
+	mov r10, r0
+	ldr r3, [r10, #8]
 	mov sb, r1
 	mov r8, r2
 	cmp r3, #0
@@ -46979,10 +46979,10 @@ _02164978:
 	mov r2, #0
 	bl func_ov61_02165938
 	cmp r0, #0
-	str r0, [sl, #8]
+	str r0, [r10, #8]
 	addeq sp, sp, #8
 	moveq r0, #5
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	cmp r7, #0
 	mov r6, #0
 	ble _02164a1c
@@ -46992,7 +46992,7 @@ _021649b0:
 	cmp r8, #2
 	addlt sp, sp, #8
 	movlt r0, #4
-	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	add r0, sb, #1
 	sub r1, r8, #1
 	bl func_ov61_02163490
@@ -47000,14 +47000,14 @@ _021649b0:
 	cmp r5, r4
 	addeq sp, sp, #8
 	moveq r0, #4
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldrb r2, [sb]
-	mov r0, sl
+	mov r0, r10
 	add r1, sb, #1
 	str r2, [sp, #4]
 	bl func_ov61_021633a4
 	str r0, [sp]
-	ldr r0, [sl, #8]
+	ldr r0, [r10, #8]
 	mov r1, r11
 	bl func_ov61_02165ad8
 	add r0, r5, #1
@@ -47019,21 +47019,21 @@ _021649b0:
 _02164a1c:
 	mov r0, #0
 	add sp, sp, #8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	arm_func_end func_ov61_0216494c
 
 	.global func_ov61_02164a28
 	arm_func_start func_ov61_02164a28
 func_ov61_02164a28: ; 0x02164a28
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x24
 	mov r8, r2
 	cmp r8, #2
-	mov sl, r0
+	mov r10, r0
 	mov sb, r1
 	addlt sp, sp, #0x24
 	movlt r0, #4
-	ldmltia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmltia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldrb r0, [sb, #1]
 	sub r8, r8, #2
 	mov r11, #0
@@ -47054,13 +47054,13 @@ _02164a7c:
 	cmp r0, r4
 	addeq sp, sp, #0x24
 	moveq r0, #4
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	sub r3, r8, r0
 	cmp r3, #0xb
 	add r2, sb, r0
 	addlt sp, sp, #0x24
 	movlt r0, #4
-	ldmltia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmltia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldrb r1, [r2]
 	ldrb r0, [r2, #1]
 	sub r8, r3, #0xa
@@ -47104,16 +47104,16 @@ _02164a7c:
 	cmp r5, r4
 	addeq sp, sp, #0x24
 	moveq r0, #4
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r1, [sp, #0x1c]
-	mov r0, sl
+	mov r0, r10
 	stmia sp, {r1, sb}
-	ldr r2, [sl, #0x494]
+	ldr r2, [r10, #0x494]
 	ldr r1, [sp, #0x10]
 	str r2, [sp, #8]
 	ldrh r3, [sp, #0x18]
 	ldr r2, [sp, #0x20]
-	ldr ip, [sl, #0x490]
+	ldr ip, [r10, #0x490]
 	blx ip
 	ldr r0, [sp, #0xc]
 	add r11, r11, #1
@@ -47128,31 +47128,31 @@ _02164ba4:
 	mov r1, #0
 	str r1, [sp]
 	str r1, [sp, #4]
-	ldr r2, [sl, #0x494]
-	mov r0, sl
+	ldr r2, [r10, #0x494]
+	mov r0, r10
 	str r2, [sp, #8]
-	ldr r4, [sl, #0x490]
+	ldr r4, [r10, #0x490]
 	mov r2, r1
 	mov r3, r1
 	blx r4
 _02164bd8:
 	mov r0, #0
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	arm_func_end func_ov61_02164a28
 
 	.global func_ov61_02164be4
 	arm_func_start func_ov61_02164be4
 func_ov61_02164be4: ; 0x02164be4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x54
 	mov r8, r2
 	cmp r8, #0xb
-	mov sl, r0
+	mov r10, r0
 	mov sb, r1
 	addlt sp, sp, #0x54
 	movlt r0, #4
-	ldmltia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmltia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldrb r2, [sb]
 	ldrb r1, [sb, #1]
 	add r3, sp, #0xc
@@ -47175,8 +47175,8 @@ func_ov61_02164be4: ; 0x02164be4
 	cmp r1, r0
 	addeq sp, sp, #0x54
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
-	mov r0, sl
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	mov r0, r10
 	bl func_ov61_021632b8
 	ldrb r2, [sb, #6]
 	ldrb r1, [sb, #7]
@@ -47217,7 +47217,7 @@ _02164ce4:
 	cmp r0, r4
 	addeq sp, sp, #0x54
 	moveq r0, #4
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	str sb, [r5, r7, lsl #2]
 	add sb, sb, r0
 	sub r8, r8, r0
@@ -47227,15 +47227,15 @@ _02164d18:
 	cmplt r7, #0x10
 	blt _02164ce4
 _02164d24:
-	ldr r4, [sl, #0x48c]
+	ldr r4, [r10, #0x48c]
 	cmp r4, #0
 	addeq sp, sp, #0x54
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	add r1, sp, #0x14
 	str r1, [sp]
-	ldr r2, [sl, #0x494]
-	mov r0, sl
+	ldr r2, [r10, #0x494]
+	mov r0, r10
 	str r2, [sp, #4]
 	ldr r2, [sp, #0x10]
 	mov r1, r11
@@ -47243,7 +47243,7 @@ _02164d24:
 	blx r4
 	mov r0, #0
 	add sp, sp, #0x54
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	arm_func_end func_ov61_02164be4
 
 	.global func_ov61_02164d68
@@ -47359,7 +47359,7 @@ _02164ec8:
 	.global func_ov61_02164eec
 	arm_func_start func_ov61_02164eec
 func_ov61_02164eec: ; 0x02164eec
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	mov sb, r0
 	ldr r0, [sb, #0x80]
 	mov r8, #0
@@ -47367,7 +47367,7 @@ func_ov61_02164eec: ; 0x02164eec
 	blt _02165088
 	ldr r5, _021650a0 ; =data_ov61_0217c054
 	ldr r4, _021650a4 ; =data_ov61_0217bfcc
-	ldr sl, _021650a8 ; =data_ov61_0217bf78
+	ldr r10, _021650a8 ; =data_ov61_0217bf78
 	ldr r11, _021650ac ; =0x000005b4
 	mov r6, r8
 	add r7, sp, #0
@@ -47391,7 +47391,7 @@ _02164f1c:
 	ldr r0, [sb, #0x80]
 	cmp r0, r2
 	movlt r0, #0
-	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmltia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r1, [sb, #0x7c]
 	ldrsb r0, [r1, #2]
 	cmp r0, #6
@@ -47426,7 +47426,7 @@ _02164fcc:
 	cmp r0, #0
 	bgt _0216502c
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02164fe8:
 	mov r0, sb
 	add r1, r1, #3
@@ -47455,7 +47455,7 @@ _0216502c:
 	bpl _02165054
 	mov r0, r5
 	mov r1, r4
-	mov r2, sl
+	mov r2, r10
 	mov r3, r11
 	bl func_02042f80
 _02165054:
@@ -47480,7 +47480,7 @@ _02165088:
 	bl func_ov61_021635ec
 _02165098:
 	mov r0, r8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02164eec
 _021650a0: .word data_ov61_0217c054
@@ -47560,7 +47560,7 @@ _02165190:
 	arm_func_start func_ov61_02165198
 func_ov61_02165198: ; 0x02165198
 	stmdb sp!, {r0, r1, r2, r3}
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x18
 	mov r5, r0
 	ldr r1, [r5]
@@ -47577,7 +47577,7 @@ _021651cc:
 	cmp r0, #1
 	addeq sp, sp, #0x18
 	moveq r0, #3
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	addeq sp, sp, #0x10
 	bxeq lr
 	ldr r0, [sp, #0x50]
@@ -47600,7 +47600,7 @@ _021651cc:
 	mov r11, #2
 	strb r2, [r1, #1]
 	ldrb sb, [r6]
-	add sl, sp, #9
+	add r10, sp, #9
 	ldrb r8, [r6, #1]
 	ldrb r7, [r6, #2]
 	ldrb r6, [r6, #3]
@@ -47610,16 +47610,16 @@ _021651cc:
 	mov r0, r5
 	mov r2, #9
 	strb r11, [sp, #8]
-	strb sb, [sl]
-	strb r8, [sl, #1]
-	strb r7, [sl, #2]
-	strb r6, [sl, #3]
+	strb sb, [r10]
+	strb r8, [r10, #1]
+	strb r7, [r10, #2]
+	strb r6, [r10, #3]
 	strb ip, [lr]
 	strb r3, [lr, #1]
 	bl func_ov61_02163a14
 	cmp r0, #0
 	addne sp, sp, #0x18
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	addne sp, sp, #0x10
 	bxne lr
 	ldr r0, [r5, #0x4b0]
@@ -47631,7 +47631,7 @@ _021651cc:
 	movlt r0, #3
 	movge r0, #0
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	add sp, sp, #0x10
 	bx lr
 	arm_func_end func_ov61_02165198
@@ -47640,7 +47640,7 @@ _021651cc:
 	arm_func_start func_ov61_021652c0
 func_ov61_021652c0: ; 0x021652c0
 	stmdb sp!, {r0, r1, r2, r3}
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x10
 	ldr r5, [sp, #0x44]
 	mov r7, #0xfd
@@ -47664,7 +47664,7 @@ func_ov61_021652c0: ; 0x021652c0
 	add r3, sp, #0x44
 	str r8, [sp, #0x44]
 	strb r7, [sp, #4]
-	ldrb sl, [r3]
+	ldrb r10, [r3]
 	add ip, sp, #0xa
 	ldrb sb, [r3, #1]
 	ldrb r8, [r3, #2]
@@ -47674,7 +47674,7 @@ func_ov61_021652c0: ; 0x021652c0
 	strb r5, [sp, #6]
 	strb lr, [sp, #8]
 	strb r11, [sp, #9]
-	strb sl, [ip]
+	strb r10, [ip]
 	strb sb, [ip, #1]
 	strb r8, [ip, #2]
 	strb r7, [ip, #3]
@@ -47682,7 +47682,7 @@ func_ov61_021652c0: ; 0x021652c0
 	str r4, [sp]
 	bl func_ov61_02165198
 	add sp, sp, #0x10
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	add sp, sp, #0x10
 	bx lr
 	arm_func_end func_ov61_021652c0
@@ -47690,12 +47690,12 @@ func_ov61_021652c0: ; 0x021652c0
 	.global func_ov61_02165378
 	arm_func_start func_ov61_02165378
 func_ov61_02165378: ; 0x02165378
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x5f0
 	mov r1, #8
-	mov sl, r0
+	mov r10, r0
 	str r1, [sp, #8]
-	ldr r0, [sl, #0x4b0]
+	ldr r0, [r10, #0x4b0]
 	bl func_ov61_02166914
 	cmp r0, #0
 	beq _02165440
@@ -47708,7 +47708,7 @@ func_ov61_02165378: ; 0x02165378
 _021653b4:
 	str sb, [sp]
 	str r8, [sp, #4]
-	ldr r0, [sl, #0x4b0]
+	ldr r0, [r10, #0x4b0]
 	mov r1, r7
 	mov r2, r6
 	mov r3, r11
@@ -47717,54 +47717,54 @@ _021653b4:
 	beq _02165430
 	ldrh r2, [sp, #0xe]
 	ldr r1, [sp, #0x10]
-	mov r0, sl
+	mov r0, r10
 	bl func_ov61_021631b8
 	cmp r0, r4
 	bne _02165430
 	ldrh r2, [sp, #0xe]
 	ldr r1, [sp, #0x10]
-	mov r0, sl
+	mov r0, r10
 	bl func_ov61_02162780
 	mov r5, r0
 	bl func_ov61_02162858
 	cmp r0, #0
 	addne sp, sp, #0x5f0
 	movne r0, #5
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	mov r0, r5
 	mov r1, #0x11
 	bl func_ov61_0216282c
-	mov r0, sl
+	mov r0, r10
 	mov r1, r5
 	bl func_ov61_02163128
 _02165430:
-	ldr r0, [sl, #0x4b0]
+	ldr r0, [r10, #0x4b0]
 	bl func_ov61_02166914
 	cmp r0, #0
 	bne _021653b4
 _02165440:
 	bl func_ov61_021665e8
-	ldr r1, [sl, #0x4b4]
+	ldr r1, [r10, #0x4b4]
 	sub r0, r0, r1
 	cmp r0, #0x7d0
 	bls _02165488
-	ldr r0, [sl, #0x4b0]
+	ldr r0, [r10, #0x4b0]
 	bl func_ov61_02166a98
 	mvn r0, #0
-	str r0, [sl, #0x4b0]
+	str r0, [r10, #0x4b0]
 	mov r0, #1
-	str r0, [sl]
+	str r0, [r10]
 	ldr r0, _02165498 ; =data_ov61_02181014
-	ldr r3, [sl, #0x494]
+	ldr r3, [r10, #0x494]
 	ldr r2, [r0]
-	ldr r4, [sl, #0x488]
-	mov r0, sl
+	ldr r4, [r10, #0x488]
+	mov r0, r10
 	mov r1, #3
 	blx r4
 _02165488:
 	mov r0, #0
 	add sp, sp, #0x5f0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02165378
 _02165494: .word 0x000005db
@@ -48650,9 +48650,9 @@ _02165f68:
 	.global func_ov61_02165f80
 	arm_func_start func_ov61_02165f80
 func_ov61_02165f80: ; 0x02165f80
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	mov r8, r2
-	mov sl, r0
+	mov r10, r0
 	mov sb, r1
 	mov r7, r3
 	cmp r8, #0
@@ -48661,29 +48661,29 @@ func_ov61_02165f80: ; 0x02165f80
 	ble _02165fd0
 	mov r5, r4
 _02165fa8:
-	mov r0, sl
+	mov r0, r10
 	add r1, sb, r5
 	blx r6
 	cmp r0, #0
 	mlaeq r0, r7, r4, sb
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	add r4, r4, #1
 	cmp r4, r8
 	add r5, r5, r7
 	blt _02165fa8
 _02165fd0:
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	arm_func_end func_ov61_02165f80
 
 	.global func_ov61_02165fd8
 	arm_func_start func_ov61_02165fd8
 func_ov61_02165fd8: ; 0x02165fd8
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	ldr r7, [sp, #0x2c]
 	mov r4, #0
 	mov r11, r0
-	mov sl, r1
+	mov r10, r1
 	mov sb, r3
 	str r4, [r7]
 	subs r5, r2, #1
@@ -48692,7 +48692,7 @@ func_ov61_02165fd8: ; 0x02165fd8
 _02166000:
 	add r0, r4, r5
 	mov r6, r0, asr #0x1
-	mla r0, r6, sb, sl
+	mla r0, r6, sb, r10
 	mov r1, r11
 	blx r8
 	cmp r0, #0
@@ -48704,8 +48704,8 @@ _02166000:
 	cmp r4, r5
 	ble _02166000
 _02166034:
-	mla r0, r4, sb, sl
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	mla r0, r4, sb, r10
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	arm_func_end func_ov61_02165fd8
 
 	.global func_ov61_0216603c
@@ -48726,9 +48726,9 @@ func_ov61_0216603c: ; 0x0216603c
 	.global func_ov61_02166064
 	arm_func_start func_ov61_02166064
 func_ov61_02166064: ; 0x02166064
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	movs r7, r3
-	mov sl, r0
+	mov r10, r0
 	mov sb, r1
 	mov r8, r2
 	ldr r6, [sp, #0x24]
@@ -48748,7 +48748,7 @@ _02166094:
 	mov r3, #0x39
 	bl func_02042f80
 _021660b4:
-	cmp sl, #0
+	cmp r10, #0
 	bne _021660d0
 	ldr r0, _02166194 ; =data_ov61_0217c24c
 	ldr r1, _02166188 ; =data_ov61_0217c238
@@ -48789,7 +48789,7 @@ _02166138:
 	mov r5, #0
 	ble _02166168
 _02166144:
-	mov r0, sl
+	mov r0, r10
 	mov r1, r8
 	mov r2, r6
 	bl func_ov61_02165938
@@ -48805,7 +48805,7 @@ _02166168:
 	str r0, [r4, #0x10]
 	mov r0, r4
 	str r7, [r4, #0xc]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02166064
 _02166184: .word data_ov61_0217c230
@@ -49947,10 +49947,10 @@ _02166e4c:
 	.global func_ov61_02166e98
 	arm_func_start func_ov61_02166e98
 func_ov61_02166e98: ; 0x02166e98
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	mov r7, r1
 	mov r6, r2
-	mov sl, r0
+	mov r10, r0
 	mov r5, r7
 	mov sb, r6
 	cmp r3, #1
@@ -49974,13 +49974,13 @@ _02166ee4:
 	cmp r6, #3
 	movge r2, r8
 	movlt r2, r6
-	mov r0, sl
+	mov r0, r10
 	mov r1, r7
 	bl func_ov61_02166e00
 	sub sb, sb, #3
 	cmp sb, #0
 	add r7, r7, #4
-	add sl, sl, #3
+	add r10, r10, #3
 	bgt _02166ee4
 _02166f10:
 	ldr r1, _02166fcc ; =0x55555556
@@ -49999,7 +49999,7 @@ _02166f40:
 	mov r0, #0
 	strb r0, [r7]
 	cmp r7, r5
-	ldmlsia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmlsia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _02166f50:
 	sub r7, r7, #1
 	cmp r7, r1
@@ -50029,7 +50029,7 @@ _02166f50:
 _02166fb4:
 	cmp r7, r5
 	bhi _02166f50
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02166e98
 _02166fc0: .word data_ov61_0217a33c
@@ -51136,42 +51136,42 @@ _02167e3c: .word func_ov61_02167cfc
 	.global func_ov61_02167e40
 	arm_func_start func_ov61_02167e40
 func_ov61_02167e40: ; 0x02167e40
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x14
 	mov r1, #0
 	mov r4, r0
 	str r1, [sp, #8]
-	ldr sl, [r4]
+	ldr r10, [r4]
 _02167e58:
 	mov r0, r4
-	add r1, sl, #0x1f4
+	add r1, r10, #0x1f4
 	bl func_ov61_0216c2e4
 	mov r1, #1
 	ldr r0, _0216812c ; =data_ov61_0217c460
 	str r1, [sp]
 	str r0, [sp, #4]
-	ldr r1, [sl, #0x1d4]
+	ldr r1, [r10, #0x1d4]
 	add r3, sp, #8
 	mov r0, r4
-	add r2, sl, #0x1f4
+	add r2, r10, #0x1f4
 	bl func_ov61_021698fc
 	cmp r0, #0
 	addne sp, sp, #0x14
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	add r1, sp, #8
 	ldr r0, _0216812c ; =data_ov61_0217c460
 	str r1, [sp]
 	str r0, [sp, #4]
-	ldr r1, [sl, #0x1d4]
+	ldr r1, [r10, #0x1d4]
 	add r3, sp, #0xc
 	mov r0, r4
-	add r2, sl, #0x1dc
+	add r2, r10, #0x1dc
 	bl func_ov61_021696d4
 	cmp r0, #0
 	beq _02167ef8
 	cmp r0, #3
 	addne sp, sp, #0x14
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r2, _02168130 ; =data_ov61_0217c464
 	mov r0, r4
 	mov r1, #5
@@ -51182,9 +51182,9 @@ _02167e58:
 	bl func_ov61_02169c10
 	add sp, sp, #0x14
 	mov r0, #3
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02167ef8:
-	ldr r0, [sl, #0x1dc]
+	ldr r0, [r10, #0x1dc]
 	ldr r1, _02168134 ; =data_ov61_0217c490
 	bl strstr
 	movs r5, r0
@@ -51198,21 +51198,21 @@ _02167f20:
 	strb sb, [r5]
 	mov r0, r4
 	mov r1, r8
-	ldr r2, [sl, #0x1dc]
+	ldr r2, [r10, #0x1dc]
 	bl func_ov61_0217163c
-	ldr r0, [sl, #0x1dc]
+	ldr r0, [r10, #0x1dc]
 	sub r1, r5, r0
 	str r1, [sp, #0xc]
-	ldr r0, [sl, #0x1f0]
+	ldr r0, [r10, #0x1f0]
 	cmp r1, r0
 	ble _02167f90
-	ldr r0, [sl, #0x1f0]
+	ldr r0, [r10, #0x1f0]
 	cmp r1, #0x800
 	movlt r1, r7
 	add r0, r0, r1
-	str r0, [sl, #0x1f0]
+	str r0, [r10, #0x1f0]
 	add r1, r0, #1
-	ldr r0, [sl, #0x1ec]
+	ldr r0, [r10, #0x1ec]
 	bl func_ov61_0213e120
 	cmp r0, #0
 	bne _02167f8c
@@ -51221,25 +51221,25 @@ _02167f20:
 	bl func_ov61_02171b10
 	add sp, sp, #0x14
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02167f8c:
-	str r0, [sl, #0x1ec]
+	str r0, [r10, #0x1ec]
 _02167f90:
 	ldr r2, [sp, #0xc]
-	ldr r0, [sl, #0x1ec]
-	ldr r1, [sl, #0x1dc]
+	ldr r0, [r10, #0x1ec]
+	ldr r1, [r10, #0x1dc]
 	add r2, r2, #1
 	bl func_02043594
-	ldr r0, [sl, #0x1dc]
+	ldr r0, [r10, #0x1dc]
 	add r1, r5, #7
-	ldr r2, [sl, #0x1e4]
+	ldr r2, [r10, #0x1e4]
 	sub r0, r1, r0
 	sub r0, r2, r0
-	str r0, [sl, #0x1e4]
+	str r0, [r10, #0x1e4]
 	add r2, r0, #1
-	ldr r0, [sl, #0x1dc]
+	ldr r0, [r10, #0x1dc]
 	bl func_020435b4
-	ldr r5, [sl, #0x1ec]
+	ldr r5, [r10, #0x1ec]
 	mov r1, r6
 	mov r0, r5
 	bl strstr
@@ -51262,12 +51262,12 @@ _02167f90:
 _02168018:
 	mov r0, r4
 	ldr r1, [sp, #0x10]
-	ldr r2, [sl, #0x1ec]
+	ldr r2, [r10, #0x1ec]
 	bl func_ov61_0216da28
 	cmp r0, #0
 	beq _021680b4
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02168038:
 	mov r1, r5
 	mov r0, r4
@@ -51276,8 +51276,8 @@ _02168038:
 	cmp r0, #0
 	addne sp, sp, #0x14
 	movne r0, #4
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
-	ldr r5, [sl, #0x1ec]
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldr r5, [r10, #0x1ec]
 	ldr r1, _02168148 ; =data_ov61_0217c4e4
 	mov r0, r5
 	mov r2, #4
@@ -51290,7 +51290,7 @@ _02168038:
 	cmp r0, #0
 	beq _021680b4
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02168090:
 	ldr r1, _0216814c ; =data_ov61_0217c4ec
 	mov r0, r5
@@ -51302,7 +51302,7 @@ _02168090:
 	mov r0, r4
 	bl func_ov61_0217163c
 _021680b4:
-	ldr r0, [sl, #0x1dc]
+	ldr r0, [r10, #0x1dc]
 	ldr r1, _02168134 ; =data_ov61_0217c490
 	bl strstr
 	movs r5, r0
@@ -51321,7 +51321,7 @@ _021680c8:
 	bl func_ov61_02169c10
 	add sp, sp, #0x14
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02168100:
 	mov r0, r4
 	bl func_ov61_0216d9ec
@@ -51334,7 +51334,7 @@ _02168118:
 	bne _02167e58
 	mov r0, #0
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02167e40
 _0216812c: .word data_ov61_0217c460
@@ -51352,9 +51352,9 @@ _02168154: .word data_ov61_0217c524
 	.global func_ov61_02168158
 	arm_func_start func_ov61_02168158
 func_ov61_02168158: ; 0x02168158
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
-	mov sl, r0
-	ldr r6, [sl]
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	mov r10, r0
+	ldr r6, [r10]
 	mov sb, r1
 	ldr r0, [r6, #0x1d8]
 	mov r7, #0
@@ -51373,7 +51373,7 @@ _0216818c:
 	mov r5, #1
 	mov r11, #0xa
 _021681a4:
-	mov r0, sl
+	mov r0, r10
 	bl func_ov61_0216b39c
 	movs r7, r0
 	bne _021681cc
@@ -51396,7 +51396,7 @@ _021681e0:
 	cmp r7, #0
 	beq _0216822c
 	add r1, sp, #0
-	mov r0, sl
+	mov r0, r10
 	mov r2, #1
 	bl func_ov61_0216d9a0
 	cmp r0, #0
@@ -51418,19 +51418,19 @@ _0216822c:
 	bhi _02168264
 	cmp r7, #0
 	bne _02168250
-	mov r0, sl
+	mov r0, r10
 	bl func_ov61_02167e40
 	mov r7, r0
 _02168250:
 	cmp r7, #0
 	bne _02168264
-	mov r0, sl
+	mov r0, r10
 	bl func_ov61_0216e668
 	mov r7, r0
 _02168264:
 	cmp r7, #0
 	bne _02168278
-	mov r0, sl
+	mov r0, r10
 	bl func_ov61_0217124c
 	mov r7, r0
 _02168278:
@@ -51444,10 +51444,10 @@ _02168288:
 	ldreq r0, [r1, #0x20]
 	streq r0, [sp]
 	beq _021682b8
-	mov r0, sl
+	mov r0, r10
 	bl func_ov61_0216d4b0
 	ldr r1, [sp]
-	mov r0, sl
+	mov r0, r10
 	ldr r2, [r1, #0x20]
 	str r2, [sp]
 	bl func_ov61_0216d950
@@ -51456,20 +51456,20 @@ _021682b8:
 	cmp r1, #0
 	bne _02168288
 _021682c4:
-	mov r0, sl
+	mov r0, r10
 	mov r1, sb
 	bl func_ov61_02169fa0
 	cmp r0, #0
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, [r6, #0x41c]
 	cmp r0, #0
 	beq _021682f0
-	mov r0, sl
+	mov r0, r10
 	mov r1, #0
 	bl func_ov61_0216b504
 _021682f0:
 	mov r0, r7
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02168158
 _021682f8: .word data_ov61_0217c54c
@@ -51529,31 +51529,31 @@ _021683b0: .word data_ov61_0217c690
 	.global func_ov61_021683b4
 	arm_func_start func_ov61_021683b4
 func_ov61_021683b4: ; 0x021683b4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x138
 	sub sp, sp, #0x1000
 	mov r7, r1
-	mov sl, r0
+	mov r10, r0
 	ldr r1, _02168d28 ; =data_ov61_0217c698
 	add r2, sp, #0x138
 	mov r0, r7
 	mov r3, #0x1000
-	ldr r8, [sl]
+	ldr r8, [r10]
 	bl func_ov61_02171720
 	cmp r0, #0
 	bne _02168418
 	ldr r2, _02168d2c ; =data_ov61_0217c6a0
-	mov r0, sl
+	mov r0, r10
 	mov r1, #1
 	bl func_ov61_02171aec
-	mov r0, sl
+	mov r0, r10
 	mov r1, #3
 	mov r2, #1
 	bl func_ov61_02169c10
 	add sp, sp, #0x138
 	add sp, sp, #0x1000
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02168418:
 	add r0, sp, #0x138
 	bl func_0204902c
@@ -51566,17 +51566,17 @@ _02168418:
 	cmp r0, #0
 	bne _02168470
 	ldr r2, _02168d2c ; =data_ov61_0217c6a0
-	mov r0, sl
+	mov r0, r10
 	mov r1, #1
 	bl func_ov61_02171aec
-	mov r0, sl
+	mov r0, r10
 	mov r1, #3
 	mov r2, #1
 	bl func_ov61_02169c10
 	add sp, sp, #0x138
 	add sp, sp, #0x1000
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02168470:
 	add r0, sp, #0x138
 	bl func_0204902c
@@ -51628,12 +51628,12 @@ _021684fc:
 	movs r4, r0
 	bne _02168540
 	ldr r1, _02168d38 ; =data_ov61_0217c6dc
-	mov r0, sl
+	mov r0, r10
 	bl func_ov61_02171b10
 	add sp, sp, #0x138
 	add sp, sp, #0x1000
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02168540:
 	ldr r1, _02168d3c ; =data_ov61_0217c6ec
 	add r2, sp, #0x138
@@ -51643,17 +51643,17 @@ _02168540:
 	cmp r0, #0
 	bne _0216858c
 	ldr r2, _02168d2c ; =data_ov61_0217c6a0
-	mov r0, sl
+	mov r0, r10
 	mov r1, #1
 	bl func_ov61_02171aec
-	mov r0, sl
+	mov r0, r10
 	mov r1, #3
 	mov r2, #1
 	bl func_ov61_02169c10
 	add sp, sp, #0x138
 	add sp, sp, #0x1000
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0216858c:
 	add r0, sp, #0x138
 	bl strlen
@@ -51663,12 +51663,12 @@ _0216858c:
 	cmp r0, #0
 	bne _021685c4
 	ldr r1, _02168d38 ; =data_ov61_0217c6dc
-	mov r0, sl
+	mov r0, r10
 	bl func_ov61_02171b10
 	add sp, sp, #0x138
 	add sp, sp, #0x1000
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _021685c4:
 	add r1, sp, #0x138
 	bl strcpy
@@ -51678,7 +51678,7 @@ _021685c4:
 	mov r2, #2
 	add r1, sp, #0x20
 	str r2, [sp, #4]
-	mov r0, sl
+	mov r0, r10
 	mov r3, r4
 	ldmia r1, {r1, r2}
 	bl func_ov61_02169d04
@@ -51686,20 +51686,20 @@ _021685c4:
 	beq _02168d18
 	add sp, sp, #0x138
 	add sp, sp, #0x1000
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02168608:
-	mov r0, sl
+	mov r0, r10
 	mov r1, r6
 	bl func_ov61_0216ef6c
 	movs r5, r0
 	bne _02168638
 	ldr r1, _02168d38 ; =data_ov61_0217c6dc
-	mov r0, sl
+	mov r0, r10
 	bl func_ov61_02171b10
 	add sp, sp, #0x138
 	add sp, sp, #0x1000
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02168638:
 	ldr r1, _02168d3c ; =data_ov61_0217c6ec
 	add r2, sp, #0x138
@@ -51709,17 +51709,17 @@ _02168638:
 	cmp r0, #0
 	bne _02168684
 	ldr r2, _02168d2c ; =data_ov61_0217c6a0
-	mov r0, sl
+	mov r0, r10
 	mov r1, #1
 	bl func_ov61_02171aec
-	mov r0, sl
+	mov r0, r10
 	mov r1, #3
 	mov r2, #1
 	bl func_ov61_02169c10
 	add sp, sp, #0x138
 	add sp, sp, #0x1000
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02168684:
 	ldr r1, _02168d40 ; =data_ov61_0217c6f4
 	add r0, sp, #0x138
@@ -51727,17 +51727,17 @@ _02168684:
 	movs r4, r0
 	bne _021686c8
 	ldr r2, _02168d2c ; =data_ov61_0217c6a0
-	mov r0, sl
+	mov r0, r10
 	mov r1, #1
 	bl func_ov61_02171aec
-	mov r0, sl
+	mov r0, r10
 	mov r1, #3
 	mov r2, #1
 	bl func_ov61_02169c10
 	add sp, sp, #0x138
 	add sp, sp, #0x1000
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _021686c8:
 	mov r1, #0
 	add r0, r4, #8
@@ -51746,17 +51746,17 @@ _021686c8:
 	cmp r0, #0x20
 	beq _02168710
 	ldr r2, _02168d2c ; =data_ov61_0217c6a0
-	mov r0, sl
+	mov r0, r10
 	mov r1, #1
 	bl func_ov61_02171aec
-	mov r0, sl
+	mov r0, r10
 	mov r1, #3
 	mov r2, #1
 	bl func_ov61_02169c10
 	add sp, sp, #0x138
 	add sp, sp, #0x1000
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02168710:
 	ldr r0, [r5, #0x10]
 	bl func_ov61_0213e13c
@@ -51779,12 +51779,12 @@ _02168710:
 	movs r4, r0
 	bne _0216877c
 	ldr r1, _02168d38 ; =data_ov61_0217c6dc
-	mov r0, sl
+	mov r0, r10
 	bl func_ov61_02171b10
 	add sp, sp, #0x138
 	add sp, sp, #0x1000
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0216877c:
 	ldr r2, _02168d48 ; =0x00000401
 	add r1, sp, #0x138
@@ -51796,7 +51796,7 @@ _0216877c:
 	mov r2, #6
 	add r1, sp, #8
 	str r2, [sp, #4]
-	mov r0, sl
+	mov r0, r10
 	mov r3, r4
 	ldmia r1, {r1, r2}
 	bl func_ov61_02169d04
@@ -51804,20 +51804,20 @@ _0216877c:
 	beq _02168d18
 	add sp, sp, #0x138
 	add sp, sp, #0x1000
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _021687c8:
-	mov r0, sl
+	mov r0, r10
 	mov r1, r6
 	bl func_ov61_0216ef6c
 	movs r4, r0
 	bne _021687f8
 	ldr r1, _02168d38 ; =data_ov61_0217c6dc
-	mov r0, sl
+	mov r0, r10
 	bl func_ov61_02171b10
 	add sp, sp, #0x138
 	add sp, sp, #0x1000
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _021687f8:
 	ldr r0, [r4, #8]
 	cmp r0, #0
@@ -51828,12 +51828,12 @@ _021687f8:
 	cmp r0, #0
 	bne _02168834
 	ldr r1, _02168d38 ; =data_ov61_0217c6dc
-	mov r0, sl
+	mov r0, r10
 	bl func_ov61_02171b10
 	add sp, sp, #0x138
 	add sp, sp, #0x1000
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02168834:
 	mov r2, #6
 	mov r1, #0
@@ -51860,17 +51860,17 @@ _0216886c:
 	cmp r0, #0
 	bne _021688bc
 	ldr r2, _02168d2c ; =data_ov61_0217c6a0
-	mov r0, sl
+	mov r0, r10
 	mov r1, #1
 	bl func_ov61_02171aec
-	mov r0, sl
+	mov r0, r10
 	mov r1, #3
 	mov r2, #1
 	bl func_ov61_02169c10
 	add sp, sp, #0x138
 	add sp, sp, #0x1000
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _021688bc:
 	ldr r1, _02168d4c ; =data_ov61_0217c700
 	add r0, sp, #0x138
@@ -51880,17 +51880,17 @@ _021688bc:
 	cmp r0, #0
 	bne _02168908
 	ldr r2, _02168d2c ; =data_ov61_0217c6a0
-	mov r0, sl
+	mov r0, r10
 	mov r1, #1
 	bl func_ov61_02171aec
-	mov r0, sl
+	mov r0, r10
 	mov r1, #3
 	mov r2, #1
 	bl func_ov61_02169c10
 	add sp, sp, #0x138
 	add sp, sp, #0x1000
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02168908:
 	add r0, sp, #0x28
 	bl func_0204902c
@@ -51913,12 +51913,12 @@ _02168908:
 	cmp r0, #0
 	bne _02168974
 	ldr r1, _02168d38 ; =data_ov61_0217c6dc
-	mov r0, sl
+	mov r0, r10
 	bl func_ov61_02171b10
 	add sp, sp, #0x138
 	add sp, sp, #0x1000
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02168974:
 	ldr r0, [r7, #0xc]
 	bl func_ov61_0213e13c
@@ -51938,12 +51938,12 @@ _02168974:
 	cmp r0, #0
 	bne _021689d4
 	ldr r1, _02168d38 ; =data_ov61_0217c6dc
-	mov r0, sl
+	mov r0, r10
 	bl func_ov61_02171b10
 	add sp, sp, #0x138
 	add sp, sp, #0x1000
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _021689d4:
 	ldr r1, _02168d58 ; =data_ov61_0217c714
 	add r0, sp, #0x138
@@ -52009,12 +52009,12 @@ _02168a9c:
 	movs r3, r0
 	bne _02168ae4
 	ldr r1, _02168d38 ; =data_ov61_0217c6dc
-	mov r0, sl
+	mov r0, r10
 	bl func_ov61_02171b10
 	add sp, sp, #0x138
 	add sp, sp, #0x1000
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02168ae4:
 	str r6, [r3]
 	ldr r0, [r7]
@@ -52025,14 +52025,14 @@ _02168ae4:
 	mov r2, #5
 	add r1, sp, #0x10
 	str r2, [sp, #4]
-	mov r0, sl
+	mov r0, r10
 	ldmia r1, {r1, r2}
 	bl func_ov61_02169d04
 	cmp r0, #0
 	beq _02168d18
 	add sp, sp, #0x138
 	add sp, sp, #0x1000
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02168b28:
 	ldr r1, _02168d3c ; =data_ov61_0217c6ec
 	add r2, sp, #0x138
@@ -52042,17 +52042,17 @@ _02168b28:
 	cmp r0, #0
 	bne _02168b74
 	ldr r2, _02168d2c ; =data_ov61_0217c6a0
-	mov r0, sl
+	mov r0, r10
 	mov r1, #1
 	bl func_ov61_02171aec
-	mov r0, sl
+	mov r0, r10
 	mov r1, #3
 	mov r2, #1
 	bl func_ov61_02169c10
 	add sp, sp, #0x138
 	add sp, sp, #0x1000
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02168b74:
 	ldr r1, _02168d5c ; =data_ov61_0217c71c
 	add r0, sp, #0x138
@@ -52060,33 +52060,33 @@ _02168b74:
 	cmp r0, #0
 	bne _02168bb8
 	ldr r2, _02168d2c ; =data_ov61_0217c6a0
-	mov r0, sl
+	mov r0, r10
 	mov r1, #1
 	bl func_ov61_02171aec
-	mov r0, sl
+	mov r0, r10
 	mov r1, #3
 	mov r2, #1
 	bl func_ov61_02169c10
 	add sp, sp, #0x138
 	add sp, sp, #0x1000
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02168bb8:
 	ldrsb r1, [r0, #3]
 	cmp r1, #0
 	bne _02168bf4
 	ldr r2, _02168d2c ; =data_ov61_0217c6a0
-	mov r0, sl
+	mov r0, r10
 	mov r1, #1
 	bl func_ov61_02171aec
-	mov r0, sl
+	mov r0, r10
 	mov r1, #3
 	mov r2, #1
 	bl func_ov61_02169c10
 	add sp, sp, #0x138
 	add sp, sp, #0x1000
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02168bf4:
 	add r0, r0, #3
 	bl func_0204902c
@@ -52114,12 +52114,12 @@ _02168c2c:
 	movs r5, r0
 	bne _02168c70
 	ldr r1, _02168d38 ; =data_ov61_0217c6dc
-	mov r0, sl
+	mov r0, r10
 	bl func_ov61_02171b10
 	add sp, sp, #0x138
 	add sp, sp, #0x1000
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02168c70:
 	str r6, [r5]
 	add r1, sp, #0x38
@@ -52130,7 +52130,7 @@ _02168c70:
 	str r2, [sp]
 	add r1, sp, #0x18
 	str r2, [sp, #4]
-	mov r0, sl
+	mov r0, r10
 	mov r3, r5
 	ldmia r1, {r1, r2}
 	bl func_ov61_02169d04
@@ -52138,7 +52138,7 @@ _02168c70:
 	beq _02168d18
 	add sp, sp, #0x138
 	add sp, sp, #0x1000
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02168cb8:
 	ldr r1, _02168d3c ; =data_ov61_0217c6ec
 	add r2, sp, #0x138
@@ -52148,20 +52148,20 @@ _02168cb8:
 	cmp r0, #0
 	bne _02168d04
 	ldr r2, _02168d2c ; =data_ov61_0217c6a0
-	mov r0, sl
+	mov r0, r10
 	mov r1, #1
 	bl func_ov61_02171aec
-	mov r0, sl
+	mov r0, r10
 	mov r1, #3
 	mov r2, #1
 	bl func_ov61_02169c10
 	add sp, sp, #0x138
 	add sp, sp, #0x1000
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02168d04:
 	ldr r3, _02168d64 ; =data_ov61_0217c724
-	mov r0, sl
+	mov r0, r10
 	mov r1, r6
 	mov r2, #0x67
 	bl func_ov61_02168e44
@@ -52169,7 +52169,7 @@ _02168d18:
 	mov r0, #0
 	add sp, sp, #0x138
 	add sp, sp, #0x1000
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_021683b4
 _02168d28: .word data_ov61_0217c698
@@ -52558,9 +52558,9 @@ _0216925c: .word data_ov61_0217c84c
 	.global func_ov61_02169260
 	arm_func_start func_ov61_02169260
 func_ov61_02169260: ; 0x02169260
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	movs r8, r2
-	mov sl, r0
+	mov r10, r0
 	mov sb, r1
 	mov r7, r3
 	bne _0216928c
@@ -52588,7 +52588,7 @@ _021692a8:
 _021692c4:
 	cmp r8, #0
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	ldr r4, [sb, #8]
 	ldr r5, [sb, #4]
 	ldr r6, [sb]
@@ -52605,10 +52605,10 @@ _021692c4:
 	movs r6, r0
 	bne _02169320
 	ldr r1, _02169368 ; =data_ov61_0217c84c
-	mov r0, sl
+	mov r0, r10
 	bl func_ov61_02171b10
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _02169320:
 	mov r1, r8
 	mov r2, r7
@@ -52622,7 +52622,7 @@ _02169320:
 	str r1, [sb, #8]
 	str r5, [sb, #4]
 	str r6, [sb]
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02169260
 _02169354: .word data_ov61_0217c85c
@@ -52805,11 +52805,11 @@ _021695a0: .word data_ov61_0217c8f0
 	.global func_ov61_021695a4
 	arm_func_start func_ov61_021695a4
 func_ov61_021695a4: ; 0x021695a4
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x14
 	mov sb, r1
 	ldr r1, [sb, #0x28]
-	mov sl, r0
+	mov r10, r0
 	mov r8, r2
 	mov r7, r3
 	cmp r1, #0
@@ -52824,7 +52824,7 @@ _021695dc:
 	mov r6, #0
 	addeq sp, sp, #0x14
 	moveq r0, r6
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r1, [sb, #0x30]
 	ldr r0, [sb, #0x34]
 	subs r0, r1, r0
@@ -52840,13 +52840,13 @@ _0216961c:
 	str r5, [sp]
 	stmib sp, {r4, r11}
 	ldr r1, [sb, #8]
-	mov r0, sl
+	mov r0, r10
 	mov r3, r7
 	add r2, r8, r6
 	bl func_ov61_021693d4
 	cmp r0, #0
 	addne sp, sp, #0x14
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, [sp, #0xc]
 	cmp r0, #0
 	subne r7, r7, r0
@@ -52857,18 +52857,18 @@ _0216961c:
 _02169660:
 	cmp r7, #0
 	beq _02169688
-	mov r0, sl
+	mov r0, r10
 	mov r3, r7
 	add r1, sb, #0x28
 	add r2, r8, r6
 	bl func_ov61_02169260
 	cmp r0, #0
 	addne sp, sp, #0x14
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02169688:
 	mov r0, #0
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_021695a4
 _02169694: .word data_ov61_0217c8cc
@@ -52896,15 +52896,15 @@ func_ov61_021696a4: ; 0x021696a4
 	.global func_ov61_021696d4
 	arm_func_start func_ov61_021696d4
 func_ov61_021696d4: ; 0x021696d4
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x18
 	str r0, [sp]
 	ldr r0, [sp, #0x44]
-	mov sl, r1
+	mov r10, r1
 	mvn r1, #0
 	str r2, [sp, #4]
 	str r3, [sp, #8]
-	cmp sl, r1
+	cmp r10, r1
 	str r0, [sp, #0x44]
 	bne _02169714
 	ldr r0, _021698c8 ; =data_ov61_0217c8f4
@@ -52967,9 +52967,9 @@ _021697a4:
 	bl func_ov61_02171b10
 	add sp, sp, #0x18
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _021697e0:
-	mov r0, sl
+	mov r0, r10
 	add r1, r5, r6
 	sub r2, r7, r6
 	mov r3, #0
@@ -52977,7 +52977,7 @@ _021697e0:
 	mov r8, r0
 	cmp r8, r4
 	bne _0216983c
-	mov r0, sl
+	mov r0, r10
 	bl func_ov61_02166ce0
 	ldr r1, [sp, #0xc]
 	cmp r0, r1
@@ -52991,7 +52991,7 @@ _021697e0:
 	bl func_ov61_02171b10
 	add sp, sp, #0x18
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0216983c:
 	cmp r8, #0
 	addne r6, r6, r8
@@ -53030,7 +53030,7 @@ _0216989c:
 	str r11, [r1]
 	mov r0, #0
 	add sp, sp, #0x18
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_021696d4
 _021698c8: .word data_ov61_0217c8f4
@@ -53050,9 +53050,9 @@ _021698f8: .word data_ov61_0217c998
 	.global func_ov61_021698fc
 	arm_func_start func_ov61_021698fc
 func_ov61_021698fc: ; 0x021698fc
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x1c
-	mov sl, r0
+	mov r10, r0
 	str r2, [sp, #0xc]
 	mov sb, r1
 	str r3, [sp, #0x10]
@@ -53073,7 +53073,7 @@ _02169934:
 	subs r5, r11, r7
 	addeq sp, sp, #0x1c
 	moveq r0, r4
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02169958:
 	add r0, sp, #0x18
 	str r0, [sp]
@@ -53081,14 +53081,14 @@ _02169958:
 	add r0, sp, #0x14
 	str r0, [sp, #4]
 	add r2, r6, r1
-	mov r0, sl
+	mov r0, r10
 	mov r1, sb
 	mov r3, r5
 	str r8, [sp, #8]
 	bl func_ov61_021693d4
 	cmp r0, #0
 	addne sp, sp, #0x1c
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, [sp, #0x14]
 	cmp r0, #0
 	subne r5, r5, r0
@@ -53143,7 +53143,7 @@ _02169a30:
 	strne r1, [r0]
 	mov r0, #0
 	add sp, sp, #0x1c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_021698fc
 _02169a58: .word data_ov61_0217c828
@@ -53537,10 +53537,10 @@ _02169f9c: .word data_ov61_0217caa8
 	.global func_ov61_02169fa0
 	arm_func_start func_ov61_02169fa0
 func_ov61_02169fa0: ; 0x02169fa0
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
-	mov sl, r0
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
+	mov r10, r0
 	movs sb, r1
-	ldr r4, [sl]
+	ldr r4, [r10]
 	beq _0216a03c
 	ldr r5, [r4, #0x438]
 	ldr r6, [r4, #0x43c]
@@ -53557,7 +53557,7 @@ _02169fd4:
 	ldrne r0, [r1, #0xc]
 	cmpne r0, #1
 	bne _0216a00c
-	mov r0, sl
+	mov r0, r10
 	cmp r7, #0
 	strne r8, [r7, #0x14]
 	moveq r5, r8
@@ -53579,7 +53579,7 @@ _0216a01c:
 	streq r5, [r4, #0x438]
 	str r6, [r4, #0x43c]
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _0216a03c:
 	ldr r1, [r4, #0x438]
 	cmp r1, #0
@@ -53592,7 +53592,7 @@ _0216a04c:
 	beq _0216a074
 _0216a05c:
 	ldr r6, [r1, #0x14]
-	mov r0, sl
+	mov r0, r10
 	bl func_ov61_02169da8
 	mov r1, r6
 	cmp r6, #0
@@ -53603,7 +53603,7 @@ _0216a074:
 	bne _0216a04c
 _0216a080:
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	arm_func_end func_ov61_02169fa0
 
 	.global func_ov61_0216a088
@@ -54290,10 +54290,10 @@ _0216aa48: .word data_ov61_0217cdf0
 	.global func_ov61_0216aa4c
 	arm_func_start func_ov61_0216aa4c
 func_ov61_0216aa4c: ; 0x0216aa4c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0xe8
-	mov sl, r0
-	ldr r5, [sl]
+	mov r10, r0
+	ldr r5, [r10]
 	mov sb, r1
 	add r0, r5, #0x77
 	add r0, r0, #0x100
@@ -54329,63 +54329,63 @@ _0216aac0:
 	strb r4, [r0, r6]
 	bl func_ov61_02166e98
 	ldr r2, _0216aca8 ; =data_ov61_0217cdf8
-	mov r0, sl
+	mov r0, r10
 	add r1, r5, #0x1f4
 	bl func_ov61_0216936c
 	ldr r2, _0216acac ; =data_ov61_0217ce04
-	mov r0, sl
+	mov r0, r10
 	add r1, r5, #0x1f4
 	bl func_ov61_0216936c
-	mov r0, sl
+	mov r0, r10
 	add r1, r5, #0x1f4
 	add r2, r5, #0x144
 	bl func_ov61_0216936c
 	ldr r2, _0216acb0 ; =data_ov61_0217ce0c
-	mov r0, sl
+	mov r0, r10
 	add r1, r5, #0x1f4
 	bl func_ov61_0216936c
-	mov r0, sl
+	mov r0, r10
 	add r1, r5, #0x1f4
 	add r2, r5, #0x110
 	bl func_ov61_0216936c
 	ldr r2, _0216acb4 ; =data_ov61_0217ce14
-	mov r0, sl
+	mov r0, r10
 	add r1, r5, #0x1f4
 	bl func_ov61_0216936c
-	mov r0, sl
+	mov r0, r10
 	add r1, r5, #0x1f4
 	add r2, sp, #0
 	bl func_ov61_0216936c
 	ldr r2, _0216acb8 ; =data_ov61_0217cdc0
-	mov r0, sl
+	mov r0, r10
 	add r1, r5, #0x1f4
 	bl func_ov61_0216936c
 	ldr r2, [r5, #0x46c]
-	mov r0, sl
+	mov r0, r10
 	add r1, r5, #0x1f4
 	bl func_ov61_0216939c
 	ldr r2, _0216acbc ; =data_ov61_0217cdcc
-	mov r0, sl
+	mov r0, r10
 	add r1, r5, #0x1f4
 	bl func_ov61_0216936c
 	ldr r2, _0216acc0 ; =data_ov61_021810c0
-	mov r0, sl
+	mov r0, r10
 	add r1, r5, #0x1f4
 	bl func_ov61_0216936c
 	ldr r2, _0216acc4 ; =data_ov61_0217cdd8
-	mov r0, sl
+	mov r0, r10
 	add r1, r5, #0x1f4
 	bl func_ov61_0216936c
 	ldr r2, [r5, #0x470]
-	mov r0, sl
+	mov r0, r10
 	add r1, r5, #0x1f4
 	bl func_ov61_0216939c
 	ldr r2, _0216acc8 ; =data_ov61_0217cd6c
-	mov r0, sl
+	mov r0, r10
 	add r1, r5, #0x1f4
 	bl func_ov61_0216936c
 	add r2, r5, #0x2f
-	mov r0, sl
+	mov r0, r10
 	add r1, r5, #0x1f4
 	add r2, r2, #0x100
 	bl func_ov61_0216936c
@@ -54426,25 +54426,25 @@ _0216ac3c:
 	strb r4, [r0, r8]
 	bl func_ov61_02166e98
 	ldr r2, _0216accc ; =data_ov61_0217ce24
-	mov r0, sl
+	mov r0, r10
 	add r1, r5, #0x1f4
 	bl func_ov61_0216936c
 	add r2, sp, #0x4c
-	mov r0, sl
+	mov r0, r10
 	add r1, r5, #0x1f4
 	bl func_ov61_0216936c
 _0216ac78:
 	ldr r2, _0216acd0 ; =data_ov61_0217cde8
-	mov r0, sl
+	mov r0, r10
 	add r1, r5, #0x1f4
 	bl func_ov61_0216936c
 	ldr r2, _0216acd4 ; =data_ov61_0217cdf0
-	mov r0, sl
+	mov r0, r10
 	add r1, r5, #0x1f4
 	bl func_ov61_0216936c
 	mov r0, #0
 	add sp, sp, #0xe8
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0216aa4c
 _0216aca4: .word 0x79707367
@@ -55456,19 +55456,19 @@ _0216ba40:
 	.global func_ov61_0216bacc
 	arm_func_start func_ov61_0216bacc
 func_ov61_0216bacc: ; 0x0216bacc
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x268
 	mov r4, r2
-	mov sl, r0
+	mov r10, r0
 	mov r11, r1
 	mov r1, r4
 	mov r2, #1
-	ldr r6, [sl]
+	ldr r6, [r10]
 	bl func_ov61_02171648
 	cmp r0, #0
 	addne sp, sp, #0x268
 	movne r0, #4
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r1, _0216c254 ; =data_ov61_0217cfa4
 	mov r0, r4
 	mov r2, #4
@@ -55476,16 +55476,16 @@ func_ov61_0216bacc: ; 0x0216bacc
 	cmp r0, #0
 	beq _0216bb44
 	ldr r2, _0216c258 ; =data_ov61_0217cfac
-	mov r0, sl
+	mov r0, r10
 	mov r1, #1
 	bl func_ov61_02171aec
-	mov r0, sl
+	mov r0, r10
 	mov r1, #3
 	mov r2, #1
 	bl func_ov61_02169c10
 	add sp, sp, #0x268
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0216bb44:
 	ldr r1, _0216c25c ; =data_ov61_0217cfdc
 	add r2, sp, #0xec
@@ -55495,16 +55495,16 @@ _0216bb44:
 	cmp r0, #0
 	bne _0216bb8c
 	ldr r2, _0216c258 ; =data_ov61_0217cfac
-	mov r0, sl
+	mov r0, r10
 	mov r1, #1
 	bl func_ov61_02171aec
-	mov r0, sl
+	mov r0, r10
 	mov r1, #3
 	mov r2, #1
 	bl func_ov61_02169c10
 	add sp, sp, #0x268
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0216bb8c:
 	add r0, sp, #0xec
 	bl func_0204902c
@@ -55518,7 +55518,7 @@ _0216bb8c:
 	bl func_02042f80
 _0216bbb4:
 	add r2, sp, #0x10
-	mov r0, sl
+	mov r0, r10
 	mov r1, sb
 	bl func_ov61_0216f050
 	mov r0, #0
@@ -55685,12 +55685,12 @@ _0216be28:
 	mov r1, r0
 	add r2, sp, #0x22c
 	add r3, sp, #0x230
-	mov r0, sl
+	mov r0, r10
 	str r5, [sp]
 	bl func_ov61_0216b82c
 	cmp r0, #0
 	addne sp, sp, #0x268
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0216be58:
 	ldr r1, _0216c2a4 ; =data_ov61_0217d088
 	add r2, sp, #0xec
@@ -55859,16 +55859,16 @@ _0216c0a8:
 	cmp r0, #0
 	bne _0216c0f0
 	ldr r2, _0216c258 ; =data_ov61_0217cfac
-	mov r0, sl
+	mov r0, r10
 	mov r1, #1
 	bl func_ov61_02171aec
-	mov r0, sl
+	mov r0, r10
 	mov r1, #3
 	mov r2, #1
 	bl func_ov61_02169c10
 	add sp, sp, #0x268
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0216c0f0:
 	ldr r7, [r6, #0x434]
 	ldr r8, [r6, #0x100]
@@ -55885,7 +55885,7 @@ _0216c108:
 	ldr r0, [sp, #0x10]
 	cmp r0, #0
 	bne _0216c138
-	mov r0, sl
+	mov r0, r10
 	mov r1, sb
 	bl func_ov61_0216ef6c
 	str r0, [sp, #0x10]
@@ -55903,7 +55903,7 @@ _0216c14c:
 	ldr r0, [r6, #0x100]
 	cmp r0, #0
 	beq _0216c174
-	mov r0, sl
+	mov r0, r10
 	mov r1, sb
 	bl func_ov61_0216ef6c
 	str r0, [sp, #0x10]
@@ -55926,7 +55926,7 @@ _0216c1a4:
 	beq _0216c1c0
 	ldr r1, [sp, #0x10]
 	add r2, sp, #0x178
-	mov r0, sl
+	mov r0, r10
 	bl func_ov61_0216d30c
 _0216c1c0:
 	ldr r1, [r11, #0xc]
@@ -55940,11 +55940,11 @@ _0216c1c0:
 	movs r4, r0
 	bne _0216c200
 	ldr r1, _0216c2e0 ; =data_ov61_0217d0f0
-	mov r0, sl
+	mov r0, r10
 	bl func_ov61_02171b10
 	add sp, sp, #0x268
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0216c200:
 	add r0, sp, #0x178
 	mov r1, r4
@@ -55954,20 +55954,20 @@ _0216c200:
 	str r11, [sp]
 	add r1, sp, #8
 	str r2, [sp, #4]
-	mov r0, sl
+	mov r0, r10
 	mov r3, r4
 	ldmia r1, {r1, r2}
 	bl func_ov61_02169d04
 	cmp r0, #0
 	addne sp, sp, #0x268
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0216c23c:
-	mov r0, sl
+	mov r0, r10
 	mov r1, r11
 	bl func_ov61_0216d950
 	mov r0, #0
 	add sp, sp, #0x268
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0216bacc
 _0216c254: .word data_ov61_0217cfa4
@@ -58143,15 +58143,15 @@ _0216e080: .word data_ov61_0217d4ac
 	.global func_ov61_0216e084
 	arm_func_start func_ov61_0216e084
 func_ov61_0216e084: ; 0x0216e084
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0xc
 	mov sb, r1
 	ldr r1, [sb, #0x30]
-	mov sl, r0
+	mov r10, r0
 	cmp r1, #0
 	addne sp, sp, #0xc
 	movne r0, #0
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, [sb, #0x38]
 	bl func_ov61_02165a68
 	cmp r0, #0
@@ -58169,7 +58169,7 @@ _0216e0cc:
 	str r6, [sp]
 	str r5, [sp, #4]
 	ldr r1, [sb, #8]
-	mov r0, sl
+	mov r0, r10
 	mov r2, r7
 	mov r3, r4
 	bl func_ov61_021698fc
@@ -58181,7 +58181,7 @@ _0216e0cc:
 	str r0, [sb]
 	add sp, sp, #0xc
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0216e11c:
 	ldr r1, [r7, #0xc]
 	ldr r0, [r7, #8]
@@ -58197,7 +58197,7 @@ _0216e11c:
 _0216e148:
 	mov r0, #0
 	add sp, sp, #0xc
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0216e084
 _0216e154: .word data_ov61_0217d47c
@@ -58205,7 +58205,7 @@ _0216e154: .word data_ov61_0217d47c
 	.global func_ov61_0216e158
 	arm_func_start func_ov61_0216e158
 func_ov61_0216e158: ; 0x0216e158
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x24
 	mov r8, r1
 	ldr r1, [r8, #0x30]
@@ -58229,7 +58229,7 @@ func_ov61_0216e158: ; 0x0216e158
 	str r0, [r8]
 	add sp, sp, #0x24
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0216e1bc:
 	ldr r0, [r8, #0x30]
 	cmp r0, #0
@@ -58239,12 +58239,12 @@ _0216e1bc:
 	bl func_ov61_0216e084
 	cmp r0, #0
 	addne sp, sp, #0x24
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, [r8]
 	cmp r0, #0x6a
 	addeq sp, sp, #0x24
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0216e1f4:
 	add r1, sp, #0x1c
 	ldr r0, _0216e3cc ; =data_ov61_0217d47c
@@ -58261,7 +58261,7 @@ _0216e1f4:
 	str r0, [r8]
 	add sp, sp, #0x24
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0216e234:
 	ldr r0, [sp, #0x20]
 	cmp r0, #0
@@ -58272,7 +58272,7 @@ _0216e234:
 	str r0, [r8, #0x10]
 _0216e250:
 	mov r4, #0
-	mov sl, #2
+	mov r10, #2
 	add r11, sp, #0x14
 	add r6, sp, #8
 _0216e260:
@@ -58284,7 +58284,7 @@ _0216e260:
 	bl func_ov61_02169a7c
 	cmp r0, #0
 	addne sp, sp, #0x24
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r1, [sp, #0x10]
 	cmp r1, #0
 	beq _0216e3a4
@@ -58326,7 +58326,7 @@ _0216e2e0:
 	bl func_ov61_02171b10
 	add sp, sp, #0x24
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0216e320:
 	ldr r0, [r8, #0xc]
 	str r0, [r5]
@@ -58338,13 +58338,13 @@ _0216e320:
 	str r0, [r5, #4]
 	mov r3, r5
 	mov r0, sb
-	stmia sp, {r4, sl}
+	stmia sp, {r4, r10}
 	ldmia r11, {r1, r2}
 	bl func_ov61_02169d04
 	cmp r0, #0
 	beq _0216e398
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0216e364:
 	ldr r1, [r8, #0xc]
 	ldr r3, _0216e3d4 ; =data_ov61_0217d51c
@@ -58374,7 +58374,7 @@ _0216e3a4:
 	strne r0, [r8]
 	mov r0, #0
 	add sp, sp, #0x24
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0216e158
 _0216e3cc: .word data_ov61_0217d47c
@@ -59890,10 +59890,10 @@ _0216f798: .word data_ov61_0217d848
 	.global func_ov61_0216f79c
 	arm_func_start func_ov61_0216f79c
 func_ov61_0216f79c: ; 0x0216f79c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x490
-	mov sl, r0
-	ldr r0, [sl]
+	mov r10, r0
+	ldr r0, [r10]
 	str r1, [sp, #0x1c]
 	ldr r1, [r1, #8]
 	str r0, [sp, #0x28]
@@ -59909,37 +59909,37 @@ _0216f7cc:
 	str r0, [sp, #4]
 	ldr r1, [r6, #4]
 	add r3, sp, #0x68
-	mov r0, sl
+	mov r0, r10
 	add r2, r6, #0x18
 	bl func_ov61_021698fc
 	cmp r0, #0
 	addne sp, sp, #0x490
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, [sp, #0x1c]
 	ldr r0, [r0, #0x14]
 	cmp r0, #1
 	bne _0216fe30
 	ldr r1, [r6, #4]
 	add r2, sp, #0x7c
-	mov r0, sl
+	mov r0, r10
 	bl func_ov61_02171828
 	cmp r0, #0
 	addne sp, sp, #0x490
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r0, [sp, #0x7c]
 	cmp r0, #4
 	bne _0216f860
 	ldr r1, _021705d8 ; =0x00000d01
 	ldr r2, _021705dc ; =data_ov61_0217d860
-	mov r0, sl
+	mov r0, r10
 	bl func_ov61_02171aec
-	mov r0, sl
+	mov r0, r10
 	mov r1, #4
 	mov r2, #0
 	bl func_ov61_02169c10
 	add sp, sp, #0x490
 	mov r0, #4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0216f860:
 	cmp r0, #3
 	bne _021711ec
@@ -59947,33 +59947,33 @@ _0216f860:
 	cmp r0, #1
 	bne _0216fa28
 	ldr r2, _021705e0 ; =data_ov61_0217d88c
-	mov r0, sl
+	mov r0, r10
 	add r1, r6, #0x18
 	bl func_ov61_0216936c
 	ldr r2, _021705e4 ; =data_ov61_0217d898
-	mov r0, sl
+	mov r0, r10
 	add r1, r6, #0x18
 	bl func_ov61_0216936c
 	ldr r0, [sp, #0x28]
 	add r1, r6, #0x18
 	ldr r2, [r0, #0x198]
-	mov r0, sl
+	mov r0, r10
 	bl func_ov61_0216939c
 	ldr r2, _021705e8 ; =data_ov61_0217d8a4
-	mov r0, sl
+	mov r0, r10
 	add r1, r6, #0x18
 	bl func_ov61_0216936c
 	ldr r2, [sp, #0x28]
-	mov r0, sl
+	mov r0, r10
 	ldr r2, [r2, #0x1a0]
 	add r1, r6, #0x18
 	bl func_ov61_0216939c
 	ldr r2, _021705ec ; =data_ov61_0217d8b0
-	mov r0, sl
+	mov r0, r10
 	add r1, r6, #0x18
 	bl func_ov61_0216936c
 	ldr r2, [sp, #0x28]
-	mov r0, sl
+	mov r0, r10
 	ldr r2, [r2, #0x470]
 	add r1, r6, #0x18
 	bl func_ov61_0216939c
@@ -59981,10 +59981,10 @@ _0216f860:
 	cmp r0, #0
 	beq _0216f91c
 	ldr r2, _021705f0 ; =data_ov61_0217d8c0
-	mov r0, sl
+	mov r0, r10
 	add r1, r6, #0x18
 	bl func_ov61_0216936c
-	mov r0, sl
+	mov r0, r10
 	add r1, r6, #0x18
 	add r2, r6, #0x28
 	bl func_ov61_0216936c
@@ -59993,10 +59993,10 @@ _0216f91c:
 	cmp r0, #0
 	beq _0216f948
 	ldr r2, _021705f4 ; =data_ov61_0217d8c8
-	mov r0, sl
+	mov r0, r10
 	add r1, r6, #0x18
 	bl func_ov61_0216936c
-	mov r0, sl
+	mov r0, r10
 	add r1, r6, #0x18
 	add r2, r6, #0x47
 	bl func_ov61_0216936c
@@ -60005,10 +60005,10 @@ _0216f948:
 	cmp r0, #0
 	beq _0216f974
 	ldr r2, _021705f8 ; =data_ov61_0217d8d8
-	mov r0, sl
+	mov r0, r10
 	add r1, r6, #0x18
 	bl func_ov61_0216936c
-	mov r0, sl
+	mov r0, r10
 	add r1, r6, #0x18
 	add r2, r6, #0x5c
 	bl func_ov61_0216936c
@@ -60017,10 +60017,10 @@ _0216f974:
 	cmp r0, #0
 	beq _0216f9a0
 	ldr r2, _021705fc ; =data_ov61_0217d8e0
-	mov r0, sl
+	mov r0, r10
 	add r1, r6, #0x18
 	bl func_ov61_0216936c
-	mov r0, sl
+	mov r0, r10
 	add r1, r6, #0x18
 	add r2, r6, #0x8f
 	bl func_ov61_0216936c
@@ -60029,10 +60029,10 @@ _0216f9a0:
 	cmp r0, #0
 	beq _0216f9cc
 	ldr r2, _02170600 ; =data_ov61_0217d8ec
-	mov r0, sl
+	mov r0, r10
 	add r1, r6, #0x18
 	bl func_ov61_0216936c
-	mov r0, sl
+	mov r0, r10
 	add r1, r6, #0x18
 	add r2, r6, #0xae
 	bl func_ov61_0216936c
@@ -60041,11 +60041,11 @@ _0216f9cc:
 	cmp r0, #0
 	beq _0216f9f8
 	ldr r2, _02170604 ; =data_ov61_0217d8f8
-	mov r0, sl
+	mov r0, r10
 	add r1, r6, #0x18
 	bl func_ov61_0216936c
 	ldr r2, [r6, #0x130]
-	mov r0, sl
+	mov r0, r10
 	add r1, r6, #0x18
 	bl func_ov61_0216939c
 _0216f9f8:
@@ -60053,11 +60053,11 @@ _0216f9f8:
 	cmp r0, #0
 	ble _0216fdf0
 	ldr r2, _02170608 ; =data_ov61_0217d904
-	mov r0, sl
+	mov r0, r10
 	add r1, r6, #0x18
 	bl func_ov61_0216936c
 	ldr r2, [r6, #0x134]
-	mov r0, sl
+	mov r0, r10
 	add r1, r6, #0x18
 	bl func_ov61_0216939c
 	b _0216fdf0
@@ -60065,14 +60065,14 @@ _0216fa28:
 	cmp r0, #2
 	bne _0216fa64
 	ldr r2, _0217060c ; =data_ov61_0217d90c
-	mov r0, sl
+	mov r0, r10
 	add r1, r6, #0x18
 	bl func_ov61_0216936c
 	ldr r2, _021705f8 ; =data_ov61_0217d8d8
-	mov r0, sl
+	mov r0, r10
 	add r1, r6, #0x18
 	bl func_ov61_0216936c
-	mov r0, sl
+	mov r0, r10
 	add r1, r6, #0x18
 	add r2, r6, #0x5c
 	bl func_ov61_0216936c
@@ -60081,31 +60081,31 @@ _0216fa64:
 	cmp r0, #3
 	bne _0216fae4
 	ldr r2, _02170610 ; =data_ov61_0217d914
-	mov r0, sl
+	mov r0, r10
 	add r1, r6, #0x18
 	bl func_ov61_0216936c
 	ldr r2, _021705f8 ; =data_ov61_0217d8d8
-	mov r0, sl
+	mov r0, r10
 	add r1, r6, #0x18
 	bl func_ov61_0216936c
-	mov r0, sl
+	mov r0, r10
 	add r1, r6, #0x18
 	add r2, r6, #0x5c
 	bl func_ov61_0216936c
 	ldr r2, _02170614 ; =data_ov61_0217d91c
-	mov r0, sl
+	mov r0, r10
 	add r1, r6, #0x18
 	bl func_ov61_0216936c
-	mov r0, sl
+	mov r0, r10
 	add r1, r6, #0x18
 	add r2, r6, #0xcd
 	bl func_ov61_0216936c
 	ldr r2, _021705ec ; =data_ov61_0217d8b0
-	mov r0, sl
+	mov r0, r10
 	add r1, r6, #0x18
 	bl func_ov61_0216936c
 	ldr r2, [sp, #0x28]
-	mov r0, sl
+	mov r0, r10
 	ldr r2, [r2, #0x470]
 	add r1, r6, #0x18
 	bl func_ov61_0216939c
@@ -60114,33 +60114,33 @@ _0216fae4:
 	cmp r0, #4
 	bne _0216fb68
 	ldr r2, _02170618 ; =data_ov61_0217d924
-	mov r0, sl
+	mov r0, r10
 	add r1, r6, #0x18
 	bl func_ov61_0216936c
 	ldr r2, _021705e4 ; =data_ov61_0217d898
-	mov r0, sl
+	mov r0, r10
 	add r1, r6, #0x18
 	bl func_ov61_0216936c
 	ldr r0, [sp, #0x28]
 	add r1, r6, #0x18
 	ldr r2, [r0, #0x198]
-	mov r0, sl
+	mov r0, r10
 	bl func_ov61_0216939c
 	ldr r2, _021705e8 ; =data_ov61_0217d8a4
-	mov r0, sl
+	mov r0, r10
 	add r1, r6, #0x18
 	bl func_ov61_0216936c
 	ldr r2, [sp, #0x28]
-	mov r0, sl
+	mov r0, r10
 	ldr r2, [r2, #0x1a0]
 	add r1, r6, #0x18
 	bl func_ov61_0216939c
 	ldr r2, _0217061c ; =data_ov61_0217d930
-	mov r0, sl
+	mov r0, r10
 	add r1, r6, #0x18
 	bl func_ov61_0216936c
 	ldr r2, [r6, #0x138]
-	mov r0, sl
+	mov r0, r10
 	add r1, r6, #0x18
 	bl func_ov61_0216939c
 	b _0216fdf0
@@ -60148,30 +60148,30 @@ _0216fb68:
 	cmp r0, #5
 	bne _0216fbe4
 	ldr r2, _02170620 ; =data_ov61_0217d93c
-	mov r0, sl
+	mov r0, r10
 	add r1, r6, #0x18
 	bl func_ov61_0216936c
 	ldr r2, _021705f0 ; =data_ov61_0217d8c0
-	mov r0, sl
+	mov r0, r10
 	add r1, r6, #0x18
 	bl func_ov61_0216936c
-	mov r0, sl
+	mov r0, r10
 	add r1, r6, #0x18
 	add r2, r6, #0x28
 	bl func_ov61_0216936c
-	mov r0, sl
+	mov r0, r10
 	add r1, r6, #0x18
 	ldr r2, _021705f8 ; =data_ov61_0217d8d8
 	bl func_ov61_0216936c
-	mov r0, sl
+	mov r0, r10
 	add r1, r6, #0x18
 	add r2, r6, #0x5c
 	bl func_ov61_0216936c
-	mov r0, sl
+	mov r0, r10
 	add r1, r6, #0x18
 	ldr r2, _02170614 ; =data_ov61_0217d91c
 	bl func_ov61_0216936c
-	mov r0, sl
+	mov r0, r10
 	add r1, r6, #0x18
 	add r2, r6, #0xcd
 	bl func_ov61_0216936c
@@ -60180,56 +60180,56 @@ _0216fbe4:
 	cmp r0, #6
 	bne _0216fcf4
 	ldr r2, _02170624 ; =data_ov61_0217d944
-	mov r0, sl
+	mov r0, r10
 	add r1, r6, #0x18
 	bl func_ov61_0216936c
 	ldr r2, _021705f0 ; =data_ov61_0217d8c0
-	mov r0, sl
+	mov r0, r10
 	add r1, r6, #0x18
 	bl func_ov61_0216936c
-	mov r0, sl
+	mov r0, r10
 	add r1, r6, #0x18
 	add r2, r6, #0x28
 	bl func_ov61_0216936c
 	ldr r2, _021705f8 ; =data_ov61_0217d8d8
-	mov r0, sl
+	mov r0, r10
 	add r1, r6, #0x18
 	bl func_ov61_0216936c
-	mov r0, sl
+	mov r0, r10
 	add r1, r6, #0x18
 	add r2, r6, #0x5c
 	bl func_ov61_0216936c
 	ldr r2, _02170614 ; =data_ov61_0217d91c
-	mov r0, sl
+	mov r0, r10
 	add r1, r6, #0x18
 	bl func_ov61_0216936c
-	mov r0, sl
+	mov r0, r10
 	add r1, r6, #0x18
 	add r2, r6, #0xcd
 	bl func_ov61_0216936c
 	ldr r2, _02170628 ; =data_ov61_0217d950
-	mov r0, sl
+	mov r0, r10
 	add r1, r6, #0x18
 	bl func_ov61_0216936c
 	ldr r2, [sp, #0x28]
-	mov r0, sl
+	mov r0, r10
 	ldr r2, [r2, #0x46c]
 	add r1, r6, #0x18
 	bl func_ov61_0216939c
 	ldr r2, _021705ec ; =data_ov61_0217d8b0
-	mov r0, sl
+	mov r0, r10
 	add r1, r6, #0x18
 	bl func_ov61_0216936c
 	ldr r2, [sp, #0x28]
-	mov r0, sl
+	mov r0, r10
 	ldr r2, [r2, #0x470]
 	add r1, r6, #0x18
 	bl func_ov61_0216939c
 	ldr r2, _021705f4 ; =data_ov61_0217d8c8
-	mov r0, sl
+	mov r0, r10
 	add r1, r6, #0x18
 	bl func_ov61_0216936c
-	mov r0, sl
+	mov r0, r10
 	add r1, r6, #0x18
 	add r2, r6, #0x47
 	bl func_ov61_0216936c
@@ -60237,10 +60237,10 @@ _0216fbe4:
 	cmp r0, #0
 	beq _0216fdf0
 	ldr r2, _0217062c ; =data_ov61_0217d95c
-	mov r0, sl
+	mov r0, r10
 	add r1, r6, #0x18
 	bl func_ov61_0216936c
-	mov r0, sl
+	mov r0, r10
 	add r1, r6, #0x18
 	add r2, r6, #0xec
 	bl func_ov61_0216936c
@@ -60249,33 +60249,33 @@ _0216fcf4:
 	cmp r0, #7
 	bne _0216fd7c
 	ldr r2, _02170630 ; =data_ov61_0217d964
-	mov r0, sl
+	mov r0, r10
 	add r1, r6, #0x18
 	bl func_ov61_0216936c
 	ldr r2, _021705e4 ; =data_ov61_0217d898
-	mov r0, sl
+	mov r0, r10
 	add r1, r6, #0x18
 	bl func_ov61_0216936c
 	ldr r0, [sp, #0x28]
 	add r1, r6, #0x18
 	ldr r2, [r0, #0x198]
-	mov r0, sl
+	mov r0, r10
 	bl func_ov61_0216939c
 	ldr r2, _021705e8 ; =data_ov61_0217d8a4
-	mov r0, sl
+	mov r0, r10
 	add r1, r6, #0x18
 	bl func_ov61_0216936c
 	ldr r2, [sp, #0x28]
-	mov r0, sl
+	mov r0, r10
 	ldr r2, [r2, #0x1a0]
 	add r1, r6, #0x18
 	bl func_ov61_0216939c
 	ldr r2, _021705ec ; =data_ov61_0217d8b0
-	mov r0, sl
+	mov r0, r10
 	add r1, r6, #0x18
 	bl func_ov61_0216936c
 	ldr r2, [sp, #0x28]
-	mov r0, sl
+	mov r0, r10
 	ldr r2, [r2, #0x470]
 	add r1, r6, #0x18
 	bl func_ov61_0216939c
@@ -60284,23 +60284,23 @@ _0216fd7c:
 	cmp r0, #8
 	bne _0216fddc
 	ldr r2, _02170634 ; =data_ov61_0217d970
-	mov r0, sl
+	mov r0, r10
 	add r1, r6, #0x18
 	bl func_ov61_0216936c
 	ldr r2, _02170638 ; =data_ov61_0217d980
-	mov r0, sl
+	mov r0, r10
 	add r1, r6, #0x18
 	bl func_ov61_0216936c
-	mov r0, sl
+	mov r0, r10
 	add r1, r6, #0x18
 	add r2, r6, #0x47
 	bl func_ov61_0216936c
 	ldr r2, _021705ec ; =data_ov61_0217d8b0
-	mov r0, sl
+	mov r0, r10
 	add r1, r6, #0x18
 	bl func_ov61_0216936c
 	ldr r2, [sp, #0x28]
-	mov r0, sl
+	mov r0, r10
 	ldr r2, [r2, #0x470]
 	add r1, r6, #0x18
 	bl func_ov61_0216939c
@@ -60313,15 +60313,15 @@ _0216fddc:
 	bl func_02042f80
 _0216fdf0:
 	ldr r2, _0217064c ; =data_ov61_0217d994
-	mov r0, sl
+	mov r0, r10
 	add r1, r6, #0x18
 	bl func_ov61_0216936c
 	ldr r2, _02170650 ; =data_ov61_021810c0
-	mov r0, sl
+	mov r0, r10
 	add r1, r6, #0x18
 	bl func_ov61_0216936c
 	ldr r2, _02170654 ; =data_ov61_0217d9a0
-	mov r0, sl
+	mov r0, r10
 	add r1, r6, #0x18
 	bl func_ov61_0216936c
 	ldr r0, [sp, #0x1c]
@@ -60337,25 +60337,25 @@ _0216fe30:
 	str r0, [sp, #4]
 	ldr r1, [r6, #4]
 	add r3, sp, #0x6c
-	mov r0, sl
+	mov r0, r10
 	add r2, r6, #8
 	bl func_ov61_021696d4
 	cmp r0, #0
 	beq _0216fe9c
 	cmp r0, #3
 	addne sp, sp, #0x490
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r1, _021705d8 ; =0x00000d01
 	ldr r2, _02170658 ; =data_ov61_0217d9a8
-	mov r0, sl
+	mov r0, r10
 	bl func_ov61_02171aec
-	mov r0, sl
+	mov r0, r10
 	mov r1, #3
 	mov r2, #0
 	bl func_ov61_02169c10
 	add sp, sp, #0x490
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0216fe9c:
 	ldr r0, [r6, #8]
 	ldr r1, _02170654 ; =data_ov61_0217d9a0
@@ -60368,7 +60368,7 @@ _0216fe9c:
 	mov r1, #5
 	str r1, [r0, #0x14]
 	ldr r1, [r6, #8]
-	mov r0, sl
+	mov r0, r10
 	mov r2, #1
 	bl func_ov61_02171648
 	cmp r0, #0
@@ -60377,7 +60377,7 @@ _0216fe9c:
 	str r0, [r6, #0x140]
 	add sp, sp, #0x490
 	mov r0, #4
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0216fef0:
 	ldr r0, [r6]
 	cmp r0, #1
@@ -60395,13 +60395,13 @@ _0216fef0:
 _0216ff24:
 	str r5, [sp]
 	ldr r1, [r6, #8]
-	mov r0, sl
+	mov r0, r10
 	mov r2, r11
 	mov r3, r4
 	bl func_ov61_0217191c
 	cmp r0, #0
 	addne sp, sp, #0x490
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r1, _02170660 ; =data_ov61_0217d9d4
 	mov r0, r4
 	bl strcmp
@@ -60409,13 +60409,13 @@ _0216ff24:
 	bne _0216ffb8
 	str r5, [sp]
 	ldr r1, [r6, #8]
-	mov r0, sl
+	mov r0, r10
 	mov r2, r11
 	mov r3, r4
 	bl func_ov61_0217191c
 	cmp r0, #0
 	addne sp, sp, #0x490
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r1, _02170664 ; =data_ov61_0217d9dc
 	mov r0, r4
 	bl strcmp
@@ -60448,11 +60448,11 @@ _0216ffb8:
 	str r7, [sp, #0x8c]
 	bne _0217000c
 	ldr r1, _0217066c ; =data_ov61_0217d758
-	mov r0, sl
+	mov r0, r10
 	bl func_ov61_02171b10
 	add sp, sp, #0x490
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0217000c:
 	ldr r0, [sp, #0x84]
 	mov r1, #0
@@ -60469,7 +60469,7 @@ _0217000c:
 	mov r8, #0
 _02170040:
 	ldr r7, [sp, #0x78]
-	mov r0, sl
+	mov r0, r10
 	str r5, [sp]
 	ldr r1, [r6, #8]
 	mov r2, r11
@@ -60477,7 +60477,7 @@ _02170040:
 	bl func_ov61_0217191c
 	cmp r0, #0
 	addne sp, sp, #0x490
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r1, _02170670 ; =data_ov61_0217d9e8
 	mov r0, r4
 	bl strcmp
@@ -60552,16 +60552,16 @@ _02170160:
 	b _02170198
 _0217016c:
 	ldr r2, _02170684 ; =data_ov61_0217da1c
-	mov r0, sl
+	mov r0, r10
 	mov r1, #1
 	bl func_ov61_02171aec
-	mov r0, sl
+	mov r0, r10
 	mov r1, #3
 	mov r2, #1
 	bl func_ov61_02169c10
 	add sp, sp, #0x490
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02170198:
 	ldr r0, [sp, #0x2c]
 	cmp r0, #0
@@ -60575,7 +60575,7 @@ _02170198:
 	cmp r3, #0
 	beq _021701d0
 	add r1, sp, #0x80
-	mov r0, sl
+	mov r0, r10
 	blx r3
 _021701d0:
 	cmp r4, #0x600
@@ -60587,7 +60587,7 @@ _021701d0:
 	add r0, r6, #0xae
 	str r0, [sp, #4]
 	ldr r1, [r6, #0x130]
-	mov r0, sl
+	mov r0, r10
 	str r1, [sp, #8]
 	ldr r3, [sp, #0x84]
 	ldr r2, [r6, #0x134]
@@ -60608,7 +60608,7 @@ _021701d0:
 	bl func_ov61_0216f5b0
 	cmp r0, #0
 	addne sp, sp, #0x490
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0217024c:
 	ldr r0, [sp, #0x8c]
 	bl func_ov61_0213e13c
@@ -60630,38 +60630,38 @@ _02170260:
 	ldr r1, [r6, #8]
 	add r2, sp, #0x78
 	add r3, sp, #0x290
-	mov r0, sl
+	mov r0, r10
 	bl func_ov61_0217191c
 	cmp r0, #0
 	addne sp, sp, #0x490
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r1, _02170688 ; =data_ov61_0217da44
 	add r0, sp, #0x290
 	bl strcmp
 	cmp r0, #0
 	beq _021702ec
 	ldr r2, _02170684 ; =data_ov61_0217da1c
-	mov r0, sl
+	mov r0, r10
 	mov r1, #1
 	bl func_ov61_02171aec
-	mov r0, sl
+	mov r0, r10
 	mov r1, #3
 	mov r2, #1
 	bl func_ov61_02169c10
 	add sp, sp, #0x490
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _021702ec:
 	mov r0, #0x3c
 	bl func_ov61_0213e10c
 	movs r4, r0
 	bne _02170314
 	ldr r1, _0217066c ; =data_ov61_0217d758
-	mov r0, sl
+	mov r0, r10
 	bl func_ov61_02171b10
 	add sp, sp, #0x490
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02170314:
 	mov r0, #0
 	str r0, [r4]
@@ -60679,14 +60679,14 @@ _02170314:
 	str r1, [sp]
 	mov r1, #0
 	str r1, [sp, #4]
-	mov r0, sl
+	mov r0, r10
 	mov r3, r4
 	ldmia r2, {r1, r2}
 	bl func_ov61_02169d04
 	cmp r0, #0
 	beq _021711e0
 	add sp, sp, #0x490
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02170374:
 	cmp r0, #3
 	bne _0217071c
@@ -60702,11 +60702,11 @@ _02170374:
 	movs r8, r0
 	bne _021703c0
 	ldr r1, _0217066c ; =data_ov61_0217d758
-	mov r0, sl
+	mov r0, r10
 	bl func_ov61_02171b10
 	add sp, sp, #0x490
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _021703c0:
 	mov r2, #0
 	add r0, r8, #4
@@ -60722,27 +60722,27 @@ _021703c0:
 	ldr r1, [r6, #8]
 	add r2, sp, #0x78
 	add r3, sp, #0x290
-	mov r0, sl
+	mov r0, r10
 	bl func_ov61_0217191c
 	cmp r0, #0
 	addne sp, sp, #0x490
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r1, _0217068c ; =data_ov61_0217da48
 	add r0, sp, #0x290
 	bl strcmp
 	cmp r0, #0
 	beq _0217044c
 	ldr r2, _02170684 ; =data_ov61_0217da1c
-	mov r0, sl
+	mov r0, r10
 	mov r1, #1
 	bl func_ov61_02171aec
-	mov r0, sl
+	mov r0, r10
 	mov r1, #3
 	mov r2, #1
 	bl func_ov61_02169c10
 	add sp, sp, #0x490
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0217044c:
 	ldr r11, _02170670 ; =data_ov61_0217d9e8
 	mov sb, #0
@@ -60752,13 +60752,13 @@ _0217044c:
 _02170460:
 	str r7, [sp]
 	ldr r1, [r6, #8]
-	mov r0, sl
+	mov r0, r10
 	mov r2, r5
 	mov r3, r4
 	bl func_ov61_0217191c
 	cmp r0, #0
 	addne sp, sp, #0x490
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	mov r0, r4
 	mov r1, r11
 	bl strcmp
@@ -60772,11 +60772,11 @@ _02170460:
 	cmp r0, #0
 	bne _021704cc
 	ldr r1, _0217066c ; =data_ov61_0217d758
-	mov r0, sl
+	mov r0, r10
 	bl func_ov61_02171b10
 	add sp, sp, #0x490
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _021704cc:
 	str r0, [r8, #0x3c]
 	mov r0, #0x1f
@@ -60784,11 +60784,11 @@ _021704cc:
 	cmp r0, #0
 	bne _021704f8
 	ldr r1, _0217066c ; =data_ov61_0217d758
-	mov r0, sl
+	mov r0, r10
 	bl func_ov61_02171b10
 	add sp, sp, #0x490
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _021704f8:
 	ldr r3, [r8, #0x3c]
 	ldr r2, [r8, #0x38]
@@ -60818,11 +60818,11 @@ _0217052c:
 	cmp r0, #0
 	bne _02170578
 	ldr r1, _0217066c ; =data_ov61_0217d758
-	mov r0, sl
+	mov r0, r10
 	bl func_ov61_02171b10
 	add sp, sp, #0x490
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02170578:
 	str r0, [r8, #0x40]
 	mov r0, #0x15
@@ -60830,11 +60830,11 @@ _02170578:
 	cmp r0, #0
 	bne _021705a4
 	ldr r1, _0217066c ; =data_ov61_0217d758
-	mov r0, sl
+	mov r0, r10
 	bl func_ov61_02171b10
 	add sp, sp, #0x490
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _021705a4:
 	ldr r3, [r8, #0x40]
 	ldr r2, [r8, #0x38]
@@ -60908,16 +60908,16 @@ _0217069c:
 	moveq sb, #1
 	beq _021706e0
 	ldr r2, _02170684 ; =data_ov61_0217da1c
-	mov r0, sl
+	mov r0, r10
 	mov r1, #1
 	bl func_ov61_02171aec
-	mov r0, sl
+	mov r0, r10
 	mov r1, #3
 	mov r2, #1
 	bl func_ov61_02169c10
 	add sp, sp, #0x490
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _021706e0:
 	cmp sb, #0
 	beq _02170460
@@ -60926,14 +60926,14 @@ _021706e0:
 	str r1, [sp]
 	mov r1, #3
 	str r1, [sp, #4]
-	mov r0, sl
+	mov r0, r10
 	mov r3, r8
 	ldmia r2, {r1, r2}
 	bl func_ov61_02169d04
 	cmp r0, #0
 	beq _021711e0
 	add sp, sp, #0x490
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0217071c:
 	cmp r0, #4
 	bne _02170998
@@ -60949,11 +60949,11 @@ _0217071c:
 	movs r11, r0
 	bne _02170768
 	ldr r1, _0217066c ; =data_ov61_0217d758
-	mov r0, sl
+	mov r0, r10
 	bl func_ov61_02171b10
 	add sp, sp, #0x490
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02170768:
 	ldr r1, [r6, #0x138]
 	mov r0, #0
@@ -60966,13 +60966,13 @@ _02170768:
 _02170788:
 	str r5, [sp]
 	ldr r1, [r6, #8]
-	mov r0, sl
+	mov r0, r10
 	add r2, sp, #0x78
 	mov r3, r4
 	bl func_ov61_0217191c
 	cmp r0, #0
 	addne sp, sp, #0x490
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r1, _02170694 ; =data_ov61_0217da54
 	mov r0, r4
 	bl strcmp
@@ -60996,11 +60996,11 @@ _02170788:
 	movs r8, r0
 	bne _0217081c
 	ldr r1, _0217066c ; =data_ov61_0217d758
-	mov r0, sl
+	mov r0, r10
 	bl func_ov61_02171b10
 	add sp, sp, #0x490
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0217081c:
 	ldr r0, [r11, #8]
 	mov r1, #0
@@ -61019,7 +61019,7 @@ _0217081c:
 	mov r8, #0
 _02170858:
 	ldr sb, [sp, #0x78]
-	mov r0, sl
+	mov r0, r10
 	str r5, [sp]
 	ldr r1, [r6, #8]
 	add r2, sp, #0x78
@@ -61027,7 +61027,7 @@ _02170858:
 	bl func_ov61_0217191c
 	cmp r0, #0
 	addne sp, sp, #0x490
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r1, _02171210 ; =data_ov61_0217da60
 	mov r0, r4
 	bl strcmp
@@ -61078,16 +61078,16 @@ _02170920:
 	b _02170958
 _0217092c:
 	ldr r2, _02170684 ; =data_ov61_0217da1c
-	mov r0, sl
+	mov r0, r10
 	mov r1, #1
 	bl func_ov61_02171aec
-	mov r0, sl
+	mov r0, r10
 	mov r1, #3
 	mov r2, #1
 	bl func_ov61_02169c10
 	add sp, sp, #0x490
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02170958:
 	ldr r0, [sp, #0x20]
 	cmp r0, #0
@@ -61097,14 +61097,14 @@ _02170958:
 	str r1, [sp]
 	mov r1, #4
 	str r1, [sp, #4]
-	mov r0, sl
+	mov r0, r10
 	mov r3, r11
 	ldmia r2, {r1, r2}
 	bl func_ov61_02169d04
 	cmp r0, #0
 	beq _021711e0
 	add sp, sp, #0x490
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02170998:
 	cmp r0, #5
 	bne _02170af4
@@ -61120,27 +61120,27 @@ _02170998:
 	ldr r1, [r6, #8]
 	add r2, sp, #0x78
 	add r3, sp, #0x290
-	mov r0, sl
+	mov r0, r10
 	bl func_ov61_0217191c
 	cmp r0, #0
 	addne sp, sp, #0x490
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r1, _02171218 ; =data_ov61_0217da74
 	add r0, sp, #0x290
 	bl strcmp
 	cmp r0, #0
 	beq _02170a24
 	ldr r2, _02170684 ; =data_ov61_0217da1c
-	mov r0, sl
+	mov r0, r10
 	mov r1, #1
 	bl func_ov61_02171aec
-	mov r0, sl
+	mov r0, r10
 	mov r1, #3
 	mov r2, #1
 	bl func_ov61_02169c10
 	add sp, sp, #0x490
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02170a24:
 	add r0, sp, #0x90
 	bl func_0204902c
@@ -61159,16 +61159,16 @@ _02170a44:
 	cmp r0, #0
 	bne _02170a8c
 	ldr r2, _02170684 ; =data_ov61_0217da1c
-	mov r0, sl
+	mov r0, r10
 	mov r1, #1
 	bl func_ov61_02171aec
-	mov r0, sl
+	mov r0, r10
 	mov r1, #3
 	mov r2, #1
 	bl func_ov61_02169c10
 	add sp, sp, #0x490
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02170a8c:
 	add r0, sp, #0x90
 	bl func_0204902c
@@ -61179,11 +61179,11 @@ _02170a98:
 	movs r3, r0
 	bne _02170ac0
 	ldr r1, _0217066c ; =data_ov61_0217d758
-	mov r0, sl
+	mov r0, r10
 	bl func_ov61_02171b10
 	add sp, sp, #0x490
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02170ac0:
 	stmia r3, {r4, r5}
 	ldr r1, [sp, #0x1c]
@@ -61191,13 +61191,13 @@ _02170ac0:
 	str r1, [sp]
 	mov r1, #0
 	str r1, [sp, #4]
-	mov r0, sl
+	mov r0, r10
 	ldmia r2, {r1, r2}
 	bl func_ov61_02169d04
 	cmp r0, #0
 	beq _021711e0
 	add sp, sp, #0x490
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02170af4:
 	cmp r0, #6
 	bne _02170c54
@@ -61213,27 +61213,27 @@ _02170af4:
 	ldr r1, [r6, #8]
 	add r2, sp, #0x78
 	add r3, sp, #0x290
-	mov r0, sl
+	mov r0, r10
 	bl func_ov61_0217191c
 	cmp r0, #0
 	addne sp, sp, #0x490
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r1, _02171220 ; =data_ov61_0217da80
 	add r0, sp, #0x290
 	bl strcmp
 	cmp r0, #0
 	beq _02170b80
 	ldr r2, _02170684 ; =data_ov61_0217da1c
-	mov r0, sl
+	mov r0, r10
 	mov r1, #1
 	bl func_ov61_02171aec
-	mov r0, sl
+	mov r0, r10
 	mov r1, #3
 	mov r2, #1
 	bl func_ov61_02169c10
 	add sp, sp, #0x490
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02170b80:
 	add r0, sp, #0x90
 	bl func_0204902c
@@ -61250,16 +61250,16 @@ _02170b80:
 	cmp r4, #0
 	bne _02170be4
 	ldr r2, _02170684 ; =data_ov61_0217da1c
-	mov r0, sl
+	mov r0, r10
 	mov r1, #1
 	bl func_ov61_02171aec
-	mov r0, sl
+	mov r0, r10
 	mov r1, #3
 	mov r2, #1
 	bl func_ov61_02169c10
 	add sp, sp, #0x490
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02170be4:
 	mov r5, #0
 	b _02170bf8
@@ -61273,11 +61273,11 @@ _02170bf8:
 	movs r3, r0
 	bne _02170c20
 	ldr r1, _0217066c ; =data_ov61_0217d758
-	mov r0, sl
+	mov r0, r10
 	bl func_ov61_02171b10
 	add sp, sp, #0x490
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02170c20:
 	stmia r3, {r4, r5}
 	ldr r1, [sp, #0x1c]
@@ -61285,13 +61285,13 @@ _02170c20:
 	str r1, [sp]
 	mov r1, #0
 	str r1, [sp, #4]
-	mov r0, sl
+	mov r0, r10
 	ldmia r2, {r1, r2}
 	bl func_ov61_02169d04
 	cmp r0, #0
 	beq _021711e0
 	add sp, sp, #0x490
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02170c54:
 	cmp r0, #7
 	bne _02170f90
@@ -61307,11 +61307,11 @@ _02170c54:
 	movs r11, r0
 	bne _02170ca0
 	ldr r1, _0217066c ; =data_ov61_0217d758
-	mov r0, sl
+	mov r0, r10
 	bl func_ov61_02171b10
 	add sp, sp, #0x490
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02170ca0:
 	mov r1, #0
 	str r1, [r11]
@@ -61322,27 +61322,27 @@ _02170ca0:
 	ldr r1, [r6, #8]
 	add r2, sp, #0x78
 	add r3, sp, #0x290
-	mov r0, sl
+	mov r0, r10
 	bl func_ov61_0217191c
 	cmp r0, #0
 	addne sp, sp, #0x490
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r1, _02171224 ; =data_ov61_0217da84
 	add r0, sp, #0x290
 	bl strcmp
 	cmp r0, #0
 	beq _02170d18
 	ldr r2, _02170684 ; =data_ov61_0217da1c
-	mov r0, sl
+	mov r0, r10
 	mov r1, #1
 	bl func_ov61_02171aec
-	mov r0, sl
+	mov r0, r10
 	mov r1, #3
 	mov r2, #1
 	bl func_ov61_02169c10
 	add sp, sp, #0x490
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02170d18:
 	mov r0, #0
 	str r0, [sp, #0x24]
@@ -61351,13 +61351,13 @@ _02170d18:
 _02170d28:
 	str r5, [sp]
 	ldr r1, [r6, #8]
-	mov r0, sl
+	mov r0, r10
 	add r2, sp, #0x78
 	mov r3, r4
 	bl func_ov61_0217191c
 	cmp r0, #0
 	addne sp, sp, #0x490
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r1, _02171228 ; =data_ov61_0217da8c
 	mov r0, r4
 	bl strcmp
@@ -61379,11 +61379,11 @@ _02170d28:
 	cmp r0, #0
 	bne _02170db4
 	ldr r1, _0217066c ; =data_ov61_0217d758
-	mov r0, sl
+	mov r0, r10
 	bl func_ov61_02171b10
 	add sp, sp, #0x490
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02170db4:
 	str r0, [r11, #8]
 	ldr r2, [r11, #4]
@@ -61404,7 +61404,7 @@ _02170db4:
 	mov r8, #0
 _02170df8:
 	ldr sb, [sp, #0x78]
-	mov r0, sl
+	mov r0, r10
 	str r5, [sp]
 	ldr r1, [r6, #8]
 	add r2, sp, #0x78
@@ -61412,7 +61412,7 @@ _02170df8:
 	bl func_ov61_0217191c
 	cmp r0, #0
 	addne sp, sp, #0x490
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r1, _02170670 ; =data_ov61_0217d9e8
 	mov r0, r4
 	bl strcmp
@@ -61487,16 +61487,16 @@ _02170f18:
 	b _02170f50
 _02170f24:
 	ldr r2, _02170684 ; =data_ov61_0217da1c
-	mov r0, sl
+	mov r0, r10
 	mov r1, #1
 	bl func_ov61_02171aec
-	mov r0, sl
+	mov r0, r10
 	mov r1, #3
 	mov r2, #1
 	bl func_ov61_02169c10
 	add sp, sp, #0x490
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02170f50:
 	ldr r0, [sp, #0x24]
 	cmp r0, #0
@@ -61506,14 +61506,14 @@ _02170f50:
 	str r1, [sp]
 	mov r1, #8
 	str r1, [sp, #4]
-	mov r0, sl
+	mov r0, r10
 	mov r3, r11
 	ldmia r2, {r1, r2}
 	bl func_ov61_02169d04
 	cmp r0, #0
 	beq _021711e0
 	add sp, sp, #0x490
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02170f90:
 	cmp r0, #8
 	bne _021711cc
@@ -61530,11 +61530,11 @@ _02170f90:
 	movs r8, r0
 	bne _02170fe0
 	ldr r1, _0217066c ; =data_ov61_0217d758
-	mov r0, sl
+	mov r0, r10
 	bl func_ov61_02171b10
 	add sp, sp, #0x490
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02170fe0:
 	mov r1, r7
 	str r1, [r8]
@@ -61545,27 +61545,27 @@ _02170fe0:
 	ldr r1, [r6, #8]
 	add r2, sp, #0x78
 	add r3, sp, #0x290
-	mov r0, sl
+	mov r0, r10
 	bl func_ov61_0217191c
 	cmp r0, #0
 	addne sp, sp, #0x490
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r1, _02171238 ; =data_ov61_0217daa8
 	add r0, sp, #0x290
 	bl strcmp
 	cmp r0, #0
 	beq _02171058
 	ldr r2, _02170684 ; =data_ov61_0217da1c
-	mov r0, sl
+	mov r0, r10
 	mov r1, #1
 	bl func_ov61_02171aec
-	mov r0, sl
+	mov r0, r10
 	mov r1, #3
 	mov r2, #1
 	bl func_ov61_02169c10
 	add sp, sp, #0x490
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02171058:
 	add r0, sp, #0x90
 	bl func_0204902c
@@ -61576,11 +61576,11 @@ _02171058:
 	cmp r0, #0
 	bne _02171090
 	ldr r1, _0217066c ; =data_ov61_0217d758
-	mov r0, sl
+	mov r0, r10
 	bl func_ov61_02171b10
 	add sp, sp, #0x490
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02171090:
 	mov sb, r7
 	add r4, sp, #0x290
@@ -61589,13 +61589,13 @@ _02171090:
 _021710a0:
 	str r5, [sp]
 	ldr r1, [r6, #8]
-	mov r0, sl
+	mov r0, r10
 	mov r2, r11
 	mov r3, r4
 	bl func_ov61_0217191c
 	cmp r0, #0
 	addne sp, sp, #0x490
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	ldr r1, _02170670 ; =data_ov61_0217d9e8
 	mov r0, r4
 	bl strcmp
@@ -61610,11 +61610,11 @@ _021710a0:
 	cmp r0, #0
 	bne _02171110
 	ldr r1, _0217066c ; =data_ov61_0217d758
-	mov r0, sl
+	mov r0, r10
 	bl func_ov61_02171b10
 	add sp, sp, #0x490
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02171110:
 	mov r1, r5
 	mov r2, #0x15
@@ -61641,16 +61641,16 @@ _02171158:
 	b _02171190
 _02171164:
 	ldr r2, _02170684 ; =data_ov61_0217da1c
-	mov r0, sl
+	mov r0, r10
 	mov r1, #1
 	bl func_ov61_02171aec
-	mov r0, sl
+	mov r0, r10
 	mov r1, #3
 	mov r2, #1
 	bl func_ov61_02169c10
 	add sp, sp, #0x490
 	mov r0, #3
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02171190:
 	cmp sb, #0
 	beq _021710a0
@@ -61659,14 +61659,14 @@ _02171190:
 	str r1, [sp]
 	mov r1, #9
 	str r1, [sp, #4]
-	mov r0, sl
+	mov r0, r10
 	mov r3, r8
 	ldmia r2, {r1, r2}
 	bl func_ov61_02169d04
 	cmp r0, #0
 	beq _021711e0
 	add sp, sp, #0x490
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _021711cc:
 	ldr r0, _0217063c ; =data_ov61_0217d990
 	ldr r1, _02170640 ; =data_ov61_0217d814
@@ -61687,7 +61687,7 @@ _021711fc:
 	bne _0216f7cc
 	mov r0, #0
 	add sp, sp, #0x490
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 _02171210: .word data_ov61_0217da60
 _02171214: .word data_ov61_0217da68
@@ -61708,9 +61708,9 @@ _02171248: .word 0x0000052a
 	.global func_ov61_0217124c
 	arm_func_start func_ov61_0217124c
 func_ov61_0217124c: ; 0x0217124c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
-	mov sl, r0
-	ldr r6, [sl]
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	mov r10, r0
+	ldr r6, [r10]
 	mov sb, #0
 	ldr r0, [r6, #0x210]
 	cmp r0, #0
@@ -61720,10 +61720,10 @@ func_ov61_0217124c: ; 0x0217124c
 	movs r7, r0
 	bne _0217128c
 	ldr r1, _02171388 ; =data_ov61_0217d758
-	mov r0, sl
+	mov r0, r10
 	bl func_ov61_02171b10
 	mov r0, #1
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _0217128c:
 	ldr r8, [r6, #0x424]
 	cmp r8, #0
@@ -61765,7 +61765,7 @@ _02171308:
 	ble _02171338
 _02171314:
 	ldr r1, [r7, r4, lsl #2]
-	mov r0, sl
+	mov r0, r10
 	bl func_ov61_0216f79c
 	cmp r0, #0
 	ldrne r1, [r7, r4, lsl #2]
@@ -61786,7 +61786,7 @@ _02171348:
 	cmp r0, #0
 	beq _0217136c
 	ldr r1, [r7, r4, lsl #2]
-	mov r0, sl
+	mov r0, r10
 	bl func_ov61_0216d950
 _0217136c:
 	add r4, r4, #1
@@ -61797,7 +61797,7 @@ _02171378:
 	bl func_ov61_0213e13c
 _02171380:
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0217124c
 _02171388: .word data_ov61_0217d758
@@ -62894,49 +62894,49 @@ _0217216c: .word data_ov61_0217dd08
 	.global func_ov61_02172170
 	arm_func_start func_ov61_02172170
 func_ov61_02172170: ; 0x02172170
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	ldr r0, _021722b8 ; =data_ov61_0217dd08
 	mvn r1, #0
 	ldr r0, [r0]
 	cmp r0, r1
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	ldr r1, _021722bc ; =data_ov61_02181154
 	ldr r1, [r1, #0x10]
 	cmp r1, #5
 	movne r0, #0
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	bl func_ov61_021723f4
 	cmp r0, #0
 	beq _0217229c
 	mov r7, #0
-	ldr sl, _021722bc ; =data_ov61_02181154
+	ldr r10, _021722bc ; =data_ov61_02181154
 	ldr sb, _021722b8 ; =data_ov61_0217dd08
 	mov r8, #0x100
 	mov r6, r7
 	mov r4, r7
 _021721c4:
-	ldr r1, [sl, #0x2c]
-	ldr r0, [sl]
+	ldr r1, [r10, #0x2c]
+	ldr r0, [r10]
 	sub r0, r1, r0
 	cmp r0, #0x80
 	bge _02172208
 	cmp r1, #0x100
-	strlt r8, [sl, #0x2c]
+	strlt r8, [r10, #0x2c]
 	movge r0, r1, lsl #0x1
-	strge r0, [sl, #0x2c]
-	ldr r1, [sl, #0x2c]
-	ldr r0, [sl, #0xc]
+	strge r0, [r10, #0x2c]
+	ldr r1, [r10, #0x2c]
+	ldr r0, [r10, #0xc]
 	add r1, r1, #1
 	bl func_ov61_0213e120
-	str r0, [sl, #0xc]
+	str r0, [r10, #0xc]
 	cmp r0, #0
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _02172208:
-	ldr r5, [sl]
-	ldr r1, [sl, #0xc]
-	ldr r2, [sl, #0x2c]
+	ldr r5, [r10]
+	ldr r1, [r10, #0xc]
+	ldr r2, [r10, #0x2c]
 	ldr r0, [sb]
 	mov r3, r7
 	add r1, r1, r5
@@ -62946,28 +62946,28 @@ _02172208:
 	bgt _0217223c
 	bl func_ov61_021720e0
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _0217223c:
-	ldr r1, [sl]
+	ldr r1, [r10]
 	add r1, r1, r0
-	str r1, [sl]
-	ldr r0, [sl, #0xc]
+	str r1, [r10]
+	ldr r0, [r10, #0xc]
 	strb r6, [r0, r1]
-	ldr r0, [sl, #0xc]
-	ldr r1, [sl]
+	ldr r0, [r10, #0xc]
+	ldr r1, [r10]
 	bl func_ov61_0217288c
-	ldr r1, [sl]
+	ldr r1, [r10]
 	mov r5, r0
 	cmp r5, r1
-	streq r4, [sl]
+	streq r4, [r10]
 	beq _0217228c
-	ldr r0, [sl, #0xc]
+	ldr r0, [r10, #0xc]
 	sub r2, r1, r5
 	add r1, r0, r5
 	bl func_020435b4
-	ldr r0, [sl]
+	ldr r0, [r10]
 	sub r0, r0, r5
-	str r0, [sl]
+	str r0, [r10]
 _0217228c:
 	ldr r0, [sb]
 	bl func_ov61_021723f4
@@ -62980,7 +62980,7 @@ _0217229c:
 	cmp r1, r0
 	moveq r0, #0
 	movne r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02172170
 _021722b8: .word data_ov61_0217dd08
@@ -63437,9 +63437,9 @@ _02172888: .word data_ov61_0217dde4
 	.global func_ov61_0217288c
 	arm_func_start func_ov61_0217288c
 func_ov61_0217288c: ; 0x0217288c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	mov sb, r1
-	mov sl, r0
+	mov r10, r0
 	mov r7, sb
 	bl func_ov61_02172400
 	mov r6, r0
@@ -63447,20 +63447,20 @@ func_ov61_0217288c: ; 0x0217288c
 	ldr r4, _02172910 ; =data_ov61_0217dd08
 	b _021728f4
 _021728b0:
-	sub r8, r6, sl
-	mov r0, sl
+	sub r8, r6, r10
+	mov r0, r10
 	mov r1, r8
 	str r5, [r4, #8]
 	bl func_ov61_021722c0
-	mov r0, sl
+	mov r0, r10
 	mov r1, r8
 	bl func_ov61_021727a4
 	add r0, r8, #7
 	sub sb, sb, r0
 	cmp sb, #0
-	add sl, r6, #7
+	add r10, r6, #7
 	ble _021728f4
-	mov r0, sl
+	mov r0, r10
 	mov r1, sb
 	bl func_ov61_02172400
 	mov r6, r0
@@ -63471,7 +63471,7 @@ _021728f4:
 	bne _021728b0
 _02172904:
 	sub r0, r7, sb
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0217288c
 _0217290c: .word data_ov61_0217dd54
@@ -63937,7 +63937,7 @@ _02172ecc: .word data_ov61_0217ddf8
 	.global func_ov61_02172ed0
 	arm_func_start func_ov61_02172ed0
 func_ov61_02172ed0: ; 0x02172ed0
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	ldrb r5, [r0]
 	mov lr, #0
 	mov r4, #1
@@ -63948,18 +63948,18 @@ func_ov61_02172ed0: ; 0x02172ed0
 	mov r2, r4
 _02172ef4:
 	add r7, r0, r4
-	ldrb sl, [r7, #-1]
-	cmp sl, r5
-	eor sl, r4, sl
+	ldrb r10, [r7, #-1]
+	cmp r10, r5
+	eor r10, r4, r10
 	movlo r8, ip
-	and sl, sl, #1
+	and r10, r10, #1
 	movhs r8, r3
 	cmp r5, #0x4f
 	movlo sb, r2
-	eor sl, lr, sl
+	eor r10, lr, r10
 	movhs sb, r1
-	eor sl, r6, sl
-	eor sb, sl, sb
+	eor r10, r6, r10
+	eor sb, r10, sb
 	eors lr, sb, r8
 	beq _02172f3c
 	ldrb r8, [r7]
@@ -63973,20 +63973,20 @@ _02172f3c:
 	bne _02172f58
 _02172f50:
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _02172f58:
 	add r4, r4, #1
 	cmp r4, #0x20
 	blt _02172ef4
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	arm_func_end func_ov61_02172ed0
 
 	.global func_ov61_02172f6c
 	arm_func_start func_ov61_02172f6c
 func_ov61_02172f6c: ; 0x02172f6c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
-	movs sl, r0
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
+	movs r10, r0
 	bne _02172f8c
 	ldr r0, _02173078 ; =data_ov61_0217de38
 	ldr r1, _0217307c ; =data_ov61_0217de40
@@ -64007,14 +64007,14 @@ _02172f8c:
 	smull r1, r2, r3, r4
 	sub r4, r0, r1
 	add r0, r4, #0x21
-	strb r0, [sl]
+	strb r0, [r10]
 	mov r11, r8
 	mov r6, r7
 	mov r4, r3
 _02172fd0:
-	add sb, sl, r7
+	add sb, r10, r7
 	ldrb r3, [sb, #-1]
-	ldrb r0, [sl]
+	ldrb r0, [r10]
 	cmp r3, r0
 	eor r3, r7, r3
 	movlo r1, r6
@@ -64055,8 +64055,8 @@ _02173064:
 	add r7, r7, #1
 	cmp r7, #0x20
 	blt _02172fd0
-	mov r0, sl
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	mov r0, r10
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02172f6c
 _02173078: .word data_ov61_0217de38
@@ -64067,7 +64067,7 @@ _02173084: .word 0x2c0b02c1
 	.global func_ov61_02173088
 	arm_func_start func_ov61_02173088
 func_ov61_02173088: ; 0x02173088
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	mov r5, r0
 	ldr r0, _02173188 ; =data_ov61_0217de14
 	mov r4, r1
@@ -64075,13 +64075,13 @@ func_ov61_02173088: ; 0x02173088
 	mov r7, r0
 	mov r0, r4
 	bl func_ov61_02172ed0
-	mov sl, #0
+	mov r10, #0
 	mov r11, r0
-	mov r8, sl
+	mov r8, r10
 _021730b4:
 	cmp r11, #0
-	cmpne sl, #0
-	cmpne sl, #0xd
+	cmpne r10, #0
+	cmpne r10, #0xd
 	bne _021730ec
 	bl func_02045b48
 	ldr r1, _0217318c ; =0x2c0b02c1
@@ -64094,14 +64094,14 @@ _021730b4:
 	add r0, r6, #0x21
 	b _02173168
 _021730ec:
-	cmp sl, #1
-	cmpne sl, #0xe
-	ldreqsb r6, [r4, sl]
-	addne r0, r4, sl
-	ldrb sb, [r4, sl]
+	cmp r10, #1
+	cmpne r10, #0xe
+	ldreqsb r6, [r4, r10]
+	addne r0, r4, r10
+	ldrb sb, [r4, r10]
 	ldrnesb r6, [r0, #-1]
 	mov r1, r7
-	add r0, sl, sb
+	add r0, r10, sb
 	bl func_02002c14
 	mul r0, r6, r8
 	mov r6, r1
@@ -64110,7 +64110,7 @@ _021730ec:
 	ldr r0, _02173188 ; =data_ov61_0217de14
 	ldrsb r3, [r0, r6]
 	ldrsb r2, [r0, r1]
-	mla r0, sl, sb, r3
+	mla r0, r10, sb, r3
 	mov r1, r0, lsr #0x1f
 	rsb r0, r1, r0, lsl #27
 	add r0, r1, r0, ror #27
@@ -64126,14 +64126,14 @@ _021730ec:
 	sub r3, r0, r2
 	add r0, r3, #0x21
 _02173168:
-	strb r0, [r5, sl]
+	strb r0, [r5, r10]
 	add r0, r8, #0x47
-	add sl, sl, #1
-	cmp sl, #0x20
+	add r10, r10, #1
+	cmp r10, #0x20
 	add r8, r0, #0x4600
 	blt _021730b4
 	mov r0, r5
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02173088
 _02173188: .word data_ov61_0217de14
@@ -66364,7 +66364,7 @@ _02174d78: .word func_ov61_021745cc
 	.global func_ov61_02174d7c
 	arm_func_start func_ov61_02174d7c
 func_ov61_02174d7c: ; 0x02174d7c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #0x10
 	mov sb, r0
 	ldr r0, [sb, #0x5c]
@@ -66375,11 +66375,11 @@ func_ov61_02174d7c: ; 0x02174d7c
 	bl func_ov61_02165a68
 	mov r4, r0
 	cmp r4, #0
-	mov sl, #0
+	mov r10, #0
 	ble _02174df8
 _02174db0:
 	ldr r0, [sb, #0x5c]
-	mov r1, sl
+	mov r1, r10
 	bl func_ov61_02165a70
 	ldrh r0, [r0, #0xc]
 	cmp r0, r7
@@ -66388,14 +66388,14 @@ _02174db0:
 	str r0, [r5]
 	add sp, sp, #0x10
 	mov r0, #1
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _02174ddc:
 	mov r1, r7
 	bl func_ov61_021745cc
 	cmp r0, #0
 	bgt _02174df8
-	add sl, sl, #1
-	cmp sl, r4
+	add r10, r10, #1
+	cmp r10, r4
 	blt _02174db0
 _02174df8:
 	add r0, sb, #0x44
@@ -66405,7 +66405,7 @@ _02174df8:
 	movlt r0, #1
 	addlt sp, sp, #0x10
 	strlt r0, [r5]
-	ldmltia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmltia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	ldr r0, [sb, #0x4c]
 	add r1, sp, #0
 	str r2, [sp, #4]
@@ -66422,7 +66422,7 @@ _02174df8:
 	movne r0, #1
 	addne sp, sp, #0x10
 	strne r0, [r5]
-	ldmneia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmneia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	ldr r2, [sp, #0x30]
 	mov r1, r6
 	add r0, sb, #0x44
@@ -66439,7 +66439,7 @@ _02174df8:
 	bne _02174f18
 	add sp, sp, #0x10
 	mov r0, #0
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _02174ea0:
 	ldr r0, [sb, #0x5c]
 	mov r1, r4
@@ -66470,13 +66470,13 @@ _02174ea0:
 	cmp r0, #0
 	addeq sp, sp, #0x10
 	moveq r0, #0
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 _02174f18:
 	mov r0, #0
 	str r0, [r5]
 	mov r0, #1
 	add sp, sp, #0x10
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02174d7c
 _02174f2c: .word func_ov61_02174d68
@@ -67158,10 +67158,10 @@ _02175804:
 	.global func_ov61_02175810
 	arm_func_start func_ov61_02175810
 func_ov61_02175810: ; 0x02175810
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x5f0
-	mov sl, r0
-	ldr r0, [sl]
+	mov r10, r0
+	ldr r0, [r10]
 	bl func_ov61_02166914
 	cmp r0, #0
 	beq _02175930
@@ -67175,7 +67175,7 @@ func_ov61_02175810: ; 0x02175810
 _02175848:
 	str sb, [sp, #8]
 	stmia sp, {r8, r11}
-	ldr r0, [sl]
+	ldr r0, [r10]
 	ldr r2, _0217593c ; =0x000005dc
 	mov r1, r7
 	mov r3, #0
@@ -67183,13 +67183,13 @@ _02175848:
 	mov r2, r0
 	cmp r2, r6
 	bne _021758dc
-	ldr r0, [sl]
+	ldr r0, [r10]
 	bl func_ov61_02166ce0
 	cmp r0, r5
 	bne _021758c0
 	ldrh ip, [sp, #0xe]
 	ldr r1, [sp, #0x10]
-	mov r0, sl
+	mov r0, r10
 	mov r2, ip, asr #0x8
 	and r3, r2, #0xff
 	mov r2, ip, lsl #0x8
@@ -67202,18 +67202,18 @@ _02175848:
 	bne _02175920
 	add sp, sp, #0x5f0
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _021758c0:
 	cmp r0, r4
 	beq _02175920
-	mov r0, sl
+	mov r0, r10
 	bl func_ov61_02176968
 	add sp, sp, #0x5f0
 	mov r0, #0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _021758dc:
 	ldrh ip, [sp, #0xe]
-	mov r0, sl
+	mov r0, r10
 	mov r1, r7
 	mov r3, ip, asr #0x8
 	mov ip, ip, lsl #0x8
@@ -67228,16 +67228,16 @@ _021758dc:
 	cmp r0, #0
 	addeq sp, sp, #0x5f0
 	moveq r0, #0
-	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02175920:
-	ldr r0, [sl]
+	ldr r0, [r10]
 	bl func_ov61_02166914
 	cmp r0, #0
 	bne _02175848
 _02175930:
 	mov r0, #1
 	add sp, sp, #0x5f0
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02175810
 _0217593c: .word 0x000005dc
@@ -69328,7 +69328,7 @@ _02177440:
 	.global func_ov61_02177454
 	arm_func_start func_ov61_02177454
 func_ov61_02177454: ; 0x02177454
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, lr}
 	sub sp, sp, #0x1c
 	mov r2, #8
 	mov sb, r0
@@ -69338,7 +69338,7 @@ func_ov61_02177454: ; 0x02177454
 	bne _02177480
 	bl func_ov61_02176d58
 	add sp, sp, #0x1c
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 _02177480:
 	ldr r0, [sb]
 	sub r1, r2, #9
@@ -69349,7 +69349,7 @@ _02177480:
 	add r7, sp, #0x10
 	mov r5, #0x200
 	mov r4, #0
-	mvn sl, #0
+	mvn r10, #0
 _021774a8:
 	bl func_ov61_02166914
 	cmp r0, #0
@@ -69362,7 +69362,7 @@ _021774a8:
 	mov r3, r4
 	bl func_ov61_02166bc0
 	mov r1, r0
-	cmp r1, sl
+	cmp r1, r10
 	beq _021774fc
 	mov r0, r6
 	mov r2, r8
@@ -69370,7 +69370,7 @@ _021774a8:
 	ldr r0, [sb, #0x10]
 	cmp r0, #4
 	ldrne r0, [sb]
-	cmpne r0, sl
+	cmpne r0, r10
 	bne _021774a8
 _021774fc:
 	ldr r0, [sb, #0x10]
@@ -69443,12 +69443,12 @@ _021775f4:
 	ldr r0, [sb, #0x10]
 	cmp r0, #1
 	addne sp, sp, #0x1c
-	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmneia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	bl func_ov61_021665e8
 	ldr r1, [sb, #0x28]
 	cmp r0, r1
 	addls sp, sp, #0x1c
-	ldmlsia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmlsia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	mov r0, #1
 	ldr r3, [sb, #0x3c]
 	ldr r4, [sb, #0x38]
@@ -69458,7 +69458,7 @@ _021775f4:
 	ldr r0, [sb, #8]
 	bl func_ov61_0217741c
 	add sp, sp, #0x1c
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02177454
 _02177640: .word data_ov61_021815cc
@@ -70012,20 +70012,20 @@ _02177d78: .word data_ov61_0217e1a0
 	.global func_ov61_02177d7c
 	arm_func_start func_ov61_02177d7c
 func_ov61_02177d7c: ; 0x02177d7c
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x14
 	mov r1, #8
-	mov sl, r0
+	mov r10, r0
 	str r1, [sp, #8]
-	ldr r0, [sl, #0xc4]
+	ldr r0, [r10, #0xc4]
 	cmp r0, #0
 	addeq sp, sp, #0x14
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
-	ldr r0, [sl]
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldr r0, [r10]
 	bl func_ov61_02166914
 	cmp r0, #0
 	addeq sp, sp, #0x14
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	mov r5, #0
 	ldr r7, _02177e24 ; =data_ov61_02181824
 	add sb, sp, #0xc
@@ -70036,7 +70036,7 @@ func_ov61_02177d7c: ; 0x02177d7c
 _02177dd0:
 	str sb, [sp]
 	str r8, [sp, #4]
-	ldr r0, [sl]
+	ldr r0, [r10]
 	mov r1, r7
 	mov r2, r6
 	mov r3, r11
@@ -70044,18 +70044,18 @@ _02177dd0:
 	mov r2, r0
 	cmp r2, r4
 	beq _02177e0c
-	mov r0, sl
+	mov r0, r10
 	mov r1, r7
 	mov r3, sb
 	strb r5, [r7, r2]
 	bl func_ov61_02178d08
 _02177e0c:
-	ldr r0, [sl]
+	ldr r0, [r10]
 	bl func_ov61_02166914
 	cmp r0, #0
 	bne _02177dd0
 	add sp, sp, #0x14
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02177d7c
 _02177e24: .word data_ov61_02181824
@@ -70454,11 +70454,11 @@ _02178304:
 	.global func_ov61_02178314
 	arm_func_start func_ov61_02178314
 func_ov61_02178314: ; 0x02178314
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x104
 	str r1, [sp]
 	add r4, sp, #4
-	mov sl, r0
+	mov r10, r0
 	mov sb, r2
 	mov r8, r3
 	mov r1, #0
@@ -70476,7 +70476,7 @@ _02178334:
 	mov r11, r6
 _02178360:
 	ldrb r3, [r6]
-	ldrb r2, [sl, r4]
+	ldrb r2, [r10, r4]
 	ldr r1, [sp]
 	add r0, r4, #1
 	add r2, r3, r2
@@ -70501,7 +70501,7 @@ _02178360:
 	mov r7, r6
 	mov r5, r6
 	addle sp, sp, #0x104
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	add r4, sp, #4
 _021783d0:
 	ldrb r0, [sb, r5]
@@ -70537,7 +70537,7 @@ _021783d0:
 	mov r5, r2, asr #0x10
 	bgt _021783d0
 	add sp, sp, #0x104
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	arm_func_end func_ov61_02178314
 
 	.global func_ov61_02178458
@@ -70655,17 +70655,17 @@ _021785d4: .word data_ov61_0217e320
 	.global func_ov61_021785d8
 	arm_func_start func_ov61_021785d8
 func_ov61_021785d8: ; 0x021785d8
-	stmdb sp!, {r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x10c
 	movs r11, r3
 	mov r3, #0
 	ldr r7, [sp, #0x130]
 	str r3, [sp, #0x108]
-	mov sl, r0
+	mov r10, r0
 	mov sb, r1
 	mov r8, r2
 	addeq sp, sp, #0x10c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	sub r0, r8, #1
 	cmp r0, #1
 	bhi _02178684
@@ -70673,9 +70673,9 @@ func_ov61_021785d8: ; 0x021785d8
 	rsb r0, r0, #0x800
 	cmp r0, #2
 	addlo sp, sp, #0x10c
-	ldmloia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
-	ldr r1, [sl, #0x10c]
-	ldr r2, [sl, #0x98]
+	ldmloia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
+	ldr r1, [r10, #0x10c]
+	ldr r2, [r10, #0x98]
 	mov r0, r8
 	blx r2
 	str r0, [sp]
@@ -70704,8 +70704,8 @@ _02178684:
 _0217868c:
 	cmp r11, #0xff
 	bne _02178760
-	ldr r2, [sl, #0x10c]
-	ldr r3, [sl, #0x94]
+	ldr r2, [r10, #0x10c]
+	ldr r3, [r10, #0x94]
 	add r1, sp, #8
 	mov r0, r8
 	blx r3
@@ -70726,8 +70726,8 @@ _021786c4:
 	cmp r8, #0
 	bne _02178714
 	ldrb r0, [r7]
-	ldr r2, [sl, #0x10c]
-	ldr r3, [sl, #0x88]
+	ldr r2, [r10, #0x10c]
+	ldr r3, [r10, #0x88]
 	mov r1, sb
 	ldr r6, [sb, #0x800]
 	blx r3
@@ -70748,7 +70748,7 @@ _02178728:
 	rsb r0, r1, #0x800
 	cmp r0, #1
 	addlt sp, sp, #0x10c
-	ldmltia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmltia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	add r0, r1, #1
 	str r0, [sb, #0x800]
 	mov r0, #0
@@ -70757,13 +70757,13 @@ _02178728:
 	cmp r8, #0
 	add r7, sp, #8
 	addeq sp, sp, #0x10c
-	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmeqia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02178760:
 	ldr r0, [sp]
 	mov r4, #0
 	cmp r0, #0
 	addle sp, sp, #0x10c
-	ldmleia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmleia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 _02178774:
 	mov r5, #0
 	cmp r11, #0
@@ -70773,8 +70773,8 @@ _02178780:
 	ldr r6, [sb, #0x800]
 	bne _021787a4
 	ldrb r0, [r7, r5]
-	ldr r2, [sl, #0x10c]
-	ldr r3, [sl, #0x88]
+	ldr r2, [r10, #0x10c]
+	ldr r3, [r10, #0x88]
 	mov r1, sb
 	blx r3
 	b _021787e8
@@ -70782,8 +70782,8 @@ _021787a4:
 	cmp r8, #1
 	bne _021787c8
 	ldrb r0, [r7, r5]
-	ldr r3, [sl, #0x10c]
-	ldr ip, [sl, #0x8c]
+	ldr r3, [r10, #0x10c]
+	ldr ip, [r10, #0x8c]
 	mov r1, r4
 	mov r2, sb
 	blx ip
@@ -70792,8 +70792,8 @@ _021787c8:
 	cmp r8, #2
 	bne _021787e8
 	ldrb r0, [r7, r5]
-	ldr r3, [sl, #0x10c]
-	ldr ip, [sl, #0x90]
+	ldr r3, [r10, #0x10c]
+	ldr ip, [r10, #0x90]
 	mov r1, r4
 	mov r2, sb
 	blx ip
@@ -70814,7 +70814,7 @@ _0217880c:
 	cmp r4, r0
 	blt _02178774
 	add sp, sp, #0x10c
-	ldmia sp!, {r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_021785d8
 _02178824: .word data_ov61_0217e32c
@@ -70902,25 +70902,25 @@ func_ov61_02178888: ; 0x02178888
 	.global func_ov61_02178940
 	arm_func_start func_ov61_02178940
 func_ov61_02178940: ; 0x02178940
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x188
 	mov r8, r2
 	sub r2, r8, #1
 	mov r3, #0
 	cmp r2, #1
-	mov sl, r0
+	mov r10, r0
 	mov sb, r1
 	str r3, [sp, #0x104]
 	movhi r11, #1
 	bhi _02178980
-	ldr r1, [sl, #0x10c]
-	ldr r2, [sl, #0x98]
+	ldr r1, [r10, #0x10c]
+	ldr r2, [r10, #0x98]
 	mov r0, r8
 	blx r2
 	mov r11, r0
 _02178980:
-	ldr r2, [sl, #0x10c]
-	ldr r3, [sl, #0x94]
+	ldr r2, [r10, #0x10c]
+	ldr r3, [r10, #0x94]
 	add r1, sp, #4
 	mov r0, r8
 	blx r3
@@ -70929,7 +70929,7 @@ _02178980:
 	str r0, [sp]
 	cmp r1, #0
 	addle sp, sp, #0x188
-	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmleia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	add r6, sp, #4
 _021789b0:
 	ldrb r1, [r6]
@@ -70947,8 +70947,8 @@ _021789b0:
 	add r0, sb, r0
 	strb r1, [r0, #-1]
 	ldrb r0, [r6]
-	ldr r2, [sl, #0x10c]
-	ldr r3, [sl, #0x88]
+	ldr r2, [r10, #0x10c]
+	ldr r3, [r10, #0x88]
 	mov r1, sb
 	ldr r4, [sb, #0x800]
 	blx r3
@@ -70987,8 +70987,8 @@ _02178a38:
 	ldrb r0, [r6]
 	mov r1, r4
 	mov r2, sb
-	ldr r3, [sl, #0x10c]
-	ldr ip, [sl, #0x8c]
+	ldr r3, [r10, #0x10c]
+	ldr ip, [r10, #0x8c]
 	blx ip
 	b _02178ab0
 _02178a90:
@@ -70997,8 +70997,8 @@ _02178a90:
 	ldrb r0, [r6]
 	mov r1, r4
 	mov r2, sb
-	ldr r3, [sl, #0x10c]
-	ldr ip, [sl, #0x90]
+	ldr r3, [r10, #0x10c]
+	ldr ip, [r10, #0x90]
 	blx ip
 _02178ab0:
 	ldr r0, [sb, #0x800]
@@ -71024,7 +71024,7 @@ _02178ae4:
 	add r6, r6, #1
 	blt _021789b0
 	add sp, sp, #0x188
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_02178940
 _02178b08: .word data_ov61_0217e4e8
@@ -71427,14 +71427,14 @@ func_ov61_0217901c: ; 0x0217901c
 	.global func_ov61_0217907c
 	arm_func_start func_ov61_0217907c
 func_ov61_0217907c: ; 0x0217907c
-	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, lr}
+	stmdb sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, lr}
 	sub sp, sp, #0x28
 	sub sp, sp, #0x800
-	mov sl, r0
+	mov r10, r0
 	mov sb, r1
 	mov r3, #0
 	add r0, sp, #0x24
-	add r2, sl, #0x84
+	add r2, r10, #0x84
 	mov r1, #3
 	str r3, [sp, #0x824]
 	bl func_ov61_02178458
@@ -71468,13 +71468,13 @@ _0217910c:
 	ldr r1, _02179268 ; =data_ov61_0217e360
 	add r0, sp, #0x24
 	bl func_ov61_0217807c
-	ldr r1, [sl, #0xc0]
+	ldr r1, [r10, #0xc0]
 	add r0, sp, #0x24
 	bl func_ov61_02178048
 	ldr r1, _0217926c ; =data_ov61_0217e36c
 	add r0, sp, #0x24
 	bl func_ov61_0217807c
-	ldr r0, [sl, #0xc8]
+	ldr r0, [r10, #0xc8]
 	cmp r0, #0
 	ldrne r1, _02179270 ; =data_ov61_0217e374
 	add r0, sp, #0x24
@@ -71493,21 +71493,21 @@ _02179168:
 	add r0, sp, #0x24
 	bl func_ov61_0217807c
 	add r0, sp, #0x24
-	add r1, sl, #4
+	add r1, r10, #4
 	bl func_ov61_0217807c
-	ldr r0, [sl, #0xa8]
+	ldr r0, [r10, #0xa8]
 	cmp r0, #0
 	beq _021791c0
 	ldr r1, _02179280 ; =data_ov61_0217e398
 	add r0, sp, #0x24
 	bl func_ov61_0217807c
-	ldr r1, [sl, #0x104]
+	ldr r1, [r10, #0x104]
 	add r0, sp, #0x24
 	bl func_ov61_02178048
 	ldr r1, _02179284 ; =data_ov61_0217e3a4
 	add r0, sp, #0x24
 	bl func_ov61_0217807c
-	add r0, sl, #0x100
+	add r0, r10, #0x100
 	ldrh r1, [r0, #8]
 	add r0, sp, #0x24
 	bl func_ov61_02178048
@@ -71520,7 +71520,7 @@ _021791c0:
 	str r3, [sp, #4]
 	str r2, [sp, #8]
 	add r1, sp, #0x24
-	mov r0, sl
+	mov r0, r10
 	str r3, [sp, #0xc]
 	bl func_ov61_02178830
 	b _02179214
@@ -71535,24 +71535,24 @@ _021791f0:
 	mov r1, #0
 	strb r1, [r0, r2]
 _02179214:
-	add r0, sl, #0xcc
+	add r0, r10, #0xcc
 	str r0, [sp]
 	mov r0, #8
 	str r0, [sp, #4]
-	ldr r0, [sl]
+	ldr r0, [r10]
 	ldr r2, [sp, #0x824]
 	add r1, sp, #0x24
 	mov r3, #0
 	bl func_ov61_02166c04
 	bl func_ov61_021665e8
-	str r0, [sl, #0xac]
-	str r0, [sl, #0xb0]
+	str r0, [r10, #0xac]
+	str r0, [r10, #0xb0]
 	cmp sb, #0
 	movne r0, #0
-	strne r0, [sl, #0xb4]
+	strne r0, [r10, #0xb4]
 	add sp, sp, #0x28
 	add sp, sp, #0x800
-	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, sl, r11, pc}
+	ldmia sp!, {r3, r4, r5, r6, r7, r8, sb, r10, r11, pc}
 	.align 2, 0
 	arm_func_end func_ov61_0217907c
 _0217925c: .word data_ov61_021817cc

--- a/docs/inline_assembler.md
+++ b/docs/inline_assembler.md
@@ -9,20 +9,27 @@ to contribute to the list!
 - [Comments](#comments)
 
 ### Pool constants
-There is no `.word` or other data directives in the inline assembler. Instead, use the built-in `dcd` instruction:
+There is no `.word` or other data directives in the inline assembler. Instead, there are three built-in instructions you can
+use:
+
+#### `dcd`: Emits a literal 32-bit value
 ```asm
 mov r0, [pc, #0]
 bx lr
 dcd 0x1234
 ```
 
-This can also be written as:
+#### `ldconst`: Loads a literal 32-bit value
 ```asm
 ldconst 0x1234
 bx lr
 ```
+This code is equivalent to the above example using `dcd`.
 
-The built-in `ldconst` instruction will be replaced by an ARM load instruction and also append a pool constant to the function.
+#### `lda`: Loads the address to a symbol
+```
+lda r0, data_ov00_02abcdef
+```
 
 ### Data sections
 Directives such as `.section`, `.data` and `.bss` are not supported in the inline assembler. It's possible to change section


### PR DESCRIPTION
The inline assembler does not support these aliases. This will affect all assembly files, but it's better to do so now than later