### PR TITLE
Make `WINE` makefile var configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ endif
 ifeq ($(OS),Windows_NT)
 	WINE :=
 else
-	WINE := wine
+	WINE ?= wine
 	PYTHON ?= python3.11
 endif
 


### PR DESCRIPTION
This allows usage of other windows compatibility layers like `wibo`.