### PR TITLE
macOS support

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -11,11 +11,13 @@ Contents:
 
 1. Use one of these platforms:
     - Windows (recommended)
+    - macOS
     - Linux
 2. Install the following:
     - Python 3.11+ and pip
     - GCC 9+
     - Ninja
+    - Wine (macOS only)
 3. Install the Python dependencies:
 ```shell
 python -m pip install -r tools/requirements.txt

--- a/tools/configure.py
+++ b/tools/configure.py
@@ -11,12 +11,17 @@ from typing import Any
 import ninja_syntax
 from get_platform import Platform, get_platform
 
+# Platform info
+platform = get_platform()
+if platform is None:
+    exit(1)
 
-DEFAULT_WIBO_PATH = "./wibo"
-
+DEFAULT_WINE_PATH = "./wibo"
+if platform.system == "macos":
+    DEFAULT_WINE_PATH = "wine"
 
 parser = argparse.ArgumentParser(description="Generates build.ninja")
-parser.add_argument('-w', type=str, default=DEFAULT_WIBO_PATH, dest="wine", required=False, help="Path to Wine/Wibo (linux only)")
+parser.add_argument('-w', type=str, default=DEFAULT_WINE_PATH, dest="wine", required=False, help="Path to Wine/Wibo (macOS/Linux only)")
 parser.add_argument("--compiler", type=Path, required=False, help="Path to pre-installed compiler root directory")
 parser.add_argument("--no-extract", action="store_true", help="Skip extract step")
 parser.add_argument("--dsd", type=Path, required=False, help="Path to pre-installed dsd CLI")
@@ -104,10 +109,6 @@ for root, dirs, _ in os.walk(libs_path):
 CC_INCLUDES = " ".join(f"-i {include}" for include in includes)
 
 
-# Platform info
-platform = get_platform()
-if platform is None:
-    exit(1)
 EXE = platform.exe
 WINE = args.wine if platform.system != "windows" else ""
 DSD = str(args.dsd or os.path.join('.', str(root_path / f"dsd{EXE}")))
@@ -402,7 +403,7 @@ def add_download_tool_builds(n: ninja_syntax.Writer, project: Project):
         )
         n.newline()
 
-    if project.platform.system != "windows" and WINE == DEFAULT_WIBO_PATH:
+    if project.platform.system != "windows" and WINE == DEFAULT_WINE_PATH:
         n.build(
             rule="download_tool",
             outputs=WINE,

--- a/tools/get_platform.py
+++ b/tools/get_platform.py
@@ -4,9 +4,9 @@ import platform
 class Platform:
     def __init__(self, *, system: str, machine: str, exe: str):
         self.system = system
-        '''Name of operating system: "windows" or "linux"'''
+        '''Name of operating system: "windows", "linux" or "macos"'''
         self.machine = machine
-        '''Name of machine architecture: "x86_64"'''
+        '''Name of machine architecture: "x86_64", "arm64"'''
         self.exe = exe
         '''Executable file extension: ".exe" for Windows, "" otherwise'''
 
@@ -19,13 +19,23 @@ def get_platform() -> Platform | None:
         exe = ".exe"
     elif system == "Linux":
         system = "linux"
-    else:
-        print(f"Unknown system '{system}'")
-        return None
+    elif system == "Darwin":
+        system = "macos"
     match platform.machine().lower():
         case "amd64" | "x86_64": machine = "x86_64"
-        case machine:
-            print(f"Unknown machine: {machine}")
-            return None
+        case "arm64": machine = "arm64"
+        case machine: pass
+    
+    supported_platforms = [
+        "windows-x86_64",
+        "linux-x86_64",
+        "macos-x86_64",
+        "macos-arm64"
+    ]
+
+    combined = f"{system}-{machine}"
+    if combined not in supported_platforms:
+        print(f"Unsupported platform: {combined}")
+        return None
 
     return Platform(system=system, machine=machine, exe=exe)


### PR DESCRIPTION
This adds support for macOS ARM64 and x86_64 through `get_platform`. As there isn't a drop-in executable like wibo available for macOS, the user must install wine themselves. The executable must be in PATH as the DEFAULT_WINE_PATH for macOS is just `wine`. Linux remains with `./wibo`

I haven't actually tested this on this repo, but it worked fine on https://github.com/Yotona/twewy/pull/2, and I don't see any reason why it shouldn't work here.