### PR TITLE
Fix shebangs and permissions

### DIFF
--- a/tools/configure.py
+++ b/tools/configure.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import os
 from pathlib import Path

--- a/tools/m2ctx.py
+++ b/tools/m2ctx.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import pyperclip

--- a/tools/ninja_syntax.py
+++ b/tools/ninja_syntax.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python
-
 # Copyright 2011 Google Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/setup.py
+++ b/tools/setup.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import requests
 import zipfile
 import io

--- a/tools/sha1.py
+++ b/tools/sha1.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from pathlib import Path
 import argparse


### PR DESCRIPTION
I gave the executable bit to all the scripts so they can be run via e.g. `./tools/configure.py` on Linux.

I also switched the usage of `#!/usr/bin/python3` shebangs to `#!/usr/bin/env python3`. The issue with the former is that it will ignore the user's virtual environment and just always use the system's python3 executable, meaning that ninja build will fail because `pyperclip` cannot be found in the system python3, even if the user installed that into their virtual env. `#!/usr/bin/env python3` avoids this issue and uses the current environment's python3 executable.

I also removed the shebang from ninja_syntax, as that's not an executable script.