### PR TITLE
Use UTF-8 in tools

### DIFF
--- a/tools/gen_externs.py
+++ b/tools/gen_externs.py
@@ -76,13 +76,13 @@ inc_files_created = 0
 def generate_externs(file: Path):
     global inc_files_created
 
-    with tempfile.NamedTemporaryFile('w', suffix='.s', delete=True, encoding='Shift-JIS') as tmp_asm_file:
+    with tempfile.NamedTemporaryFile('w', suffix='.s', delete=True) as tmp_asm_file:
         file_name = file.name.rsplit('.', 1)[0]
         inc_file_name = f'{file_name}.inc'
         inc_path = file.parent / inc_file_name
 
         # Comment out '.include ".../my_file.inc"
-        with open(file, 'r', encoding='Shift-JIS') as f:
+        with open(file, 'r') as f:
             contents = f.read()
         lines = contents.splitlines()
         has_inc_file = False
@@ -112,7 +112,7 @@ def generate_externs(file: Path):
         if not has_inc_file:
             relative_inc_path = inc_path.relative_to('asm/')
             lines.insert(0, f'    .include "{relative_inc_path}"')
-            with open(file, 'w', encoding='Shift-JIS') as f:
+            with open(file, 'w') as f:
                 for line in lines:
                     f.write(line)
                     f.write('\n')

--- a/tools/m2ctx.py
+++ b/tools/m2ctx.py
@@ -11,7 +11,7 @@ parser = argparse.ArgumentParser(description="Generates a context for decomp.me"
 parser.add_argument('file', help="Input file to preprocess")
 parser.add_argument('-f', type=str, dest='out_file', required=False, help='Output context file')
 parser.add_argument('-c', action=argparse.BooleanOptionalAction, dest='clipboard', required=False, help='Copy output to clipboard')
-parser.add_argument('-e', type=str, dest='encoding', required=False, default="Shift-JIS", help='Input file encoding')
+parser.add_argument('-e', type=str, dest='encoding', required=False, default="utf-8", help='Input file encoding')
 parser.add_argument('-v', action=argparse.BooleanOptionalAction, dest='verbose', required=False, help='Verbose error output')
 args = parser.parse_args()
 

--- a/tools/rename_symbols.py
+++ b/tools/rename_symbols.py
@@ -35,7 +35,7 @@ lines_updated = 0
 
 def rename_in_file(file: Path):
     global files_updated, lines_updated
-    with open(file, 'r', encoding="Shift-JIS") as f:
+    with open(file, 'r') as f:
         contents = f.read()
     has_symbol = any(contents.find(symbol) >= 0 for symbol in symbols_to_rename.keys())
     if not has_symbol: return
@@ -49,7 +49,7 @@ def rename_in_file(file: Path):
             lines_updated += 1
     print()
     files_updated += 1
-    with open(file, 'w', encoding="Shift-JIS") as f:
+    with open(file, 'w') as f:
         for line in lines:
             f.write(line)
             f.write('\n')


### PR DESCRIPTION
The tools still assumed that files were encoded in Shift-JIS, but that was changed to UTF-8 in #43.