### PR TITLE
Set up clangd

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,10 @@
+CompileFlags:
+  Add:
+  - -m32
+  - -nostdinc
+  - -Iinclude
+  - -Ilibs/c/include
+  - -Ilibs/cpp/include
+  - -Ilibs/nds/include
+  - -Ilibs/nitro/include
+  - -Ilibs/nns/include

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ build.ninja
 .ninja_deps
 /wibo
 /sjiswrap.exe
+/compile_commands.json

--- a/tools/configure.py
+++ b/tools/configure.py
@@ -165,7 +165,7 @@ class Project:
     def build_rom_config(self) -> Path:
         return self.game_build / "build" / "rom_config.yaml"
 
-    def source_files(self) -> Generator[Path]:
+    def source_files(self) -> Generator[Path, None, None]:
         yield from get_c_cpp_files([src_path, libs_path])
 
     def source_object_files(self) -> list[str]:

--- a/tools/configure.py
+++ b/tools/configure.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import argparse
 import sys
 import subprocess
-from typing import Any
+from typing import Any, Generator
 
 import ninja_syntax
 from get_platform import Platform, get_platform
@@ -165,9 +165,12 @@ class Project:
     def build_rom_config(self) -> Path:
         return self.game_build / "build" / "rom_config.yaml"
 
+    def source_files(self) -> Generator[Path]:
+        yield from get_c_cpp_files([src_path, libs_path])
+
     def source_object_files(self) -> list[str]:
         files: list[str] = []
-        for source_file in get_c_cpp_files([src_path, libs_path]):
+        for source_file in self.source_files():
             src_obj_path = self.game_build / source_file
             files.append(str(src_obj_path.with_suffix(".o")))
         return files
@@ -360,6 +363,8 @@ def main():
             generator=True
         )
         n.newline()
+
+        create_compilation_database(project)
 
         add_download_tool_builds(n, project)
         add_configure_build(n, project)
@@ -733,6 +738,20 @@ def get_config_files(game_config: Path, name: str) -> list[str]:
         for file in files
         if file == name
     ]
+
+
+def create_compilation_database(project: Project):
+    db_path = root_path / "compile_commands.json"
+    db: list[dict] = []
+    abs_root_path = root_path.absolute()
+    for src_file in project.source_files():
+        db.append({
+            "directory": str(abs_root_path),
+            "arguments": ["#"], # clangd ignores entries with empty arguments
+            "file": str(src_file)
+        })
+    with db_path.open("w") as f:
+        f.write(json.dumps(db))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds support for the clangd language server. `tools/configure.py` will now generate a `compile_commands.json` with one entry for each .c and .cpp file, providing the bare minimum for clangd so it will recognize all C/C++ files as part of the project.

Global compiler flags can be added to `.clangd`. For now it has:
* `-m32`: 32-bit target machine
* `-nostdinc`: No standard headers from Clang, as we don't actually use Clang for building
* Includes all `include/` directories