### PR TITLE
Bump dsd to 0.9.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,5 @@ objdiff.json
 build.ninja
 .ninja_log*
 .ninja_lock
+.ninja_deps
 /wibo

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,14 +17,13 @@
 - `extract/`: Game assets, extracted from your own supplied ROM
     - `eur|usa/`: [`ds-rom`](https://github.com/AetiasHax/ds-rom) extract directories
 - `include/`: Include files
-- `src/`: Source C/C++ files
+- `libs/`: Source C/C++ files for libraries used by the game
+- `src/`: Source C/C++ files for the game
 - `tools/`: Tools for this project
     - `mwccarm/`: Compiler toolchain
     - `configure.py`: Generates `build.ninja`
-    - `m2ctx.py`: Generates context for [decomp.me](https://decomp.me/)
     - `mangle.py`: Shows mangled symbol names in a given C/C++ file
     - `requirements.txt`: Python libraries
-    - `setup.py`: Sets up the project
 - `*.sha1`: SHA-1 digests of different versions of the game
 
 ## Decompiling

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -32,9 +32,6 @@ python tools/configure.py <eur|usa>
 
 Now you can run `ninja` to build a ROM for the chosen version.
 
-> [!IMPORTANT]
-> Rerun `configure.py` often to ensure that all C/C++ code gets compiled.
-
 > [!NOTE]
 > For Linux users: Wibo is used by default. If you want to use Wine instead, run `configure.py` with `-w <path/to/wine>`.
 
@@ -49,5 +46,3 @@ ARM7 BIOS in the root directory of this repository, and verify that your dumped 
 | --------------- | ------------------------------------------ |
 | `arm7_bios.bin` | `6ee830c7f552c5bf194c20a2c13d5bb44bdb5c03` |
 | `arm7_bios.bin` | `24f67bdea115a2c847c8813a262502ee1607b7df` |
-
-Now, rerun `configure.py` so it can update `build.ninja` to build a matching ROM.

--- a/tools/configure.py
+++ b/tools/configure.py
@@ -305,6 +305,12 @@ def main():
         n.newline()
 
         n.rule(
+            name="apply",
+            command=f"{DSD} {DSD_BASE_FLAGS} apply --config-path $config_path --elf-path $elf_path"
+        )
+        n.newline()
+
+        n.rule(
             name="sha1",
             command=f"{PYTHON} tools/sha1.py $in -c $sha1_file"
         )
@@ -327,6 +333,7 @@ def main():
         add_check_builds(n, project)
         add_objdiff_builds(n, project)
         add_configure_build(n, project)
+        add_apply_build(n, project)
 
         n.default(["objdiff", "check", "sha1"])
 
@@ -644,6 +651,20 @@ def add_configure_build(n: ninja_syntax.Writer, project: Project):
             *project.dsd_configs(),
         ]
     )
+
+
+def add_apply_build(n: ninja_syntax.Writer, project: Project):
+    n.build(
+        inputs=project.dsd_configs() + [str(project.arm9_o())],
+        implicit=DSD,
+        rule="apply",
+        outputs="apply",
+        variables={
+            "config_path": str(project.arm9_config_yaml()),
+            "elf_path": str(project.arm9_o()),
+        }
+    )
+    n.newline()
 
 
 def get_config_files(game_config: Path, name: str) -> list[str]:

--- a/tools/configure.py
+++ b/tools/configure.py
@@ -26,7 +26,7 @@ args = parser.parse_args()
 
 # Config
 GAME = "ph"
-DSD_VERSION = 'v0.8.0'
+DSD_VERSION = 'v0.9.0'
 WIBO_VERSION = '0.6.16'
 OBJDIFF_VERSION = 'v2.7.1'
 MWCC_VERSION = "2.0/sp1p5"

--- a/tools/configure.py
+++ b/tools/configure.py
@@ -655,9 +655,10 @@ def add_objdiff_builds(n: ninja_syntax.Writer, project: Project):
     )
     n.newline()
 
+    delink_files = [file['delink_file'] for module in project.modules() for file in module['files']]
     n.build(
         inputs=["objdiff.json"],
-        implicit=[OBJDIFF] + project.source_object_files(),
+        implicit=[OBJDIFF] + delink_files + project.source_object_files(),
         rule="objdiff_report",
         outputs=str(project.objdiff_report()),
     )

--- a/tools/configure.py
+++ b/tools/configure.py
@@ -4,6 +4,7 @@ import os
 from pathlib import Path
 import argparse
 import sys
+import subprocess
 
 import ninja_syntax
 from get_platform import get_platform
@@ -275,6 +276,14 @@ def main():
         )
         n.newline()
 
+        configure_cmdline = subprocess.list2cmdline(sys.argv[1:])
+        n.rule(
+            name="configure",
+            command=f"{PYTHON} tools/configure.py {configure_cmdline}",
+            generator=True
+        )
+        n.newline()
+
         add_download_tool_builds(n)
         add_extract_build(n, project)
         add_delink_and_lcf_builds(n, project)
@@ -282,6 +291,7 @@ def main():
         add_mwld_and_rom_builds(n, project)
         add_check_builds(n, project)
         add_objdiff_builds(n, project)
+        add_configure_build(n, project)
 
 
 def add_download_tool_builds(n: ninja_syntax.Writer):
@@ -559,6 +569,17 @@ def add_objdiff_builds(n: ninja_syntax.Writer, project: Project):
         outputs="report",
     )
     n.newline()
+
+
+def add_configure_build(n: ninja_syntax.Writer, project: Project):
+    this_file = str(Path(__file__).resolve())
+    n.build(
+        outputs="build.ninja",
+        rule="configure",
+        implicit=[
+            this_file,
+        ]
+    )
 
 
 def get_config_files(game_config: Path, name: str) -> list[str]:

--- a/tools/configure.py
+++ b/tools/configure.py
@@ -210,6 +210,8 @@ def can_run_dsd() -> bool:
         return version == DSD_VERSION
     except subprocess.CalledProcessError:
         return False
+    except FileNotFoundError:
+        return False
 
 
 def main():

--- a/tools/configure.py
+++ b/tools/configure.py
@@ -172,6 +172,9 @@ class Project:
     def arm9_o(self) -> Path:
         return self.game_build / "arm9.o"
 
+    def arm9_disassembly_dir(self) -> Path:
+        return self.game_build / "asm"
+
     def objdiff_report(self) -> Path:
         return self.game_build / "report.json"
 
@@ -224,6 +227,12 @@ def main():
         n.rule(
             name="delink",
             command=f"{DSD} {DSD_BASE_FLAGS} delink --config-path $config_path"
+        )
+        n.newline()
+
+        n.rule(
+            name="disassemble",
+            command=f"{DSD} {DSD_BASE_FLAGS} dis --config-path $config_path --asm-path $output_path --ual"
         )
         n.newline()
 
@@ -312,11 +321,14 @@ def main():
         add_download_tool_builds(n, project)
         add_extract_build(n, project)
         add_delink_and_lcf_builds(n, project)
+        add_disassemble_builds(n, project)
         add_mwcc_builds(n, project, mwcc_implicit)
         add_mwld_and_rom_builds(n, project)
         add_check_builds(n, project)
         add_objdiff_builds(n, project)
         add_configure_build(n, project)
+
+        n.default(["objdiff", "check", "sha1"])
 
 
 def add_download_tool_builds(n: ninja_syntax.Writer, project: Project):
@@ -536,6 +548,20 @@ def add_delink_and_lcf_builds(n: ninja_syntax.Writer, project: Project):
         outputs=lcf_files,
         variables={
             "config_path": str(project.arm9_config_yaml()),
+        }
+    )
+    n.newline()
+
+
+def add_disassemble_builds(n: ninja_syntax.Writer, project: Project):
+    n.build(
+        inputs=project.dsd_configs(),
+        implicit=DSD,
+        rule="disassemble",
+        outputs="dis",
+        variables={
+            "config_path": str(project.arm9_config_yaml()),
+            "output_path": str(project.arm9_disassembly_dir()),
         }
     )
     n.newline()


### PR DESCRIPTION
This introduces parallel linking and fixes an issue when linking multiple objects with the same name. I noticed this as I was working on `LinkStateMove` which has one `LinkStateMove.cpp` file for each overlay it's in.

In addition, I've added `ninja dis` to disassemble all code in a format supported by m2c, and `ninja apply` to run `dsd apply` which takes symbol properties from `arm9.o` and applies it to symbols.txt files.