### PR TITLE
Fix `clang-format` error

### DIFF
--- a/include/System/SysNew.hpp
+++ b/include/System/SysNew.hpp
@@ -4,6 +4,6 @@
 
 class SysObject {
 public:
-    static void* operator new(unsigned long length, u32 *id, u32 idLength);
+    static void *operator new(unsigned long length, u32 *id, u32 idLength);
     static void operator delete(void *ptr);
 };


### PR DESCRIPTION
This unrelated change keeps getting applied when I run `clang-format` on my branches :slightly_smiling_face:  

@AetiasHax 