### PR TITLE
Match most of `OverlayManager.cpp`

### DIFF
--- a/config/eur/arm9/delinks.txt
+++ b/config/eur/arm9/delinks.txt
@@ -10,6 +10,9 @@ src/Main/Actor/ActorType.cpp:
     .text       start:0x0203e784 end:0x0203e8a0
     .bss        start:0x02069180 end:0x02069188
 
+src/Main/System/OverlayManager.cpp:
+    .text       start:0x0202ff44 end:0x0203003c
+
 libs/cpp/src/__register_global_object.cpp:
     complete
     .text       start:0x0204f8d4 end:0x0204f8f4

--- a/config/usa/arm9/delinks.txt
+++ b/config/usa/arm9/delinks.txt
@@ -10,6 +10,9 @@ src/Main/Actor/ActorType.cpp:
     .text       start:0x0203e740 end:0x0203e85c
     .bss        start:0x02069120 end:0x02069128
 
+src/Main/System/OverlayManager.cpp:
+    .text       start:0x0202ff40 end:0x02030038
+
 libs/cpp/src/__register_global_object.cpp:
     complete
     .text       start:0x0204f890 end:0x0204f8b0

--- a/include/System/OverlayManager.hpp
+++ b/include/System/OverlayManager.hpp
@@ -6,6 +6,7 @@
 
 typedef u32 OverlayId;
 enum OverlayId_ {
+    OverlayId_None = -1,
     OverlayId_Core,
     OverlayId_01,
     OverlayId_02,

--- a/libs/nds/include/nds/Overlay.h
+++ b/libs/nds/include/nds/Overlay.h
@@ -1,6 +1,10 @@
 #ifndef _NDS_OVERLAY_H
 #define _NDS_OVERLAY_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct Overlay {
     /* 00 */ unk32 mId;
     /* 04 */ void *mBaseAddress;
@@ -26,5 +30,9 @@ void Overlay_RunGlobalDestructors(Overlay *overlay);
 bool Overlay_Destroy(Overlay *overlay);
 bool Overlay_Load(Overlay *overlay, unk32 param2);
 bool Overlay_Unload(Overlay *overlay, unk32 param2);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/Main/System/OverlayManager.cpp
+++ b/src/Main/System/OverlayManager.cpp
@@ -1,7 +1,87 @@
+#include "global.h"
 #include "System/OverlayManager.hpp"
+#include "nds/Overlay.h"
 
-void OverlayManager::Load(OverlayIndex index, OverlayId id) {}
-void OverlayManager::LoadIfNotLoaded(OverlayIndex index, OverlayId id) {}
-void OverlayManager::Unload(OverlayIndex index) {}
-void OverlayManager::LoadOverlaySetup(s32 index) {}
-void OverlayManager::UnloadOverlaySetup() {}
+struct UnkStruct_020ee698 {
+    /* 00 */ unk8 mUnk_00[0x2C];
+    /* 2c */ unk32 mUnk_2c;
+    /* 30 */
+};
+extern UnkStruct_020ee698 data_ov000_020ee698;
+
+struct OverlaySetup {
+    /* 00 */ unk8 mUnk_00;
+    /* 01 */ unk8 mUnk_01;
+    /* 02 */ unk8 mUnk_02;
+    /* 03 */ unk8 mUnk_03;
+    /* 04 */ OverlayId slot1Overlay;
+    /* 08 */ OverlayId slot2Overlay;
+    /* 0c */ OverlayId slot3Overlay;
+    /* 10 */ OverlayId slot12Overlay;
+    /* 14 */ void* mUnk_14;
+    /* 18 */ void* mUnk_18;
+    /* 1c */
+};
+extern OverlaySetup gOverlaySetups[];
+
+extern u32 *data_027e0ce0[];
+extern "C" void func_ov007_02102850(u32**);
+extern "C" void func_ov007_021028a0(u32**);
+
+THUMB void OverlayManager::Load(OverlayIndex index, OverlayId id) {
+    if (id != OverlayId_None) {
+        Overlay_Load(NULL, id);
+    }
+
+    this->mLoadedOverlays[index] = id;
+}
+
+// non-matching (regalloc)
+THUMB void OverlayManager::LoadIfNotLoaded(OverlayIndex index, OverlayId id) {
+    if (this->mLoadedOverlays[index] != id) {
+        this->Unload(index);
+        this->Load(index, id);
+    }
+}
+
+THUMB void OverlayManager::Unload(OverlayIndex index) {
+    if (this->mLoadedOverlays[index] != OverlayId_None) {
+        Overlay_Unload(NULL, this->mLoadedOverlays[index]);
+        this->mLoadedOverlays[index] = OverlayId_None;
+    }
+}
+
+//! TODO: solve the .word issue with the overlay IDs
+//! both functions should match otherwise
+THUMB void OverlayManager::LoadOverlaySetup(s32 index) {
+    OverlayId overlayId;
+    OverlaySetup* pSetup;
+
+    pSetup = &gOverlaySetups[index];
+
+    this->LoadIfNotLoaded(OverlayIndex_1, pSetup->slot1Overlay);
+    this->LoadIfNotLoaded(OverlayIndex_2, pSetup->slot2Overlay);
+
+    if (index == 5) {
+        func_ov007_02102850(data_027e0ce0);
+    } else {
+        overlayId = pSetup->slot12Overlay;
+    
+        if (index == 6 && data_ov000_020ee698.mUnk_2c == 2) {
+            overlayId = OverlayId_61;
+        }
+    
+        this->Load(OverlayIndex_3, pSetup->slot3Overlay);
+        this->Load(OverlayIndex_12, overlayId);
+    }
+}
+
+THUMB void OverlayManager::UnloadOverlaySetup() {
+    this->Unload(OverlayIndex_12);
+    this->Unload(OverlayIndex_3);
+
+    if (this->mLoadedOverlays[2] == OverlayId_07) {
+        func_ov007_021028a0(data_027e0ce0);
+        this->Unload(OverlayIndex_2);
+    }
+}

--- a/src/Main/System/OverlayManager.cpp
+++ b/src/Main/System/OverlayManager.cpp
@@ -1,5 +1,5 @@
-#include "global.h"
 #include "System/OverlayManager.hpp"
+#include "global.h"
 #include "nds/Overlay.h"
 
 struct UnkStruct_020ee698 {
@@ -18,15 +18,15 @@ struct OverlaySetup {
     /* 08 */ OverlayId slot2Overlay;
     /* 0c */ OverlayId slot3Overlay;
     /* 10 */ OverlayId slot12Overlay;
-    /* 14 */ void* mUnk_14;
-    /* 18 */ void* mUnk_18;
+    /* 14 */ void *mUnk_14;
+    /* 18 */ void *mUnk_18;
     /* 1c */
 };
 extern OverlaySetup gOverlaySetups[];
 
 extern u32 *data_027e0ce0[];
-extern "C" void func_ov007_02102850(u32**);
-extern "C" void func_ov007_021028a0(u32**);
+extern "C" void func_ov007_02102850(u32 **);
+extern "C" void func_ov007_021028a0(u32 **);
 
 THUMB void OverlayManager::Load(OverlayIndex index, OverlayId id) {
     if (id != OverlayId_None) {
@@ -55,7 +55,7 @@ THUMB void OverlayManager::Unload(OverlayIndex index) {
 //! both functions should match otherwise
 THUMB void OverlayManager::LoadOverlaySetup(s32 index) {
     OverlayId overlayId;
-    OverlaySetup* pSetup;
+    OverlaySetup *pSetup;
 
     pSetup = &gOverlaySetups[index];
 
@@ -66,11 +66,11 @@ THUMB void OverlayManager::LoadOverlaySetup(s32 index) {
         func_ov007_02102850(data_027e0ce0);
     } else {
         overlayId = pSetup->slot12Overlay;
-    
+
         if (index == 6 && data_ov000_020ee698.mUnk_2c == 2) {
             overlayId = OverlayId_61;
         }
-    
+
         this->Load(OverlayIndex_3, pSetup->slot3Overlay);
         this->Load(OverlayIndex_12, overlayId);
     }

--- a/src/Main/System/OverlayManager.cpp
+++ b/src/Main/System/OverlayManager.cpp
@@ -36,9 +36,10 @@ THUMB void OverlayManager::Load(OverlayIndex index, OverlayId id) {
     this->mLoadedOverlays[index] = id;
 }
 
-// non-matching (regalloc)
 THUMB void OverlayManager::LoadIfNotLoaded(OverlayIndex index, OverlayId id) {
-    if (this->mLoadedOverlays[index] != id) {
+    OverlayId loadedId = this->mLoadedOverlays[index];
+
+    if (loadedId != id) {
         this->Unload(index);
         this->Load(index, id);
     }


### PR DESCRIPTION
`LoadOverlaySetup` and `UnloadOverlaySetup` have a strange issue where specific numbers don't goes in the appropriate "part" (I'm not sure how to describe that), I have another non-matching issue which is only regalloc related (I couldn't figure it out though), scratches for both issues: https://decomp.me/scratch/SFt0e & https://decomp.me/scratch/xIyKR

Closes #69 